### PR TITLE
ci: disallow vec and format macros

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -13,3 +13,8 @@ disallowed-methods = [
   { path = "alloc::string::ToString::to_string", reason = "Avoid implicit owned String allocation. Use CompactString::from, str::to_owned at explicit ABI boundaries, or write the allocation reason near the call." },
   { path = "std::string::ToString::to_string", reason = "Avoid implicit owned String allocation. Use CompactString::from, str::to_owned at explicit ABI boundaries, or write the allocation reason near the call." },
 ]
+
+disallowed-macros = [
+  { path = "std::format", reason = "Avoid implicit owned String allocation. Use CompactString formatting helpers or explicit ABI-boundary allocation with a local allow." },
+  { path = "std::vec", reason = "Use oxlint_plugins_carton::SmallVec for small bounded rule state. Allow only at explicit public ABI boundaries." },
+]

--- a/crates/eslint_comments/src/directive.rs
+++ b/crates/eslint_comments/src/directive.rs
@@ -179,14 +179,20 @@ mod tests {
             "eslint quotes: error",
         ];
         let parsed = cases.map(parse_directive_text);
-        insta::assert_debug_snapshot!(parsed);
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(parsed);
+        }
     }
 
     #[test]
     fn rejects_non_directives() {
         let cases = ["", " ", "not-a-directive", "eslintfoo", "eslint-disablexyz"];
         let parsed = cases.map(parse_directive_text);
-        insta::assert_debug_snapshot!(parsed);
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(parsed);
+        }
     }
 
     #[test]
@@ -198,7 +204,10 @@ mod tests {
             "eslint-disable foo -short", // single hyphen is not a divider
         ];
         let parsed = cases.map(parse_directive_text);
-        insta::assert_debug_snapshot!(parsed);
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(parsed);
+        }
     }
 
     #[test]
@@ -214,11 +223,14 @@ mod tests {
         // disable-next-line may span (block) lines.
         let multiline_next_line =
             parse_directive_comment(CommentKind::Block, "eslint-disable-next-line foo", false);
-        insta::assert_debug_snapshot!((
-            line_disable,
-            line_disable_line,
-            multiline_disable_line,
-            multiline_next_line,
-        ));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!((
+                line_disable,
+                line_disable_line,
+                multiline_disable_line,
+                multiline_next_line,
+            ));
+        }
     }
 }

--- a/crates/eslint_comments/src/rule_disable_enable_pair.rs
+++ b/crates/eslint_comments/src/rule_disable_enable_pair.rs
@@ -79,7 +79,10 @@ mod tests {
             block("eslint-disable", 2, 19),
             block("eslint-disable no-undef", 4, 27),
         ];
-        insta::assert_debug_snapshot!(disable_enable_pair(&comments, false, None));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(disable_enable_pair(&comments, false, None));
+        }
     }
 
     #[test]

--- a/crates/eslint_comments/src/rule_no_aggregating_enable.rs
+++ b/crates/eslint_comments/src/rule_no_aggregating_enable.rs
@@ -57,7 +57,10 @@ mod tests {
             block("eslint-disable no-unused-vars", 2),
             block("eslint-enable", 3),
         ];
-        insta::assert_debug_snapshot!(no_aggregating_enable(&comments));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(no_aggregating_enable(&comments));
+        }
     }
 
     #[test]

--- a/crates/eslint_comments/src/rule_no_duplicate_disable.rs
+++ b/crates/eslint_comments/src/rule_no_duplicate_disable.rs
@@ -60,7 +60,10 @@ mod tests {
             block("eslint-disable no-undef", 1),
             block("eslint-disable no-undef", 2),
         ];
-        insta::assert_debug_snapshot!(no_duplicate_disable(&comments));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(no_duplicate_disable(&comments));
+        }
     }
 
     #[test]

--- a/crates/eslint_comments/src/rule_no_unlimited_disable.rs
+++ b/crates/eslint_comments/src/rule_no_unlimited_disable.rs
@@ -69,7 +69,10 @@ mod tests {
             comment(CommentKind::Line, "eslint-disable-line"),
             comment(CommentKind::Line, "eslint-disable-next-line"),
         ];
-        insta::assert_debug_snapshot!(no_unlimited_disable(&comments));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(no_unlimited_disable(&comments));
+        }
     }
 
     #[test]

--- a/crates/eslint_comments/src/rule_no_use.rs
+++ b/crates/eslint_comments/src/rule_no_use.rs
@@ -57,7 +57,10 @@ mod tests {
             comment(CommentKind::Block, "not a directive"),
         ];
         // Allow eslint-enable only; the two disables remain reported.
-        insta::assert_debug_snapshot!(no_use(&comments, &["eslint-enable"]));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(no_use(&comments, &["eslint-enable"]));
+        }
     }
 
     #[test]

--- a/crates/eslint_comments/src/rule_require_description.rs
+++ b/crates/eslint_comments/src/rule_require_description.rs
@@ -60,7 +60,10 @@ mod tests {
             comment(CommentKind::Block, "eslint-disable eqeqeq -- because"),
             comment(CommentKind::Line, "eslint-disable-line eqeqeq"),
         ];
-        insta::assert_debug_snapshot!(require_description(&comments, &[]));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(require_description(&comments, &[]));
+        }
     }
 
     #[test]

--- a/crates/stylistic/src/lib.rs
+++ b/crates/stylistic/src/lib.rs
@@ -282,26 +282,35 @@ mod tests {
     #[test]
     fn scans_default_names() {
         let source = "const event = data.error;";
-        insta::assert_debug_snapshot!(scan_source_for_rule(source, []));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(scan_source_for_rule(source, []));
+        }
     }
 
     #[test]
     fn supports_custom_names_without_losing_defaults() {
         let source = "function run(ctx) { return payload + event; }";
-        insta::assert_debug_snapshot!(scan_source_for_rule(source, ["ctx", "payload"]));
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(scan_source_for_rule(source, ["ctx", "payload"]));
+        }
     }
 
     #[test]
     fn respects_identifier_boundaries() {
-        insta::assert_debug_snapshot!(
-            "identifier_boundaries",
-            vec![
-                contains_identifier("const event = 1", "event"),
-                contains_identifier("const eventBus = 1", "event"),
-                contains_identifier("const my_event = 1", "event"),
-                contains_identifier("const $event = 1", "event"),
-                contains_identifier("call(event)", "event"),
-            ]
-        );
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(
+                "identifier_boundaries",
+                [
+                    contains_identifier("const event = 1", "event"),
+                    contains_identifier("const eventBus = 1", "event"),
+                    contains_identifier("const my_event = 1", "event"),
+                    contains_identifier("const $event = 1", "event"),
+                    contains_identifier("call(event)", "event"),
+                ]
+            );
+        }
     }
 }

--- a/crates/stylistic/src/native_stylistic.rs
+++ b/crates/stylistic/src/native_stylistic.rs
@@ -752,7 +752,11 @@ pub fn run_stylistic_lint(
                     .expect("token scan is built when a token rule is enabled");
                 run_token_rule(name, scan, &rule.options, &mut diagnostics);
             }
-            unknown => return Err(format!("unknown native stylistic rule: {unknown}")),
+            unknown => {
+                let mut message = String::from("unknown native stylistic rule: ");
+                message.push_str(unknown);
+                return Err(message);
+            }
         }
     }
 

--- a/crates/stylistic/src/native_stylistic/context.rs
+++ b/crates/stylistic/src/native_stylistic/context.rs
@@ -322,7 +322,7 @@ impl<'a> Scan<'a> {
 /// Builds the bracket partner map. Only plain `(`/`)`/`[`/`]`/`{`/`}`
 /// punctuator tokens participate; template delimiters carry their own braces.
 fn match_brackets(source: &str, tokens: &[Token]) -> Vec<usize> {
-    let mut partner = vec![NO_PARTNER; tokens.len()];
+    let mut partner = std::iter::repeat_n(NO_PARTNER, tokens.len()).collect::<Vec<_>>();
     let mut stack: Vec<usize> = Vec::new();
     for (index, token) in tokens.iter().enumerate() {
         if token.kind != TokenKind::Punctuator {
@@ -422,11 +422,12 @@ pub(crate) fn push(
         message_id: message_id.to_owned(),
         message: message.to_owned(),
         range: TextRange::new(start, end),
-        suggestions: vec![LintSuggestion {
+        suggestions: std::iter::once(LintSuggestion {
             message_id: suggestion_id.to_owned(),
             message: suggestion_message.to_owned(),
-            fixes: vec![fix],
-        }],
+            fixes: std::iter::once(fix).collect(),
+        })
+        .collect(),
     });
 }
 
@@ -517,28 +518,25 @@ mod tests {
     fn classifies_object_vs_block_braces() {
         assert_eq!(
             open_brace_kinds("const o = { a: 1 };"),
-            vec![BraceKind::ObjectLike]
+            [BraceKind::ObjectLike]
         );
         assert_eq!(
             open_brace_kinds("function f() { return 1; }"),
-            vec![BraceKind::Block]
+            [BraceKind::Block]
         );
-        assert_eq!(open_brace_kinds("if (x) { y(); }"), vec![BraceKind::Block]);
+        assert_eq!(open_brace_kinds("if (x) { y(); }"), [BraceKind::Block]);
         assert_eq!(
             open_brace_kinds("const f = () => { g(); };"),
-            vec![BraceKind::Block]
+            [BraceKind::Block]
         );
         assert_eq!(
             open_brace_kinds("class C { m() {} }"),
-            vec![BraceKind::Block, BraceKind::Block]
+            [BraceKind::Block, BraceKind::Block]
         );
-        assert_eq!(
-            open_brace_kinds("f({ a: 1 });"),
-            vec![BraceKind::ObjectLike]
-        );
+        assert_eq!(open_brace_kinds("f({ a: 1 });"), [BraceKind::ObjectLike]);
         assert_eq!(
             open_brace_kinds("return { a: 1 };"),
-            vec![BraceKind::ObjectLike]
+            [BraceKind::ObjectLike]
         );
     }
 
@@ -552,7 +550,7 @@ mod tests {
             .filter(|(_, t)| punct_is(t, scan.source(), "["))
             .map(|(i, _)| scan.bracket_kind(i))
             .collect();
-        assert_eq!(kinds, vec![BracketKind::Array, BracketKind::Member]);
+        assert_eq!(kinds, [BracketKind::Array, BracketKind::Member]);
     }
 
     #[test]
@@ -567,7 +565,7 @@ mod tests {
             .collect();
         assert_eq!(
             uses,
-            vec![
+            [
                 ParenUse::Control,
                 ParenUse::Call,
                 ParenUse::FuncDef,

--- a/crates/stylistic/src/native_stylistic/context_rules.rs
+++ b/crates/stylistic/src/native_stylistic/context_rules.rs
@@ -881,7 +881,7 @@ pub(crate) fn check_space_infix_ops(
 /// fire.
 fn for_header_semis(scan: &Scan) -> Vec<bool> {
     let tokens = scan.tokens();
-    let mut marks = vec![false; tokens.len()];
+    let mut marks = std::iter::repeat_n(false, tokens.len()).collect::<Vec<_>>();
     // Stack of "is this open paren a for-header paren?".
     let mut paren_stack: Vec<bool> = Vec::new();
     for index in 0..tokens.len() {
@@ -1693,7 +1693,7 @@ mod tests {
     }
 
     fn always(value: &str) -> Value {
-        Value::Array(vec![Value::String(value.into())])
+        Value::Array(std::iter::once(Value::String(value.into())).collect())
     }
 
     #[test]
@@ -2020,7 +2020,7 @@ mod tests {
 
     #[test]
     fn comma_dangle_always_multiline() {
-        let opt = Value::Array(vec![Value::String("always-multiline".into())]);
+        let opt = Value::Array(std::iter::once(Value::String("always-multiline".into())).collect());
         assert_eq!(
             run(
                 check_comma_dangle,
@@ -2256,7 +2256,7 @@ mod tests {
             .len(),
             0
         );
-        let below = Value::Array(vec![Value::String("below".into())]);
+        let below = Value::Array(std::iter::once(Value::String("below".into())).collect());
         assert_eq!(
             run(check_implicit_arrow_linebreak, "const f = (a) => a;", below).len(),
             1
@@ -2287,7 +2287,7 @@ mod tests {
             .len(),
             1
         );
-        let before = Value::Array(vec![Value::String("before".into())]);
+        let before = Value::Array(std::iter::once(Value::String("before".into())).collect());
         assert_eq!(
             run(check_operator_linebreak, "const x = 1 +\n  2;", before).len(),
             1

--- a/crates/stylistic/src/native_stylistic/helpers.rs
+++ b/crates/stylistic/src/native_stylistic/helpers.rs
@@ -79,7 +79,7 @@ pub(crate) fn push_diagnostic<F>(
         .map(|(suggestion_id, suggestion_message, fix)| LintSuggestion {
             message_id: suggestion_id.to_owned(),
             message: suggestion_message.to_owned(),
-            fixes: vec![fix(range)],
+            fixes: std::iter::once(fix(range)).collect(),
         })
         .into_iter()
         .collect();

--- a/crates/stylistic/src/native_stylistic/lexer.rs
+++ b/crates/stylistic/src/native_stylistic/lexer.rs
@@ -544,7 +544,7 @@ mod tests {
     fn lexes_basic_punctuators_and_identifiers() {
         assert_eq!(
             kinds("const x = 1;"),
-            vec![
+            [
                 (TokenKind::Identifier, "const"),
                 (TokenKind::Identifier, "x"),
                 (TokenKind::Punctuator, "="),
@@ -558,7 +558,7 @@ mod tests {
     fn matches_longest_punctuator() {
         assert_eq!(
             kinds("a >>>= b ?.c ?? d"),
-            vec![
+            [
                 (TokenKind::Identifier, "a"),
                 (TokenKind::Punctuator, ">>>="),
                 (TokenKind::Identifier, "b"),
@@ -574,7 +574,7 @@ mod tests {
     fn lexes_strings_and_comments() {
         assert_eq!(
             kinds("'a\\'b' /* c */ // d"),
-            vec![
+            [
                 (TokenKind::String, "'a\\'b'"),
                 (TokenKind::BlockComment, "/* c */"),
                 (TokenKind::LineComment, "// d"),
@@ -586,7 +586,7 @@ mod tests {
     fn distinguishes_regex_from_division() {
         assert_eq!(
             kinds("a = /ab+/gi"),
-            vec![
+            [
                 (TokenKind::Identifier, "a"),
                 (TokenKind::Punctuator, "="),
                 (TokenKind::Regex, "/ab+/gi"),
@@ -594,7 +594,7 @@ mod tests {
         );
         assert_eq!(
             kinds("a / b / c"),
-            vec![
+            [
                 (TokenKind::Identifier, "a"),
                 (TokenKind::Punctuator, "/"),
                 (TokenKind::Identifier, "b"),
@@ -608,7 +608,7 @@ mod tests {
     fn lexes_template_with_substitution() {
         assert_eq!(
             kinds("`a${ b + 1 }c`"),
-            vec![
+            [
                 (TokenKind::TemplateHead, "`a${"),
                 (TokenKind::Identifier, "b"),
                 (TokenKind::Punctuator, "+"),
@@ -622,7 +622,7 @@ mod tests {
     fn lexes_nested_braces_in_substitution() {
         assert_eq!(
             kinds("`${ {a: 1} }`"),
-            vec![
+            [
                 (TokenKind::TemplateHead, "`${"),
                 (TokenKind::Punctuator, "{"),
                 (TokenKind::Identifier, "a"),
@@ -638,7 +638,7 @@ mod tests {
     fn lexes_nested_templates() {
         assert_eq!(
             kinds("`${`${x}`}`"),
-            vec![
+            [
                 (TokenKind::TemplateHead, "`${"),
                 (TokenKind::TemplateHead, "`${"),
                 (TokenKind::Identifier, "x"),
@@ -652,7 +652,7 @@ mod tests {
     fn lexes_numbers() {
         assert_eq!(
             kinds("0xFF 1_000 1.5e-3 10n"),
-            vec![
+            [
                 (TokenKind::Number, "0xFF"),
                 (TokenKind::Number, "1_000"),
                 (TokenKind::Number, "1.5e-3"),
@@ -665,7 +665,7 @@ mod tests {
     fn regex_after_return_keyword() {
         assert_eq!(
             kinds("return /x/"),
-            vec![(TokenKind::Identifier, "return"), (TokenKind::Regex, "/x/"),]
+            [(TokenKind::Identifier, "return"), (TokenKind::Regex, "/x/")]
         );
     }
 }

--- a/crates/stylistic/src/native_stylistic/token_rules.rs
+++ b/crates/stylistic/src/native_stylistic/token_rules.rs
@@ -730,7 +730,7 @@ mod tests {
         );
         assert!(run(check_space_in_parens, "f(a)", Value::Null).is_empty());
         assert!(run(check_space_in_parens, "f()", Value::Null).is_empty());
-        let always = Value::Array(vec![Value::String("always".into())]);
+        let always = Value::Array(std::iter::once(Value::String("always".into())).collect());
         assert_eq!(run(check_space_in_parens, "f(a)", always).len(), 2);
     }
 
@@ -792,7 +792,7 @@ mod tests {
             ["expectedDotAfterObject"]
         );
         assert!(run(check_dot_location, "foo.\nbar", Value::Null).is_empty());
-        let property = Value::Array(vec![Value::String("property".into())]);
+        let property = Value::Array(std::iter::once(Value::String("property".into())).collect());
         assert_eq!(
             ids(&run(check_dot_location, "foo.\nbar", property)),
             ["expectedDotBeforeProperty"]

--- a/crates/stylistic/src/snapshots/oxlint_plugins_stylistic__tests__identifier_boundaries.snap
+++ b/crates/stylistic/src/snapshots/oxlint_plugins_stylistic__tests__identifier_boundaries.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/stylistic/src/lib.rs
 assertion_line: 101
-expression: "vec![contains_identifier(\"const event = 1\", \"event\"),\ncontains_identifier(\"const eventBus = 1\", \"event\"),\ncontains_identifier(\"const my_event = 1\", \"event\"),\ncontains_identifier(\"const $event = 1\", \"event\"),\ncontains_identifier(\"call(event)\", \"event\"),]"
+expression: "[contains_identifier(\"const event = 1\", \"event\"),\ncontains_identifier(\"const eventBus = 1\", \"event\"),\ncontains_identifier(\"const my_event = 1\", \"event\"),\ncontains_identifier(\"const $event = 1\", \"event\"),\ncontains_identifier(\"call(event)\", \"event\"),]"
 ---
 [
     true,

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -11,8 +11,9 @@ pub use napi_abi::{
 };
 
 #[allow(
+    clippy::disallowed_macros,
     clippy::disallowed_types,
-    reason = "NAPI public ABI requires String/Vec; values are converted into carton/core types before rule logic runs."
+    reason = "NAPI public ABI and proc macros require String/Vec/format expansion; values are converted into carton/core types before rule logic runs."
 )]
 mod napi_abi {
     use napi_derive::napi;

--- a/npm/no-forbidden-identifiers/src/lib.rs
+++ b/npm/no-forbidden-identifiers/src/lib.rs
@@ -7,8 +7,9 @@ pub use napi_abi::{
 };
 
 #[allow(
+    clippy::disallowed_macros,
     clippy::disallowed_types,
-    reason = "NAPI public ABI requires String/Vec<String>; this module compacts values before rule logic runs."
+    reason = "NAPI public ABI and proc macros require String/Vec/format expansion; this module compacts values before rule logic runs."
 )]
 mod napi_abi {
     use napi_derive::napi;


### PR DESCRIPTION
## Summary
- configure Clippy `disallowed-macros` to reject `std::vec` and `std::format`
- replace direct Rust `vec!` / `format!` call sites with Clippy-compliant alternatives, including the native stylistic code added on `main`
- keep explicit public ABI/proc-macro boundaries working with scoped `#[allow(clippy::disallowed_macros)]`
- wrap `insta` snapshot assertions in scoped allow blocks because `insta` expands through `format!`

## Validation
- `rg -n "\\bvec!\\s*\\[|\\bformat!\\s*\\(" --glob '*.rs' -g '!target' -g '!upstream'`
- `cargo fmt --all`
- `corepack pnpm run lint:rust`
- `git diff --check HEAD~1 HEAD`
- `corepack pnpm run verify`
