### PR TITLE
ci: enable corepack so pnpm is available in run steps

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,6 +29,8 @@ jobs:
           node-version: '24'
           cache: true
 
+      - run: corepack enable
+
       - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy,rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           node-version: '24'
           cache: true
 
+      - run: corepack enable
+
       - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy,rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
           node-version: '24'
           cache: true
 
+      - run: corepack enable
+
       - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy,rustfmt
@@ -55,6 +57,8 @@ jobs:
         with:
           node-version: '24'
           cache: false
+
+      - run: corepack enable
 
       - uses: dtolnay/rust-toolchain@1.96.0
         with:


### PR DESCRIPTION
`setup-vp` provisions Node but does not put the `pnpm` binary (from the `packageManager` field) on PATH, so `pnpm run verify` / `pnpm run bench` steps failed with `pnpm: command not found` (CI was red on `main` independent of any change). Enabling corepack right after `setup-vp` activates the pinned pnpm.

Second half of restoring CI (after #2 fixed the `rust-cache@v3` action pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783528023&installation_id=136613492&pr_number=3&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F3&signature=23e1b15bf927990eb38617c1af9513828c42693c12d6b9d2221ecbf2f196fb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->