### PR TITLE
ci: split checks and add Blacksmith sticky disks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: useblacksmith/checkout@v1
 
       - uses: actions/setup-node@v4
         with:
@@ -39,7 +39,27 @@ jobs:
         with:
           components: clippy,rustfmt
 
+      - name: Mount pnpm store
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-bench-pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: ~/.local/share/pnpm/store
+
+      - name: Mount node_modules
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-bench-node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: ./node_modules
+
+      - name: Mount Cargo target
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-bench-cargo-target-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: ./target
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - run: vp install --frozen-lockfile
       - run: vp build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,53 @@ env:
   RUST_BACKTRACE: '1'
 
 jobs:
-  verify:
-    name: Verify
+  check:
+    name: ${{ matrix.name }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Format
+            cache_scope: format
+            command: |
+              pnpm run fmt:rust:check
+              vp fmt --check
+          - name: Typecheck
+            cache_scope: typecheck
+            command: pnpm run typecheck
+          - name: Lint
+            cache_scope: lint
+            command: |
+              vp lint
+              pnpm run lint:rust
+              pnpm run lint:rust:layout
+          - name: Build
+            cache_scope: build
+            command: vp build
+          - name: JS Tests
+            cache_scope: js-tests
+            command: vp test
+          - name: Rust Tests
+            cache_scope: rust-tests
+            command: pnpm run test:rust
+          - name: Bench Check
+            cache_scope: bench-check
+            command: pnpm run bench:check
+          - name: Policy
+            cache_scope: policy
+            command: |
+              pnpm run security:audit
+              pnpm run license
+              pnpm run status:check
+          - name: Publish Readiness
+            cache_scope: publish-readiness
+            command: |
+              vp build
+              node tools/tasks/verify-package-publish-ready.ts
     steps:
-      - uses: actions/checkout@v6
+      - uses: useblacksmith/checkout@v1
 
       - uses: actions/setup-node@v4
         with:
@@ -41,7 +82,28 @@ jobs:
         with:
           components: clippy,rustfmt
 
+      - name: Mount pnpm store
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-${{ matrix.cache_scope }}-pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: ~/.local/share/pnpm/store
+
+      - name: Mount node_modules
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-${{ matrix.cache_scope }}-node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: ./node_modules
+
+      - name: Mount Cargo target
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-${{ matrix.cache_scope }}-cargo-target-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: ./target
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - run: vp install --frozen-lockfile
-      - run: pnpm run verify
+      - name: Run ${{ matrix.name }}
+        run: ${{ matrix.command }}


### PR DESCRIPTION
## Summary
- split the monolithic CI verify job into focused matrix checks for format, typecheck, lint, build, tests, bench check, policy, and publish readiness
- use Blacksmith checkout caching in CI and benchmark workflows
- mount Blacksmith sticky disks for pnpm store, node_modules, and Cargo target per check scope

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/ci.yml .github/workflows/bench.yml`
- `git diff --check`
- `./node_modules/.bin/vp install --frozen-lockfile && corepack pnpm run verify`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783576781&installation_id=136613492&pr_number=33&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F33&signature=e47f51b819f7fdf444897e82ea296102b54e1c22ee802e862d693718d6eda3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->