### PR TITLE
feat(eslint-comments): port no-unused-enable

### DIFF
--- a/crates/eslint_comments/src/lib.rs
+++ b/crates/eslint_comments/src/lib.rs
@@ -13,6 +13,7 @@ mod rule_disable_enable_pair;
 mod rule_no_aggregating_enable;
 mod rule_no_duplicate_disable;
 mod rule_no_unlimited_disable;
+mod rule_no_unused_enable;
 mod rule_no_use;
 mod rule_require_description;
 
@@ -21,6 +22,7 @@ pub use rule_disable_enable_pair::disable_enable_pair;
 pub use rule_no_aggregating_enable::no_aggregating_enable;
 pub use rule_no_duplicate_disable::no_duplicate_disable;
 pub use rule_no_unlimited_disable::no_unlimited_disable;
+pub use rule_no_unused_enable::no_unused_enable;
 pub use rule_no_use::no_use;
 pub use rule_require_description::require_description;
 

--- a/crates/eslint_comments/src/rule_no_unused_enable.rs
+++ b/crates/eslint_comments/src/rule_no_unused_enable.rs
@@ -1,0 +1,75 @@
+//! `no-unused-enable`: disallow `eslint-enable` comments that re-enable rules
+//! which were never disabled.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::disabled_area::build_disabled_area;
+use crate::loc::to_rule_id_location;
+use crate::{Comment, Diagnostic, DiagnosticData};
+
+/// Report each `eslint-enable` directive that does not close any open disable.
+pub fn no_unused_enable(comments: &[Comment]) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+    let state = build_disabled_area(comments);
+
+    for item in &state.unused_enable_directives {
+        let comment = &comments[item.comment];
+        let loc = to_rule_id_location(comment.value, comment.loc, item.rule_id.as_deref());
+        let message_id = if item.rule_id.is_some() {
+            "unusedRule"
+        } else {
+            "unused"
+        };
+
+        diagnostics.push(Diagnostic {
+            message_id: CompactString::from(message_id),
+            data: DiagnosticData {
+                rule_id: item.rule_id.clone(),
+                ..DiagnosticData::default()
+            },
+            loc,
+        });
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, no_unused_enable};
+
+    fn block<'a>(value: &'a str, line: u32) -> Comment<'a> {
+        Comment {
+            kind: CommentKind::Block,
+            value,
+            loc: Location {
+                start: Position { line, column: 0 },
+                end: Position {
+                    line,
+                    column: value.len() as i32 + 4,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_unused_enable() {
+        // Enable a rule that was never disabled.
+        let comments = [block("eslint-enable no-undef", 1)];
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(no_unused_enable(&comments));
+        }
+    }
+
+    #[test]
+    fn matched_enable_is_ok() {
+        let comments = [
+            block("eslint-disable no-undef", 1),
+            block("eslint-enable no-undef", 2),
+        ];
+        assert!(no_unused_enable(&comments).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_unused_enable__tests__reports_unused_enable.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_unused_enable__tests__reports_unused_enable.snap
@@ -1,0 +1,26 @@
+---
+source: crates/eslint_comments/src/rule_no_unused_enable.rs
+expression: no_unused_enable(&comments)
+---
+[
+    Diagnostic {
+        message_id: "unusedRule",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: Some(
+                "no-undef",
+            ),
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 1,
+                column: 16,
+            },
+            end: Position {
+                line: 1,
+                column: 24,
+            },
+        },
+    },
+]

--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -28,10 +28,11 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 | `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported |
 | `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported |
 | `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported |
+| `no-unused-enable`      | disallow unused `eslint-enable` comments                   | ported |
 | `no-use`                | disallow ESLint directive-comments                         | ported |
 | `require-description`   | require descriptions in ESLint directive-comments          | ported |
 
-Remaining upstream rules (`no-restricted-disable`, `no-unused-disable`, `no-unused-enable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
+Remaining upstream rules (`no-restricted-disable`, `no-unused-disable`) are tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and land one rule per pull request.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -263,11 +263,30 @@ const noDuplicateDisable = commentScanRule(
   (comments) => native.scanNoDuplicateDisable(comments),
 );
 
+const noUnusedEnable = commentScanRule(
+  {
+    type: 'problem',
+    docs: {
+      description: 'disallow unused `eslint-enable` comments',
+      recommended: true,
+      url: `${DOCS_BASE}#no-unused-enable`,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      unused: 'ESLint rules are re-enabled but those have not been disabled.',
+      unusedRule: "'{{ruleId}}' rule is re-enabled but it has not been disabled.",
+    },
+  },
+  (comments) => native.scanNoUnusedEnable(comments),
+);
+
 const rules = {
   'disable-enable-pair': disableEnablePair,
   'no-aggregating-enable': noAggregatingEnable,
   'no-duplicate-disable': noDuplicateDisable,
   'no-unlimited-disable': noUnlimitedDisable,
+  'no-unused-enable': noUnusedEnable,
   'no-use': noUse,
   'require-description': requireDescription,
 };
@@ -279,6 +298,7 @@ const recommendedRuleNames = [
   'no-aggregating-enable',
   'no-duplicate-disable',
   'no-unlimited-disable',
+  'no-unused-enable',
 ];
 
 const plugin = eslintCompatPlugin({

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -7,7 +7,7 @@
 pub use napi_abi::{
     CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, PositionInput,
     scan_disable_enable_pair, scan_no_aggregating_enable, scan_no_duplicate_disable,
-    scan_no_unlimited_disable, scan_no_use, scan_require_description,
+    scan_no_unlimited_disable, scan_no_unused_enable, scan_no_use, scan_require_description,
 };
 
 #[allow(
@@ -20,8 +20,8 @@ mod napi_abi {
     use oxlint_plugins_eslint_comments::directive::CommentKind;
     use oxlint_plugins_eslint_comments::{
         Comment, Diagnostic as CoreDiagnostic, Location, Position, disable_enable_pair,
-        no_aggregating_enable, no_duplicate_disable, no_unlimited_disable, no_use,
-        require_description,
+        no_aggregating_enable, no_duplicate_disable, no_unlimited_disable, no_unused_enable,
+        no_use, require_description,
     };
 
     /// A comment token, as collected from `sourceCode.getAllComments()`.
@@ -124,6 +124,16 @@ mod napi_abi {
     pub fn scan_no_duplicate_disable(comments: Vec<CommentInput>) -> Vec<Diagnostic> {
         let core = to_core_comments(&comments);
         no_duplicate_disable(&core)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `no-unused-enable`: report enables that close no open disable.
+    #[napi]
+    pub fn scan_no_unused_enable(comments: Vec<CommentInput>) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        no_unused_enable(&core)
             .into_iter()
             .map(diagnostic_from_core)
             .collect()

--- a/npm/eslint-comments/test/fixtures/no-unused-enable.json
+++ b/npm/eslint-comments/test/fixtures/no-unused-enable.json
@@ -1,0 +1,76 @@
+{
+  "__generated": {
+    "source": "@eslint-community/eslint-plugin-eslint-comments",
+    "version": "4.7.2",
+    "sourceFile": "tests/lib/rules/no-unused-enable.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-comments-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n/*eslint no-undef:error*/\n/*eslint-disable*/\nvar a = b\n/*eslint-enable*/\n"
+    },
+    {
+      "code": "\n/*eslint no-undef:error*/\n/*eslint-disable no-undef*/\nvar a = b\n/*eslint-enable no-undef*/\n"
+    },
+    {
+      "code": "\n/*eslint no-undef:error*/\n/*eslint-disable no-undef*/\nvar a = b\n/*eslint-enable*/\n"
+    },
+    {
+      "code": "\n/*eslint no-undef:error, no-unused-vars:error*/\n/*eslint-disable no-undef,no-unused-vars*/\nvar a = b\n/*eslint-enable no-undef*/\n"
+    },
+    {
+      "code": "\n/*eslint no-undef:error, no-unused-vars:error*/\n/*eslint-disable no-undef,no-unused-vars*/\nvar a = b\n/*eslint-enable*/\n"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "/*eslint-enable*/",
+      "errors": [
+        {
+          "message": "ESLint rules are re-enabled but those have not been disabled.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "/*eslint-enable no-undef*/",
+      "errors": [
+        {
+          "message": "'no-undef' rule is re-enabled but it has not been disabled.",
+          "line": 1,
+          "column": 17,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "\n/*eslint-disable no-unused-vars*/\n/*eslint-enable no-undef*/\n",
+      "errors": [
+        {
+          "message": "'no-undef' rule is re-enabled but it has not been disabled.",
+          "line": 3,
+          "column": 17,
+          "endLine": 3,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "/*eslint-enable -- description*/",
+      "errors": [
+        {
+          "message": "ESLint rules are re-enabled but those have not been disabled.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 33
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-comments/test/plugin.test.mjs
+++ b/npm/eslint-comments/test/plugin.test.mjs
@@ -21,6 +21,7 @@ describe('eslint-comments plugin shape', () => {
       'eslint-comments/no-aggregating-enable': 'error',
       'eslint-comments/no-duplicate-disable': 'error',
       'eslint-comments/no-unlimited-disable': 'error',
+      'eslint-comments/no-unused-enable': 'error',
     });
   });
 });

--- a/status.json
+++ b/status.json
@@ -109,6 +109,22 @@
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-duplicate-disable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "no-unused-enable",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-unused-enable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
       }
     ]
   },


### PR DESCRIPTION
Part of #4 — seventh rule, last of the disabled-area family.

## `no-unused-enable`

Reports an `eslint-enable` comment that re-enables rules which were never disabled (no open disable for it to close).

- `rule_no_unused_enable.rs` reuses the shared `disabled_area` unused-enable tracking; core + insta snapshot. Reports `unusedRule` (with `{{ruleId}}`) or `unused`, at the rule-name column via `to_rule_id_location`.
- NAPI `scan_no_unused_enable`; registered in `index.js` (type `problem`), added to `recommended`.
- `test/fixtures/no-unused-enable.json` from upstream (5 valid / 4 invalid), replayed via espree.

## Verification
- `cargo clippy -D warnings` ✓, `cargo test` ✓
- `vitest` ✓ — 158 cases across the seven ported rules
- `status:check` ✓, sync idempotent ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783583231&installation_id=136613492&pr_number=38&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F38&signature=7ea1c7c79e3facbcfa1f8220d522f7d7509bf7bacd796afb7ed601cab140a63d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->