### PR TITLE
feat(eslint-comments): port no-duplicate-disable

### DIFF
--- a/crates/eslint_comments/src/lib.rs
+++ b/crates/eslint_comments/src/lib.rs
@@ -11,6 +11,7 @@ pub mod loc;
 
 mod rule_disable_enable_pair;
 mod rule_no_aggregating_enable;
+mod rule_no_duplicate_disable;
 mod rule_no_unlimited_disable;
 mod rule_no_use;
 mod rule_require_description;
@@ -18,6 +19,7 @@ mod rule_require_description;
 pub use loc::{Location, Position};
 pub use rule_disable_enable_pair::disable_enable_pair;
 pub use rule_no_aggregating_enable::no_aggregating_enable;
+pub use rule_no_duplicate_disable::no_duplicate_disable;
 pub use rule_no_unlimited_disable::no_unlimited_disable;
 pub use rule_no_use::no_use;
 pub use rule_require_description::require_description;

--- a/crates/eslint_comments/src/rule_no_duplicate_disable.rs
+++ b/crates/eslint_comments/src/rule_no_duplicate_disable.rs
@@ -1,0 +1,74 @@
+//! `no-duplicate-disable`: disallow `eslint-disable` comments that re-disable
+//! a rule already disabled by an earlier, still-open directive.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::disabled_area::build_disabled_area;
+use crate::loc::to_rule_id_location;
+use crate::{Comment, Diagnostic, DiagnosticData};
+
+/// Report each disable directive that duplicates an already-active disable.
+pub fn no_duplicate_disable(comments: &[Comment]) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+    let state = build_disabled_area(comments);
+
+    for item in &state.duplicate_disable_directives {
+        let comment = &comments[item.comment];
+        let loc = to_rule_id_location(comment.value, comment.loc, item.rule_id.as_deref());
+        let message_id = if item.rule_id.is_some() {
+            "duplicateRule"
+        } else {
+            "duplicate"
+        };
+
+        diagnostics.push(Diagnostic {
+            message_id: CompactString::from(message_id),
+            data: DiagnosticData {
+                rule_id: item.rule_id.clone(),
+                ..DiagnosticData::default()
+            },
+            loc,
+        });
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, no_duplicate_disable};
+
+    fn block<'a>(value: &'a str, line: u32) -> Comment<'a> {
+        Comment {
+            kind: CommentKind::Block,
+            value,
+            loc: Location {
+                start: Position { line, column: 0 },
+                end: Position {
+                    line,
+                    column: value.len() as i32 + 4,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_duplicate_disable() {
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-disable no-undef", 2),
+        ];
+        insta::assert_debug_snapshot!(no_duplicate_disable(&comments));
+    }
+
+    #[test]
+    fn distinct_rules_are_ok() {
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-disable no-unused-vars", 2),
+        ];
+        assert!(no_duplicate_disable(&comments).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_duplicate_disable__tests__reports_duplicate_disable.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_duplicate_disable__tests__reports_duplicate_disable.snap
@@ -1,0 +1,26 @@
+---
+source: crates/eslint_comments/src/rule_no_duplicate_disable.rs
+expression: no_duplicate_disable(&comments)
+---
+[
+    Diagnostic {
+        message_id: "duplicateRule",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: Some(
+                "no-undef",
+            ),
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 2,
+                column: 17,
+            },
+            end: Position {
+                line: 2,
+                column: 25,
+            },
+        },
+    },
+]

--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -26,11 +26,12 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 | ----------------------- | ---------------------------------------------------------- | ------ |
 | `disable-enable-pair`   | require an `eslint-enable` for every `eslint-disable`      | ported |
 | `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported |
+| `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported |
 | `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported |
 | `no-use`                | disallow ESLint directive-comments                         | ported |
 | `require-description`   | require descriptions in ESLint directive-comments          | ported |
 
-Remaining upstream rules (`no-duplicate-disable`, `no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
+Remaining upstream rules (`no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -245,9 +245,28 @@ const noAggregatingEnable = commentScanRule(
   (comments) => native.scanNoAggregatingEnable(comments),
 );
 
+const noDuplicateDisable = commentScanRule(
+  {
+    type: 'problem',
+    docs: {
+      description: 'disallow duplicate `eslint-disable` comments',
+      recommended: true,
+      url: `${DOCS_BASE}#no-duplicate-disable`,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      duplicate: 'ESLint rules have been disabled already.',
+      duplicateRule: "'{{ruleId}}' rule has been disabled already.",
+    },
+  },
+  (comments) => native.scanNoDuplicateDisable(comments),
+);
+
 const rules = {
   'disable-enable-pair': disableEnablePair,
   'no-aggregating-enable': noAggregatingEnable,
+  'no-duplicate-disable': noDuplicateDisable,
   'no-unlimited-disable': noUnlimitedDisable,
   'no-use': noUse,
   'require-description': requireDescription,
@@ -258,6 +277,7 @@ const rules = {
 const recommendedRuleNames = [
   'disable-enable-pair',
   'no-aggregating-enable',
+  'no-duplicate-disable',
   'no-unlimited-disable',
 ];
 

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -6,8 +6,8 @@
 
 pub use napi_abi::{
     CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, PositionInput,
-    scan_disable_enable_pair, scan_no_aggregating_enable, scan_no_unlimited_disable, scan_no_use,
-    scan_require_description,
+    scan_disable_enable_pair, scan_no_aggregating_enable, scan_no_duplicate_disable,
+    scan_no_unlimited_disable, scan_no_use, scan_require_description,
 };
 
 #[allow(
@@ -19,7 +19,8 @@ mod napi_abi {
     use oxlint_plugins_eslint_comments::directive::CommentKind;
     use oxlint_plugins_eslint_comments::{
         Comment, Diagnostic as CoreDiagnostic, Location, Position, disable_enable_pair,
-        no_aggregating_enable, no_unlimited_disable, no_use, require_description,
+        no_aggregating_enable, no_duplicate_disable, no_unlimited_disable, no_use,
+        require_description,
     };
 
     /// A comment token, as collected from `sourceCode.getAllComments()`.
@@ -112,6 +113,16 @@ mod napi_abi {
     pub fn scan_no_aggregating_enable(comments: Vec<CommentInput>) -> Vec<Diagnostic> {
         let core = to_core_comments(&comments);
         no_aggregating_enable(&core)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `no-duplicate-disable`: report disables that duplicate an active disable.
+    #[napi]
+    pub fn scan_no_duplicate_disable(comments: Vec<CommentInput>) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        no_duplicate_disable(&core)
             .into_iter()
             .map(diagnostic_from_core)
             .collect()

--- a/npm/eslint-comments/test/fixtures/no-duplicate-disable.json
+++ b/npm/eslint-comments/test/fixtures/no-duplicate-disable.json
@@ -1,0 +1,109 @@
+{
+  "__generated": {
+    "source": "@eslint-community/eslint-plugin-eslint-comments",
+    "version": "4.7.2",
+    "sourceFile": "tests/lib/rules/no-duplicate-disable.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-comments-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n//eslint-disable-line\n"
+    },
+    {
+      "code": "\n/*eslint-disable-line*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-line no-unused-vars\n//eslint-disable-next-line semi\n/*eslint-disable eqeqeq*/\n"
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-unused-vars*/\n/*eslint-disable-next-line semi*/\n/*eslint-disable eqeqeq*/\n"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-line no-undef\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-next-line no-undef\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 28,
+          "endLine": 3,
+          "endColumn": 36
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-next-line no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 28,
+          "endLine": 3,
+          "endColumn": 36
+        }
+      ]
+    },
+    {
+      "code": "\n//eslint-disable-next-line no-undef\n//eslint-disable-line no-undef\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable-next-line no-undef*/\n/*eslint-disable-line no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "\n// eslint-disable-next-line no-undef -- description\n// eslint-disable-line no-undef -- description\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 24,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-comments/test/plugin.test.mjs
+++ b/npm/eslint-comments/test/plugin.test.mjs
@@ -19,6 +19,7 @@ describe('eslint-comments plugin shape', () => {
     expect(plugin.configs.recommended.rules).toEqual({
       'eslint-comments/disable-enable-pair': 'error',
       'eslint-comments/no-aggregating-enable': 'error',
+      'eslint-comments/no-duplicate-disable': 'error',
       'eslint-comments/no-unlimited-disable': 'error',
     });
   });

--- a/status.json
+++ b/status.json
@@ -93,6 +93,22 @@
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-aggregating-enable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "no-duplicate-disable",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-duplicate-disable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
       }
     ]
   },


### PR DESCRIPTION
Part of #4 — sixth rule, third of the disabled-area family.

> Stacked on #29 (→ #28 → #26 → #25 → #23).

## `no-duplicate-disable`

Reports an `eslint-disable` directive that disables a rule already disabled by an earlier directive whose region is still open.

- `rule_no_duplicate_disable.rs` reuses the shared `disabled_area` duplicate-disable tracking; core + insta snapshot. Reports `duplicateRule` (with `{{ruleId}}`) or `duplicate`, at the rule-name column via `to_rule_id_location`.
- NAPI `scan_no_duplicate_disable`; registered in `index.js` (type `problem`), added to `recommended`.
- `test/fixtures/no-duplicate-disable.json` from upstream (4 valid / 7 invalid), replayed via espree.

## Verification
- `cargo clippy -D warnings` ✓, `cargo test` ✓
- `vitest` ✓ — 149 cases across six ported rules
- `vp fmt --check` ✓, `status:check` ✓, sync idempotent ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783569649&installation_id=136613492&pr_number=30&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F30&signature=962cab78a3b7587227617540566117c5c892f1e05c6e14949dc5a8125b3d1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->