### PR TITLE
ci: pin Swatinem/rust-cache to v2 (v3 does not exist)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           components: clippy,rustfmt
 
-      - uses: Swatinem/rust-cache@v3
+      - uses: Swatinem/rust-cache@v2
 
       - run: vp install --frozen-lockfile
       - run: vp build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           components: clippy,rustfmt
 
-      - uses: Swatinem/rust-cache@v3
+      - uses: Swatinem/rust-cache@v2
 
       - run: vp install --frozen-lockfile
       - run: pnpm run verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           components: clippy,rustfmt
 
-      - uses: Swatinem/rust-cache@v3
+      - uses: Swatinem/rust-cache@v2
 
       - run: vp install --frozen-lockfile
       - run: node tools/tasks/verify-release-tag.ts
@@ -60,7 +60,7 @@ jobs:
         with:
           components: clippy,rustfmt
 
-      - uses: Swatinem/rust-cache@v3
+      - uses: Swatinem/rust-cache@v2
 
       - run: vp install --frozen-lockfile
       - run: node tools/tasks/verify-release-tag.ts


### PR DESCRIPTION
All workflows referenced `Swatinem/rust-cache@v3`, which has no published `v3` tag (latest major is `v2.9.1`). Every CI / bench / release run failed at *Set up job → Prepare all required actions* with:

> Unable to resolve action `swatinem/rust-cache@v3`, unable to find version `v3`

Pinned the four references (`ci.yml`, `bench.yml`, `release.yml` ×2) to the existing `v2` major so CI can actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783527406&installation_id=136613492&pr_number=2&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F2&signature=469eeebce92f9a113bb6447079c5ebdee0916abd28bdcb6bd9164bcb3f4c3b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->