### PR TITLE
feat(eslint-comments): port require-description

### DIFF
--- a/crates/eslint_comments/src/lib.rs
+++ b/crates/eslint_comments/src/lib.rs
@@ -10,10 +10,12 @@ pub mod loc;
 
 mod rule_no_unlimited_disable;
 mod rule_no_use;
+mod rule_require_description;
 
 pub use loc::{Location, Position};
 pub use rule_no_unlimited_disable::no_unlimited_disable;
 pub use rule_no_use::no_use;
+pub use rule_require_description::require_description;
 
 use oxlint_plugins_carton::CompactString;
 

--- a/crates/eslint_comments/src/rule_require_description.rs
+++ b/crates/eslint_comments/src/rule_require_description.rs
@@ -1,0 +1,71 @@
+//! `require-description`: require descriptions in ESLint directive comments.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::directive::parse_directive_comment;
+use crate::loc::to_force_location;
+use crate::{Comment, Diagnostic, DiagnosticData};
+
+/// Report directive comments without a description, unless their kind is ignored.
+pub fn require_description(comments: &[Comment], ignored: &[&str]) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+
+    for comment in comments {
+        let same_line = comment.loc.start.line == comment.loc.end.line;
+        let Some(parsed) = parse_directive_comment(comment.kind, comment.value, same_line) else {
+            continue;
+        };
+
+        if ignored.contains(&parsed.kind.as_str()) {
+            continue;
+        }
+
+        let has_description = parsed.description.as_deref().is_some_and(|d| !d.is_empty());
+        if !has_description {
+            diagnostics.push(Diagnostic {
+                message_id: CompactString::from("missingDescription"),
+                data: DiagnosticData::default(),
+                loc: to_force_location(comment.loc),
+            });
+        }
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, require_description};
+
+    fn comment(kind: CommentKind, value: &str) -> Comment<'_> {
+        Comment {
+            kind,
+            value,
+            loc: Location {
+                start: Position { line: 1, column: 0 },
+                end: Position {
+                    line: 1,
+                    column: value.len() as i32 + 4,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_directives_without_descriptions() {
+        let comments = [
+            comment(CommentKind::Block, "eslint-disable eqeqeq"),
+            comment(CommentKind::Block, "eslint-disable eqeqeq -- because"),
+            comment(CommentKind::Line, "eslint-disable-line eqeqeq"),
+        ];
+        insta::assert_debug_snapshot!(require_description(&comments, &[]));
+    }
+
+    #[test]
+    fn skips_ignored_kinds() {
+        let comments = [comment(CommentKind::Block, "eslint-disable eqeqeq")];
+        assert!(require_description(&comments, &["eslint-disable"]).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_require_description__tests__reports_directives_without_descriptions.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_require_description__tests__reports_directives_without_descriptions.snap
@@ -1,0 +1,42 @@
+---
+source: crates/eslint_comments/src/rule_require_description.rs
+expression: "require_description(&comments, &[])"
+---
+[
+    Diagnostic {
+        message_id: "missingDescription",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: None,
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 1,
+                column: -1,
+            },
+            end: Position {
+                line: 1,
+                column: 25,
+            },
+        },
+    },
+    Diagnostic {
+        message_id: "missingDescription",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: None,
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 1,
+                column: -1,
+            },
+            end: Position {
+                line: 1,
+                column: 30,
+            },
+        },
+    },
+]

--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -26,8 +26,9 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 | ---------------------- | ----------------------------------------------------- | ------ |
 | `no-unlimited-disable` | disallow `eslint-disable` comments without rule names | ported |
 | `no-use`               | disallow ESLint directive-comments                    | ported |
+| `require-description`  | require descriptions in ESLint directive-comments     | ported |
 
-Remaining upstream rules (`disable-enable-pair`, `no-aggregating-enable`, `no-duplicate-disable`, `no-restricted-disable`, `no-unused-disable`, `no-unused-enable`, `require-description`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
+Remaining upstream rules (`disable-enable-pair`, `no-aggregating-enable`, `no-duplicate-disable`, `no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -155,9 +155,44 @@ const noUse = commentScanRule(
   },
 );
 
+const requireDescription = commentScanRule(
+  {
+    type: 'suggestion',
+    docs: {
+      description: 'require include descriptions in ESLint directive-comments',
+      recommended: false,
+      url: `${DOCS_BASE}#require-description`,
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignore: {
+            type: 'array',
+            items: { enum: DIRECTIVE_KINDS },
+            additionalItems: false,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingDescription:
+        'Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.',
+    },
+  },
+  (comments, context) => {
+    const ignore = (context.options[0] && context.options[0].ignore) || [];
+    return native.scanRequireDescription(comments, ignore);
+  },
+);
+
 const rules = {
   'no-unlimited-disable': noUnlimitedDisable,
   'no-use': noUse,
+  'require-description': requireDescription,
 };
 
 // Mirror of upstream's `recommended` config, limited to the rules ported so far.

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -5,7 +5,8 @@
 //! file level instead of one NAPI call per AST node.
 
 pub use napi_abi::{
-    CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, scan_no_unlimited_disable, scan_no_use,
+    CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, scan_no_unlimited_disable,
+    scan_no_use, scan_require_description,
 };
 
 #[allow(
@@ -17,6 +18,7 @@ mod napi_abi {
     use oxlint_plugins_eslint_comments::directive::CommentKind;
     use oxlint_plugins_eslint_comments::{
         Comment, Diagnostic as CoreDiagnostic, Location, Position, no_unlimited_disable, no_use,
+        require_description,
     };
 
     /// A comment token, as collected from `sourceCode.getAllComments()`.
@@ -77,6 +79,20 @@ mod napi_abi {
         let core = to_core_comments(&comments);
         let allowed: Vec<&str> = allow.iter().map(String::as_str).collect();
         no_use(&core, &allowed)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `require-description`: report directive comments without a description.
+    #[napi]
+    pub fn scan_require_description(
+        comments: Vec<CommentInput>,
+        ignore: Vec<String>,
+    ) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        let ignored: Vec<&str> = ignore.iter().map(String::as_str).collect();
+        require_description(&core, &ignored)
             .into_iter()
             .map(diagnostic_from_core)
             .collect()

--- a/npm/eslint-comments/test/fixtures/require-description.json
+++ b/npm/eslint-comments/test/fixtures/require-description.json
@@ -1,0 +1,297 @@
+{
+  "__generated": {
+    "source": "@eslint-community/eslint-plugin-eslint-comments",
+    "version": "4.7.2",
+    "sourceFile": "tests/lib/rules/require-description.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-comments-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "/* eslint eqeqeq: \"off\", curly: \"error\" -- Here's a description about why this configuration is necessary. */"
+    },
+    {
+      "code": "/* eslint-disable -- description */"
+    },
+    {
+      "code": "/* eslint-enable -- description */"
+    },
+    {
+      "code": "/* exported -- description */"
+    },
+    {
+      "code": "/* global -- description */"
+    },
+    {
+      "code": "/* globals -- description */"
+    },
+    {
+      "code": "/* eslint-env -- description */"
+    },
+    {
+      "code": "/* just eslint in a normal comment */"
+    },
+    {
+      "code": "// eslint-disable-line -- description"
+    },
+    {
+      "code": "// eslint-disable-next-line -- description"
+    },
+    {
+      "code": "/* eslint-disable-line -- description */"
+    },
+    {
+      "code": "/* eslint-disable-next-line -- description */"
+    },
+    {
+      "code": "// eslint-disable-line eqeqeq -- description"
+    },
+    {
+      "code": "// eslint-disable-next-line eqeqeq -- description"
+    },
+    {
+      "code": "/* eslint */",
+      "options": [
+        {
+          "ignore": [
+            "eslint"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* eslint-env */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-env"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* eslint-enable */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-enable"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* eslint-disable */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "// eslint-disable-line",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-line"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "// eslint-disable-next-line",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-next-line"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* eslint-disable-line */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-line"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* eslint-disable-next-line */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-next-line"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* exported */",
+      "options": [
+        {
+          "ignore": [
+            "exported"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* global */",
+      "options": [
+        {
+          "ignore": [
+            "global"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "/* globals */",
+      "options": [
+        {
+          "ignore": [
+            "globals"
+          ]
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "/* eslint */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint eqeqeq: \"off\", curly: \"error\" */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-env */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-env node */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-enable */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-enable eqeqeq */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable eqeqeq */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "// eslint-disable-line",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "// eslint-disable-line eqeqeq",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "// eslint-disable-next-line",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "// eslint-disable-next-line eqeqeq",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable-line */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable-line eqeqeq */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable-next-line */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable-next-line eqeqeq */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* exported */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* global */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* global _ */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* globals */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* globals _ */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    },
+    {
+      "code": "/* eslint-disable-next-line eqeqeq -- */",
+      "errors": [
+        "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+      ]
+    }
+  ]
+}

--- a/status.json
+++ b/status.json
@@ -45,6 +45,22 @@
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-use; supports the allow option; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "require-description",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/require-description; supports the ignore option; upstream RuleTester cases replayed via test/fixtures."
       }
     ]
   },


### PR DESCRIPTION
Part of #4 — third rule of the `@eslint-community/eslint-plugin-eslint-comments` port.

> Stacked on #25 (→ #23). Review/merge the lower PRs first; bases retarget to `main` as each lands.

## `require-description`

Reports ESLint directive comments that lack a trailing ` -- description`, unless their kind is in the `ignore` option.

- `crates/eslint_comments/src/rule_require_description.rs` — core + insta snapshot (treats an empty description as missing, matching upstream).
- NAPI `scan_require_description(comments, ignore)`; registered in `index.js` with the upstream `ignore` schema and `missingDescription` message.
- `test/fixtures/require-description.json` captured from upstream (25 valid / 22 invalid), replayed via espree in Vitest.
- `status.json` + README updated.

## Test-sync correctness fix (flows in via #23)

While porting this rule I found the sync tool's `semver` stub returned `false` for **all** ranges, which made version-guarded upstream cases (e.g. `require-description`'s `>=7.0.0` guard) get skipped, and also under-captured `no-unlimited-disable`/`no-use`. The stub now evaluates ranges against the stub `Linter.version` (8.57.0) — `>=7.0.0` true, `>=9.6.0` false — and generated fixtures are excluded from the formatter so `pnpm run port:tests:eslint-comments` is idempotent. These changes are in #23; this PR adds the rule on top.

## Verification
- `cargo clippy -D warnings` ✓, `cargo test` ✓
- `vitest` ✓ — 104 cases across the three ported rules
- `vp fmt --check` ✓, `status:check` ✓, sync idempotent ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783568547&installation_id=136613492&pr_number=26&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F26&signature=c425829d07cc1e3a3d8051cdea0c1692823bbcaf9994047769b366c5a5a2f0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->