### PR TITLE
docs: note eslint-plugin-vue exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ vp run release patch
 
 ## Port Targets
 
-`tools/port-targets.json` lists the ESLint plugins used by flyle-nexus that Oxlint does not yet support natively (`eslint-plugin-svelte` is excluded; it is handled by [rsvelte](https://github.com/baseballyama/rsvelte)). Their sources are vendored under `upstream/` as submodules.
+`tools/port-targets.json` lists the ESLint plugins used by flyle-nexus that Oxlint does not yet support natively (`eslint-plugin-svelte` is excluded; it is handled by [rsvelte](https://github.com/baseballyama/rsvelte), and `eslint-plugin-vue` is excluded; it is handled by [vize](https://vizejs.dev/)). Their sources are vendored under `upstream/` as submodules.
 
 ```sh
 git submodule update --init --depth 1   # fetch upstream sources

--- a/docs/port-targets/README.md
+++ b/docs/port-targets/README.md
@@ -2,7 +2,7 @@
 
 # Port targets
 
-ESLint plugins and adjacent packages used by [flyle-nexus], collected here as port targets or upstream references. `eslint-plugin-svelte` is intentionally excluded — it is handled by [rsvelte](https://github.com/baseballyama/rsvelte). Oxlint-supported plugins (`eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-unicorn`) are used directly via Oxlint and are not listed here.
+ESLint plugins and adjacent packages used by [flyle-nexus], collected here as port targets or upstream references. `eslint-plugin-svelte` is intentionally excluded — it is handled by [rsvelte](https://github.com/baseballyama/rsvelte). `eslint-plugin-vue` is intentionally excluded — it is handled by [vize](https://vizejs.dev/). Oxlint-supported plugins (`eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-unicorn`) are used directly via Oxlint and are not listed here.
 
 Upstream source is vendored under `upstream/` as git submodules pinned to each plugin's baseline version. The per-rule inventory below is generated from that source.
 

--- a/tools/port-targets.json
+++ b/tools/port-targets.json
@@ -1,5 +1,5 @@
 {
-  "$note": "Port-target manifest for ESLint plugins and adjacent upstream packages used by flyle-nexus (eslint-plugin-svelte is intentionally excluded; it is handled by rsvelte). This file is the single source of truth for tools/tasks/enumerate-port-rules.ts (rule enumeration) and .github/workflows/track-upstream-releases.yml (release follow-up issues). baselineVersion is the upstream npm version flyle-nexus currently uses and the version the port should target first.",
+  "$note": "Port-target manifest for ESLint plugins and adjacent upstream packages used by flyle-nexus (eslint-plugin-svelte is intentionally excluded; it is handled by rsvelte. eslint-plugin-vue is intentionally excluded; it is handled by vize). This file is the single source of truth for tools/tasks/enumerate-port-rules.ts (rule enumeration) and .github/workflows/track-upstream-releases.yml (release follow-up issues). baselineVersion is the upstream npm version flyle-nexus currently uses and the version the port should target first.",
   "submoduleRoot": "upstream",
   "plugins": [
     {

--- a/tools/tasks/enumerate-port-rules.ts
+++ b/tools/tasks/enumerate-port-rules.ts
@@ -376,6 +376,7 @@ function renderIndex(
   lines.push(
     'ESLint plugins and adjacent packages used by [flyle-nexus], collected here as port targets or upstream references. ' +
       '`eslint-plugin-svelte` is intentionally excluded — it is handled by [rsvelte](https://github.com/baseballyama/rsvelte). ' +
+      '`eslint-plugin-vue` is intentionally excluded — it is handled by [vize](https://vizejs.dev/). ' +
       'Oxlint-supported plugins (`eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-unicorn`) are used directly via Oxlint and are not listed here.',
   );
   lines.push('');


### PR DESCRIPTION
## Summary

- Note that `eslint-plugin-vue` is intentionally excluded because vize covers it.
- Keep the generated port-targets README in sync with the generator and manifest note.

## Verification

- `node tools/tasks/enumerate-port-rules.ts`
- `git diff --check`