### PR TITLE
feat(eslint-comments): expose directive scan apis

### DIFF
--- a/npm/eslint-comments/api.d.ts
+++ b/npm/eslint-comments/api.d.ts
@@ -28,4 +28,42 @@ export interface Diagnostic {
   loc: DiagnosticLoc;
 }
 
+export interface PositionInput {
+  line: number;
+  column: number;
+}
+
+export interface ProblemInput {
+  ruleId?: string | null;
+  line?: number;
+  column?: number;
+  loc?: {
+    start?: {
+      line?: number;
+      column?: number;
+    };
+  };
+}
+
+export declare function scanDisableEnablePair(
+  comments: CommentInput[],
+  allowWholeFile?: boolean,
+  firstTokenStart?: PositionInput | null,
+): Diagnostic[];
+export declare function scanNoAggregatingEnable(comments: CommentInput[]): Diagnostic[];
+export declare function scanNoDuplicateDisable(comments: CommentInput[]): Diagnostic[];
+export declare function scanNoRestrictedDisable(
+  comments: CommentInput[],
+  patterns?: string[],
+): Diagnostic[];
 export declare function scanNoUnlimitedDisable(comments: CommentInput[]): Diagnostic[];
+export declare function scanNoUnusedDisable(
+  comments: CommentInput[],
+  problems?: ProblemInput[],
+): Diagnostic[];
+export declare function scanNoUnusedEnable(comments: CommentInput[]): Diagnostic[];
+export declare function scanNoUse(comments: CommentInput[], allow?: string[]): Diagnostic[];
+export declare function scanRequireDescription(
+  comments: CommentInput[],
+  ignore?: string[],
+): Diagnostic[];

--- a/npm/eslint-comments/api.js
+++ b/npm/eslint-comments/api.js
@@ -27,11 +27,104 @@ function normalizeComments(comments) {
   });
 }
 
+function normalizeStrings(name, values) {
+  if (!Array.isArray(values) || values.some((value) => typeof value !== 'string')) {
+    throw new TypeError(`${name} must be an array of strings.`);
+  }
+
+  return values;
+}
+
+function normalizePosition(position) {
+  if (!position || typeof position.line !== 'number' || typeof position.column !== 'number') {
+    throw new TypeError('position must have numeric line and column fields.');
+  }
+
+  return {
+    line: position.line >>> 0,
+    column: position.column | 0,
+  };
+}
+
+function normalizeProblems(problems = []) {
+  if (!Array.isArray(problems)) {
+    throw new TypeError('problems must be an array.');
+  }
+
+  return problems.map((problem) => {
+    if (!problem || (problem.ruleId != null && typeof problem.ruleId !== 'string')) {
+      throw new TypeError('each problem must have a nullable string ruleId.');
+    }
+
+    const line = problem.line ?? problem.loc?.start?.line;
+    const column = problem.column ?? problem.loc?.start?.column;
+    if (typeof line !== 'number' || typeof column !== 'number') {
+      throw new TypeError('each problem must have numeric line and column fields.');
+    }
+
+    return {
+      ruleId: problem.ruleId == null ? null : problem.ruleId,
+      line: line >>> 0,
+      column: column | 0,
+    };
+  });
+}
+
+function scanDisableEnablePair(comments, allowWholeFile = false, firstTokenStart = null) {
+  return native.scanDisableEnablePair(
+    normalizeComments(comments),
+    !!allowWholeFile,
+    firstTokenStart == null ? null : normalizePosition(firstTokenStart),
+  );
+}
+
+function scanNoAggregatingEnable(comments) {
+  return native.scanNoAggregatingEnable(normalizeComments(comments));
+}
+
+function scanNoDuplicateDisable(comments) {
+  return native.scanNoDuplicateDisable(normalizeComments(comments));
+}
+
+function scanNoRestrictedDisable(comments, patterns = []) {
+  return native.scanNoRestrictedDisable(
+    normalizeComments(comments),
+    normalizeStrings('patterns', patterns),
+  );
+}
+
 function scanNoUnlimitedDisable(comments) {
   return native.scanNoUnlimitedDisable(normalizeComments(comments));
 }
 
+function scanNoUnusedDisable(comments, problems = []) {
+  return native.scanNoUnusedDisable(normalizeComments(comments), normalizeProblems(problems));
+}
+
+function scanNoUnusedEnable(comments) {
+  return native.scanNoUnusedEnable(normalizeComments(comments));
+}
+
+function scanNoUse(comments, allow = []) {
+  return native.scanNoUse(normalizeComments(comments), normalizeStrings('allow', allow));
+}
+
+function scanRequireDescription(comments, ignore = []) {
+  return native.scanRequireDescription(
+    normalizeComments(comments),
+    normalizeStrings('ignore', ignore),
+  );
+}
+
 module.exports = {
+  scanDisableEnablePair,
+  scanNoAggregatingEnable,
+  scanNoDuplicateDisable,
+  scanNoRestrictedDisable,
   scanNoUnlimitedDisable,
+  scanNoUnusedDisable,
+  scanNoUnusedEnable,
+  scanNoUse,
+  scanRequireDescription,
 };
 module.exports.default = module.exports;

--- a/npm/eslint-comments/test/api.test.mjs
+++ b/npm/eslint-comments/test/api.test.mjs
@@ -1,27 +1,47 @@
 import { describe, expect, it } from 'vitest';
 
-import { scanNoUnlimitedDisable } from '../api.js';
+import {
+  scanDisableEnablePair,
+  scanNoAggregatingEnable,
+  scanNoDuplicateDisable,
+  scanNoRestrictedDisable,
+  scanNoUnlimitedDisable,
+  scanNoUnusedDisable,
+  scanNoUnusedEnable,
+  scanNoUse,
+  scanRequireDescription,
+} from '../api.js';
+
+function block(value, line = 1) {
+  return {
+    kind: 'Block',
+    value,
+    startLine: line,
+    startColumn: 0,
+    endLine: line,
+    endColumn: value.length + 4,
+  };
+}
 
 describe('JS API', () => {
+  it('exports the NAPI-backed scans used by the plugin rules', () => {
+    expect(
+      [
+        scanDisableEnablePair,
+        scanNoAggregatingEnable,
+        scanNoDuplicateDisable,
+        scanNoRestrictedDisable,
+        scanNoUnlimitedDisable,
+        scanNoUnusedDisable,
+        scanNoUnusedEnable,
+        scanNoUse,
+        scanRequireDescription,
+      ].every((fn) => typeof fn === 'function'),
+    ).toBe(true);
+  });
+
   it('reports unlimited disables and ignores scoped ones', () => {
-    const comments = [
-      {
-        kind: 'Block',
-        value: 'eslint-disable ',
-        startLine: 1,
-        startColumn: 0,
-        endLine: 1,
-        endColumn: 19,
-      },
-      {
-        kind: 'Block',
-        value: 'eslint-disable eqeqeq',
-        startLine: 2,
-        startColumn: 0,
-        endLine: 2,
-        endColumn: 25,
-      },
-    ];
+    const comments = [block('eslint-disable '), block('eslint-disable eqeqeq', 2)];
 
     expect(scanNoUnlimitedDisable(comments)).toEqual([
       {
@@ -34,5 +54,104 @@ describe('JS API', () => {
 
   it('rejects non-array input', () => {
     expect(() => scanNoUnlimitedDisable(null)).toThrow(TypeError);
+  });
+
+  it('reports disabled areas without enable pairs', () => {
+    expect(scanDisableEnablePair([block('eslint-disable no-undef')])).toEqual([
+      {
+        messageId: 'missingRulePair',
+        data: { ruleId: 'no-undef' },
+        loc: { startLine: 1, startColumn: 17, endLine: 1, endColumn: 25 },
+      },
+    ]);
+  });
+
+  it('reports aggregating enables and duplicate disables', () => {
+    const comments = [
+      block('eslint-disable no-undef'),
+      block('eslint-disable no-unused-vars', 2),
+      block('eslint-enable', 3),
+    ];
+
+    expect(scanNoAggregatingEnable(comments)).toEqual([
+      {
+        messageId: 'aggregatingEnable',
+        data: { count: 2 },
+        loc: { startLine: 3, startColumn: -1, endLine: 3, endColumn: 17 },
+      },
+    ]);
+
+    expect(
+      scanNoDuplicateDisable([
+        block('eslint-disable no-undef'),
+        block('eslint-disable no-undef', 2),
+      ]),
+    ).toEqual([
+      {
+        messageId: 'duplicateRule',
+        data: { ruleId: 'no-undef' },
+        loc: { startLine: 2, startColumn: 17, endLine: 2, endColumn: 25 },
+      },
+    ]);
+  });
+
+  it('reports restricted disables with rule-id locations', () => {
+    expect(
+      scanNoRestrictedDisable(
+        [block('eslint-disable semi, no-extra-semi, comma-style')],
+        ['*semi*'],
+      ),
+    ).toEqual([
+      {
+        messageId: 'disallow',
+        data: { ruleId: 'semi' },
+        loc: { startLine: 1, startColumn: 17, endLine: 1, endColumn: 21 },
+      },
+      {
+        messageId: 'disallow',
+        data: { ruleId: 'no-extra-semi' },
+        loc: { startLine: 1, startColumn: 23, endLine: 1, endColumn: 36 },
+      },
+    ]);
+  });
+
+  it('reports unused disables from synthetic lint problems', () => {
+    expect(scanNoUnusedDisable([block('eslint-disable no-undef')], [])).toEqual([
+      {
+        messageId: 'unusedRule',
+        data: { ruleId: 'no-undef' },
+        loc: { startLine: 1, startColumn: 17, endLine: 1, endColumn: 25 },
+      },
+    ]);
+
+    expect(
+      scanNoUnusedDisable(
+        [block('eslint-disable no-undef')],
+        [{ ruleId: 'no-undef', loc: { start: { line: 2, column: 0 } } }],
+      ),
+    ).toEqual([]);
+  });
+
+  it('reports unused enables for global and rule-specific directives', () => {
+    expect(
+      scanNoUnusedEnable([block('eslint-enable'), block('eslint-enable no-undef', 2)]),
+    ).toEqual([
+      {
+        messageId: 'unused',
+        data: {},
+        loc: { startLine: 1, startColumn: -1, endLine: 1, endColumn: 17 },
+      },
+      {
+        messageId: 'unusedRule',
+        data: { ruleId: 'no-undef' },
+        loc: { startLine: 2, startColumn: 16, endLine: 2, endColumn: 24 },
+      },
+    ]);
+  });
+
+  it('normalizes rule option lists for no-use and require-description', () => {
+    expect(scanNoUse([block('eslint-disable')], ['eslint-disable'])).toEqual([]);
+    expect(scanRequireDescription([block('eslint-disable')], ['eslint-disable'])).toEqual([]);
+    expect(() => scanNoRestrictedDisable([], ['semi', 1])).toThrow(TypeError);
   });
 });

--- a/npm/eslint-comments/test/lsp.test.mjs
+++ b/npm/eslint-comments/test/lsp.test.mjs
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 
 import { runRule } from './harness.mjs';
 
-function toLspDiagnostics(reports) {
+function toLspDiagnostics(ruleName, reports) {
   return reports.map((report) => ({
     range: {
       start: { line: report.line - 1, character: Math.max(0, report.column - 1) },
@@ -15,16 +15,17 @@ function toLspDiagnostics(reports) {
     },
     severity: 1,
     source: 'oxlint-plugins',
-    code: `eslint-comments/no-unlimited-disable`,
+    code: `eslint-comments/${ruleName}`,
     message: report.message,
   }));
 }
 
 describe('LSP diagnostics fixture', () => {
   it('emits a diagnostic for an unlimited disable', () => {
-    const reports = runRule('no-unlimited-disable', { code: '\n/*eslint-disable*/\n' });
+    const ruleName = 'no-unlimited-disable';
+    const reports = runRule(ruleName, { code: '\n/*eslint-disable*/\n' });
 
-    expect(toLspDiagnostics(reports)).toMatchInlineSnapshot(`
+    expect(toLspDiagnostics(ruleName, reports)).toMatchInlineSnapshot(`
       [
         {
           "code": "eslint-comments/no-unlimited-disable",
@@ -36,6 +37,77 @@ describe('LSP diagnostics fixture', () => {
             },
             "start": {
               "character": 0,
+              "line": 1,
+            },
+          },
+          "severity": 1,
+          "source": "oxlint-plugins",
+        },
+      ]
+    `);
+  });
+
+  it('emits diagnostics for restricted disables', () => {
+    const ruleName = 'no-restricted-disable';
+    const reports = runRule(ruleName, {
+      code: '\n/*eslint-disable semi, no-extra-semi, comma-style*/\n',
+      options: ['*semi*'],
+    });
+
+    expect(toLspDiagnostics(ruleName, reports)).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "eslint-comments/no-restricted-disable",
+          "message": "Disabling 'semi' is not allowed.",
+          "range": {
+            "end": {
+              "character": 21,
+              "line": 1,
+            },
+            "start": {
+              "character": 17,
+              "line": 1,
+            },
+          },
+          "severity": 1,
+          "source": "oxlint-plugins",
+        },
+        {
+          "code": "eslint-comments/no-restricted-disable",
+          "message": "Disabling 'no-extra-semi' is not allowed.",
+          "range": {
+            "end": {
+              "character": 36,
+              "line": 1,
+            },
+            "start": {
+              "character": 23,
+              "line": 1,
+            },
+          },
+          "severity": 1,
+          "source": "oxlint-plugins",
+        },
+      ]
+    `);
+  });
+
+  it('emits diagnostics for unused enables', () => {
+    const ruleName = 'no-unused-enable';
+    const reports = runRule(ruleName, { code: '\n/*eslint-enable no-undef*/\n' });
+
+    expect(toLspDiagnostics(ruleName, reports)).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "eslint-comments/no-unused-enable",
+          "message": "'no-undef' rule is re-enabled but it has not been disabled.",
+          "range": {
+            "end": {
+              "character": 24,
+              "line": 1,
+            },
+            "start": {
+              "character": 16,
               "line": 1,
             },
           },

--- a/status.json
+++ b/status.json
@@ -121,7 +121,7 @@
         "tests": {
           "insta": true,
           "vitest": true,
-          "lsp": false,
+          "lsp": true,
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-unused-enable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
@@ -137,7 +137,7 @@
         "tests": {
           "insta": true,
           "vitest": true,
-          "lsp": false,
+          "lsp": true,
           "oxlintIntegration": false
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-restricted-disable; gitignore-style pattern matching in Rust; upstream RuleTester cases replayed via test/fixtures."


### PR DESCRIPTION
## What changed

- Exposes every NAPI-backed eslint-comments rule scan through the package-level `api.js` / `api.d.ts` programmatic API.
- Adds input normalization for comment batches, string option lists, first-token positions, and synthetic lint problems used by `no-unused-disable`.
- Expands JS API coverage across the completed directive-comment rules, including unused-disable synthetic problem handling.
- Adds LSP diagnostic snapshots for `no-restricted-disable` and `no-unused-enable`, and updates `status.json` to reflect that coverage.

## Validation

- `vp test npm/eslint-comments/test`
- `vp run verify`

Note: local `vp lint` still reports an existing warning in `npm/type-aware/src/rules/native_bridge.ts:588` for `renderTypeTexts`, but `vp run verify` exits 0.