### PR TITLE
feat(eslint-comments): port disable-enable-pair

### DIFF
--- a/crates/eslint_comments/src/disabled_area.rs
+++ b/crates/eslint_comments/src/disabled_area.rs
@@ -1,0 +1,227 @@
+//! Clean-room port of upstream's `DisabledArea` bookkeeping.
+//!
+//! Walks the directive comments of a file in source order and records the
+//! disabled regions, duplicate `eslint-disable` directives, unused
+//! `eslint-enable` directives, and how many disables each enable closes. The
+//! disabled-area rules (`disable-enable-pair`, `no-aggregating-enable`,
+//! `no-duplicate-disable`, `no-unused-enable`) read this shared result.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::Comment;
+use crate::directive::parse_directive_comment;
+use crate::loc::{Position, lte};
+
+/// Whether a disabled area came from a block (`eslint-disable`) or line
+/// (`eslint-disable-line` / `-next-line`) directive.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AreaKind {
+    Block,
+    Line,
+}
+
+/// A disabled region opened by a disable directive and (maybe) closed by an enable.
+#[derive(Clone, Debug)]
+pub struct Area {
+    /// Index into the input comments of the directive that opened the area.
+    pub comment: usize,
+    /// The rule the area disables, or `None` for "all rules".
+    pub rule_id: Option<CompactString>,
+    pub kind: AreaKind,
+    pub start: Position,
+    pub end: Option<Position>,
+}
+
+/// A reference to a directive comment plus the rule it concerns.
+#[derive(Clone, Debug)]
+pub struct DirectiveRef {
+    pub comment: usize,
+    pub rule_id: Option<CompactString>,
+}
+
+/// The bookkeeping result for a file.
+#[derive(Debug, Default)]
+pub struct DisabledArea {
+    pub areas: SmallVec<[Area; 8]>,
+    pub duplicate_disable_directives: SmallVec<[DirectiveRef; 4]>,
+    pub unused_enable_directives: SmallVec<[DirectiveRef; 4]>,
+    /// `(enable comment index, number of disables it closed)`, in source order.
+    pub related_counts: SmallVec<[(usize, u32); 4]>,
+}
+
+impl DisabledArea {
+    /// Index of the most recent open area covering `location` for `rule_id`
+    /// (matching a global `None` area or one with the same rule).
+    fn open_area_at(&self, rule_id: Option<&str>, location: Position) -> Option<usize> {
+        for (index, area) in self.areas.iter().enumerate().rev() {
+            let rule_matches = area.rule_id.is_none() || area.rule_id.as_deref() == rule_id;
+            let within = lte(area.start, location) && area.end.is_none_or(|end| lte(location, end));
+            if rule_matches && within {
+                return Some(index);
+            }
+        }
+        None
+    }
+
+    fn disable(
+        &mut self,
+        comment: usize,
+        location: Position,
+        rule_ids: Option<&[CompactString]>,
+        kind: AreaKind,
+    ) {
+        match rule_ids {
+            Some(rule_ids) => {
+                for rule_id in rule_ids {
+                    if self.open_area_at(Some(rule_id), location).is_some() {
+                        self.duplicate_disable_directives.push(DirectiveRef {
+                            comment,
+                            rule_id: Some(rule_id.clone()),
+                        });
+                    }
+                    self.areas.push(Area {
+                        comment,
+                        rule_id: Some(rule_id.clone()),
+                        kind,
+                        start: location,
+                        end: None,
+                    });
+                }
+            }
+            None => {
+                if self.open_area_at(None, location).is_some() {
+                    self.duplicate_disable_directives.push(DirectiveRef {
+                        comment,
+                        rule_id: None,
+                    });
+                }
+                self.areas.push(Area {
+                    comment,
+                    rule_id: None,
+                    kind,
+                    start: location,
+                    end: None,
+                });
+            }
+        }
+    }
+
+    fn enable(
+        &mut self,
+        comment: usize,
+        location: Position,
+        rule_ids: Option<&[CompactString]>,
+        kind: AreaKind,
+    ) {
+        let mut related: SmallVec<[usize; 8]> = SmallVec::new();
+        let mut note_related = |area_comment: usize| {
+            if !related.contains(&area_comment) {
+                related.push(area_comment);
+            }
+        };
+
+        match rule_ids {
+            Some(rule_ids) => {
+                for rule_id in rule_ids {
+                    let mut used = false;
+                    for area in self.areas.iter_mut().rev() {
+                        if area.end.is_none()
+                            && area.kind == kind
+                            && area.rule_id.as_deref() == Some(rule_id.as_str())
+                        {
+                            note_related(area.comment);
+                            area.end = Some(location);
+                            used = true;
+                        }
+                    }
+                    if !used {
+                        self.unused_enable_directives.push(DirectiveRef {
+                            comment,
+                            rule_id: Some(rule_id.clone()),
+                        });
+                    }
+                }
+            }
+            None => {
+                let mut used = false;
+                for area in self.areas.iter_mut().rev() {
+                    if area.end.is_none() && area.kind == kind {
+                        note_related(area.comment);
+                        area.end = Some(location);
+                        used = true;
+                    }
+                }
+                if !used {
+                    self.unused_enable_directives.push(DirectiveRef {
+                        comment,
+                        rule_id: None,
+                    });
+                }
+            }
+        }
+
+        self.related_counts.push((comment, related.len() as u32));
+    }
+}
+
+/// Split a directive value into rule ids, or `None` when it disables all rules.
+fn split_rule_ids(value: &str) -> Option<SmallVec<[CompactString; 4]>> {
+    if value.is_empty() {
+        return None;
+    }
+    let ids: SmallVec<[CompactString; 4]> = value
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .filter(|part| !part.is_empty())
+        .map(CompactString::from)
+        .collect();
+    if ids.is_empty() { None } else { Some(ids) }
+}
+
+/// Build the disabled-area bookkeeping for a file's comments.
+pub fn build_disabled_area(comments: &[Comment]) -> DisabledArea {
+    let mut state = DisabledArea::default();
+
+    for (index, comment) in comments.iter().enumerate() {
+        let same_line = comment.loc.start.line == comment.loc.end.line;
+        let Some(parsed) = parse_directive_comment(comment.kind, comment.value, same_line) else {
+            continue;
+        };
+
+        let rule_ids = split_rule_ids(&parsed.value);
+        let rule_ids = rule_ids.as_deref();
+        let line = comment.loc.start.line;
+
+        match parsed.kind.as_str() {
+            "eslint-disable" => {
+                state.disable(index, comment.loc.start, rule_ids, AreaKind::Block);
+            }
+            "eslint-enable" => {
+                state.enable(index, comment.loc.start, rule_ids, AreaKind::Block);
+            }
+            "eslint-disable-line" => {
+                let start = Position { line, column: 0 };
+                let end = Position {
+                    line: line + 1,
+                    column: -1,
+                };
+                state.disable(index, start, rule_ids, AreaKind::Line);
+                state.enable(index, end, rule_ids, AreaKind::Line);
+            }
+            "eslint-disable-next-line" => {
+                let start = Position {
+                    line: line + 1,
+                    column: 0,
+                };
+                let end = Position {
+                    line: line + 2,
+                    column: -1,
+                };
+                state.disable(index, start, rule_ids, AreaKind::Line);
+                state.enable(index, end, rule_ids, AreaKind::Line);
+            }
+            _ => {}
+        }
+    }
+
+    state
+}

--- a/crates/eslint_comments/src/lib.rs
+++ b/crates/eslint_comments/src/lib.rs
@@ -10,12 +10,16 @@ pub mod disabled_area;
 pub mod loc;
 
 mod rule_disable_enable_pair;
+mod rule_no_aggregating_enable;
+mod rule_no_duplicate_disable;
 mod rule_no_unlimited_disable;
 mod rule_no_use;
 mod rule_require_description;
 
 pub use loc::{Location, Position};
 pub use rule_disable_enable_pair::disable_enable_pair;
+pub use rule_no_aggregating_enable::no_aggregating_enable;
+pub use rule_no_duplicate_disable::no_duplicate_disable;
 pub use rule_no_unlimited_disable::no_unlimited_disable;
 pub use rule_no_use::no_use;
 pub use rule_require_description::require_description;

--- a/crates/eslint_comments/src/lib.rs
+++ b/crates/eslint_comments/src/lib.rs
@@ -6,13 +6,16 @@
 //! than one call per AST node.
 
 pub mod directive;
+pub mod disabled_area;
 pub mod loc;
 
+mod rule_disable_enable_pair;
 mod rule_no_unlimited_disable;
 mod rule_no_use;
 mod rule_require_description;
 
 pub use loc::{Location, Position};
+pub use rule_disable_enable_pair::disable_enable_pair;
 pub use rule_no_unlimited_disable::no_unlimited_disable;
 pub use rule_no_use::no_use;
 pub use rule_require_description::require_description;

--- a/crates/eslint_comments/src/loc.rs
+++ b/crates/eslint_comments/src/loc.rs
@@ -33,3 +33,81 @@ pub fn to_force_location(location: Location) -> Location {
 pub fn lte(a: Position, b: Position) -> bool {
     a.line < b.line || (a.line == b.line && a.column <= b.column)
 }
+
+/// `true` when the byte is a rule-id separator: ASCII whitespace or a comma
+/// (the `[\s,]` character class in upstream's rule-id pattern).
+fn is_rule_id_separator(byte: u8) -> bool {
+    byte == b',' || byte.is_ascii_whitespace()
+}
+
+/// Find the byte offset of the first occurrence of `rule_id` in `line` that is
+/// bounded by a separator (or the line edge) on both sides — the match of
+/// upstream's `([\s,]|^)<ruleId>(?:[\s,]|$)` pattern.
+fn find_rule_id(line: &str, rule_id: &str) -> Option<usize> {
+    if rule_id.is_empty() {
+        return None;
+    }
+
+    let bytes = line.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = line[from..].find(rule_id) {
+        let start = from + rel;
+        let end = start + rule_id.len();
+        let before_ok = start == 0 || is_rule_id_separator(bytes[start - 1]);
+        let after_ok = end == line.len() || is_rule_id_separator(bytes[end]);
+        if before_ok && after_ok {
+            return Some(start);
+        }
+        from = start + 1;
+    }
+
+    None
+}
+
+/// Compute the location of `rule_id` inside a directive comment. Mirrors
+/// upstream `toRuleIdLocation`: when `rule_id` is `None` the whole line is
+/// forced; otherwise the column points at the rule name within the comment.
+///
+/// `comment_value` is the comment body without its `//` or `/* */` delimiters;
+/// `comment_loc.start.column` is the 0-indexed column of the opening delimiter.
+/// Line splitting handles `\n` and `\r\n`; the rarer Unicode line separators
+/// (` `/` `) are not split on.
+pub fn to_rule_id_location(
+    comment_value: &str,
+    comment_loc: Location,
+    rule_id: Option<&str>,
+) -> Location {
+    let Some(rule_id) = rule_id else {
+        return to_force_location(comment_loc);
+    };
+
+    let start_line = comment_loc.start.line;
+    for (index, raw_line) in comment_value.split('\n').enumerate() {
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+        let Some(pos) = find_rule_id(line, rule_id) else {
+            continue;
+        };
+
+        // The opening delimiter (`//` or `/*`) only shifts the first line, since
+        // later lines begin at column 0 in the source.
+        let column = if index == 0 {
+            2 + comment_loc.start.column + pos as i32
+        } else {
+            pos as i32
+        };
+        let line_number = start_line + index as u32;
+
+        return Location {
+            start: Position {
+                line: line_number,
+                column,
+            },
+            end: Position {
+                line: line_number,
+                column: column + rule_id.len() as i32,
+            },
+        };
+    }
+
+    comment_loc
+}

--- a/crates/eslint_comments/src/rule_disable_enable_pair.rs
+++ b/crates/eslint_comments/src/rule_disable_enable_pair.rs
@@ -1,0 +1,100 @@
+//! `disable-enable-pair`: require an `eslint-enable` for every `eslint-disable`.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::disabled_area::build_disabled_area;
+use crate::loc::{Position, lte, to_rule_id_location};
+use crate::{Comment, Diagnostic, DiagnosticData};
+
+/// Report every disabled area that is never closed by an `eslint-enable`.
+///
+/// With `allow_whole_file`, areas that start at or before the first token are
+/// treated as intentional whole-file disables; `first_token_start` is the first
+/// non-comment token's position (or `None` when the file has no tokens).
+pub fn disable_enable_pair(
+    comments: &[Comment],
+    allow_whole_file: bool,
+    first_token_start: Option<Position>,
+) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+
+    if allow_whole_file && first_token_start.is_none() {
+        return diagnostics;
+    }
+
+    let state = build_disabled_area(comments);
+
+    for area in &state.areas {
+        if area.end.is_some() {
+            continue;
+        }
+        if allow_whole_file && first_token_start.is_some_and(|first| lte(area.start, first)) {
+            continue;
+        }
+
+        let comment = &comments[area.comment];
+        let loc = to_rule_id_location(comment.value, comment.loc, area.rule_id.as_deref());
+        let message_id = if area.rule_id.is_some() {
+            "missingRulePair"
+        } else {
+            "missingPair"
+        };
+
+        diagnostics.push(Diagnostic {
+            message_id: CompactString::from(message_id),
+            data: DiagnosticData {
+                rule_id: area.rule_id.clone(),
+                ..DiagnosticData::default()
+            },
+            loc,
+        });
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, disable_enable_pair};
+
+    fn block<'a>(value: &'a str, line: u32, end_column: i32) -> Comment<'a> {
+        Comment {
+            kind: CommentKind::Block,
+            value,
+            loc: Location {
+                start: Position { line, column: 0 },
+                end: Position {
+                    line,
+                    column: end_column,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_unpaired_disables() {
+        let comments = [
+            block("eslint-disable", 2, 19),
+            block("eslint-disable no-undef", 4, 27),
+        ];
+        insta::assert_debug_snapshot!(disable_enable_pair(&comments, false, None));
+    }
+
+    #[test]
+    fn paired_disable_is_ok() {
+        let comments = [
+            block("eslint-disable no-undef", 1, 27),
+            block("eslint-enable no-undef", 3, 26),
+        ];
+        assert!(disable_enable_pair(&comments, false, None).is_empty());
+    }
+
+    #[test]
+    fn allow_whole_file_skips_leading_disable() {
+        let comments = [block("eslint-disable", 1, 19)];
+        let first_token = Position { line: 2, column: 0 };
+        assert!(disable_enable_pair(&comments, true, Some(first_token)).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/rule_no_aggregating_enable.rs
+++ b/crates/eslint_comments/src/rule_no_aggregating_enable.rs
@@ -1,0 +1,71 @@
+//! `no-aggregating-enable`: disallow an `eslint-enable` that closes many disables.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::disabled_area::build_disabled_area;
+use crate::loc::to_force_location;
+use crate::{Comment, Diagnostic, DiagnosticData};
+
+/// Report `eslint-enable` comments that re-enable two or more `eslint-disable`
+/// comments at once.
+pub fn no_aggregating_enable(comments: &[Comment]) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+    let state = build_disabled_area(comments);
+
+    for &(comment_index, count) in &state.related_counts {
+        if count >= 2 {
+            let comment = &comments[comment_index];
+            diagnostics.push(Diagnostic {
+                message_id: CompactString::from("aggregatingEnable"),
+                data: DiagnosticData {
+                    count: Some(count),
+                    ..DiagnosticData::default()
+                },
+                loc: to_force_location(comment.loc),
+            });
+        }
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, no_aggregating_enable};
+
+    fn block<'a>(value: &'a str, line: u32) -> Comment<'a> {
+        Comment {
+            kind: CommentKind::Block,
+            value,
+            loc: Location {
+                start: Position { line, column: 0 },
+                end: Position {
+                    line,
+                    column: value.len() as i32 + 4,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_aggregating_enable() {
+        // One bare enable closes two separate disables.
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-disable no-unused-vars", 2),
+            block("eslint-enable", 3),
+        ];
+        insta::assert_debug_snapshot!(no_aggregating_enable(&comments));
+    }
+
+    #[test]
+    fn single_pair_is_ok() {
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-enable no-undef", 2),
+        ];
+        assert!(no_aggregating_enable(&comments).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/rule_no_duplicate_disable.rs
+++ b/crates/eslint_comments/src/rule_no_duplicate_disable.rs
@@ -1,0 +1,74 @@
+//! `no-duplicate-disable`: disallow `eslint-disable` comments that re-disable
+//! a rule already disabled by an earlier, still-open directive.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::disabled_area::build_disabled_area;
+use crate::loc::to_rule_id_location;
+use crate::{Comment, Diagnostic, DiagnosticData};
+
+/// Report each disable directive that duplicates an already-active disable.
+pub fn no_duplicate_disable(comments: &[Comment]) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+    let state = build_disabled_area(comments);
+
+    for item in &state.duplicate_disable_directives {
+        let comment = &comments[item.comment];
+        let loc = to_rule_id_location(comment.value, comment.loc, item.rule_id.as_deref());
+        let message_id = if item.rule_id.is_some() {
+            "duplicateRule"
+        } else {
+            "duplicate"
+        };
+
+        diagnostics.push(Diagnostic {
+            message_id: CompactString::from(message_id),
+            data: DiagnosticData {
+                rule_id: item.rule_id.clone(),
+                ..DiagnosticData::default()
+            },
+            loc,
+        });
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, no_duplicate_disable};
+
+    fn block<'a>(value: &'a str, line: u32) -> Comment<'a> {
+        Comment {
+            kind: CommentKind::Block,
+            value,
+            loc: Location {
+                start: Position { line, column: 0 },
+                end: Position {
+                    line,
+                    column: value.len() as i32 + 4,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_duplicate_disable() {
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-disable no-undef", 2),
+        ];
+        insta::assert_debug_snapshot!(no_duplicate_disable(&comments));
+    }
+
+    #[test]
+    fn distinct_rules_are_ok() {
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-disable no-unused-vars", 2),
+        ];
+        assert!(no_duplicate_disable(&comments).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_disable_enable_pair__tests__reports_unpaired_disables.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_disable_enable_pair__tests__reports_unpaired_disables.snap
@@ -1,0 +1,44 @@
+---
+source: crates/eslint_comments/src/rule_disable_enable_pair.rs
+expression: "disable_enable_pair(&comments, false, None)"
+---
+[
+    Diagnostic {
+        message_id: "missingPair",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: None,
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 2,
+                column: -1,
+            },
+            end: Position {
+                line: 2,
+                column: 19,
+            },
+        },
+    },
+    Diagnostic {
+        message_id: "missingRulePair",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: Some(
+                "no-undef",
+            ),
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 4,
+                column: 17,
+            },
+            end: Position {
+                line: 4,
+                column: 25,
+            },
+        },
+    },
+]

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_aggregating_enable__tests__reports_aggregating_enable.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_aggregating_enable__tests__reports_aggregating_enable.snap
@@ -1,0 +1,26 @@
+---
+source: crates/eslint_comments/src/rule_no_aggregating_enable.rs
+expression: no_aggregating_enable(&comments)
+---
+[
+    Diagnostic {
+        message_id: "aggregatingEnable",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: None,
+            count: Some(
+                2,
+            ),
+        },
+        loc: Location {
+            start: Position {
+                line: 3,
+                column: -1,
+            },
+            end: Position {
+                line: 3,
+                column: 17,
+            },
+        },
+    },
+]

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_duplicate_disable__tests__reports_duplicate_disable.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_duplicate_disable__tests__reports_duplicate_disable.snap
@@ -1,0 +1,26 @@
+---
+source: crates/eslint_comments/src/rule_no_duplicate_disable.rs
+expression: no_duplicate_disable(&comments)
+---
+[
+    Diagnostic {
+        message_id: "duplicateRule",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: Some(
+                "no-undef",
+            ),
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 2,
+                column: 17,
+            },
+            end: Position {
+                line: 2,
+                column: 25,
+            },
+        },
+    },
+]

--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -22,14 +22,16 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 
 ## Rules
 
-| Rule                   | Description                                           | Status |
-| ---------------------- | ----------------------------------------------------- | ------ |
-| `disable-enable-pair`  | require an `eslint-enable` for every `eslint-disable` | ported |
-| `no-unlimited-disable` | disallow `eslint-disable` comments without rule names | ported |
-| `no-use`               | disallow ESLint directive-comments                    | ported |
-| `require-description`  | require descriptions in ESLint directive-comments     | ported |
+| Rule                    | Description                                                | Status |
+| ----------------------- | ---------------------------------------------------------- | ------ |
+| `disable-enable-pair`   | require an `eslint-enable` for every `eslint-disable`      | ported |
+| `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported |
+| `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported |
+| `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported |
+| `no-use`                | disallow ESLint directive-comments                         | ported |
+| `require-description`   | require descriptions in ESLint directive-comments          | ported |
 
-Remaining upstream rules (`no-aggregating-enable`, `no-duplicate-disable`, `no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
+Remaining upstream rules (`no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -24,11 +24,12 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 
 | Rule                   | Description                                           | Status |
 | ---------------------- | ----------------------------------------------------- | ------ |
+| `disable-enable-pair`  | require an `eslint-enable` for every `eslint-disable` | ported |
 | `no-unlimited-disable` | disallow `eslint-disable` comments without rule names | ported |
 | `no-use`               | disallow ESLint directive-comments                    | ported |
 | `require-description`  | require descriptions in ESLint directive-comments     | ported |
 
-Remaining upstream rules (`disable-enable-pair`, `no-aggregating-enable`, `no-duplicate-disable`, `no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
+Remaining upstream rules (`no-aggregating-enable`, `no-duplicate-disable`, `no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -189,15 +189,54 @@ const requireDescription = commentScanRule(
   },
 );
 
+function firstTokenStart(context) {
+  const tokens = context.sourceCode.ast && context.sourceCode.ast.tokens;
+  if (!tokens || tokens.length === 0) {
+    return null;
+  }
+  const first = tokens[0];
+  return { line: first.loc.start.line, column: first.loc.start.column };
+}
+
+const disableEnablePair = commentScanRule(
+  {
+    type: 'suggestion',
+    docs: {
+      description: 'require a `eslint-enable` comment for every `eslint-disable` comment',
+      recommended: true,
+      url: `${DOCS_BASE}#disable-enable-pair`,
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowWholeFile: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingPair: "Requires 'eslint-enable' directive.",
+      missingRulePair: "Requires 'eslint-enable' directive for '{{ruleId}}'.",
+    },
+  },
+  (comments, context) => {
+    const allowWholeFile = !!(context.options[0] && context.options[0].allowWholeFile);
+    return native.scanDisableEnablePair(comments, allowWholeFile, firstTokenStart(context));
+  },
+);
+
 const rules = {
+  'disable-enable-pair': disableEnablePair,
   'no-unlimited-disable': noUnlimitedDisable,
   'no-use': noUse,
   'require-description': requireDescription,
 };
 
 // Mirror of upstream's `recommended` config, limited to the rules ported so far.
-// (no-use is not part of upstream's recommended set.)
-const recommendedRuleNames = ['no-unlimited-disable'];
+// (no-use and require-description are not part of upstream's recommended set.)
+const recommendedRuleNames = ['disable-enable-pair', 'no-unlimited-disable'];
 
 const plugin = eslintCompatPlugin({
   meta: {

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -227,8 +227,46 @@ const disableEnablePair = commentScanRule(
   },
 );
 
+const noAggregatingEnable = commentScanRule(
+  {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow a `eslint-enable` comment for multiple `eslint-disable` comments',
+      recommended: true,
+      url: `${DOCS_BASE}#no-aggregating-enable`,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      aggregatingEnable:
+        'This `eslint-enable` comment affects {{count}} `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment.',
+    },
+  },
+  (comments) => native.scanNoAggregatingEnable(comments),
+);
+
+const noDuplicateDisable = commentScanRule(
+  {
+    type: 'problem',
+    docs: {
+      description: 'disallow duplicate `eslint-disable` comments',
+      recommended: true,
+      url: `${DOCS_BASE}#no-duplicate-disable`,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      duplicate: 'ESLint rules have been disabled already.',
+      duplicateRule: "'{{ruleId}}' rule has been disabled already.",
+    },
+  },
+  (comments) => native.scanNoDuplicateDisable(comments),
+);
+
 const rules = {
   'disable-enable-pair': disableEnablePair,
+  'no-aggregating-enable': noAggregatingEnable,
+  'no-duplicate-disable': noDuplicateDisable,
   'no-unlimited-disable': noUnlimitedDisable,
   'no-use': noUse,
   'require-description': requireDescription,
@@ -236,7 +274,12 @@ const rules = {
 
 // Mirror of upstream's `recommended` config, limited to the rules ported so far.
 // (no-use and require-description are not part of upstream's recommended set.)
-const recommendedRuleNames = ['disable-enable-pair', 'no-unlimited-disable'];
+const recommendedRuleNames = [
+  'disable-enable-pair',
+  'no-aggregating-enable',
+  'no-duplicate-disable',
+  'no-unlimited-disable',
+];
 
 const plugin = eslintCompatPlugin({
   meta: {

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -6,7 +6,8 @@
 
 pub use napi_abi::{
     CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, PositionInput,
-    scan_disable_enable_pair, scan_no_unlimited_disable, scan_no_use, scan_require_description,
+    scan_disable_enable_pair, scan_no_aggregating_enable, scan_no_duplicate_disable,
+    scan_no_unlimited_disable, scan_no_use, scan_require_description,
 };
 
 #[allow(
@@ -18,7 +19,8 @@ mod napi_abi {
     use oxlint_plugins_eslint_comments::directive::CommentKind;
     use oxlint_plugins_eslint_comments::{
         Comment, Diagnostic as CoreDiagnostic, Location, Position, disable_enable_pair,
-        no_unlimited_disable, no_use, require_description,
+        no_aggregating_enable, no_duplicate_disable, no_unlimited_disable, no_use,
+        require_description,
     };
 
     /// A comment token, as collected from `sourceCode.getAllComments()`.
@@ -101,6 +103,26 @@ mod napi_abi {
         let core = to_core_comments(&comments);
         let ignored: Vec<&str> = ignore.iter().map(String::as_str).collect();
         require_description(&core, &ignored)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `no-aggregating-enable`: report enables that close multiple disables.
+    #[napi]
+    pub fn scan_no_aggregating_enable(comments: Vec<CommentInput>) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        no_aggregating_enable(&core)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `no-duplicate-disable`: report disables that duplicate an active disable.
+    #[napi]
+    pub fn scan_no_duplicate_disable(comments: Vec<CommentInput>) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        no_duplicate_disable(&core)
             .into_iter()
             .map(diagnostic_from_core)
             .collect()

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -5,8 +5,8 @@
 //! file level instead of one NAPI call per AST node.
 
 pub use napi_abi::{
-    CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, scan_no_unlimited_disable,
-    scan_no_use, scan_require_description,
+    CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, PositionInput,
+    scan_disable_enable_pair, scan_no_unlimited_disable, scan_no_use, scan_require_description,
 };
 
 #[allow(
@@ -17,8 +17,8 @@ mod napi_abi {
     use napi_derive::napi;
     use oxlint_plugins_eslint_comments::directive::CommentKind;
     use oxlint_plugins_eslint_comments::{
-        Comment, Diagnostic as CoreDiagnostic, Location, Position, no_unlimited_disable, no_use,
-        require_description,
+        Comment, Diagnostic as CoreDiagnostic, Location, Position, disable_enable_pair,
+        no_unlimited_disable, no_use, require_description,
     };
 
     /// A comment token, as collected from `sourceCode.getAllComments()`.
@@ -33,6 +33,14 @@ mod napi_abi {
         pub start_column: i32,
         pub end_line: u32,
         pub end_column: i32,
+    }
+
+    /// A source position passed from the wrapper (e.g. the first token).
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct PositionInput {
+        pub line: u32,
+        pub column: i32,
     }
 
     /// Values interpolated into a diagnostic message template.
@@ -93,6 +101,24 @@ mod napi_abi {
         let core = to_core_comments(&comments);
         let ignored: Vec<&str> = ignore.iter().map(String::as_str).collect();
         require_description(&core, &ignored)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `disable-enable-pair`: report disabled areas with no matching enable.
+    #[napi]
+    pub fn scan_disable_enable_pair(
+        comments: Vec<CommentInput>,
+        allow_whole_file: bool,
+        first_token_start: Option<PositionInput>,
+    ) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        let first = first_token_start.map(|position| Position {
+            line: position.line,
+            column: position.column,
+        });
+        disable_enable_pair(&core, allow_whole_file, first)
             .into_iter()
             .map(diagnostic_from_core)
             .collect()

--- a/npm/eslint-comments/test/fixtures/disable-enable-pair.json
+++ b/npm/eslint-comments/test/fixtures/disable-enable-pair.json
@@ -1,0 +1,205 @@
+{
+  "__generated": {
+    "source": "@eslint-community/eslint-plugin-eslint-comments",
+    "version": "4.7.2",
+    "sourceFile": "tests/lib/rules/disable-enable-pair.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-comments-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n/*eslint-disable*/\n/*eslint-enable*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable no-undef,no-unused-vars*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable*/\n"
+    },
+    {
+      "code": "//eslint-disable-line"
+    },
+    {
+      "code": "//eslint-disable-next-line"
+    },
+    {
+      "code": "/*eslint-disable-line*/"
+    },
+    {
+      "code": "/*eslint-disable-next-line*/"
+    },
+    {
+      "code": "/*eslint no-undef: off */"
+    },
+    {
+      "code": "\nfunction foo() {\n    /*eslint-disable*/\n    /*eslint-enable*/\n}\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable no-unused-vars*/\n/*eslint-enable*/\n/*eslint-enable*/\n"
+    },
+    {
+      "code": "\nconsole.log('This code does not even have any special comments')\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable no-unused-vars*/\n/*eslint-enable*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ]
+    },
+    {
+      "code": "\n\n/**\n * @file This test case makes sure comments and blank lines\n * before \"whole-file\" eslint-disable are allowed.\n */\n\n/*eslint-disable*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-unused-vars, no-undef */\nvar foo = 1\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef -- description*/\n/*eslint-enable no-undef*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef,no-unused-vars -- description*/\n/*eslint-enable no-undef,no-unused-vars*/\n"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n/*eslint-disable*/\n",
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive.",
+          "line": 2,
+          "column": 0,
+          "endLine": 2,
+          "endColumn": 19
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n",
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-undef'.",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable no-undef*/\n",
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 2,
+          "column": 27,
+          "endLine": 2,
+          "endColumn": 41
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable no-unused-vars*/\n/*eslint-enable no-unused-vars*/\n",
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-undef'.",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\nconsole.log();\n/*eslint-disable no-unused-vars*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 4,
+          "column": 18,
+          "endLine": 4,
+          "endColumn": 32
+        }
+      ]
+    },
+    {
+      "code": "\nconsole.log();\n/*eslint-disable no-unused-vars*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ]
+    },
+    {
+      "code": "\n{\n/*eslint-disable no-unused-vars*/\n}\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ]
+    },
+    {
+      "code": "\n{\n/*eslint-disable no-unused-vars -- description */\n}\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "errors": [
+        {
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-comments/test/fixtures/no-aggregating-enable.json
+++ b/npm/eslint-comments/test/fixtures/no-aggregating-enable.json
@@ -1,0 +1,52 @@
+{
+  "__generated": {
+    "source": "@eslint-community/eslint-plugin-eslint-comments",
+    "version": "4.7.2",
+    "sourceFile": "tests/lib/rules/no-aggregating-enable.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-comments-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n            /*eslint-disable no-redeclare*/\n            /*eslint-enable no-redeclare*/\n        "
+    },
+    {
+      "code": "\n            /*eslint-disable no-redeclare*/\n            /*eslint-enable no-shadow*/\n        "
+    },
+    {
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable*/\n        "
+    },
+    {
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable no-redeclare, no-shadow*/\n        "
+    },
+    {
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable no-redeclare*/\n            /*eslint-enable no-shadow*/\n        "
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable*/\n            ",
+      "errors": [
+        "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment."
+      ]
+    },
+    {
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-disable no-undef*/\n                /*eslint-enable*/\n            ",
+      "errors": [
+        "This `eslint-enable` comment affects 3 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment."
+      ]
+    },
+    {
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable no-redeclare, no-shadow*/\n            ",
+      "errors": [
+        "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment."
+      ]
+    },
+    {
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable -- description*/\n            ",
+      "errors": [
+        "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment."
+      ]
+    }
+  ]
+}

--- a/npm/eslint-comments/test/fixtures/no-duplicate-disable.json
+++ b/npm/eslint-comments/test/fixtures/no-duplicate-disable.json
@@ -1,0 +1,109 @@
+{
+  "__generated": {
+    "source": "@eslint-community/eslint-plugin-eslint-comments",
+    "version": "4.7.2",
+    "sourceFile": "tests/lib/rules/no-duplicate-disable.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-comments-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n//eslint-disable-line\n"
+    },
+    {
+      "code": "\n/*eslint-disable-line*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-line no-unused-vars\n//eslint-disable-next-line semi\n/*eslint-disable eqeqeq*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-unused-vars*/\n/*eslint-disable-next-line semi*/\n/*eslint-disable eqeqeq*/\n"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-line no-undef\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-next-line no-undef\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 28,
+          "endLine": 3,
+          "endColumn": 36
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-next-line no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 28,
+          "endLine": 3,
+          "endColumn": 36
+        }
+      ]
+    },
+    {
+      "code": "\n//eslint-disable-next-line no-undef\n//eslint-disable-line no-undef\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable-next-line no-undef*/\n/*eslint-disable-line no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n// eslint-disable-next-line no-undef -- description\n// eslint-disable-line no-undef -- description\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 24,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-comments/test/harness.mjs
+++ b/npm/eslint-comments/test/harness.mjs
@@ -16,6 +16,7 @@ function parseOptions(testCase) {
 
   return {
     comment: true,
+    tokens: true,
     loc: true,
     range: true,
     ecmaVersion: languageOptions.ecmaVersion ?? parserOptions.ecmaVersion ?? 'latest',

--- a/npm/eslint-comments/test/plugin.test.mjs
+++ b/npm/eslint-comments/test/plugin.test.mjs
@@ -18,6 +18,8 @@ describe('eslint-comments plugin shape', () => {
   it('ships a recommended config for ported rules', () => {
     expect(plugin.configs.recommended.rules).toEqual({
       'eslint-comments/disable-enable-pair': 'error',
+      'eslint-comments/no-aggregating-enable': 'error',
+      'eslint-comments/no-duplicate-disable': 'error',
       'eslint-comments/no-unlimited-disable': 'error',
     });
   });

--- a/npm/eslint-comments/test/plugin.test.mjs
+++ b/npm/eslint-comments/test/plugin.test.mjs
@@ -17,6 +17,7 @@ describe('eslint-comments plugin shape', () => {
 
   it('ships a recommended config for ported rules', () => {
     expect(plugin.configs.recommended.rules).toEqual({
+      'eslint-comments/disable-enable-pair': 'error',
       'eslint-comments/no-unlimited-disable': 'error',
     });
   });

--- a/status.json
+++ b/status.json
@@ -77,6 +77,38 @@
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/disable-enable-pair; supports the allowWholeFile option; shared disabled-area algorithm in Rust; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "no-aggregating-enable",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-aggregating-enable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "no-duplicate-disable",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-duplicate-disable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
       }
     ]
   },

--- a/status.json
+++ b/status.json
@@ -61,6 +61,22 @@
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/require-description; supports the ignore option; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "disable-enable-pair",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/disable-enable-pair; supports the allowWholeFile option; shared disabled-area algorithm in Rust; upstream RuleTester cases replayed via test/fixtures."
       }
     ]
   },


### PR DESCRIPTION
Part of #4 — fourth rule, and the first of the disabled-area family.

> Stacked on #26 (→ #25 → #23). Review/merge lower PRs first; bases retarget to `main` as each lands.

## `disable-enable-pair`

Reports every `eslint-disable` region that is never closed by a matching `eslint-enable`. Supports `allowWholeFile` (a disable at the very top of the file is treated as an intentional whole-file disable).

### Shared infrastructure (reused by the next 3 rules)
- `crates/eslint_comments/src/disabled_area.rs` — clean-room port of upstream's `DisabledArea` bookkeeping: open areas, duplicate disables, unused enables, and per-enable related-disable counts, walked in source order. Carton `SmallVec` only.
- `crates/eslint_comments/src/loc.rs::to_rule_id_location` — computes the exact column of a rule name inside a directive comment, so reported `line`/`column`/`endColumn` match upstream (e.g. `no-undef` → column 18, endColumn 26).

### Rule
- `rule_disable_enable_pair.rs` core + insta snapshot.
- NAPI `scan_disable_enable_pair(comments, allowWholeFile, firstTokenStart)`; the wrapper supplies the first token position from `sourceCode.ast.tokens[0]`.
- Added to the `recommended` config (matches upstream).
- `test/fixtures/disable-enable-pair.json` captured from upstream (17 valid / 8 invalid), replayed via espree (harness now parses `tokens`).

## Verification
- `cargo clippy -D warnings` ✓, `cargo test` ✓
- `vitest` ✓ — 129 cases across the four ported rules, exact column assertions included
- `vp fmt --check` ✓, `status:check` ✓, sync idempotent ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783569291&installation_id=136613492&pr_number=28&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F28&signature=e8d581853b670564ab6ef18eb2208b69d14600ddab3be536e6ffa2f1d3896098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->