### PR TITLE
fix(ci): add vite and typescript deps so verify pipeline passes

### DIFF
--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -31,5 +31,8 @@
   "dependencies": {
     "@ox-content/wasm": "catalog:",
     "void": "catalog:"
+  },
+  "devDependencies": {
+    "vite": "catalog:"
   }
 }

--- a/npm/type-aware/package.json
+++ b/npm/type-aware/package.json
@@ -47,5 +47,8 @@
   },
   "dependencies": {
     "@corsa-bind/napi": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ catalogs:
     '@typescript/native-preview':
       specifier: ^7.0.0-dev.20260608.1
       version: 7.0.0-dev.20260608.1
+    typescript:
+      specifier: ^5.9.2
+      version: 5.9.3
+    vite:
+      specifier: ^8.0.16
+      version: 8.0.16
     vite-plus:
       specifier: ^0.1.24
       version: 0.1.24
@@ -49,7 +55,7 @@ importers:
         version: 7.0.0-dev.20260608.1
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+        version: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
@@ -61,7 +67,11 @@ importers:
         version: 2.64.0
       void:
         specifier: 'catalog:'
-        version: 0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3)
+        version: 0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1(typescript@5.9.3))(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3)
+    devDependencies:
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)
 
   npm/no-forbidden-identifiers:
     dependencies:
@@ -74,6 +84,10 @@ importers:
       '@corsa-bind/napi':
         specifier: 'catalog:'
         version: 0.42.0
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
 packages:
 
@@ -3151,6 +3165,11 @@ packages:
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -4737,7 +4756,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)':
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)':
     dependencies:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
@@ -4748,6 +4767,7 @@ snapshots:
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.4
+      typescript: 5.9.3
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.24':
     optional: true
@@ -4767,11 +4787,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))':
+  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)
       es-module-lexer: 1.7.0
       obug: 2.1.2
       pixelmatch: 7.2.0
@@ -4952,10 +4972,10 @@ snapshots:
       kysely: 0.29.2
       pg: 8.21.0
 
-  drizzle-valibot@0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1):
+  drizzle-valibot@0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1(typescript@5.9.3)):
     dependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0)
-      valibot: 1.4.1
+      valibot: 1.4.1(typescript@5.9.3)
 
   drizzle-zod@0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(zod@4.4.3):
     dependencies:
@@ -5244,7 +5264,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
+  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -5267,7 +5287,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.52.0
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -5278,7 +5298,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.67.0
       '@oxlint/binding-android-arm64': 1.67.0
@@ -5300,7 +5320,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.67.0
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
 
   path-to-regexp@6.3.0: {}
 
@@ -5550,6 +5570,8 @@ snapshots:
 
   typanion@3.14.0: {}
 
+  typescript@5.9.3: {}
+
   undici-types@7.18.2: {}
 
   undici@7.24.8: {}
@@ -5562,16 +5584,18 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.4.1: {}
+  valibot@1.4.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
-  vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)):
+  vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)):
     dependencies:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
-      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
       oxlint-tsgolint: 0.23.0
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
@@ -5654,7 +5678,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  void@0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3):
+  void@0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1(typescript@5.9.3))(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3):
     dependencies:
       '@cloudflare/sandbox': 0.10.3
       '@cloudflare/vite-plugin': 1.40.0(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(workerd@1.20260603.1)(wrangler@4.98.0(@cloudflare/workers-types@4.20260607.1))
@@ -5667,7 +5691,7 @@ snapshots:
       drizzle-arktype: 0.1.3(arktype@2.2.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0)
-      drizzle-valibot: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1)
+      drizzle-valibot: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1(typescript@5.9.3))
       drizzle-zod: 0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(zod@4.4.3)
       es-module-lexer: 2.1.0
       hono: 4.12.23
@@ -5678,7 +5702,7 @@ snapshots:
       wrangler: 4.98.0(@cloudflare/workers-types@4.20260607.1)
     optionalDependencies:
       arktype: 2.2.0
-      valibot: 1.4.1
+      valibot: 1.4.1(typescript@5.9.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ catalog:
   '@oxlint/plugins': ^1.68.0
   '@types/node': ^24.10.1
   '@typescript/native-preview': ^7.0.0-dev.20260608.1
+  typescript: ^5.9.2
+  vite: ^8.0.16
   vite-plus: ^0.1.24
   vitest: ^4.1.8
   void: ^0.9.2


### PR DESCRIPTION
## Problem

`pnpm run verify` (and therefore CI) has been red on `main` for many commits. Two workspace packages relied on dependencies they never declared:

1. **`docs/site`** references `vite/client` ambient types (`docs/site/src/vite-env.d.ts`) and imports `vite` in `docs/site/vite.config.ts`, but never declared `vite`. So `tsgo` could not resolve `*.md?raw`, `status.json?raw`, `*.css`, or `vite` → `typecheck` failed (14 errors).
2. **`npm/type-aware`**'s build (`vp pack --dts`) needs real `typescript` for declaration generation; it was not installed anywhere in the tree → `build:workspace` failed with `Cannot find module 'typescript'`.

## Fix

Add both via the workspace catalog — `vite` as a `docs/site` devDependency, `typescript` as a `npm/type-aware` devDependency. No source changes.

## Verification (local, via corepack pnpm)

- `pnpm run typecheck` ✓ (was 14 errors)
- `vp lint` ✓
- `pnpm --recursive build` ✓ — all packages (docs/site, type-aware → `dist/index.mjs`, no-forbidden-identifiers)
- `vitest run` ✓
- `cargo test --workspace` ✓
- `status:check` ✓
- `pnpm install --frozen-lockfile` ✓

This unblocks `verify` so feature PRs (the eslint-comments port in #23) can show a green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)