### PR TITLE
feat(react-refresh): port only-export-components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +19,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -108,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "ctor"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +155,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "encode_unicode"
@@ -293,6 +317,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -442,10 +469,254 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "oxc-miette"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
+dependencies = [
+ "cfg-if",
+ "owo-colors",
+ "oxc-miette-derive",
+ "textwrap",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "oxc-miette-derive"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d732c2d8df8067a8d7417be81a8a4631e3201ad420ae70aa2426aebf7bc0326"
+dependencies = [
+ "allocator-api2",
+ "hashbrown 0.17.1",
+ "oxc_data_structures",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29512a9acf168a734cbead68ae798c07102b9ecb897cdbe17a40d327b5fff2ec"
+dependencies = [
+ "bitflags",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06186227ab1f27f214d824030ef8d7abd604fb24cd647d2acfebfe6bbe378dc6"
+dependencies = [
+ "phf",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46270ed833a7d2e5f5fbf0c51f970c2d7e1ef09356d40798cf4702f7d2dae30d"
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b0ebb338486583af9e603f4d20be123ad3ae52a5415265454995020386d8afe"
+dependencies = [
+ "cow-utils",
+ "oxc-miette",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef5f3e346539b48dbda9d0b618021ba6bb781f7a192476e4bf9b18df7ccaab4"
+dependencies = [
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816dfd17df8b02a45b122a1f7bb3c1486d4392e0163aea0e6334ad3894a7ea6b"
+
+[[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
+ "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cb9af99a1d02989ed53780e3b2b67757226d4501365e65781ae4519be150b6"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecfe28ec0ffa88784155900d5b7ea1f8383f69d80659ed86f1c4a18a6f117488"
+dependencies = [
+ "bitflags",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "rustc-hash",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fbd1667674fd9c25e079a0ab84a87b26e2946d1ce86ad6c5827afa0518c493"
+dependencies = [
+ "compact_str",
+ "oxc-miette",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887823468316c2b4798275976857edeb0574201a944810f2f94f3d79aaf6187e"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.1",
+ "oxc_allocator",
+ "oxc_estree",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad8963ea5ad880d3185db2f8a50809e3a10772c2762500518229bca5347be04"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_index",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "unicode-id-start",
+]
 
 [[package]]
 name = "oxlint-plugin-eslint-comments"
@@ -467,6 +738,17 @@ dependencies = [
  "napi-derive",
  "oxlint-plugins-_carton",
  "oxlint-plugins-stylistic",
+]
+
+[[package]]
+name = "oxlint-plugin-react-refresh"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-react-refresh",
 ]
 
 [[package]]
@@ -501,6 +783,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugins-react-refresh"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxlint-plugins-_carton",
+]
+
+[[package]]
 name = "oxlint-plugins-stylistic"
 version = "0.0.0"
 dependencies = [
@@ -511,6 +805,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -639,6 +939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +1012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,16 +1058,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,11 @@
 members = [
   "crates/_carton",
   "crates/eslint_comments",
+  "crates/react_refresh",
   "crates/stylistic",
   "npm/eslint-comments",
   "npm/no-forbidden-identifiers",
+  "npm/react-refresh",
   "npm/stylistic",
 ]
 resolver = "3"
@@ -25,8 +27,13 @@ insta = "1.47.2"
 napi = { version = "3.9.0", default-features = false, features = ["napi9", "serde-json"] }
 napi-build = "2.3.2"
 napi-derive = "3.5.6"
+oxc_allocator = "0.135.0"
+oxc_ast = "0.135.0"
+oxc_parser = "0.135.0"
+oxc_span = "0.135.0"
 oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_carton", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }
+oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }
 phf = { version = "0.13.1", features = ["macros"] }
 rustc-hash = "2.1.1"

--- a/crates/react_refresh/Cargo.toml
+++ b/crates/react_refresh/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oxlint-plugins-react-refresh"
+description = "Shared rule helpers for the Rust-backed react-refresh oxlint plugin."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/react_refresh/src/lib.rs
+++ b/crates/react_refresh/src/lib.rs
@@ -1,0 +1,829 @@
+#![doc = "Rust implementation of eslint-plugin-react-refresh rule logic."]
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, BindingIdentifier, BindingPattern, CallExpression, Class, ClassElement, Declaration,
+    ExportDefaultDeclaration, ExportDefaultDeclarationKind, ExportNamedDeclaration, Expression,
+    FunctionType, IdentifierReference, ImportOrExportKind, ModuleExportName, PropertyKey,
+    Statement, TaggedTemplateExpression, VariableDeclaration,
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Built-in higher-order components accepted by `only-export-components`.
+pub const DEFAULT_HOCS: [&str; 3] = ["memo", "forwardRef", "lazy"];
+
+/// Expression node kinds that can be exported alongside components when
+/// `allowConstantExport` is enabled.
+pub const CONSTANT_EXPORT_EXPRESSION_KINDS: [&str; 4] = [
+    "Literal",
+    "UnaryExpression",
+    "TemplateLiteral",
+    "BinaryExpression",
+];
+
+#[derive(Debug, Default)]
+pub struct OnlyExportComponentsOptions {
+    pub extra_hocs: SmallVec<[CompactString; 4]>,
+    pub allow_export_names: SmallVec<[CompactString; 8]>,
+    pub allow_constant_export: bool,
+    pub check_js: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub message_id: &'static str,
+    pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Copy)]
+struct NamedSpan<'a> {
+    name: &'a str,
+    span: Span,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ComponentCheck {
+    Yes,
+    No,
+    NeedName,
+}
+
+#[derive(Default)]
+struct ScanState {
+    has_exports: bool,
+    has_react_export: bool,
+    react_is_in_scope: bool,
+    local_components: SmallVec<[Span; 8]>,
+    non_component_exports: SmallVec<[Span; 8]>,
+    react_context_exports: SmallVec<[Span; 4]>,
+    diagnostics: SmallVec<[Diagnostic; 8]>,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+/// Returns true when `name` follows React component PascalCase naming.
+pub fn is_react_component_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_uppercase() {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+/// Returns true for filenames intentionally skipped by upstream.
+pub fn is_excluded_test_like_filename(filename: &str) -> bool {
+    [".test.", ".spec.", ".cy.", ".stories."]
+        .iter()
+        .any(|needle| filename.contains(needle))
+}
+
+/// Returns true when the rule should inspect the file.
+pub fn should_scan_filename(filename: &str, check_js: bool) -> bool {
+    if is_excluded_test_like_filename(filename) {
+        return false;
+    }
+
+    filename.ends_with(".jsx")
+        || filename.ends_with(".tsx")
+        || (check_js && filename.ends_with(".js"))
+}
+
+pub fn is_constant_export_expression_kind(kind: &str) -> bool {
+    CONSTANT_EXPORT_EXPRESSION_KINDS.contains(&kind)
+}
+
+pub fn default_hocs() -> SmallVec<[&'static str; 3]> {
+    DEFAULT_HOCS.into_iter().collect()
+}
+
+pub fn scan_only_export_components(
+    source_text: &str,
+    filename: &str,
+    options: &OnlyExportComponentsOptions,
+) -> SmallVec<[Diagnostic; 8]> {
+    if !should_scan_filename(filename, options.check_js) {
+        return SmallVec::new();
+    }
+
+    let allocator = Allocator::default();
+    let source_type = source_type_for_filename(filename, options.check_js);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let line_index = LineIndex::new(source_text);
+    let mut scanner = Scanner {
+        line_index: &line_index,
+        options,
+        source_text,
+        state: ScanState::default(),
+    };
+    scanner.scan_program(&parser_return.program.body);
+    scanner.finish()
+}
+
+fn source_type_for_filename(filename: &str, check_js: bool) -> SourceType {
+    if filename.ends_with(".tsx") {
+        SourceType::tsx()
+    } else if filename.ends_with(".jsx") || (check_js && filename.ends_with(".js")) {
+        SourceType::jsx()
+    } else {
+        SourceType::from_path(Path::new(filename)).unwrap_or_else(|_| SourceType::mjs())
+    }
+}
+
+struct Scanner<'a> {
+    line_index: &'a LineIndex,
+    options: &'a OnlyExportComponentsOptions,
+    source_text: &'a str,
+    state: ScanState,
+}
+
+impl Scanner<'_> {
+    fn scan_program(&mut self, body: &[Statement<'_>]) {
+        for node in body {
+            match node {
+                Statement::ExportAllDeclaration(declaration) => {
+                    if declaration.export_kind == ImportOrExportKind::Type {
+                        continue;
+                    }
+                    self.state.has_exports = true;
+                    self.report("exportAll", declaration.span);
+                }
+                Statement::ExportDefaultDeclaration(declaration) => {
+                    self.state.has_exports = true;
+                    self.handle_default_export_declaration(declaration);
+                }
+                Statement::ExportNamedDeclaration(declaration) => {
+                    self.handle_named_export_declaration(declaration);
+                }
+                Statement::VariableDeclaration(declaration) => {
+                    self.collect_local_variable_components(declaration);
+                }
+                Statement::FunctionDeclaration(function) => {
+                    if let Some(id) = &function.id
+                        && is_react_component_name(id.name.as_str())
+                    {
+                        self.state.local_components.push(id.span);
+                    }
+                }
+                Statement::ImportDeclaration(declaration)
+                    if declaration.source.value.as_str() == "react" =>
+                {
+                    self.state.react_is_in_scope = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn finish(mut self) -> SmallVec<[Diagnostic; 8]> {
+        if self.options.check_js && !self.state.react_is_in_scope {
+            return SmallVec::new();
+        }
+
+        if self.state.has_exports {
+            if self.state.has_react_export {
+                for span in std::mem::take(&mut self.state.non_component_exports) {
+                    self.report("namedExport", span);
+                }
+                for span in std::mem::take(&mut self.state.react_context_exports) {
+                    self.report("reactContext", span);
+                }
+            } else if !self.state.local_components.is_empty() {
+                for span in std::mem::take(&mut self.state.local_components) {
+                    self.report("localComponents", span);
+                }
+            }
+        } else if !self.state.local_components.is_empty() {
+            for span in std::mem::take(&mut self.state.local_components) {
+                self.report("noExport", span);
+            }
+        }
+
+        self.state.diagnostics
+    }
+
+    fn handle_named_export_declaration(&mut self, declaration: &ExportNamedDeclaration<'_>) {
+        if declaration.export_kind == ImportOrExportKind::Type {
+            return;
+        }
+
+        if let Some(Declaration::FunctionDeclaration(function)) = &declaration.declaration
+            && function.r#type == FunctionType::TSDeclareFunction
+        {
+            return;
+        }
+
+        self.state.has_exports = true;
+        if let Some(declaration) = &declaration.declaration {
+            self.handle_export_declaration(declaration);
+        }
+
+        for specifier in &declaration.specifiers {
+            if specifier.export_kind == ImportOrExportKind::Type {
+                continue;
+            }
+            let exported = named_export_identifier(&specifier.exported);
+            if exported.is_some_and(|named| named.name == "default") {
+                self.handle_export_name(
+                    named_export_identifier(&specifier.local),
+                    None,
+                    specifier.local.span(),
+                );
+            } else {
+                self.handle_export_name(exported, None, specifier.exported.span());
+            }
+        }
+    }
+
+    fn handle_default_export_declaration(&mut self, declaration: &ExportDefaultDeclaration<'_>) {
+        match &declaration.declaration {
+            ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                if let Some(id) = &function.id {
+                    self.handle_export_name(Some(binding_identifier(id)), None, id.span);
+                } else {
+                    self.report("anonymousExport", function.span);
+                }
+            }
+            ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+                if let Some(id) = &class.id {
+                    if is_react_class_component(class) {
+                        self.state.has_react_export = true;
+                    } else {
+                        self.state.non_component_exports.push(id.span);
+                    }
+                } else {
+                    self.report("anonymousExport", class.span);
+                }
+            }
+            ExportDefaultDeclarationKind::CallExpression(call) => {
+                self.handle_export_call_expression(call);
+            }
+            ExportDefaultDeclarationKind::Identifier(identifier) => {
+                self.handle_export_name(
+                    Some(identifier_reference(identifier)),
+                    None,
+                    identifier.span,
+                );
+            }
+            ExportDefaultDeclarationKind::ArrowFunctionExpression(_) => {
+                self.report("anonymousExport", declaration.span);
+            }
+            ExportDefaultDeclarationKind::TSAsExpression(expression) => {
+                self.handle_default_export_expression(&expression.expression, declaration.span);
+            }
+            ExportDefaultDeclarationKind::TSSatisfiesExpression(expression) => {
+                self.handle_default_export_expression(&expression.expression, declaration.span);
+            }
+            ExportDefaultDeclarationKind::TSTypeAssertion(expression) => {
+                self.handle_default_export_expression(&expression.expression, declaration.span);
+            }
+            ExportDefaultDeclarationKind::TSNonNullExpression(expression) => {
+                self.handle_default_export_expression(&expression.expression, declaration.span);
+            }
+            ExportDefaultDeclarationKind::TSInstantiationExpression(expression) => {
+                self.handle_default_export_expression(&expression.expression, declaration.span);
+            }
+            _ => {
+                self.state.non_component_exports.push(declaration.span);
+            }
+        }
+    }
+
+    fn handle_default_export_expression(&mut self, expression: &Expression<'_>, span: Span) {
+        match expression.get_inner_expression() {
+            Expression::CallExpression(call) => self.handle_export_call_expression(call),
+            Expression::Identifier(identifier) => {
+                self.handle_export_name(
+                    Some(identifier_reference(identifier)),
+                    None,
+                    identifier.span,
+                );
+            }
+            Expression::ArrowFunctionExpression(_) => self.report("anonymousExport", span),
+            _ => self.state.non_component_exports.push(span),
+        }
+    }
+
+    fn handle_export_call_expression(&mut self, call: &CallExpression<'_>) {
+        match self.is_call_expression_react_component(call) {
+            ComponentCheck::No => self.state.non_component_exports.push(call.span),
+            ComponentCheck::NeedName => self.report("anonymousExport", call.span),
+            ComponentCheck::Yes => self.state.has_react_export = true,
+        }
+    }
+
+    fn handle_export_declaration(&mut self, declaration: &Declaration<'_>) {
+        match declaration {
+            Declaration::VariableDeclaration(declaration) => {
+                for variable in &declaration.declarations {
+                    let fallback = variable.id.span();
+                    let name = binding_pattern_identifier(&variable.id);
+                    if let Some(init) = &variable.init {
+                        self.handle_export_name(name, Some(init), fallback);
+                    } else {
+                        self.handle_export_name(name, None, fallback);
+                    }
+                }
+            }
+            Declaration::FunctionDeclaration(function) => {
+                if let Some(id) = &function.id {
+                    self.handle_export_name(Some(binding_identifier(id)), None, id.span);
+                } else {
+                    self.report("anonymousExport", function.span);
+                }
+            }
+            Declaration::ClassDeclaration(class) => {
+                if let Some(id) = &class.id {
+                    if is_react_class_component(class) {
+                        self.state.has_react_export = true;
+                    } else {
+                        self.state.non_component_exports.push(id.span);
+                    }
+                } else {
+                    self.report("anonymousExport", class.span);
+                }
+            }
+            _ => self.state.non_component_exports.push(declaration.span()),
+        }
+    }
+
+    fn handle_export_name(
+        &mut self,
+        name: Option<NamedSpan<'_>>,
+        init: Option<&Expression<'_>>,
+        fallback: Span,
+    ) {
+        let Some(name) = name else {
+            self.state.non_component_exports.push(fallback);
+            return;
+        };
+
+        if self
+            .options
+            .allow_export_names
+            .iter()
+            .any(|allowed| allowed == name.name)
+        {
+            return;
+        }
+
+        let Some(init) = init.map(Expression::get_inner_expression) else {
+            if is_react_component_name(name.name) {
+                self.state.has_react_export = true;
+            } else {
+                self.state.non_component_exports.push(name.span);
+            }
+            return;
+        };
+
+        if self.options.allow_constant_export && is_constant_export_expression(init) {
+            return;
+        }
+
+        if is_create_context_call(init) {
+            self.state.react_context_exports.push(name.span);
+            return;
+        }
+
+        let is_react_component = is_react_component_name(name.name)
+            && self.is_expression_react_component(init) != ComponentCheck::No;
+
+        if is_react_component {
+            self.state.has_react_export = true;
+        } else {
+            self.state.non_component_exports.push(name.span);
+        }
+    }
+
+    fn collect_local_variable_components(&mut self, declaration: &VariableDeclaration<'_>) {
+        for variable in &declaration.declarations {
+            let Some(name) = binding_pattern_identifier(&variable.id) else {
+                continue;
+            };
+            let Some(init) = &variable.init else {
+                continue;
+            };
+            if is_react_component_name(name.name)
+                && self.is_expression_react_component(init) != ComponentCheck::No
+            {
+                self.state.local_components.push(name.span);
+            }
+        }
+    }
+
+    fn is_expression_react_component(&self, expression: &Expression<'_>) -> ComponentCheck {
+        match expression.get_inner_expression() {
+            Expression::Identifier(identifier) => {
+                component_check_for_name(identifier.name.as_str())
+            }
+            Expression::ArrowFunctionExpression(function) => {
+                if function_param_count(&function.params) > 2 {
+                    ComponentCheck::No
+                } else {
+                    ComponentCheck::NeedName
+                }
+            }
+            Expression::FunctionExpression(function) => {
+                if function_param_count(&function.params) > 2 {
+                    ComponentCheck::No
+                } else if let Some(id) = &function.id {
+                    component_check_for_name(id.name.as_str())
+                } else {
+                    ComponentCheck::NeedName
+                }
+            }
+            Expression::ConditionalExpression(expression) => {
+                let consequent = self.is_expression_react_component(&expression.consequent);
+                let alternate = self.is_expression_react_component(&expression.alternate);
+                if consequent == ComponentCheck::No || alternate == ComponentCheck::No {
+                    ComponentCheck::No
+                } else if consequent == ComponentCheck::NeedName
+                    || alternate == ComponentCheck::NeedName
+                {
+                    ComponentCheck::NeedName
+                } else {
+                    ComponentCheck::Yes
+                }
+            }
+            Expression::CallExpression(call) => self.is_call_expression_react_component(call),
+            Expression::TaggedTemplateExpression(tagged) => {
+                if self.get_tagged_template_hoc_name(tagged).is_some() {
+                    ComponentCheck::NeedName
+                } else {
+                    ComponentCheck::No
+                }
+            }
+            _ => ComponentCheck::No,
+        }
+    }
+
+    fn is_call_expression_react_component(&self, call: &CallExpression<'_>) -> ComponentCheck {
+        let Some(hoc_name) = self.get_call_hoc_name(call) else {
+            return ComponentCheck::No;
+        };
+        if !self.is_valid_hoc(hoc_name) {
+            return ComponentCheck::No;
+        }
+
+        if hoc_name != "memo" && hoc_name != "forwardRef" {
+            return ComponentCheck::Yes;
+        }
+
+        let Some(argument) = call.arguments.first() else {
+            return ComponentCheck::No;
+        };
+
+        self.is_argument_react_component(argument)
+    }
+
+    fn is_argument_react_component(&self, argument: &Argument<'_>) -> ComponentCheck {
+        match argument {
+            Argument::Identifier(identifier) => component_check_for_name(identifier.name.as_str()),
+            Argument::FunctionExpression(function) => {
+                if let Some(id) = &function.id {
+                    component_check_for_name(id.name.as_str())
+                } else {
+                    ComponentCheck::NeedName
+                }
+            }
+            Argument::ArrowFunctionExpression(function) => {
+                if function_param_count(&function.params) > 2 {
+                    ComponentCheck::No
+                } else {
+                    ComponentCheck::NeedName
+                }
+            }
+            Argument::CallExpression(call) => self.is_call_expression_react_component(call),
+            Argument::TSAsExpression(expression) => {
+                self.is_expression_react_component(&expression.expression)
+            }
+            Argument::TSSatisfiesExpression(expression) => {
+                self.is_expression_react_component(&expression.expression)
+            }
+            Argument::TSTypeAssertion(expression) => {
+                self.is_expression_react_component(&expression.expression)
+            }
+            Argument::TSNonNullExpression(expression) => {
+                self.is_expression_react_component(&expression.expression)
+            }
+            Argument::TSInstantiationExpression(expression) => {
+                self.is_expression_react_component(&expression.expression)
+            }
+            _ => ComponentCheck::No,
+        }
+    }
+
+    fn get_call_hoc_name<'a>(&self, call: &'a CallExpression<'a>) -> Option<&'a str> {
+        self.get_hoc_name_from_expression(&call.callee)
+    }
+
+    fn get_tagged_template_hoc_name<'a>(
+        &self,
+        tagged: &'a TaggedTemplateExpression<'a>,
+    ) -> Option<&'a str> {
+        let name = self.get_hoc_name_from_expression(&tagged.tag)?;
+        self.is_valid_hoc(name).then_some(name)
+    }
+
+    fn get_hoc_name_from_expression<'a>(&self, expression: &'a Expression<'a>) -> Option<&'a str> {
+        match expression.get_inner_expression() {
+            Expression::CallExpression(call) => self.get_call_hoc_name(call),
+            Expression::StaticMemberExpression(member) => {
+                let property_name = member.property.name.as_str();
+                if self.is_valid_hoc(property_name) {
+                    return Some(property_name);
+                }
+                if let Expression::Identifier(object) = member.object.get_inner_expression() {
+                    let object_name = object.name.as_str();
+                    if self.is_valid_hoc(object_name) {
+                        return Some(object_name);
+                    }
+                }
+                if let Expression::CallExpression(call) = member.object.get_inner_expression() {
+                    return self.get_call_hoc_name(call);
+                }
+                None
+            }
+            Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+            _ => None,
+        }
+    }
+
+    fn is_valid_hoc(&self, name: &str) -> bool {
+        DEFAULT_HOCS.contains(&name) || self.options.extra_hocs.iter().any(|hoc| hoc == name)
+    }
+
+    fn report(&mut self, message_id: &'static str, span: Span) {
+        self.state.diagnostics.push(Diagnostic {
+            message_id,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+fn component_check_for_name(name: &str) -> ComponentCheck {
+    if is_react_component_name(name) {
+        ComponentCheck::Yes
+    } else {
+        ComponentCheck::No
+    }
+}
+
+fn binding_identifier<'a>(identifier: &BindingIdentifier<'a>) -> NamedSpan<'a> {
+    NamedSpan {
+        name: identifier.name.as_str(),
+        span: identifier.span,
+    }
+}
+
+fn identifier_reference<'a>(identifier: &IdentifierReference<'a>) -> NamedSpan<'a> {
+    NamedSpan {
+        name: identifier.name.as_str(),
+        span: identifier.span,
+    }
+}
+
+fn binding_pattern_identifier<'a>(pattern: &BindingPattern<'a>) -> Option<NamedSpan<'a>> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(binding_identifier(identifier)),
+        _ => None,
+    }
+}
+
+fn named_export_identifier<'a>(name: &ModuleExportName<'a>) -> Option<NamedSpan<'a>> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(NamedSpan {
+            name: identifier.name.as_str(),
+            span: identifier.span,
+        }),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier_reference(identifier)),
+        ModuleExportName::StringLiteral(_) => None,
+    }
+}
+
+fn is_react_class_component(class: &Class<'_>) -> bool {
+    let Some(id) = &class.id else {
+        return false;
+    };
+    is_react_component_name(id.name.as_str())
+        && class.super_class.is_some()
+        && class.body.body.iter().any(|element| match element {
+            ClassElement::MethodDefinition(method) => {
+                property_key_name(&method.key) == Some("render")
+            }
+            _ => false,
+        })
+}
+
+fn property_key_name<'a>(key: &PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn function_param_count(params: &oxc_ast::ast::FormalParameters<'_>) -> usize {
+    params.items.len() + usize::from(params.rest.is_some())
+}
+
+fn is_constant_export_expression(expression: &Expression<'_>) -> bool {
+    matches!(
+        expression.get_inner_expression(),
+        Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::TemplateLiteral(_)
+            | Expression::UnaryExpression(_)
+            | Expression::BinaryExpression(_)
+    )
+}
+
+fn is_create_context_call(expression: &Expression<'_>) -> bool {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return false;
+    };
+    match call.callee.get_inner_expression() {
+        Expression::Identifier(identifier) => identifier.name == "createContext",
+        Expression::StaticMemberExpression(member) => member.property.name == "createContext",
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OnlyExportComponentsOptions, is_constant_export_expression_kind,
+        is_excluded_test_like_filename, is_react_component_name, scan_only_export_components,
+        should_scan_filename,
+    };
+
+    fn message_ids(
+        source_text: &str,
+        filename: &str,
+        options: OnlyExportComponentsOptions,
+    ) -> oxlint_plugins_carton::SmallVec<[&'static str; 8]> {
+        scan_only_export_components(source_text, filename, &options)
+            .into_iter()
+            .map(|diagnostic| diagnostic.message_id)
+            .collect()
+    }
+
+    #[test]
+    fn classifies_component_names() {
+        let cases = [
+            ("Foo", true),
+            ("Foo2", true),
+            ("Foo_", true),
+            ("CMS", true),
+            ("foo", false),
+            ("_Foo", false),
+            ("Foo-Bar", false),
+            ("", false),
+        ];
+
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(
+                cases.map(|(name, _)| (name, is_react_component_name(name)))
+            );
+        }
+        for (name, expected) in cases {
+            assert_eq!(is_react_component_name(name), expected);
+        }
+    }
+
+    #[test]
+    fn classifies_scannable_filenames() {
+        let cases = [
+            ("App.tsx", false),
+            ("App.jsx", false),
+            ("App.js", false),
+            ("App.js", true),
+            ("App.test.tsx", false),
+            ("App.stories.jsx", false),
+            ("App.ts", false),
+        ];
+
+        let actual = cases.map(|(filename, check_js)| {
+            (
+                filename,
+                check_js,
+                is_excluded_test_like_filename(filename),
+                should_scan_filename(filename, check_js),
+            )
+        });
+        #[allow(clippy::disallowed_macros)]
+        {
+            insta::assert_debug_snapshot!(actual);
+        }
+    }
+
+    #[test]
+    fn classifies_constant_export_kinds() {
+        assert!(is_constant_export_expression_kind("Literal"));
+        assert!(is_constant_export_expression_kind("UnaryExpression"));
+        assert!(is_constant_export_expression_kind("TemplateLiteral"));
+        assert!(is_constant_export_expression_kind("BinaryExpression"));
+        assert!(!is_constant_export_expression_kind("ObjectExpression"));
+        assert!(!is_constant_export_expression_kind("CallExpression"));
+    }
+
+    #[test]
+    fn scans_only_export_components_in_rust() {
+        let cases: [(&str, &str, OnlyExportComponentsOptions, &[&str]); 4] = [
+            (
+                "export const Foo = () => null;\nexport const foo = 1;\n",
+                "Component.tsx",
+                OnlyExportComponentsOptions::default(),
+                &["namedExport"],
+            ),
+            (
+                "const Foo = () => null;\n",
+                "Component.tsx",
+                OnlyExportComponentsOptions::default(),
+                &["noExport"],
+            ),
+            (
+                "export default memo(() => null);\n",
+                "Component.tsx",
+                OnlyExportComponentsOptions::default(),
+                &["anonymousExport"],
+            ),
+            (
+                "export const Foo = () => null;\nexport const answer = 42;\n",
+                "Component.tsx",
+                OnlyExportComponentsOptions {
+                    allow_constant_export: true,
+                    ..OnlyExportComponentsOptions::default()
+                },
+                &[],
+            ),
+        ];
+
+        for (source_text, filename, options, expected) in cases {
+            assert_eq!(
+                message_ids(source_text, filename, options).as_slice(),
+                expected
+            );
+        }
+    }
+}

--- a/crates/react_refresh/src/snapshots/oxlint_plugins_react_refresh__tests__classifies_component_names.snap
+++ b/crates/react_refresh/src/snapshots/oxlint_plugins_react_refresh__tests__classifies_component_names.snap
@@ -1,0 +1,38 @@
+---
+source: crates/react_refresh/src/lib.rs
+expression: "cases.map(|(name, _)| (name, is_react_component_name(name)))"
+---
+[
+    (
+        "Foo",
+        true,
+    ),
+    (
+        "Foo2",
+        true,
+    ),
+    (
+        "Foo_",
+        true,
+    ),
+    (
+        "CMS",
+        true,
+    ),
+    (
+        "foo",
+        false,
+    ),
+    (
+        "_Foo",
+        false,
+    ),
+    (
+        "Foo-Bar",
+        false,
+    ),
+    (
+        "",
+        false,
+    ),
+]

--- a/crates/react_refresh/src/snapshots/oxlint_plugins_react_refresh__tests__classifies_scannable_filenames.snap
+++ b/crates/react_refresh/src/snapshots/oxlint_plugins_react_refresh__tests__classifies_scannable_filenames.snap
@@ -1,0 +1,48 @@
+---
+source: crates/react_refresh/src/lib.rs
+expression: actual
+---
+[
+    (
+        "App.tsx",
+        false,
+        false,
+        true,
+    ),
+    (
+        "App.jsx",
+        false,
+        false,
+        true,
+    ),
+    (
+        "App.js",
+        false,
+        false,
+        false,
+    ),
+    (
+        "App.js",
+        true,
+        false,
+        true,
+    ),
+    (
+        "App.test.tsx",
+        false,
+        true,
+        false,
+    ),
+    (
+        "App.stories.jsx",
+        false,
+        true,
+        false,
+    ),
+    (
+        "App.ts",
+        false,
+        false,
+        false,
+    ),
+]

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ allow = [
   "Apache-2.0",
   "BSD-2-Clause",
   "BSD-3-Clause",
+  "BSL-1.0",
   "ISC",
   "MIT",
   "MPL-2.0",
@@ -22,4 +23,3 @@ confidence-threshold = 0.8
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-

--- a/npm/react-refresh/Cargo.toml
+++ b/npm/react-refresh/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "oxlint-plugin-react-refresh"
+description = "Rust helpers for the react-refresh oxlint JavaScript plugin."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_react_refresh"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-react-refresh.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"

--- a/npm/react-refresh/LICENSE
+++ b/npm/react-refresh/LICENSE
@@ -1,0 +1,50 @@
+MIT License
+
+Copyright (c) 2026 @ubugeeei and @baseballyama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This package is a port of eslint-plugin-react-refresh
+(https://github.com/ArnaudBarre/eslint-plugin-react-refresh), which is
+distributed under the MIT License. Rule behavior, diagnostic message strings,
+and test cases are derived from that project for behavioral parity:
+
+MIT License
+
+Copyright (c) 2023 Arnaud Barré
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/react-refresh/README.md
+++ b/npm/react-refresh/README.md
@@ -1,0 +1,37 @@
+# @oxlint-plugins/oxlint-plugin-react-refresh
+
+Rust-backed Oxlint port of [`eslint-plugin-react-refresh`](https://github.com/ArnaudBarre/eslint-plugin-react-refresh).
+
+This is unofficial community work and is not an official Oxlint, React, or eslint-plugin-react-refresh project.
+
+## Usage
+
+```jsonc
+{
+  "jsPlugins": [
+    {
+      "name": "react-refresh",
+      "specifier": "@oxlint-plugins/oxlint-plugin-react-refresh",
+    },
+  ],
+  "rules": {
+    "react-refresh/only-export-components": "error",
+  },
+}
+```
+
+## Rules
+
+| Rule                     | Description                                                  | Status |
+| ------------------------ | ------------------------------------------------------------ | ------ |
+| `only-export-components` | validate exports that can safely participate in Fast Refresh | ported |
+
+## Configs
+
+- `recommended`: enables `react-refresh/only-export-components`.
+- `vite`: enables the rule with `allowConstantExport: true`.
+- `next`: enables the rule with Next.js route segment and metadata export names allowed.
+
+## Attribution
+
+Rule behavior, diagnostic message strings, and test cases are derived from `eslint-plugin-react-refresh` (v0.5.2, MIT, Copyright 2023 Arnaud Barré). See [`LICENSE`](./LICENSE).

--- a/npm/react-refresh/api.d.ts
+++ b/npm/react-refresh/api.d.ts
@@ -1,0 +1,24 @@
+export declare function defaultHocs(): string[];
+export declare function isReactComponentName(name: string): boolean;
+export declare function shouldScanFilename(filename: string, checkJS?: boolean): boolean;
+export declare function isConstantExportExpressionKind(kind: string): boolean;
+export type OnlyExportComponentsOptions = {
+  extraHOCs?: string[];
+  allowExportNames?: string[];
+  allowConstantExport?: boolean;
+  checkJS?: boolean;
+};
+export type ReactRefreshDiagnostic = {
+  messageId: string;
+  loc: {
+    startLine: number;
+    startColumn: number;
+    endLine: number;
+    endColumn: number;
+  };
+};
+export declare function scanOnlyExportComponents(
+  sourceText: string,
+  filename: string,
+  options?: OnlyExportComponentsOptions,
+): ReactRefreshDiagnostic[];

--- a/npm/react-refresh/api.js
+++ b/npm/react-refresh/api.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const native = require('./native.js');
+
+function defaultHocs() {
+  return native.defaultHocs();
+}
+
+function isReactComponentName(name) {
+  if (typeof name !== 'string') {
+    throw new TypeError('name must be a string.');
+  }
+  return native.isReactComponentName(name);
+}
+
+function shouldScanFilename(filename, checkJS = false) {
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.shouldScanFilename(filename, !!checkJS);
+}
+
+function isConstantExportExpressionKind(kind) {
+  if (typeof kind !== 'string') {
+    throw new TypeError('kind must be a string.');
+  }
+  return native.isConstantExportExpressionKind(kind);
+}
+
+function scanOnlyExportComponents(sourceText, filename, options = {}) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanOnlyExportComponents(sourceText, filename, {
+    extraHocs: Array.isArray(options.extraHOCs) ? options.extraHOCs : [],
+    allowExportNames: Array.isArray(options.allowExportNames) ? options.allowExportNames : [],
+    allowConstantExport: options.allowConstantExport === true,
+    checkJs: options.checkJS === true,
+  });
+}
+
+module.exports = {
+  defaultHocs,
+  isConstantExportExpressionKind,
+  isReactComponentName,
+  scanOnlyExportComponents,
+  shouldScanFilename,
+};
+module.exports.default = module.exports;

--- a/npm/react-refresh/build.rs
+++ b/npm/react-refresh/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/react-refresh/index.js
+++ b/npm/react-refresh/index.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-react-refresh (MIT).
+// The JavaScript layer is only an Oxlint/NAPI adapter; parsing and rule
+// classification run in Rust through Oxc.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const native = require('./native.js');
+
+const PLUGIN_NAME = 'react-refresh';
+const RULE_NAME = 'only-export-components';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/react-refresh';
+
+function normalizeOptions(raw) {
+  const options = raw && typeof raw === 'object' ? raw : {};
+  return {
+    extraHocs: Array.isArray(options.extraHOCs)
+      ? options.extraHOCs.filter((value) => typeof value === 'string' && value.length > 0)
+      : [],
+    allowExportNames: Array.isArray(options.allowExportNames)
+      ? options.allowExportNames.filter((value) => typeof value === 'string')
+      : [],
+    allowConstantExport: options.allowConstantExport === true,
+    checkJs: options.checkJS === true,
+  };
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function reportDiagnostics(context, diagnostics) {
+  for (const diagnostic of diagnostics) {
+    context.report({
+      messageId: diagnostic.messageId,
+      loc: {
+        start: {
+          line: diagnostic.loc.startLine,
+          column: diagnostic.loc.startColumn,
+        },
+        end: {
+          line: diagnostic.loc.endLine,
+          column: diagnostic.loc.endColumn,
+        },
+      },
+    });
+  }
+}
+
+const onlyExportComponents = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'validate that Fast Refresh files only export components',
+      recommended: true,
+      url: `${DOCS_BASE}#only-export-components`,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          extraHOCs: { type: 'array', items: { type: 'string' } },
+          allowExportNames: { type: 'array', items: { type: 'string' } },
+          allowConstantExport: { type: 'boolean' },
+          checkJS: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      exportAll: "This rule can't verify that `export *` only exports components.",
+      namedExport:
+        'Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.',
+      anonymousExport: "Fast refresh can't handle anonymous components. Add a name to your export.",
+      localComponents:
+        'Fast refresh only works when a file only exports components. Move your component(s) to a separate file. If all exports are HOCs, add them to the `extraHOCs` option.',
+      noExport:
+        'Fast refresh only works when a file has exports. Move your component(s) to a separate file.',
+      reactContext:
+        'Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.',
+    },
+  },
+  createOnce(context) {
+    return {
+      Program() {
+        const diagnostics = native.scanOnlyExportComponents(
+          sourceTextForContext(context),
+          context.filename,
+          normalizeOptions(context.options?.[0]),
+        );
+        reportDiagnostics(context, diagnostics);
+      },
+    };
+  },
+};
+
+function buildConfig(name, baseOptions) {
+  return (options = {}) => ({
+    name: `${PLUGIN_NAME}/${name}`,
+    plugins: [PLUGIN_NAME],
+    rules: {
+      [`${PLUGIN_NAME}/${RULE_NAME}`]: ['error', { ...baseOptions, ...options }],
+    },
+  });
+}
+
+const configs = {
+  recommended: buildConfig('recommended', {}),
+  vite: buildConfig('vite', { allowConstantExport: true }),
+  next: buildConfig('next', {
+    allowExportNames: [
+      'experimental_ppr',
+      'dynamic',
+      'dynamicParams',
+      'revalidate',
+      'fetchCache',
+      'runtime',
+      'preferredRegion',
+      'maxDuration',
+      'metadata',
+      'generateMetadata',
+      'viewport',
+      'generateViewport',
+      'generateImageMetadata',
+      'generateSitemaps',
+      'generateStaticParams',
+    ],
+  }),
+};
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules: {
+    [RULE_NAME]: onlyExportComponents,
+  },
+  configs: {
+    recommended: configs.recommended(),
+    vite: configs.vite(),
+    next: configs.next(),
+  },
+});
+
+plugin.reactRefresh = { plugin, configs };
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.reactRefresh = plugin.reactRefresh;

--- a/npm/react-refresh/package.json
+++ b/npm/react-refresh/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-react-refresh",
+  "version": "0.0.0",
+  "description": "Rust-backed Oxlint plugin port of eslint-plugin-react-refresh.",
+  "keywords": [
+    "eslint-plugin",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "react-refresh",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/react-refresh"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_react_refresh",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/react-refresh/src/lib.rs
+++ b/npm/react-refresh/src/lib.rs
@@ -1,0 +1,99 @@
+//! NAPI boundary for the react-refresh oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticLoc, OnlyExportComponentsOptions, default_hocs,
+    is_constant_export_expression_kind, is_react_component_name, scan_only_export_components,
+    should_scan_filename,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI and proc macros require String/Vec/Option; values are converted before calling core helpers."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use oxlint_plugins_react_refresh as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct OnlyExportComponentsOptions {
+        pub extra_hocs: Option<Vec<String>>,
+        pub allow_export_names: Option<Vec<String>>,
+        pub allow_constant_export: Option<bool>,
+        pub check_js: Option<bool>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub message_id: String,
+        pub loc: DiagnosticLoc,
+    }
+
+    #[napi]
+    pub fn is_react_component_name(name: String) -> bool {
+        core::is_react_component_name(&name)
+    }
+
+    #[napi]
+    pub fn should_scan_filename(filename: String, check_js: bool) -> bool {
+        core::should_scan_filename(&filename, check_js)
+    }
+
+    #[napi]
+    pub fn is_constant_export_expression_kind(kind: String) -> bool {
+        core::is_constant_export_expression_kind(&kind)
+    }
+
+    #[napi]
+    pub fn default_hocs() -> Vec<String> {
+        core::DEFAULT_HOCS.into_iter().map(str::to_owned).collect()
+    }
+
+    #[napi]
+    pub fn scan_only_export_components(
+        source_text: String,
+        filename: String,
+        options: Option<OnlyExportComponentsOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::OnlyExportComponentsOptions {
+            extra_hocs: compact_strings4(options.extra_hocs.unwrap_or_default()),
+            allow_export_names: compact_strings8(options.allow_export_names.unwrap_or_default()),
+            allow_constant_export: options.allow_constant_export.unwrap_or(false),
+            check_js: options.check_js.unwrap_or(false),
+        };
+
+        core::scan_only_export_components(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                message_id: diagnostic.message_id.to_owned(),
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+            })
+            .collect()
+    }
+
+    fn compact_strings4(values: Vec<String>) -> SmallVec<[CompactString; 4]> {
+        values.into_iter().map(CompactString::from).collect()
+    }
+
+    fn compact_strings8(values: Vec<String>) -> SmallVec<[CompactString; 8]> {
+        values.into_iter().map(CompactString::from).collect()
+    }
+}

--- a/npm/react-refresh/test/api.test.mjs
+++ b/npm/react-refresh/test/api.test.mjs
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultHocs,
+  isConstantExportExpressionKind,
+  isReactComponentName,
+  scanOnlyExportComponents,
+  shouldScanFilename,
+} from '../api.js';
+
+describe('react-refresh native api', () => {
+  it('classifies React component names like upstream', () => {
+    expect(isReactComponentName('Foo')).toBe(true);
+    expect(isReactComponentName('Foo2')).toBe(true);
+    expect(isReactComponentName('CMS')).toBe(true);
+    expect(isReactComponentName('foo')).toBe(false);
+    expect(isReactComponentName('_Foo')).toBe(false);
+    expect(isReactComponentName('Foo-Bar')).toBe(false);
+  });
+
+  it('keeps upstream filename scan gates', () => {
+    expect(shouldScanFilename('/src/App.tsx')).toBe(true);
+    expect(shouldScanFilename('/src/App.jsx')).toBe(true);
+    expect(shouldScanFilename('/src/App.js')).toBe(false);
+    expect(shouldScanFilename('/src/App.js', true)).toBe(true);
+    expect(shouldScanFilename('/src/App.test.tsx')).toBe(false);
+    expect(shouldScanFilename('/src/App.spec.jsx')).toBe(false);
+    expect(shouldScanFilename('/src/App.cy.jsx')).toBe(false);
+    expect(shouldScanFilename('/src/App.stories.tsx')).toBe(false);
+  });
+
+  it('exposes higher-order component and constant export helpers', () => {
+    expect(defaultHocs()).toEqual(['memo', 'forwardRef', 'lazy']);
+    expect(isConstantExportExpressionKind('Literal')).toBe(true);
+    expect(isConstantExportExpressionKind('UnaryExpression')).toBe(true);
+    expect(isConstantExportExpressionKind('TemplateLiteral')).toBe(true);
+    expect(isConstantExportExpressionKind('BinaryExpression')).toBe(true);
+    expect(isConstantExportExpressionKind('ObjectExpression')).toBe(false);
+    expect(isConstantExportExpressionKind('CallExpression')).toBe(false);
+  });
+
+  it('runs the rule scan in native code', () => {
+    expect(
+      scanOnlyExportComponents(
+        'export const Foo = () => null;\nexport const foo = 1;\n',
+        'Component.tsx',
+      ).map((diagnostic) => diagnostic.messageId),
+    ).toEqual(['namedExport']);
+
+    expect(
+      scanOnlyExportComponents(
+        "import React from 'react';\nexport const Foo = () => null;\nexport const foo = 1;\n",
+        'Component.js',
+        { checkJS: true },
+      ).map((diagnostic) => diagnostic.messageId),
+    ).toEqual(['namedExport']);
+  });
+});

--- a/npm/react-refresh/test/lsp.test.mjs
+++ b/npm/react-refresh/test/lsp.test.mjs
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const ruleName = 'only-export-components';
+const rule = plugin.rules[ruleName];
+
+function runRule({ code, filename = 'Component.tsx', options = [] }) {
+  const reports = [];
+  const visitor = rule.createOnce({
+    filename,
+    options,
+    sourceCode: {
+      getText() {
+        return code;
+      },
+    },
+    report(descriptor) {
+      reports.push({
+        message: rule.meta.messages[descriptor.messageId],
+        messageId: descriptor.messageId,
+        loc: descriptor.loc,
+      });
+    },
+  });
+
+  visitor.Program({ type: 'Program' });
+  return reports;
+}
+
+function toLspDiagnostics(reports) {
+  return reports.map((report) => ({
+    range: {
+      start: {
+        line: report.loc.start.line - 1,
+        character: report.loc.start.column,
+      },
+      end: {
+        line: report.loc.end.line - 1,
+        character: report.loc.end.column,
+      },
+    },
+    severity: 1,
+    source: 'oxlint-plugins',
+    code: `react-refresh/${ruleName}`,
+    message: report.message,
+  }));
+}
+
+describe('react-refresh LSP diagnostics fixture', () => {
+  it('maps a non-component export diagnostic', () => {
+    const reports = runRule({
+      code: 'export const Foo = () => null;\nexport const foo = 1;\n',
+    });
+
+    expect(toLspDiagnostics(reports)).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "react-refresh/only-export-components",
+          "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.",
+          "range": {
+            "end": {
+              "character": 16,
+              "line": 1,
+            },
+            "start": {
+              "character": 13,
+              "line": 1,
+            },
+          },
+          "severity": 1,
+          "source": "oxlint-plugins",
+        },
+      ]
+    `);
+  });
+
+  it('maps a local component without exports diagnostic', () => {
+    const reports = runRule({
+      code: 'const Foo = () => null;\n',
+    });
+
+    expect(toLspDiagnostics(reports)).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "react-refresh/only-export-components",
+          "message": "Fast refresh only works when a file has exports. Move your component(s) to a separate file.",
+          "range": {
+            "end": {
+              "character": 9,
+              "line": 0,
+            },
+            "start": {
+              "character": 6,
+              "line": 0,
+            },
+          },
+          "severity": 1,
+          "source": "oxlint-plugins",
+        },
+      ]
+    `);
+  });
+});

--- a/npm/react-refresh/test/plugin.test.mjs
+++ b/npm/react-refresh/test/plugin.test.mjs
@@ -1,0 +1,280 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+const ruleName = 'only-export-components';
+const fullRuleName = `react-refresh/${ruleName}`;
+
+const validCases = [
+  {
+    name: 'named function component export',
+    filename: 'NamedFunction.tsx',
+    code: 'export function Foo() { return null; }\n',
+  },
+  {
+    name: 'export specifier for a local component',
+    filename: 'Specifier.tsx',
+    code: 'const Foo = () => null;\nexport { Foo };\n',
+  },
+  {
+    name: 'default named function component',
+    filename: 'DefaultFunction.tsx',
+    code: 'export default function Foo() { return null; }\n',
+  },
+  {
+    name: 'component variable arrow export',
+    filename: 'Arrow.tsx',
+    code: 'export const Foo = () => null;\n',
+  },
+  {
+    name: 'memo and forwardRef built-in HOCs',
+    filename: 'Hoc.tsx',
+    code: [
+      "import { memo, forwardRef } from 'react';",
+      'export const Foo = memo(function Foo() { return null; });',
+      'export const Bar = forwardRef(function Bar() { return null; });',
+    ].join('\n'),
+  },
+  {
+    name: 'nested built-in HOCs',
+    filename: 'NestedHoc.tsx',
+    code: 'export default memo(forwardRef(function Foo() { return null; }));\n',
+  },
+  {
+    name: 'extra HOC option for styled-components',
+    filename: 'Styled.tsx',
+    options: { extraHOCs: ['styled'] },
+    code: 'export const Button = styled.div`color: red;`;\n',
+  },
+  {
+    name: 'allowed constant export option',
+    filename: 'Constant.tsx',
+    options: { allowConstantExport: true },
+    code: 'export const Foo = () => null;\nexport const answer = 42;\n',
+  },
+  {
+    name: 'allowed framework export names',
+    filename: 'Framework.tsx',
+    options: { allowExportNames: ['loader'] },
+    code: 'export const Foo = () => null;\nexport const loader = () => null;\n',
+  },
+  {
+    name: 'standalone React context export',
+    filename: 'Context.tsx',
+    code: "import { createContext } from 'react';\nexport const FooContext = createContext(null);\n",
+  },
+  {
+    name: 'React class component export',
+    filename: 'Class.tsx',
+    code: 'export class Foo extends React.Component { render() { return null; } }\n',
+  },
+  {
+    name: 'js files are ignored without checkJS',
+    filename: 'Ignored.js',
+    code: 'export const Foo = () => null;\nexport const foo = 1;\n',
+  },
+  {
+    name: 'checkJS skips js files without React import',
+    filename: 'NoReactImport.js',
+    options: { checkJS: true },
+    code: 'export const Foo = () => null;\nexport const foo = 1;\n',
+  },
+  {
+    name: 'test-like files are ignored',
+    filename: 'Component.test.tsx',
+    code: 'export const Foo = () => null;\nexport const foo = 1;\n',
+  },
+];
+
+const invalidCases = [
+  {
+    name: 'non-component named export next to a component',
+    filename: 'NamedExport.tsx',
+    code: 'export const Foo = () => null;\nexport const foo = 1;\n',
+    messageIds: ['namedExport'],
+  },
+  {
+    name: 'underscore-prefixed export next to a component',
+    filename: 'Underscore.tsx',
+    code: 'export const _Foo = () => null;\nexport const Bar = () => null;\n',
+    messageIds: ['namedExport'],
+  },
+  {
+    name: 'export all declaration',
+    filename: 'ExportAll.tsx',
+    code: "export * from './foo';\n",
+    messageIds: ['exportAll'],
+  },
+  {
+    name: 'anonymous default arrow export',
+    filename: 'AnonymousArrow.tsx',
+    code: 'export default () => null;\n',
+    messageIds: ['anonymousExport'],
+  },
+  {
+    name: 'anonymous memo default export',
+    filename: 'AnonymousMemo.tsx',
+    code: 'export default memo(() => null);\n',
+    messageIds: ['anonymousExport'],
+  },
+  {
+    name: 'local component with only non-component exports',
+    filename: 'LocalComponent.tsx',
+    code: 'const Foo = () => null;\nexport const tabs = [];\n',
+    messageIds: ['localComponents'],
+  },
+  {
+    name: 'local component without exports',
+    filename: 'NoExport.tsx',
+    code: 'const Foo = () => null;\n',
+    messageIds: ['noExport'],
+  },
+  {
+    name: 'checkJS reports js files with React import',
+    filename: 'ReactImport.js',
+    options: { checkJS: true },
+    code: "import React from 'react';\nexport const Foo = () => null;\nexport const foo = 1;\n",
+    messageIds: ['namedExport'],
+  },
+  {
+    name: 'custom HOC requires extraHOCs',
+    filename: 'CustomHoc.tsx',
+    code: 'const MyComponent = () => null;\nexport default observer(MyComponent);\n',
+    messageIds: ['localComponents'],
+  },
+  {
+    name: 'React context next to a component',
+    filename: 'ContextWithComponent.tsx',
+    code: 'export const FooContext = React.createContext(null);\nexport const Foo = () => null;\n',
+    messageIds: ['reactContext'],
+  },
+  {
+    name: 'non-React class next to a component',
+    filename: 'PlainClass.tsx',
+    code: 'export class Foo { render() { return null; } }\nexport const Bar = () => null;\n',
+    messageIds: ['namedExport'],
+  },
+  {
+    name: 'anonymous default class export',
+    filename: 'AnonymousClass.tsx',
+    code: 'export default class { render() { return null; } }\n',
+    messageIds: ['anonymousExport'],
+  },
+  {
+    name: 'TypeScript enum next to a component',
+    filename: 'Enum.tsx',
+    code: 'export const Foo = () => null;\nexport enum RouteKind { Static }\n',
+    messageIds: ['namedExport'],
+  },
+];
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint({ filename, code, options }) {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'react-refresh-plugin-'));
+
+  try {
+    const sourcePath = join(temp, filename);
+    const configPath = join(temp, 'oxlint.config.jsonc');
+    const ruleConfig = options == null ? 'error' : ['error', options];
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'react-refresh',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [fullRuleName]: ruleConfig,
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('react-refresh plugin shape', () => {
+  it('exposes the only-export-components rule', () => {
+    expect(plugin.meta?.name).toBe('react-refresh');
+    expect(plugin.rules[ruleName].meta.messages.namedExport).toContain('Fast refresh');
+    expect(typeof plugin.rules[ruleName].createOnce).toBe('function');
+  });
+
+  it('ships upstream-compatible configs', () => {
+    expect(plugin.configs.recommended.rules).toEqual({
+      [fullRuleName]: ['error', {}],
+    });
+    expect(plugin.configs.vite.rules).toEqual({
+      [fullRuleName]: ['error', { allowConstantExport: true }],
+    });
+    expect(plugin.configs.next.rules[fullRuleName][1].allowExportNames).toContain('revalidate');
+    expect(plugin.reactRefresh.configs.recommended().rules).toEqual(
+      plugin.configs.recommended.rules,
+    );
+  });
+});
+
+describe('react-refresh only-export-components through oxlint jsPlugins', () => {
+  it.each(validCases)('accepts $name', (fixture) => {
+    const result = runOxlint(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(invalidCases)('reports $name', (fixture) => {
+    const result = runOxlint(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
+      fixture.messageIds.map(() => 'react-refresh(only-export-components)'),
+    );
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual(
+      fixture.messageIds.map((messageId) => plugin.rules[ruleName].meta.messages[messageId]),
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/react-refresh:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/stylistic:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -189,6 +189,39 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-react-refresh",
+    "directory": "npm/react-refresh",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-react-refresh",
+      "version": "0.5.2",
+      "repository": "https://github.com/ArnaudBarre/eslint-plugin-react-refresh",
+      "license": "MIT"
+    },
+    "status": "ported",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "only-export-components",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": true,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc parser port of eslint-plugin-react-refresh/only-export-components; covers native helpers, LSP-shaped diagnostics, and upstream-style valid/invalid cases through Oxlint jsPlugins."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-stylistic",
     "directory": "npm/stylistic",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -20,6 +20,10 @@ const nativePackages = [
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     binding: 'npm/stylistic/native.js',
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-react-refresh',
+    binding: 'npm/react-refresh/native.js',
+  },
 ];
 
 for (const pkg of nativePackages) {

--- a/tools/tasks/security-audit.ts
+++ b/tools/tasks/security-audit.ts
@@ -17,6 +17,7 @@ type AuditJson = {
 const publishablePrefixes = [
   '@oxlint-plugins/oxlint-plugin-type-aware>',
   '@oxlint-plugins/oxlint-plugin-no-forbidden-identifiers>',
+  '@oxlint-plugins/oxlint-plugin-react-refresh>',
   '@oxlint-plugins/oxlint-plugin-stylistic>',
 ];
 

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -25,6 +25,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-react-refresh',
+    dir: 'npm/react-refresh',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     dir: 'npm/stylistic',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary

- Port `eslint-plugin-react-refresh/only-export-components` as `@oxlint-plugins/oxlint-plugin-react-refresh`.
- Implement the rule core in Rust using Oxc parser, with the JavaScript layer kept as a thin Oxlint/NAPI adapter.
- Add native helper, LSP-shaped diagnostic, and Oxlint `jsPlugins` integration tests for upstream-style valid/invalid cases.
- Register the package in workspace status, publish-ready checks, and production audit coverage.

## Validation

- `vp exec pnpm run verify`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->