### PR TITLE
ci: open follow-up issues when port-target upstreams release new versions

### DIFF
--- a/.github/workflows/track-upstream-releases.yml
+++ b/.github/workflows/track-upstream-releases.yml
@@ -1,0 +1,35 @@
+name: Track upstream releases
+
+# Opens a follow-up issue whenever a port-target plugin (tools/port-targets.json)
+# publishes a version newer than the baseline we pinned, so the vendored
+# submodule and the port can be kept in sync. Issue-only; it does not bump
+# anything automatically.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: track-upstream-releases
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check upstream releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - run: node tools/tasks/check-upstream-releases.ts --apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lint:rust": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
     "lint:rust:layout": "node tools/tasks/check-rust-layout.ts",
     "new": "node tools/tasks/new-port-prompt.ts",
+    "port:releases": "node tools/tasks/check-upstream-releases.ts",
     "port:rules": "node tools/tasks/enumerate-port-rules.ts",
     "profile": "node tools/tasks/profile.ts",
     "release": "node tools/tasks/release.ts",

--- a/tools/tasks/check-upstream-releases.ts
+++ b/tools/tasks/check-upstream-releases.ts
@@ -1,0 +1,178 @@
+// Checks every port target in tools/port-targets.json against the npm registry
+// and, when an upstream has published a version newer than the baseline we
+// pinned, opens (or reuses) a GitHub issue so the submodule + port can follow
+// up. Reads only the committed manifest and the public registry, so it needs
+// neither the submodules nor pnpm/vp — just Node (global fetch) and the `gh`
+// CLI for issue creation.
+//
+// Usage:
+//   node tools/tasks/check-upstream-releases.ts            # dry run (prints)
+//   node tools/tasks/check-upstream-releases.ts --apply    # create issues (CI)
+//
+// The scheduled workflow .github/workflows/track-upstream-releases.yml runs it
+// with --apply and GH_TOKEN set.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type Plugin = {
+  id: string;
+  npm: string;
+  repo: string;
+  submodule: string;
+  baselineVersion: string;
+  pinnedRef: string;
+  license: string;
+};
+type Manifest = { plugins: Plugin[] };
+
+type ExistingIssue = { title: string; number: number; state: string };
+
+const apply = process.argv.includes('--apply');
+const repoSlug = process.env.GITHUB_REPOSITORY ?? 'ubugeeei-prod/oxlint-plugins';
+
+const manifest = JSON.parse(
+  readFileSync(join(process.cwd(), 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+
+const existing = apply ? listExistingIssues() : [];
+const filed: string[] = [];
+const failed: string[] = [];
+
+for (const plugin of manifest.plugins) {
+  const latest = await fetchLatestVersion(plugin.npm);
+  if (!latest) {
+    console.log(`? ${plugin.npm}: could not resolve latest version`);
+    continue;
+  }
+  if (!isNewer(latest, plugin.baselineVersion)) {
+    console.log(
+      `= ${plugin.npm}: up to date (baseline ${plugin.baselineVersion}, latest ${latest})`,
+    );
+    continue;
+  }
+
+  const marker = `${plugin.npm}@${latest}`;
+  console.log(`+ ${plugin.npm}: ${plugin.baselineVersion} -> ${latest} (follow-up needed)`);
+
+  if (!apply) {
+    filed.push(marker);
+    continue;
+  }
+
+  if (existing.some((issue) => issue.title.includes(marker))) {
+    console.log(`  issue already exists for ${marker}, skipping`);
+    continue;
+  }
+
+  try {
+    const url = createIssue(plugin, latest);
+    filed.push(url);
+    console.log(`  filed ${url}`);
+  } catch (error) {
+    failed.push(`${marker}: ${(error as Error).message.split('\n')[0]}`);
+    console.error(`  failed to file issue for ${marker}`);
+  }
+}
+
+console.log(
+  `\n${apply ? 'Filed' : 'Would file'} ${filed.length} follow-up issue(s).` +
+    (failed.length > 0 ? ` ${failed.length} failed.` : ''),
+);
+if (failed.length > 0) {
+  for (const failure of failed) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+async function fetchLatestVersion(npm: string): Promise<string | null> {
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${npm}/latest`, {
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as { version?: string };
+    return body.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isNewer(candidate: string, baseline: string): boolean {
+  const a = parseVersion(candidate);
+  const b = parseVersion(baseline);
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return false;
+}
+
+function parseVersion(version: string): [number, number, number] {
+  const match = String(version).match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return [0, 0, 0];
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function listExistingIssues(): ExistingIssue[] {
+  try {
+    const out = execFileSync(
+      'gh',
+      [
+        'issue',
+        'list',
+        '--repo',
+        repoSlug,
+        '--label',
+        'upstream-release',
+        '--state',
+        'all',
+        '--limit',
+        '300',
+        '--json',
+        'title,number,state',
+      ],
+      { encoding: 'utf8' },
+    );
+    return JSON.parse(out) as ExistingIssue[];
+  } catch {
+    return [];
+  }
+}
+
+function createIssue(plugin: Plugin, latest: string): string {
+  const title = `upstream release: ${plugin.npm}@${latest} (baseline ${plugin.baselineVersion})`;
+  const body = [
+    `**${plugin.npm}** published \`${latest}\`. The port baseline in \`tools/port-targets.json\` is \`${plugin.baselineVersion}\`, so the vendored submodule and the port may need to follow up.`,
+    '',
+    `- Upstream repo: ${plugin.repo}`,
+    `- Releases: ${plugin.repo}/releases`,
+    `- Submodule: \`${plugin.submodule}\` (pinned to \`${plugin.pinnedRef}\`)`,
+    `- License: ${plugin.license}`,
+    '',
+    '### Follow-up',
+    '',
+    '- [ ] Review the upstream changelog and the added / removed / changed rules',
+    `- [ ] Bump the submodule and update \`baselineVersion\` + \`pinnedRef\` for \`${plugin.id}\` in \`tools/port-targets.json\``,
+    '- [ ] Re-run `pnpm run port:rules` and reconcile `expectedRuleCount`',
+    '- [ ] Port new rules / adjust changed behavior',
+    '',
+    '_Filed automatically by `.github/workflows/track-upstream-releases.yml`._',
+  ].join('\n');
+
+  return execFileSync(
+    'gh',
+    [
+      'issue',
+      'create',
+      '--repo',
+      repoSlug,
+      '--title',
+      title,
+      '--body',
+      body,
+      '--label',
+      'upstream-release',
+    ],
+    { encoding: 'utf8' },
+  ).trim();
+}


### PR DESCRIPTION
## What

A scheduled workflow + script that keeps the vendored port-target submodules honest: it checks every plugin in `tools/port-targets.json` against the npm registry and opens (or reuses) an issue labelled `upstream-release` whenever an upstream publishes a version **newer than the pinned baseline**. Issue-only — nothing is bumped automatically (matches the request to *file an issue saying a follow-up is needed*).

## Changes

- **`tools/tasks/check-upstream-releases.ts`** — registry diff + `gh` issue filing. Dry-run by default; `--apply` creates issues. De-dupes against existing `upstream-release` issues by `npm@version` marker. Reads only the committed manifest + public registry, so it needs **neither the submodules nor pnpm/vp** — just Node (global `fetch`) and `gh`.
- **`.github/workflows/track-upstream-releases.yml`** — weekly cron (`Mon 06:00 UTC`) + `workflow_dispatch`, `issues: write`. Uses `actions/setup-node` so it does not depend on the `setup-vp` package-manager path.
- **`package.json`** — `port:releases` script (`pnpm run port:releases` for a local dry run).

## Dry run (today's baselines)

```
+ eslint-plugin-functional: 9.0.5 -> 10.0.0 (follow-up needed)
+ eslint-plugin-storybook:  10.3.6 -> 10.4.2 (follow-up needed)
+ @unocss/eslint-plugin:    66.6.8 -> 66.7.0 (follow-up needed)
+ @eslint/json:             1.2.0 -> 2.0.0 (follow-up needed)
= (the other 8 are up to date with their baseline)
```

Validated locally: `tsgo` typecheck clean, `vp fmt --check` clean.

> Note: repo CI (`pnpm run verify`) is currently red on `main` for a pre-existing reason unrelated to this PR — `setup-vp` does not expose `pnpm` on PATH for `run:` steps (`pnpm: command not found`). This workflow deliberately uses `actions/setup-node` instead and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783528488&installation_id=136613492&pr_number=16&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F16&signature=e066c13da2468bffb162c9fae3b576b985ecb64d4a82c3bc598150947b8589d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->