### PR TITLE
test(stylistic): cover plugin rule execution

### DIFF
--- a/npm/stylistic/test/plugin.test.mjs
+++ b/npm/stylistic/test/plugin.test.mjs
@@ -1,6 +1,80 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const stylisticRuleFixtures = [
+  ['eol-last', 'const x = 1;', [], ['missing']],
+  ['linebreak-style', 'const x = 1;\r\n', ['unix'], ['expectedUnix']],
+  ['no-multiple-empty-lines', 'const a = 1;\n\n\nconst b = 2;\n', [{ max: 1 }], ['tooMany']],
+  ['no-tabs', 'const\tlabel = 1;\n', [], ['unexpectedTab']],
+  ['no-trailing-spaces', 'const x = 1;  \n', [], ['trailingSpace']],
+  ['quotes', 'const label = "value";\n', ['single'], ['wrongQuote']],
+  ['unicode-bom', '\u{feff}const x = 1;\n', ['never'], ['unexpected']],
+  ['arrow-spacing', 'const f = ()=>1;\n', [], ['expectedBefore', 'expectedAfter']],
+  ['comma-spacing', '[1 ,2]\n', [], ['unexpected', 'missing']],
+  ['semi-spacing', 'a ;b\n', [], ['unexpected', 'missing']],
+  ['space-in-parens', 'f( a )\n', [], ['rejectedOpeningSpace', 'rejectedClosingSpace']],
+  ['template-curly-spacing', '`${ x }`\n', [], ['unexpectedAfter', 'unexpectedBefore']],
+  ['rest-spread-spacing', 'f(... args)\n', [], ['unexpectedWhitespace']],
+  ['no-multi-spaces', 'a  =  b\n', [], ['multipleSpaces', 'multipleSpaces']],
+  ['no-whitespace-before-property', 'foo .bar\n', [], ['unexpectedWhitespace']],
+  ['dot-location', 'foo\n.bar\n', [], ['expectedDotAfterObject']],
+  ['spaced-comment', '//x\n', [], ['expectedSpaceAfter']],
+  [
+    'object-curly-spacing',
+    'const o = { a: 1 };\n',
+    [],
+    ['unexpectedSpaceAfter', 'unexpectedSpaceBefore'],
+  ],
+  [
+    'array-bracket-spacing',
+    'const a = [ 1, 2 ];\n',
+    [],
+    ['unexpectedSpaceAfter', 'unexpectedSpaceBefore'],
+  ],
+  ['computed-property-spacing', 'a[ 0 ];\n', [], ['unexpectedSpaceAfter', 'unexpectedSpaceBefore']],
+  ['block-spacing', 'function f() {g();}\n', [], ['missing', 'missing']],
+  ['space-before-blocks', 'if (x){ y(); }\n', [], ['missingSpace']],
+  ['function-call-spacing', 'foo ();\n', [], ['unexpectedWhitespace']],
+  ['space-before-function-paren', 'function f() {}\n', [], ['missingSpace']],
+  ['no-floating-decimal', 'const x = .5;\n', [], ['leading']],
+  ['template-tag-spacing', 'tag `hello`;\n', [], ['unexpectedSpace']],
+  [
+    'yield-star-spacing',
+    'function* g() { yield *h(); }\n',
+    [],
+    ['unexpectedBefore', 'missingAfter'],
+  ],
+  ['generator-star-spacing', 'function* g() {}\n', [], ['missingBefore', 'unexpectedAfter']],
+  ['comma-dangle', 'const a = [1, 2,];\n', [], ['unexpected']],
+  ['space-infix-ops', 'const x = a+b;\n', [], ['missingSpace']],
+  ['max-len', 'const abcdefghij = 1;\n', [{ code: 10 }], ['tooLong']],
+  ['semi-style', 'foo()\n;[1].forEach(bar)\n', [], ['expectedSemiColon']],
+  ['comma-style', 'const a = [\n  1\n  , 2\n];\n', [], ['expectedCommaLast']],
+  ['arrow-parens', 'const f = a => a;\n', [], ['expectedParens']],
+  [
+    'switch-colon-spacing',
+    'switch (x) { case 0 :foo(); }\n',
+    [],
+    ['unexpectedSpaceBefore', 'expectedSpaceAfter'],
+  ],
+  ['no-extra-semi', 'var x = 5;;\n', [], ['unexpected']],
+  ['new-parens', 'var x = new Person;\n', [], ['missing']],
+  ['space-unary-ops', '++ foo\n', [], ['nonwordOperatorAfter']],
+  ['wrap-regex', '/foo/.test(bar);\n', [], ['requireParens']],
+  ['implicit-arrow-linebreak', 'const f = (a) =>\n  a;\n', [], ['unexpectedLinebreak']],
+  ['operator-linebreak', 'const x = 1\n  + 2;\n', [], ['operatorAtBeginning']],
+  ['keyword-spacing', 'if(foo) {}\n', [], ['missingAfter']],
+];
 
 function runRule(ruleName, sourceText, options, settings) {
   const reports = [];
@@ -24,6 +98,25 @@ function runRule(ruleName, sourceText, options, settings) {
   return reports;
 }
 
+function messageIds(reports) {
+  return reports.map((report) => report.messageId);
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
 describe('stylistic plugin', () => {
   it('exports the stylistic plugin surface', () => {
     expect(plugin.corsaStylisticPlugin).toBe(plugin);
@@ -31,8 +124,38 @@ describe('stylistic plugin', () => {
     expect(Object.keys(plugin.rules)).toContain('no-trailing-spaces');
   });
 
+  it('has a fixture for every native stylistic rule', () => {
+    expect(
+      stylisticRuleFixtures.map(([ruleName]) => ruleName).sort((a, b) => a.localeCompare(b)),
+    ).toEqual([...plugin.implementedStylisticRuleNames].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it.each(stylisticRuleFixtures)(
+    'reports %s through direct rule options',
+    (ruleName, sourceText, options, expectedMessageIds) => {
+      expect(messageIds(runRule(ruleName, sourceText, options))).toEqual(expectedMessageIds);
+    },
+  );
+
+  it.each(stylisticRuleFixtures)(
+    'reports %s through shared stylistic settings',
+    (ruleName, sourceText, options, expectedMessageIds) => {
+      expect(
+        messageIds(
+          runRule(ruleName, sourceText, [], {
+            corsaStylistic: {
+              rules: {
+                [ruleName]: options,
+              },
+            },
+          }),
+        ),
+      ).toEqual(expectedMessageIds);
+    },
+  );
+
   it('reports direct rule options', () => {
-    expect(runRule('quotes', 'const label = "value";', ['single'])).toMatchObject([
+    expect(runRule('quotes', 'const label = "value";\n', ['single'])).toMatchObject([
       {
         messageId: 'wrongQuote',
         node: { range: [14, 21] },
@@ -107,5 +230,57 @@ describe('stylistic plugin', () => {
         },
       }),
     ).toEqual([{ range: [insertAt, insertAt], replacementText: ',' }]);
+  });
+
+  it('works through oxlint jsPlugins config', () => {
+    const oxlint = findOxlintCli();
+    const temp = mkdtempSync(join(tmpdir(), 'stylistic-plugin-'));
+
+    try {
+      const sourcePath = join(temp, 'sample.js');
+      const configPath = join(temp, 'oxlint.config.jsonc');
+
+      writeFileSync(sourcePath, '"value";  \n');
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'stylistic',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          settings: {
+            corsaStylistic: {
+              rules: {
+                quotes: ['single'],
+                'no-trailing-spaces': [],
+              },
+            },
+          },
+          rules: {
+            'stylistic/quotes': 'error',
+            'stylistic/no-trailing-spaces': 'error',
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        oxlint,
+        ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+        {
+          encoding: 'utf8',
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(JSON.parse(result.stdout).diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+        'stylistic(no-trailing-spaces)',
+        'stylistic(quotes)',
+      ]);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add JS plugin smoke fixtures for every native stylistic rule.
- Cover both direct rule options and shared `settings.corsaStylistic.rules` execution paths.
- Add an oxlint `jsPlugins` integration test for the documented configuration shape.

## Validation

- `node_modules/.bin/vp test npm/stylistic/test`
- `cargo test -p oxlint-plugins-stylistic --all-features`
- `corepack pnpm run test`
- `node_modules/.bin/vp fmt --check`
- `node_modules/.bin/vp lint` (exits 0; reports existing unrelated warning in `npm/type-aware/src/rules/native_bridge.ts`)
- `corepack pnpm run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783581033&installation_id=136613492&pr_number=37&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F37&signature=89926dc5537212d7e8f0a16f3cded76bd55ac041fd870f8f5996a35428b0d0de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->