### PR TITLE
feat(eslint-comments): port no-unused-disable (approximation)

### DIFF
--- a/crates/eslint_comments/src/lib.rs
+++ b/crates/eslint_comments/src/lib.rs
@@ -14,6 +14,7 @@ mod rule_no_aggregating_enable;
 mod rule_no_duplicate_disable;
 mod rule_no_restricted_disable;
 mod rule_no_unlimited_disable;
+mod rule_no_unused_disable;
 mod rule_no_unused_enable;
 mod rule_no_use;
 mod rule_require_description;
@@ -24,6 +25,7 @@ pub use rule_no_aggregating_enable::no_aggregating_enable;
 pub use rule_no_duplicate_disable::no_duplicate_disable;
 pub use rule_no_restricted_disable::no_restricted_disable;
 pub use rule_no_unlimited_disable::no_unlimited_disable;
+pub use rule_no_unused_disable::no_unused_disable;
 pub use rule_no_unused_enable::no_unused_enable;
 pub use rule_no_use::no_use;
 pub use rule_require_description::require_description;
@@ -38,6 +40,16 @@ pub struct Comment<'a> {
     pub kind: CommentKind,
     pub value: &'a str,
     pub loc: Location,
+}
+
+/// A lint problem reported elsewhere in the file, used by `no-unused-disable`
+/// to decide whether a disable directive actually suppressed anything.
+#[derive(Clone, Copy, Debug)]
+pub struct Problem<'a> {
+    /// The reporting rule, or `None` for a syntax-level problem.
+    pub rule_id: Option<&'a str>,
+    /// The problem's start position.
+    pub position: Position,
 }
 
 /// Values interpolated into a diagnostic's message template.

--- a/crates/eslint_comments/src/rule_no_unused_disable.rs
+++ b/crates/eslint_comments/src/rule_no_unused_disable.rs
@@ -1,0 +1,103 @@
+//! `no-unused-disable`: disallow `eslint-disable` comments that suppress no
+//! problem.
+//!
+//! Upstream implements this by patching ESLint's `Linter#verify` to enable
+//! `reportUnusedDisableDirectives` and is deprecated in favor of that built-in.
+//! There is no equivalent hook in the Oxlint plugin API, so this is an
+//! approximation: it reuses the shared disabled-area ranges and marks a disable
+//! as unused when no reported problem matches its rule within its range. The
+//! problems come from `sourceCode.getDisableDirectives().problems` at runtime
+//! (so this rule is exercised with synthetic problems in tests, not via the
+//! espree replay harness).
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::disabled_area::build_disabled_area;
+use crate::loc::{lte, to_rule_id_location};
+use crate::{Comment, Diagnostic, DiagnosticData, Problem};
+
+/// Report each disable directive whose range contains no matching problem.
+pub fn no_unused_disable(comments: &[Comment], problems: &[Problem]) -> SmallVec<[Diagnostic; 8]> {
+    let mut diagnostics = SmallVec::new();
+    let state = build_disabled_area(comments);
+
+    for area in &state.areas {
+        let suppressed_something = problems.iter().any(|problem| {
+            let rule_matches = match area.rule_id.as_deref() {
+                None => true,
+                Some(rule_id) => problem.rule_id == Some(rule_id),
+            };
+            let within = lte(area.start, problem.position)
+                && area.end.is_none_or(|end| lte(problem.position, end));
+            rule_matches && within
+        });
+
+        if suppressed_something {
+            continue;
+        }
+
+        let comment = &comments[area.comment];
+        let loc = to_rule_id_location(comment.value, comment.loc, area.rule_id.as_deref());
+        let message_id = if area.rule_id.is_some() {
+            "unusedRule"
+        } else {
+            "unused"
+        };
+
+        diagnostics.push(Diagnostic {
+            message_id: CompactString::from(message_id),
+            data: DiagnosticData {
+                rule_id: area.rule_id.clone(),
+                ..DiagnosticData::default()
+            },
+            loc,
+        });
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directive::CommentKind;
+    use crate::loc::{Location, Position};
+    use crate::{Comment, Problem, no_unused_disable};
+
+    fn block<'a>(value: &'a str, line: u32) -> Comment<'a> {
+        Comment {
+            kind: CommentKind::Block,
+            value,
+            loc: Location {
+                start: Position { line, column: 0 },
+                end: Position {
+                    line,
+                    column: value.len() as i32 + 4,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn reports_disable_without_matching_problem() {
+        let comments = [block("eslint-disable no-undef", 1)];
+        // A problem for a different rule does not justify the disable.
+        let problems = [Problem {
+            rule_id: Some("eqeqeq"),
+            position: Position { line: 5, column: 0 },
+        }];
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(no_unused_disable(&comments, &problems));
+        }
+    }
+
+    #[test]
+    fn used_disable_is_ok() {
+        let comments = [block("eslint-disable no-undef", 1)];
+        let problems = [Problem {
+            rule_id: Some("no-undef"),
+            position: Position { line: 3, column: 4 },
+        }];
+        assert!(no_unused_disable(&comments, &problems).is_empty());
+    }
+}

--- a/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_unused_disable__tests__reports_disable_without_matching_problem.snap
+++ b/crates/eslint_comments/src/snapshots/oxlint_plugins_eslint_comments__rule_no_unused_disable__tests__reports_disable_without_matching_problem.snap
@@ -1,0 +1,26 @@
+---
+source: crates/eslint_comments/src/rule_no_unused_disable.rs
+expression: "no_unused_disable(&comments, &problems)"
+---
+[
+    Diagnostic {
+        message_id: "unusedRule",
+        data: DiagnosticData {
+            kind: None,
+            rule_id: Some(
+                "no-undef",
+            ),
+            count: None,
+        },
+        loc: Location {
+            start: Position {
+                line: 1,
+                column: 17,
+            },
+            end: Position {
+                line: 1,
+                column: 25,
+            },
+        },
+    },
+]

--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -22,18 +22,21 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 
 ## Rules
 
-| Rule                    | Description                                                | Status |
-| ----------------------- | ---------------------------------------------------------- | ------ |
-| `disable-enable-pair`   | require an `eslint-enable` for every `eslint-disable`      | ported |
-| `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported |
-| `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported |
-| `no-restricted-disable` | disallow `eslint-disable` comments about specific rules    | ported |
-| `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported |
-| `no-unused-enable`      | disallow unused `eslint-enable` comments                   | ported |
-| `no-use`                | disallow ESLint directive-comments                         | ported |
-| `require-description`   | require descriptions in ESLint directive-comments          | ported |
+| Rule                    | Description                                                | Status        |
+| ----------------------- | ---------------------------------------------------------- | ------------- |
+| `disable-enable-pair`   | require an `eslint-enable` for every `eslint-disable`      | ported        |
+| `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported        |
+| `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported        |
+| `no-restricted-disable` | disallow `eslint-disable` comments about specific rules    | ported        |
+| `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported        |
+| `no-unused-disable`     | disallow unused `eslint-disable` comments                  | approximation |
+| `no-unused-enable`      | disallow unused `eslint-enable` comments                   | ported        |
+| `no-use`                | disallow ESLint directive-comments                         | ported        |
+| `require-description`   | require descriptions in ESLint directive-comments          | ported        |
 
-The remaining upstream rule (`no-unused-disable`) is tracked in [issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4) and lands one rule per pull request.
+All nine upstream rules of [`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) are now ported ([issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4)).
+
+> `no-unused-disable` is deprecated upstream (use Oxlint's / ESLint's built-in unused-directive reporting). It is implemented here as an approximation over `sourceCode.getDisableDirectives().problems`; because its upstream test suite needs the lint runtime, it is covered by a synthetic-problem mechanism test rather than the espree replay harness.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -302,12 +302,59 @@ const noRestrictedDisable = commentScanRule(
   (comments, context) => native.scanNoRestrictedDisable(comments, context.options || []),
 );
 
+// `no-unused-disable` needs the file's lint problems, which only exist at run
+// time via `sourceCode.getDisableDirectives()`. It is an approximation of
+// upstream's deprecated Linter-patch behavior and is skipped when the runtime
+// does not expose disable directives.
+const noUnusedDisable = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow unused `eslint-disable` comments',
+      recommended: false,
+      url: `${DOCS_BASE}#no-unused-disable`,
+    },
+    deprecated: true,
+    fixable: null,
+    schema: [],
+    messages: {
+      unused: 'Unused eslint-disable directive (no problems were reported).',
+      unusedRule: "Unused eslint-disable directive (no problems were reported from '{{ruleId}}').",
+    },
+  },
+  createOnce(context) {
+    return {
+      Program() {
+        const sourceCode = context.sourceCode;
+        if (typeof sourceCode.getDisableDirectives !== 'function') {
+          return;
+        }
+
+        const comments = collectComments(sourceCode);
+        if (comments.length === 0) {
+          return;
+        }
+
+        const { problems } = sourceCode.getDisableDirectives();
+        const problemInputs = (problems || []).map((problem) => ({
+          ruleId: problem.ruleId == null ? null : problem.ruleId,
+          line: problem.loc.start.line,
+          column: problem.loc.start.column,
+        }));
+
+        reportDiagnostics(context, native.scanNoUnusedDisable(comments, problemInputs));
+      },
+    };
+  },
+};
+
 const rules = {
   'disable-enable-pair': disableEnablePair,
   'no-aggregating-enable': noAggregatingEnable,
   'no-duplicate-disable': noDuplicateDisable,
   'no-restricted-disable': noRestrictedDisable,
   'no-unlimited-disable': noUnlimitedDisable,
+  'no-unused-disable': noUnusedDisable,
   'no-unused-enable': noUnusedEnable,
   'no-use': noUse,
   'require-description': requireDescription,

--- a/npm/eslint-comments/src/lib.rs
+++ b/npm/eslint-comments/src/lib.rs
@@ -5,10 +5,10 @@
 //! file level instead of one NAPI call per AST node.
 
 pub use napi_abi::{
-    CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, PositionInput,
+    CommentInput, Diagnostic, DiagnosticData, DiagnosticLoc, PositionInput, ProblemInput,
     scan_disable_enable_pair, scan_no_aggregating_enable, scan_no_duplicate_disable,
-    scan_no_restricted_disable, scan_no_unlimited_disable, scan_no_unused_enable, scan_no_use,
-    scan_require_description,
+    scan_no_restricted_disable, scan_no_unlimited_disable, scan_no_unused_disable,
+    scan_no_unused_enable, scan_no_use, scan_require_description,
 };
 
 #[allow(
@@ -20,9 +20,9 @@ mod napi_abi {
     use napi_derive::napi;
     use oxlint_plugins_eslint_comments::directive::CommentKind;
     use oxlint_plugins_eslint_comments::{
-        Comment, Diagnostic as CoreDiagnostic, Location, Position, disable_enable_pair,
+        Comment, Diagnostic as CoreDiagnostic, Location, Position, Problem, disable_enable_pair,
         no_aggregating_enable, no_duplicate_disable, no_restricted_disable, no_unlimited_disable,
-        no_unused_enable, no_use, require_description,
+        no_unused_disable, no_unused_enable, no_use, require_description,
     };
 
     /// A comment token, as collected from `sourceCode.getAllComments()`.
@@ -43,6 +43,15 @@ mod napi_abi {
     #[napi(object)]
     #[derive(Clone, Debug)]
     pub struct PositionInput {
+        pub line: u32,
+        pub column: i32,
+    }
+
+    /// A lint problem from `sourceCode.getDisableDirectives().problems`.
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct ProblemInput {
+        pub rule_id: Option<String>,
         pub line: u32,
         pub column: i32,
     }
@@ -149,6 +158,29 @@ mod napi_abi {
         let core = to_core_comments(&comments);
         let pattern_refs: Vec<&str> = patterns.iter().map(String::as_str).collect();
         no_restricted_disable(&core, &pattern_refs)
+            .into_iter()
+            .map(diagnostic_from_core)
+            .collect()
+    }
+
+    /// `no-unused-disable`: report disables that suppress none of `problems`.
+    #[napi]
+    pub fn scan_no_unused_disable(
+        comments: Vec<CommentInput>,
+        problems: Vec<ProblemInput>,
+    ) -> Vec<Diagnostic> {
+        let core = to_core_comments(&comments);
+        let core_problems: Vec<Problem> = problems
+            .iter()
+            .map(|problem| Problem {
+                rule_id: problem.rule_id.as_deref(),
+                position: Position {
+                    line: problem.line,
+                    column: problem.column,
+                },
+            })
+            .collect();
+        no_unused_disable(&core, &core_problems)
             .into_iter()
             .map(diagnostic_from_core)
             .collect()

--- a/npm/eslint-comments/test/no-unused-disable.test.mjs
+++ b/npm/eslint-comments/test/no-unused-disable.test.mjs
@@ -1,0 +1,60 @@
+// `no-unused-disable` needs the file's lint problems, which exist only at
+// runtime via `sourceCode.getDisableDirectives()`. The espree replay harness
+// cannot provide those, so this rule's mechanism is exercised here with a mock
+// `sourceCode` that supplies synthetic problems.
+
+import * as espree from 'espree';
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const rule = plugin.rules['no-unused-disable'];
+
+function run(code, problems) {
+  const ast = espree.parse(code, { comment: true, loc: true, range: true, ecmaVersion: 'latest' });
+  const sourceCode = {
+    text: code,
+    ast,
+    getAllComments: () => ast.comments ?? [],
+    getDisableDirectives: () => ({ problems, directives: [] }),
+  };
+
+  const reports = [];
+  const context = { options: [], sourceCode, report: (d) => reports.push(d) };
+  const visitor = rule.createOnce(context);
+  visitor.Program?.(ast);
+
+  return reports.map((d) => ({
+    messageId: d.messageId,
+    ruleId: d.data?.ruleId,
+    line: d.loc.start.line,
+    column: d.loc.start.column + 1,
+  }));
+}
+
+function problem(ruleId, line, column) {
+  return { ruleId, loc: { start: { line, column }, end: { line, column } } };
+}
+
+describe('no-unused-disable (approximation)', () => {
+  it('is marked deprecated', () => {
+    expect(rule.meta.deprecated).toBe(true);
+  });
+
+  it('reports a disable that suppressed no matching problem', () => {
+    expect(run('/* eslint-disable no-undef */\nvar a = 1\n', [])).toEqual([
+      { messageId: 'unusedRule', ruleId: 'no-undef', line: 1, column: 19 },
+    ]);
+  });
+
+  it('does not report a disable that suppressed a matching problem', () => {
+    expect(run('/* eslint-disable no-undef */\nb()\n', [problem('no-undef', 2, 0)])).toEqual([]);
+  });
+
+  it('reports a bare disable only when nothing was reported', () => {
+    expect(run('/* eslint-disable */\nvar a = 1\n', [])).toEqual([
+      { messageId: 'unused', ruleId: undefined, line: 1, column: 0 },
+    ]);
+    expect(run('/* eslint-disable */\nb()\n', [problem('no-undef', 2, 0)])).toEqual([]);
+  });
+});

--- a/status.json
+++ b/status.json
@@ -141,6 +141,22 @@
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-restricted-disable; gitignore-style pattern matching in Rust; upstream RuleTester cases replayed via test/fixtures."
+      },
+      {
+        "name": "no-unused-disable",
+        "status": "approximation",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Deprecated upstream (use reportUnusedDisableDirectives). Approximation built on sourceCode.getDisableDirectives().problems; the upstream RuleTester suite needs the ESLint runtime, so the rule is covered by a synthetic-problem mechanism test (insta + Vitest) instead of the espree replay harness."
       }
     ]
   },

--- a/tools/tasks/sync-eslint-comments-tests.ts
+++ b/tools/tasks/sync-eslint-comments-tests.ts
@@ -247,14 +247,24 @@ function isPresent<T>(value: T | null): value is T {
   return value != null;
 }
 
+// Rules whose upstream RuleTester suite cannot be replayed by the espree
+// harness because it depends on the ESLint runtime (lint problems), not just
+// parsed comments. These are covered by dedicated mechanism tests instead.
+const RUNTIME_ONLY_RULES = new Set(['no-unused-disable']);
+
 function getPortedRules(): string[] {
   const pkgRequire = createRequire(join(ROOT, 'npm', 'eslint-comments', 'index.js'));
   const loaded = pkgRequire(resolve(ROOT, 'npm', 'eslint-comments', 'index.js')) as {
     rules?: Record<string, unknown>;
   };
-  const rules = loaded.rules ? Object.keys(loaded.rules) : [];
+  const rules = (loaded.rules ? Object.keys(loaded.rules) : []).filter(
+    (rule) => !RUNTIME_ONLY_RULES.has(rule),
+  );
   if (rules.length === 0) {
     throw new Error('No rules found on the eslint-comments plugin; build it first (vp build).');
+  }
+  for (const rule of RUNTIME_ONLY_RULES) {
+    console.log(`- ${rule}: skipped (needs ESLint runtime problems; covered by a mechanism test)`);
   }
   return rules.sort();
 }


### PR DESCRIPTION
Part of #4 — ninth and final rule. Completes the port of all nine upstream rules.

## `no-unused-disable` (approximation)

Deprecated upstream: it patches ESLint's `Linter#verify` to enable `reportUnusedDisableDirectives`. The Oxlint plugin API has no such hook, so this is an approximation built on `sourceCode.getDisableDirectives().problems`: it reuses the shared disabled-area ranges and marks a disable unused when no reported problem matches its rule within its range.

- `rule_no_unused_disable.rs`: core + insta snapshot (synthetic problems).
- New `Problem`/`ProblemInput` types; NAPI `scan_no_unused_disable(comments, problems)`. The `index.js` rule is marked `deprecated`, gathers problems from `getDisableDirectives()`, and is a no-op when the runtime lacks that API.
- Its upstream RuleTester suite needs the lint runtime, so it is **excluded from the espree replay** (the sync tool skips it and logs why) and covered by a **synthetic-problem mechanism test** instead.
- Sync tool also stubs `eslint/use-at-your-own-risk` for capture robustness.
- `status.json` (status `approximation`) and README updated.

## Verification
- `cargo clippy -D warnings` ✓, `cargo test` ✓
- `vitest` ✓ — 193 cases across all nine ported rules
- `status:check` ✓, sync idempotent ✓

With this PR, all nine rules of `@eslint-community/eslint-plugin-eslint-comments` are ported (issue #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584288&installation_id=136613492&pr_number=40&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F40&signature=8fc1f1b44f57c7c3aab88ef612be70d16425dc3feabc26e1c117e589372d901f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->