### PR TITLE
feat(security): port eslint-plugin-security

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-security"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-security",
+]
+
+[[package]]
 name = "oxlint-plugin-stylistic"
 version = "0.0.0"
 dependencies = [
@@ -791,6 +802,19 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_span",
+ "oxlint-plugins-_carton",
+]
+
+[[package]]
+name = "oxlint-plugins-security"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxc_syntax",
  "oxlint-plugins-_carton",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,12 @@ members = [
   "crates/_carton",
   "crates/eslint_comments",
   "crates/react_refresh",
+  "crates/security",
   "crates/stylistic",
   "npm/eslint-comments",
   "npm/no-forbidden-identifiers",
   "npm/react-refresh",
+  "npm/security",
   "npm/stylistic",
 ]
 resolver = "3"
@@ -31,9 +33,11 @@ oxc_allocator = "0.135.0"
 oxc_ast = "0.135.0"
 oxc_parser = "0.135.0"
 oxc_span = "0.135.0"
+oxc_syntax = "0.135.0"
 oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_carton", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
+oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }
 phf = { version = "0.13.1", features = ["macros"] }
 rustc-hash = "2.1.1"

--- a/crates/security/Cargo.toml
+++ b/crates/security/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "oxlint-plugins-security"
+description = "Rust core for the security oxlint JavaScript plugin."
+edition.workspace = true
+license = "Apache-2.0"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
+oxc_syntax.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -1,0 +1,1520 @@
+#![doc = "Rust implementation of eslint-plugin-security rule logic."]
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, AssignmentTarget, BindingPattern, BindingProperty,
+    CallExpression, ChainElement, Class, ClassElement, Declaration, ExportDefaultDeclarationKind,
+    Expression, ForStatementInit, ForStatementLeft, Function, FunctionBody, ImportDeclaration,
+    ImportDeclarationSpecifier, ModuleExportName, NewExpression, ObjectPropertyKind, PropertyKey,
+    Statement, VariableDeclaration,
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+use oxc_syntax::operator::BinaryOperator;
+use oxlint_plugins_carton::{CompactString, FastHashMap, SmallVec};
+
+pub const RULE_NAMES: [&str; 14] = [
+    "detect-bidi-characters",
+    "detect-buffer-noassert",
+    "detect-child-process",
+    "detect-disable-mustache-escape",
+    "detect-eval-with-expression",
+    "detect-new-buffer",
+    "detect-no-csrf-before-method-override",
+    "detect-non-literal-fs-filename",
+    "detect-non-literal-regexp",
+    "detect-non-literal-require",
+    "detect-object-injection",
+    "detect-possible-timing-attacks",
+    "detect-pseudoRandomBytes",
+    "detect-unsafe-regex",
+];
+
+const CHILD_PROCESS_PACKAGES: [&str; 2] = ["child_process", "node:child_process"];
+const FS_PACKAGES: [&str; 5] = [
+    "fs",
+    "node:fs",
+    "fs/promises",
+    "node:fs/promises",
+    "fs-extra",
+];
+const PATH_PACKAGES: [&str; 4] = ["path", "node:path", "path/posix", "node:path/posix"];
+const URL_PACKAGES: [&str; 2] = ["url", "node:url"];
+const PATH_CONSTRUCTION_METHODS: [&str; 8] = [
+    "basename",
+    "dirname",
+    "extname",
+    "join",
+    "normalize",
+    "relative",
+    "resolve",
+    "toNamespacedPath",
+];
+const PATH_STATIC_MEMBERS: [&str; 2] = ["delimiter", "sep"];
+const TIMING_KEYWORDS: [&str; 8] = [
+    "password", "secret", "api", "apikey", "token", "auth", "pass", "hash",
+];
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub text: Option<CompactString>,
+    pub method: Option<CompactString>,
+    pub package_name: Option<CompactString>,
+    pub fn_name: Option<CompactString>,
+    pub indices: Option<CompactString>,
+    pub side: Option<CompactString>,
+    pub value: Option<CompactString>,
+    pub argument_type: Option<CompactString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: DiagnosticData,
+    pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AccessPath {
+    package_name: CompactString,
+    path: SmallVec<[CompactString; 4]>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Binding {
+    Unknown,
+    Static,
+    Import(AccessPath),
+}
+
+#[derive(Default)]
+struct Scope {
+    bindings: FastHashMap<CompactString, Binding>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ParentKind {
+    None,
+    VariableInit,
+    AssignmentRight,
+    AssignmentLeft,
+    MemberObject,
+    CallCallee,
+    CallArgument,
+    NewCallee,
+    NewArgument,
+    Other,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_security_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_security(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 16]> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::mjs())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let line_index = LineIndex::new(source_text);
+    let mut scanner = Scanner {
+        source_text,
+        line_index,
+        diagnostics: SmallVec::new(),
+        scopes: SmallVec::new(),
+        csrf_seen: false,
+        comment_spans: parser_return
+            .program
+            .comments
+            .iter()
+            .map(|comment| comment.span)
+            .collect(),
+    };
+    scanner.push_scope();
+    scanner.scan_bidi_characters();
+    scanner.scan_program(&parser_return.program.body);
+    scanner.diagnostics
+}
+
+struct Scanner<'a> {
+    source_text: &'a str,
+    line_index: LineIndex,
+    diagnostics: SmallVec<[Diagnostic; 16]>,
+    scopes: SmallVec<[Scope; 8]>,
+    csrf_seen: bool,
+    comment_spans: SmallVec<[Span; 16]>,
+}
+
+impl<'a> Scanner<'a> {
+    fn push_scope(&mut self) {
+        self.scopes.push(Scope::default());
+    }
+
+    fn pop_scope(&mut self) {
+        let _ = self.scopes.pop();
+    }
+
+    fn current_scope_mut(&mut self) -> &mut Scope {
+        self.scopes
+            .last_mut()
+            .expect("scanner always has an active scope")
+    }
+
+    fn bind(&mut self, name: &str, binding: Binding) {
+        self.current_scope_mut()
+            .bindings
+            .insert(CompactString::from(name), binding);
+    }
+
+    fn lookup(&self, name: &str) -> Option<&Binding> {
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.bindings.get(name))
+    }
+
+    fn report(&mut self, rule_name: &'static str, message_id: &'static str, span: Span) {
+        self.report_with_data(rule_name, message_id, DiagnosticData::default(), span);
+    }
+
+    fn report_with_data(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        data: DiagnosticData,
+        span: Span,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+
+    fn scan_program(&mut self, body: &'a [Statement<'a>]) {
+        for statement in body {
+            self.scan_statement(statement);
+        }
+    }
+
+    fn scan_statement(&mut self, statement: &'a Statement<'a>) {
+        match statement {
+            Statement::BlockStatement(block) => {
+                for statement in &block.body {
+                    self.scan_statement(statement);
+                }
+            }
+            Statement::ExpressionStatement(statement) => {
+                self.scan_expression(&statement.expression, ParentKind::None);
+            }
+            Statement::IfStatement(statement) => {
+                self.check_possible_timing_attack(statement.span, &statement.test);
+                self.scan_expression(&statement.test, ParentKind::Other);
+                self.scan_statement(&statement.consequent);
+                if let Some(alternate) = &statement.alternate {
+                    self.scan_statement(alternate);
+                }
+            }
+            Statement::ReturnStatement(statement) => {
+                if let Some(argument) = &statement.argument {
+                    self.scan_expression(argument, ParentKind::Other);
+                }
+            }
+            Statement::ThrowStatement(statement) => {
+                self.scan_expression(&statement.argument, ParentKind::Other);
+            }
+            Statement::WhileStatement(statement) => {
+                self.scan_expression(&statement.test, ParentKind::Other);
+                self.scan_statement(&statement.body);
+            }
+            Statement::DoWhileStatement(statement) => {
+                self.scan_statement(&statement.body);
+                self.scan_expression(&statement.test, ParentKind::Other);
+            }
+            Statement::ForStatement(statement) => {
+                if let Some(init) = &statement.init {
+                    self.scan_for_init(init);
+                }
+                if let Some(test) = &statement.test {
+                    self.scan_expression(test, ParentKind::Other);
+                }
+                if let Some(update) = &statement.update {
+                    self.scan_expression(update, ParentKind::Other);
+                }
+                self.scan_statement(&statement.body);
+            }
+            Statement::ForInStatement(statement) => {
+                self.scan_for_left(&statement.left);
+                self.scan_expression(&statement.right, ParentKind::Other);
+                self.scan_statement(&statement.body);
+            }
+            Statement::ForOfStatement(statement) => {
+                self.scan_for_left(&statement.left);
+                self.scan_expression(&statement.right, ParentKind::Other);
+                self.scan_statement(&statement.body);
+            }
+            Statement::SwitchStatement(statement) => {
+                self.scan_expression(&statement.discriminant, ParentKind::Other);
+                for case in &statement.cases {
+                    if let Some(test) = &case.test {
+                        self.scan_expression(test, ParentKind::Other);
+                    }
+                    for statement in &case.consequent {
+                        self.scan_statement(statement);
+                    }
+                }
+            }
+            Statement::TryStatement(statement) => {
+                for statement in &statement.block.body {
+                    self.scan_statement(statement);
+                }
+                if let Some(handler) = &statement.handler {
+                    self.push_scope();
+                    if let Some(param) = &handler.param {
+                        self.bind_pattern_unknown(&param.pattern);
+                    }
+                    for statement in &handler.body.body {
+                        self.scan_statement(statement);
+                    }
+                    self.pop_scope();
+                }
+                if let Some(finalizer) = &statement.finalizer {
+                    for statement in &finalizer.body {
+                        self.scan_statement(statement);
+                    }
+                }
+            }
+            Statement::LabeledStatement(statement) => {
+                self.scan_statement(&statement.body);
+            }
+            Statement::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            Statement::FunctionDeclaration(function) => {
+                if let Some(id) = &function.id {
+                    self.bind(id.name.as_str(), Binding::Unknown);
+                }
+                self.scan_function(function);
+            }
+            Statement::ClassDeclaration(class) => {
+                if let Some(id) = &class.id {
+                    self.bind(id.name.as_str(), Binding::Unknown);
+                }
+                self.scan_class(class);
+            }
+            Statement::ImportDeclaration(declaration) => {
+                self.scan_import_declaration(declaration);
+            }
+            Statement::ExportNamedDeclaration(declaration) => {
+                if let Some(declaration) = &declaration.declaration {
+                    self.scan_declaration(declaration);
+                }
+            }
+            Statement::ExportDefaultDeclaration(declaration) => match &declaration.declaration {
+                ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                    self.scan_function(function);
+                }
+                ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+                    self.scan_class(class);
+                }
+                _ => {
+                    if let Some(expression) = declaration.declaration.as_expression() {
+                        self.scan_expression(expression, ParentKind::Other);
+                    }
+                }
+            },
+            _ => {}
+        }
+    }
+
+    fn scan_declaration(&mut self, declaration: &'a Declaration<'a>) {
+        match declaration {
+            Declaration::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            Declaration::FunctionDeclaration(function) => {
+                if let Some(id) = &function.id {
+                    self.bind(id.name.as_str(), Binding::Unknown);
+                }
+                self.scan_function(function);
+            }
+            Declaration::ClassDeclaration(class) => {
+                if let Some(id) = &class.id {
+                    self.bind(id.name.as_str(), Binding::Unknown);
+                }
+                self.scan_class(class);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_for_init(&mut self, init: &'a ForStatementInit<'a>) {
+        match init {
+            ForStatementInit::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            _ => {
+                if let Some(expression) = init.as_expression() {
+                    self.scan_expression(expression, ParentKind::Other);
+                }
+            }
+        }
+    }
+
+    fn scan_for_left(&mut self, left: &'a ForStatementLeft<'a>) {
+        if let ForStatementLeft::VariableDeclaration(declaration) = left {
+            self.scan_variable_declaration(declaration);
+        }
+    }
+
+    fn scan_import_declaration(&mut self, declaration: &'a ImportDeclaration<'a>) {
+        let package_name = declaration.source.value.as_str();
+        let interesting = is_interesting_package(package_name);
+
+        if let Some(specifiers) = &declaration.specifiers {
+            for specifier in specifiers {
+                match specifier {
+                    ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                        let imported = module_export_name(&specifier.imported);
+                        let binding = if interesting {
+                            imported.map(|name| {
+                                Binding::Import(AccessPath {
+                                    package_name: CompactString::from(package_name),
+                                    path: small_path([name]),
+                                })
+                            })
+                        } else {
+                            None
+                        }
+                        .unwrap_or(Binding::Unknown);
+                        self.bind(specifier.local.name.as_str(), binding);
+                    }
+                    ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                        let binding = if interesting {
+                            Binding::Import(AccessPath {
+                                package_name: CompactString::from(package_name),
+                                path: SmallVec::new(),
+                            })
+                        } else {
+                            Binding::Unknown
+                        };
+                        self.bind(specifier.local.name.as_str(), binding);
+                    }
+                    ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                        let binding = if interesting {
+                            Binding::Import(AccessPath {
+                                package_name: CompactString::from(package_name),
+                                path: SmallVec::new(),
+                            })
+                        } else {
+                            Binding::Unknown
+                        };
+                        self.bind(specifier.local.name.as_str(), binding);
+                    }
+                }
+            }
+        }
+    }
+
+    fn scan_variable_declaration(&mut self, declaration: &'a VariableDeclaration<'a>) {
+        for declarator in &declaration.declarations {
+            if let Some(init) = &declarator.init {
+                if let Some(path) = self.import_access_path(init, &INTERESTING_PACKAGES) {
+                    self.bind_pattern_from_import(&declarator.id, &path);
+                } else if self.is_static_expression(init, 0) {
+                    self.bind_pattern_static_or_unknown(&declarator.id, true);
+                } else {
+                    self.bind_pattern_unknown(&declarator.id);
+                }
+                self.scan_expression(init, ParentKind::VariableInit);
+            } else {
+                self.bind_pattern_unknown(&declarator.id);
+            }
+        }
+    }
+
+    fn scan_function(&mut self, function: &'a Function<'a>) {
+        self.push_scope();
+        for param in &function.params.items {
+            self.bind_pattern_unknown(&param.pattern);
+            if let Some(initializer) = &param.initializer {
+                self.scan_expression(initializer, ParentKind::Other);
+            }
+        }
+        if let Some(rest) = &function.params.rest {
+            self.bind_pattern_unknown(&rest.rest.argument);
+        }
+        if let Some(body) = &function.body {
+            self.scan_function_body(body);
+        }
+        self.pop_scope();
+    }
+
+    fn scan_function_body(&mut self, body: &'a FunctionBody<'a>) {
+        for statement in &body.statements {
+            self.scan_statement(statement);
+        }
+    }
+
+    fn scan_class(&mut self, class: &'a Class<'a>) {
+        if let Some(super_class) = &class.super_class {
+            self.scan_expression(super_class, ParentKind::Other);
+        }
+        for element in &class.body.body {
+            match element {
+                ClassElement::StaticBlock(block) => {
+                    self.push_scope();
+                    for statement in &block.body {
+                        self.scan_statement(statement);
+                    }
+                    self.pop_scope();
+                }
+                ClassElement::MethodDefinition(method) => {
+                    self.scan_function(&method.value);
+                }
+                ClassElement::PropertyDefinition(property) => {
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value, ParentKind::Other);
+                    }
+                }
+                ClassElement::AccessorProperty(property) => {
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value, ParentKind::Other);
+                    }
+                }
+                ClassElement::TSIndexSignature(_) => {}
+            }
+        }
+    }
+
+    fn scan_expression(&mut self, expression: &'a Expression<'a>, parent: ParentKind) {
+        match expression.get_inner_expression() {
+            Expression::CallExpression(call) => {
+                self.check_call_expression(call, parent);
+                self.scan_expression(&call.callee, ParentKind::CallCallee);
+                for argument in &call.arguments {
+                    self.scan_argument(argument, ParentKind::CallArgument);
+                }
+            }
+            Expression::NewExpression(new_expression) => {
+                self.check_new_expression(new_expression);
+                self.scan_expression(&new_expression.callee, ParentKind::NewCallee);
+                for argument in &new_expression.arguments {
+                    self.scan_argument(argument, ParentKind::NewArgument);
+                }
+            }
+            Expression::AssignmentExpression(assignment) => {
+                self.check_disable_mustache_escape(
+                    assignment.span,
+                    &assignment.left,
+                    &assignment.right,
+                );
+                self.scan_assignment_target(&assignment.left, ParentKind::AssignmentLeft);
+                self.scan_expression(&assignment.right, ParentKind::AssignmentRight);
+            }
+            Expression::StaticMemberExpression(member) => {
+                if member.property.name == "pseudoRandomBytes" {
+                    self.report("detect-pseudoRandomBytes", "found", member.span);
+                }
+                self.scan_expression(&member.object, ParentKind::MemberObject);
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.check_object_injection(member.span, &member.expression, parent);
+                self.scan_expression(&member.object, ParentKind::MemberObject);
+                self.scan_expression(&member.expression, ParentKind::Other);
+            }
+            Expression::BinaryExpression(binary) => {
+                self.scan_expression(&binary.left, ParentKind::Other);
+                self.scan_expression(&binary.right, ParentKind::Other);
+            }
+            Expression::LogicalExpression(logical) => {
+                self.scan_expression(&logical.left, ParentKind::Other);
+                self.scan_expression(&logical.right, ParentKind::Other);
+            }
+            Expression::ConditionalExpression(conditional) => {
+                self.scan_expression(&conditional.test, ParentKind::Other);
+                self.scan_expression(&conditional.consequent, ParentKind::Other);
+                self.scan_expression(&conditional.alternate, ParentKind::Other);
+            }
+            Expression::ArrayExpression(array) => {
+                for element in &array.elements {
+                    if let Some(expression) = array_element_expression(element) {
+                        self.scan_expression(expression, ParentKind::Other);
+                    }
+                }
+            }
+            Expression::ObjectExpression(object) => {
+                for property in &object.properties {
+                    match property {
+                        ObjectPropertyKind::ObjectProperty(property) => {
+                            if property.computed {
+                                self.scan_property_key(&property.key);
+                            }
+                            self.scan_expression(&property.value, ParentKind::Other);
+                        }
+                        ObjectPropertyKind::SpreadProperty(spread) => {
+                            self.scan_expression(&spread.argument, ParentKind::Other);
+                        }
+                    }
+                }
+            }
+            Expression::TemplateLiteral(template) => {
+                for expression in &template.expressions {
+                    self.scan_expression(expression, ParentKind::Other);
+                }
+            }
+            Expression::TaggedTemplateExpression(tagged) => {
+                self.scan_expression(&tagged.tag, ParentKind::Other);
+                for expression in &tagged.quasi.expressions {
+                    self.scan_expression(expression, ParentKind::Other);
+                }
+            }
+            Expression::FunctionExpression(function) => self.scan_function(function),
+            Expression::ArrowFunctionExpression(function) => {
+                self.push_scope();
+                for param in &function.params.items {
+                    self.bind_pattern_unknown(&param.pattern);
+                }
+                for statement in &function.body.statements {
+                    self.scan_statement(statement);
+                }
+                self.pop_scope();
+            }
+            Expression::ClassExpression(class) => self.scan_class(class),
+            Expression::SequenceExpression(sequence) => {
+                for expression in &sequence.expressions {
+                    self.scan_expression(expression, ParentKind::Other);
+                }
+            }
+            Expression::AwaitExpression(await_expression) => {
+                self.scan_expression(&await_expression.argument, ParentKind::Other);
+            }
+            Expression::UnaryExpression(unary) => {
+                self.scan_expression(&unary.argument, ParentKind::Other);
+            }
+            Expression::UpdateExpression(_) => {}
+            Expression::YieldExpression(yield_expression) => {
+                if let Some(argument) = &yield_expression.argument {
+                    self.scan_expression(argument, ParentKind::Other);
+                }
+            }
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::CallExpression(call) => {
+                    self.check_call_expression(call, parent);
+                    self.scan_expression(&call.callee, ParentKind::CallCallee);
+                    for argument in &call.arguments {
+                        self.scan_argument(argument, ParentKind::CallArgument);
+                    }
+                }
+                ChainElement::StaticMemberExpression(member) => {
+                    self.scan_expression(&member.object, ParentKind::MemberObject);
+                }
+                ChainElement::ComputedMemberExpression(member) => {
+                    self.check_object_injection(member.span, &member.expression, parent);
+                    self.scan_expression(&member.object, ParentKind::MemberObject);
+                    self.scan_expression(&member.expression, ParentKind::Other);
+                }
+                ChainElement::PrivateFieldExpression(member) => {
+                    self.scan_expression(&member.object, ParentKind::MemberObject);
+                }
+                ChainElement::TSNonNullExpression(expression) => {
+                    self.scan_expression(&expression.expression, parent);
+                }
+            },
+            Expression::RegExpLiteral(literal)
+                if is_unsafe_regex(literal.regex.pattern.text.as_str()) =>
+            {
+                self.report("detect-unsafe-regex", "literal", literal.span);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_property_key(&mut self, key: &'a PropertyKey<'a>) {
+        if let Some(expression) = key.as_expression() {
+            self.scan_expression(expression, ParentKind::Other);
+        }
+    }
+
+    fn scan_argument(&mut self, argument: &'a Argument<'a>, parent: ParentKind) {
+        if let Some(expression) = argument.as_expression() {
+            self.scan_expression(expression, parent);
+        } else if let Argument::SpreadElement(spread) = argument {
+            self.scan_expression(&spread.argument, parent);
+        }
+    }
+
+    fn scan_assignment_target(&mut self, target: &'a AssignmentTarget<'a>, parent: ParentKind) {
+        match target {
+            AssignmentTarget::ComputedMemberExpression(member) => {
+                self.check_object_injection(member.span, &member.expression, parent);
+                self.scan_expression(&member.object, ParentKind::MemberObject);
+                self.scan_expression(&member.expression, ParentKind::Other);
+            }
+            AssignmentTarget::StaticMemberExpression(member) => {
+                self.scan_expression(&member.object, ParentKind::MemberObject);
+            }
+            AssignmentTarget::PrivateFieldExpression(member) => {
+                self.scan_expression(&member.object, ParentKind::MemberObject);
+            }
+            AssignmentTarget::TSAsExpression(expression) => {
+                self.scan_expression(&expression.expression, parent);
+            }
+            AssignmentTarget::TSSatisfiesExpression(expression) => {
+                self.scan_expression(&expression.expression, parent);
+            }
+            AssignmentTarget::TSNonNullExpression(expression) => {
+                self.scan_expression(&expression.expression, parent);
+            }
+            AssignmentTarget::TSTypeAssertion(expression) => {
+                self.scan_expression(&expression.expression, parent);
+            }
+            _ => {}
+        }
+    }
+
+    fn check_call_expression(&mut self, call: &'a CallExpression<'a>, parent: ParentKind) {
+        if let Some(package_name) = self.require_package_name(call)
+            && CHILD_PROCESS_PACKAGES.contains(&package_name)
+            && !matches!(
+                parent,
+                ParentKind::VariableInit | ParentKind::AssignmentRight | ParentKind::MemberObject
+            )
+        {
+            self.report_with_data(
+                "detect-child-process",
+                "require",
+                DiagnosticData {
+                    value: Some(CompactString::from(package_name)),
+                    ..DiagnosticData::default()
+                },
+                call.span,
+            );
+        }
+
+        if call.callee.is_specific_id("eval")
+            && let Some(argument) = call.arguments.first().and_then(Argument::as_expression)
+            && !argument.is_literal()
+        {
+            self.report_with_data(
+                "detect-eval-with-expression",
+                "nonLiteral",
+                DiagnosticData {
+                    argument_type: Some(CompactString::from(expression_type(argument))),
+                    ..DiagnosticData::default()
+                },
+                call.span,
+            );
+        }
+
+        if call.callee.is_specific_id("require")
+            && let Some(argument) = call.arguments.first().and_then(Argument::as_expression)
+            && !self.is_static_expression(argument, 0)
+        {
+            self.report("detect-non-literal-require", "nonLiteral", call.span);
+        }
+
+        if let Some(path) = self.import_access_path(&call.callee, &CHILD_PROCESS_PACKAGES)
+            && path.path.len() == 1
+            && path.path[0].as_str() == "exec"
+            && let Some(argument) = call.arguments.first().and_then(Argument::as_expression)
+            && !self.is_static_expression(argument, 0)
+        {
+            self.report("detect-child-process", "execNonLiteral", call.span);
+        }
+
+        self.check_buffer_noassert(call);
+        self.check_no_csrf_before_method_override(call);
+        self.check_non_literal_fs_filename(call);
+    }
+
+    fn check_new_expression(&mut self, new_expression: &'a NewExpression<'a>) {
+        if new_expression.callee.is_specific_id("Buffer")
+            && let Some(argument) = new_expression
+                .arguments
+                .first()
+                .and_then(Argument::as_expression)
+            && !argument.is_literal()
+        {
+            self.report("detect-new-buffer", "found", new_expression.span);
+        }
+
+        if new_expression.callee.is_specific_id("RegExp")
+            && let Some(argument) = new_expression
+                .arguments
+                .first()
+                .and_then(Argument::as_expression)
+        {
+            if !self.is_static_expression(argument, 0) {
+                self.report(
+                    "detect-non-literal-regexp",
+                    "nonLiteral",
+                    new_expression.span,
+                );
+            } else if let Some(pattern) = string_literal_value(argument)
+                && is_unsafe_regex(pattern)
+            {
+                self.report("detect-unsafe-regex", "newRegExp", new_expression.span);
+            }
+        }
+    }
+
+    fn check_buffer_noassert(&mut self, call: &'a CallExpression<'a>) {
+        let Some(method) = static_member_property(&call.callee) else {
+            return;
+        };
+        let index = if BUFFER_READ_METHODS.contains(&method) {
+            Some(1)
+        } else if BUFFER_WRITE_METHODS.contains(&method) {
+            Some(2)
+        } else {
+            None
+        };
+
+        if let Some(index) = index
+            && let Some(argument) = call.arguments.get(index).and_then(Argument::as_expression)
+            && matches!(argument.get_inner_expression(), Expression::BooleanLiteral(value) if value.value)
+        {
+            self.report_with_data(
+                "detect-buffer-noassert",
+                "found",
+                DiagnosticData {
+                    method: Some(CompactString::from(method)),
+                    ..DiagnosticData::default()
+                },
+                call.callee.span(),
+            );
+        }
+    }
+
+    fn check_no_csrf_before_method_override(&mut self, call: &'a CallExpression<'a>) {
+        if !call.callee.is_specific_member_access("express", "csrf")
+            && !call
+                .callee
+                .is_specific_member_access("express", "methodOverride")
+        {
+            return;
+        }
+
+        if call
+            .callee
+            .is_specific_member_access("express", "methodOverride")
+            && self.csrf_seen
+        {
+            self.report("detect-no-csrf-before-method-override", "found", call.span);
+        }
+        if call.callee.is_specific_member_access("express", "csrf") {
+            self.csrf_seen = true;
+        }
+    }
+
+    fn check_disable_mustache_escape(
+        &mut self,
+        span: Span,
+        left: &'a AssignmentTarget<'a>,
+        right: &'a Expression<'a>,
+    ) {
+        if !matches!(left, AssignmentTarget::StaticMemberExpression(member) if member.property.name == "escapeMarkup")
+        {
+            return;
+        }
+        if matches!(right.get_inner_expression(), Expression::BooleanLiteral(value) if !value.value)
+        {
+            self.report("detect-disable-mustache-escape", "found", span);
+        }
+    }
+
+    fn check_non_literal_fs_filename(&mut self, call: &'a CallExpression<'a>) {
+        if call.callee.is_specific_id("require") || call.arguments.iter().all(argument_is_literal) {
+            return;
+        }
+
+        let Some(path) = self.import_access_path(&call.callee, &FS_PACKAGES) else {
+            return;
+        };
+        let fn_name = match path.path.as_slice() {
+            [name] => name.as_str(),
+            [_, name] => name.as_str(),
+            _ => return,
+        };
+        let Some(indices_to_check) = fs_argument_indices(fn_name) else {
+            return;
+        };
+
+        let mut indices: SmallVec<[usize; 2]> = SmallVec::new();
+        for index in indices_to_check {
+            if let Some(argument) = call.arguments.get(*index).and_then(Argument::as_expression)
+                && !self.is_static_expression(argument, 0)
+            {
+                indices.push(*index);
+            }
+        }
+
+        if !indices.is_empty() {
+            let joined = join_usize(&indices);
+            self.report_with_data(
+                "detect-non-literal-fs-filename",
+                "nonLiteral",
+                DiagnosticData {
+                    fn_name: Some(CompactString::from(fn_name)),
+                    package_name: Some(path.package_name),
+                    indices: Some(joined),
+                    ..DiagnosticData::default()
+                },
+                call.span,
+            );
+        }
+    }
+
+    fn check_object_injection(
+        &mut self,
+        span: Span,
+        property: &'a Expression<'a>,
+        parent: ParentKind,
+    ) {
+        if !matches!(property.get_inner_expression(), Expression::Identifier(_)) {
+            return;
+        }
+        let message_id = match parent {
+            ParentKind::VariableInit => "variable",
+            ParentKind::CallCallee => "functionCall",
+            _ => "generic",
+        };
+        self.report("detect-object-injection", message_id, span);
+    }
+
+    fn check_possible_timing_attack(&mut self, span: Span, test: &'a Expression<'a>) {
+        let Expression::BinaryExpression(binary) = test.get_inner_expression() else {
+            return;
+        };
+        if !matches!(
+            binary.operator,
+            BinaryOperator::Equality
+                | BinaryOperator::StrictEquality
+                | BinaryOperator::Inequality
+                | BinaryOperator::StrictInequality
+        ) {
+            return;
+        }
+        if contains_timing_keyword(&binary.left) {
+            self.report_with_data(
+                "detect-possible-timing-attacks",
+                "found",
+                DiagnosticData {
+                    side: Some(CompactString::from("left")),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        } else if contains_timing_keyword(&binary.right) {
+            self.report_with_data(
+                "detect-possible-timing-attacks",
+                "found",
+                DiagnosticData {
+                    side: Some(CompactString::from("right")),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+    }
+
+    fn scan_bidi_characters(&mut self) {
+        for (start, ch) in self.source_text.char_indices() {
+            if !is_dangerous_bidi(ch) {
+                continue;
+            }
+            let end = start + ch.len_utf8();
+            let in_comment = self
+                .comment_spans
+                .iter()
+                .any(|span| span.start as usize <= start && end <= span.end as usize);
+            let line_text = source_line_at(self.source_text, start);
+            self.report_with_data(
+                "detect-bidi-characters",
+                if in_comment { "comment" } else { "code" },
+                DiagnosticData {
+                    text: Some(CompactString::from(line_text)),
+                    ..DiagnosticData::default()
+                },
+                Span::new(start as u32, end as u32),
+            );
+        }
+    }
+
+    fn require_package_name(&self, call: &'a CallExpression<'a>) -> Option<&'a str> {
+        if !call.callee.is_specific_id("require") {
+            return None;
+        }
+        let Some(Expression::StringLiteral(literal)) =
+            call.arguments.first().and_then(Argument::as_expression)
+        else {
+            return None;
+        };
+        Some(literal.value.as_str())
+    }
+
+    fn import_access_path(
+        &self,
+        expression: &'a Expression<'a>,
+        package_names: &[&str],
+    ) -> Option<AccessPath> {
+        match expression.get_inner_expression() {
+            Expression::Identifier(identifier) => match self.lookup(identifier.name.as_str()) {
+                Some(Binding::Import(path))
+                    if package_names.contains(&path.package_name.as_str()) =>
+                {
+                    Some(path.clone())
+                }
+                _ => None,
+            },
+            Expression::StaticMemberExpression(member) => {
+                let mut path = self.import_access_path(&member.object, package_names)?;
+                path.path
+                    .push(CompactString::from(member.property.name.as_str()));
+                Some(path)
+            }
+            Expression::CallExpression(call) => {
+                let package_name = self.require_package_name(call)?;
+                if !package_names.contains(&package_name) {
+                    return None;
+                }
+                Some(AccessPath {
+                    package_name: CompactString::from(package_name),
+                    path: SmallVec::new(),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn is_static_expression(&self, expression: &'a Expression<'a>, depth: usize) -> bool {
+        if depth > 32 {
+            return false;
+        }
+
+        match expression.get_inner_expression() {
+            Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_)
+            | Expression::StringLiteral(_) => true,
+            Expression::TemplateLiteral(template) => template
+                .expressions
+                .iter()
+                .all(|expression| self.is_static_expression(expression, depth + 1)),
+            Expression::BinaryExpression(binary) => {
+                self.is_static_expression(&binary.left, depth + 1)
+                    && self.is_static_expression(&binary.right, depth + 1)
+            }
+            Expression::Identifier(identifier) => match identifier.name.as_str() {
+                "__dirname" | "__filename" => true,
+                name => matches!(self.lookup(name), Some(Binding::Static)),
+            },
+            Expression::StaticMemberExpression(member) => {
+                is_import_meta_url(expression)
+                    || self.is_static_path_member(member.property.name.as_str(), &member.object)
+            }
+            Expression::CallExpression(call) => {
+                self.is_static_path_call(call, depth)
+                    || self.is_static_file_url_to_path(call, depth)
+                    || self.is_static_require_resolve(call, depth)
+                    || self.is_static_process_cwd(call)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_static_path_member(&self, name: &str, object: &'a Expression<'a>) -> bool {
+        if !PATH_STATIC_MEMBERS.contains(&name) {
+            return false;
+        }
+        self.import_access_path(object, &PATH_PACKAGES).is_some()
+    }
+
+    fn is_static_path_call(&self, call: &'a CallExpression<'a>, depth: usize) -> bool {
+        let Some(path) = self.import_access_path(&call.callee, &PATH_PACKAGES) else {
+            return false;
+        };
+        let method = match path.path.as_slice() {
+            [name] => name.as_str(),
+            [namespace, name] if namespace.as_str() == "posix" => name.as_str(),
+            _ => return false,
+        };
+        PATH_CONSTRUCTION_METHODS.contains(&method)
+            && !call.arguments.is_empty()
+            && call.arguments.iter().all(|argument| {
+                argument
+                    .as_expression()
+                    .is_some_and(|expression| self.is_static_expression(expression, depth + 1))
+            })
+    }
+
+    fn is_static_file_url_to_path(&self, call: &'a CallExpression<'a>, depth: usize) -> bool {
+        let Some(path) = self.import_access_path(&call.callee, &URL_PACKAGES) else {
+            return false;
+        };
+        matches!(path.path.as_slice(), [name] if name.as_str() == "fileURLToPath")
+            && !call.arguments.is_empty()
+            && call.arguments.iter().all(|argument| {
+                argument
+                    .as_expression()
+                    .is_some_and(|expression| self.is_static_expression(expression, depth + 1))
+            })
+    }
+
+    fn is_static_require_resolve(&self, call: &'a CallExpression<'a>, depth: usize) -> bool {
+        if !call.callee.is_specific_member_access("require", "resolve") {
+            return false;
+        }
+        if matches!(
+            self.lookup("require"),
+            Some(Binding::Unknown | Binding::Import(_))
+        ) {
+            return false;
+        }
+        !call.arguments.is_empty()
+            && call.arguments.iter().all(|argument| {
+                argument
+                    .as_expression()
+                    .is_some_and(|expression| self.is_static_expression(expression, depth + 1))
+            })
+    }
+
+    fn is_static_process_cwd(&self, call: &'a CallExpression<'a>) -> bool {
+        call.callee.is_specific_member_access("process", "cwd")
+            && !matches!(
+                self.lookup("process"),
+                Some(Binding::Unknown | Binding::Import(_))
+            )
+    }
+
+    fn bind_pattern_from_import(&mut self, pattern: &'a BindingPattern<'a>, path: &AccessPath) {
+        match pattern {
+            BindingPattern::BindingIdentifier(identifier) => {
+                self.bind(identifier.name.as_str(), Binding::Import(path.clone()));
+            }
+            BindingPattern::ObjectPattern(pattern) => {
+                for property in &pattern.properties {
+                    self.bind_object_property_from_import(property, path);
+                }
+                if let Some(rest) = &pattern.rest {
+                    self.bind_pattern_unknown(&rest.argument);
+                }
+            }
+            BindingPattern::ArrayPattern(pattern) => {
+                for element in pattern.elements.iter().flatten() {
+                    self.bind_pattern_unknown(element);
+                }
+                if let Some(rest) = &pattern.rest {
+                    self.bind_pattern_unknown(&rest.argument);
+                }
+            }
+            BindingPattern::AssignmentPattern(pattern) => {
+                self.bind_pattern_from_import(&pattern.left, path);
+            }
+        }
+    }
+
+    fn bind_object_property_from_import(
+        &mut self,
+        property: &'a BindingProperty<'a>,
+        base: &AccessPath,
+    ) {
+        let Some(key_name) = property_key_name(&property.key) else {
+            self.bind_pattern_unknown(&property.value);
+            return;
+        };
+        let mut path = base.clone();
+        path.path.push(CompactString::from(key_name));
+        self.bind_pattern_from_import(&property.value, &path);
+    }
+
+    fn bind_pattern_static_or_unknown(&mut self, pattern: &'a BindingPattern<'a>, is_static: bool) {
+        match pattern {
+            BindingPattern::BindingIdentifier(identifier) => {
+                self.bind(
+                    identifier.name.as_str(),
+                    if is_static {
+                        Binding::Static
+                    } else {
+                        Binding::Unknown
+                    },
+                );
+            }
+            BindingPattern::ObjectPattern(pattern) => {
+                for property in &pattern.properties {
+                    self.bind_pattern_static_or_unknown(&property.value, false);
+                }
+                if let Some(rest) = &pattern.rest {
+                    self.bind_pattern_unknown(&rest.argument);
+                }
+            }
+            BindingPattern::ArrayPattern(pattern) => {
+                for element in pattern.elements.iter().flatten() {
+                    self.bind_pattern_static_or_unknown(element, false);
+                }
+                if let Some(rest) = &pattern.rest {
+                    self.bind_pattern_unknown(&rest.argument);
+                }
+            }
+            BindingPattern::AssignmentPattern(pattern) => {
+                self.bind_pattern_static_or_unknown(&pattern.left, false);
+            }
+        }
+    }
+
+    fn bind_pattern_unknown(&mut self, pattern: &'a BindingPattern<'a>) {
+        self.bind_pattern_static_or_unknown(pattern, false);
+    }
+}
+
+const INTERESTING_PACKAGES: [&str; 13] = [
+    "child_process",
+    "node:child_process",
+    "fs",
+    "node:fs",
+    "fs/promises",
+    "node:fs/promises",
+    "fs-extra",
+    "path",
+    "node:path",
+    "path/posix",
+    "node:path/posix",
+    "url",
+    "node:url",
+];
+
+const BUFFER_READ_METHODS: [&str; 14] = [
+    "readUInt8",
+    "readUInt16LE",
+    "readUInt16BE",
+    "readUInt32LE",
+    "readUInt32BE",
+    "readInt8",
+    "readInt16LE",
+    "readInt16BE",
+    "readInt32LE",
+    "readInt32BE",
+    "readFloatLE",
+    "readFloatBE",
+    "readDoubleLE",
+    "readDoubleBE",
+];
+
+const BUFFER_WRITE_METHODS: [&str; 14] = [
+    "writeUInt8",
+    "writeUInt16LE",
+    "writeUInt16BE",
+    "writeUInt32LE",
+    "writeUInt32BE",
+    "writeInt8",
+    "writeInt16LE",
+    "writeInt16BE",
+    "writeInt32LE",
+    "writeInt32BE",
+    "writeFloatLE",
+    "writeFloatBE",
+    "writeDoubleLE",
+    "writeDoubleBE",
+];
+
+fn small_path<const N: usize>(values: [&str; N]) -> SmallVec<[CompactString; 4]> {
+    values.into_iter().map(CompactString::from).collect()
+}
+
+fn is_interesting_package(package_name: &str) -> bool {
+    INTERESTING_PACKAGES.contains(&package_name)
+}
+
+fn module_export_name<'a>(name: &'a ModuleExportName<'a>) -> Option<&'a str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        PropertyKey::Identifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn static_member_property<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    let Expression::StaticMemberExpression(member) = expression.get_inner_expression() else {
+        return None;
+    };
+    Some(member.property.name.as_str())
+}
+
+fn argument_is_literal(argument: &Argument<'_>) -> bool {
+    argument.as_expression().is_some_and(Expression::is_literal)
+}
+
+fn array_element_expression<'a>(
+    element: &'a ArrayExpressionElement<'a>,
+) -> Option<&'a Expression<'a>> {
+    element.as_expression()
+}
+
+fn string_literal_value<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    match expression.get_inner_expression() {
+        Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
+fn contains_timing_keyword(expression: &Expression<'_>) -> bool {
+    let Expression::Identifier(identifier) = expression.get_inner_expression() else {
+        return false;
+    };
+    let name = identifier.name.as_str();
+    TIMING_KEYWORDS
+        .iter()
+        .any(|keyword| name.eq_ignore_ascii_case(keyword))
+}
+
+fn is_import_meta_url(expression: &Expression<'_>) -> bool {
+    let Expression::StaticMemberExpression(member) = expression.get_inner_expression() else {
+        return false;
+    };
+    if member.property.name != "url" {
+        return false;
+    }
+    matches!(
+        member.object.get_inner_expression(),
+        Expression::MetaProperty(meta)
+            if meta.meta.name == "import" && meta.property.name == "meta"
+    )
+}
+
+fn source_line_at(source_text: &str, offset: usize) -> &str {
+    let start = source_text[..offset]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let end = source_text[offset..]
+        .find('\n')
+        .map_or(source_text.len(), |index| offset + index);
+    &source_text[start..end]
+}
+
+fn is_dangerous_bidi(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'
+            | '\u{202b}'
+            | '\u{202c}'
+            | '\u{202d}'
+            | '\u{202e}'
+            | '\u{2066}'
+            | '\u{2067}'
+            | '\u{2068}'
+            | '\u{2069}'
+    )
+}
+
+fn expression_type(expression: &Expression<'_>) -> &'static str {
+    match expression.get_inner_expression() {
+        Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_) => "Literal",
+        Expression::TemplateLiteral(_) => "TemplateLiteral",
+        Expression::Identifier(_) => "Identifier",
+        Expression::CallExpression(_) => "CallExpression",
+        Expression::NewExpression(_) => "NewExpression",
+        Expression::StaticMemberExpression(_) => "MemberExpression",
+        Expression::ComputedMemberExpression(_) => "MemberExpression",
+        Expression::BinaryExpression(_) => "BinaryExpression",
+        Expression::ObjectExpression(_) => "ObjectExpression",
+        Expression::ArrayExpression(_) => "ArrayExpression",
+        Expression::ArrowFunctionExpression(_) => "ArrowFunctionExpression",
+        Expression::FunctionExpression(_) => "FunctionExpression",
+        _ => "Expression",
+    }
+}
+
+fn fs_argument_indices(fn_name: &str) -> Option<&'static [usize]> {
+    match fn_name {
+        "appendFile" | "appendFileSync" | "chmod" | "chmodSync" | "chown" | "chownSync"
+        | "createReadStream" | "createWriteStream" | "exists" | "existsSync" | "lchmod"
+        | "lchmodSync" | "lchown" | "lchownSync" | "lstat" | "lstatSync" | "mkdir"
+        | "mkdirSync" | "open" | "openSync" | "readdir" | "readdirSync" | "readFile"
+        | "readFileSync" | "readlink" | "readlinkSync" | "realpath" | "realpathSync" | "rmdir"
+        | "rmdirSync" | "stat" | "statSync" | "truncate" | "truncateSync" | "unlink"
+        | "unlinkSync" | "unwatchFile" | "utimes" | "utimesSync" | "watch" | "watchFile"
+        | "writeFile" | "writeFileSync" => Some(&[0]),
+        "link" | "linkSync" | "rename" | "renameSync" | "symlink" | "symlinkSync" => Some(&[0, 1]),
+        _ => None,
+    }
+}
+
+fn join_usize(values: &[usize]) -> CompactString {
+    let mut out = CompactString::new("");
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str(match value {
+            0 => "0",
+            1 => "1",
+            2 => "2",
+            3 => "3",
+            _ => "?",
+        });
+    }
+    out
+}
+
+pub fn is_unsafe_regex(pattern: &str) -> bool {
+    let chars: SmallVec<[char; 64]> = pattern.chars().collect();
+    let mut stack: SmallVec<[bool; 8]> = SmallVec::new();
+    let mut escaped = false;
+
+    for (index, ch) in chars.iter().copied().enumerate() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        match ch {
+            '(' => stack.push(false),
+            '*' | '+' => {
+                if let Some(in_group) = stack.last_mut() {
+                    *in_group = true;
+                }
+            }
+            '{' => {
+                if let Some(in_group) = stack.last_mut() {
+                    *in_group = true;
+                }
+            }
+            ')' => {
+                let group_has_quantifier = stack.pop().unwrap_or_else(|| {
+                    index > 0 && is_regex_quantifier(chars[index.saturating_sub(1)])
+                });
+                if group_has_quantifier
+                    && chars
+                        .get(index + 1)
+                        .copied()
+                        .is_some_and(is_regex_quantifier)
+                {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn is_regex_quantifier(ch: char) -> bool {
+    matches!(ch, '*' | '+' | '?' | '{')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_unsafe_regex, scan_security};
+
+    #[test]
+    fn scans_core_security_rules() {
+        let diagnostics = scan_security(
+            "var fs = require('fs');\nfs.readFile(filename);\neval(name);\n",
+            "fixture.js",
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.rule_name == "detect-non-literal-fs-filename")
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.rule_name == "detect-eval-with-expression")
+        );
+    }
+
+    #[test]
+    fn treats_static_path_builders_as_static() {
+        let diagnostics = scan_security(
+            "import fs from 'fs';\nimport path from 'path';\nfs.readFileSync(path.resolve(__dirname, './index.html'));\n",
+            "fixture.mjs",
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn detects_nested_quantified_regexes() {
+        assert!(is_unsafe_regex("(x+x+)+y"));
+        assert!(is_unsafe_regex("x+x+)+y"));
+        assert!(!is_unsafe_regex("^d+1337d+$"));
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ wildcards = "deny"
 allow = [
   "0BSD",
   "Apache-2.0",
+  "BSL-1.0",
   "BSD-2-Clause",
   "BSD-3-Clause",
   "BSL-1.0",

--- a/npm/security/Cargo.toml
+++ b/npm/security/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "oxlint-plugin-security"
+description = "Rust-backed oxlint plugin port of eslint-plugin-security."
+edition.workspace = true
+license = "Apache-2.0"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_security"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-security.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/npm/security/LICENSE
+++ b/npm/security/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 &yet, LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/npm/security/README.md
+++ b/npm/security/README.md
@@ -1,0 +1,23 @@
+# @oxlint-plugins/oxlint-plugin-security
+
+Rust-backed Oxlint plugin port of `eslint-plugin-security` v4.0.0.
+
+The JavaScript layer is an Oxlint/NAPI adapter. Parsing, import/require tracking,
+static-expression classification, and rule checks run in Rust through Oxc.
+
+## Rules
+
+- `security/detect-bidi-characters`
+- `security/detect-buffer-noassert`
+- `security/detect-child-process`
+- `security/detect-disable-mustache-escape`
+- `security/detect-eval-with-expression`
+- `security/detect-new-buffer`
+- `security/detect-no-csrf-before-method-override`
+- `security/detect-non-literal-fs-filename`
+- `security/detect-non-literal-regexp`
+- `security/detect-non-literal-require`
+- `security/detect-object-injection`
+- `security/detect-possible-timing-attacks`
+- `security/detect-pseudoRandomBytes`
+- `security/detect-unsafe-regex`

--- a/npm/security/api.d.ts
+++ b/npm/security/api.d.ts
@@ -1,0 +1,27 @@
+export type SecurityDiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type SecurityDiagnosticData = {
+  text?: string | null;
+  method?: string | null;
+  packageName?: string | null;
+  fnName?: string | null;
+  indices?: string | null;
+  side?: string | null;
+  value?: string | null;
+  argumentType?: string | null;
+};
+
+export type SecurityDiagnostic = {
+  ruleName: string;
+  messageId: string;
+  data: SecurityDiagnosticData;
+  loc: SecurityDiagnosticLoc;
+};
+
+export function implementedSecurityRuleNames(): string[];
+export function scanSecurity(sourceText: string, filename?: string): SecurityDiagnostic[];

--- a/npm/security/api.js
+++ b/npm/security/api.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanSecurity(sourceText, filename = 'file.js') {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanSecurity(sourceText, filename);
+}
+
+module.exports = {
+  implementedSecurityRuleNames: native.implementedSecurityRuleNames,
+  scanSecurity,
+};
+module.exports.default = module.exports;

--- a/npm/security/build.rs
+++ b/npm/security/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/security/index.js
+++ b/npm/security/index.js
@@ -1,0 +1,209 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-security (Apache-2.0).
+// The JavaScript layer is only an Oxlint/NAPI adapter; parsing, import/require
+// tracking, static-expression classification, and rule checks run in Rust.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedSecurityRuleNames, scanSecurity } = require('./api.js');
+
+const PLUGIN_NAME = 'security';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/security';
+const diagnosticsCache = new WeakMap();
+
+const messages = {
+  'detect-bidi-characters': {
+    code: "Detected potential trojan source attack with unicode bidi introduced in this code: '{{text}}'.",
+    comment:
+      "Detected potential trojan source attack with unicode bidi introduced in this comment: '{{text}}'.",
+  },
+  'detect-buffer-noassert': {
+    found: 'Found Buffer.{{method}} with noAssert flag set true',
+  },
+  'detect-child-process': {
+    require: 'Found require("{{value}}")',
+    execNonLiteral: 'Found child_process.exec() with non Literal first argument',
+  },
+  'detect-disable-mustache-escape': {
+    found: 'Markup escaping disabled.',
+  },
+  'detect-eval-with-expression': {
+    nonLiteral: 'eval with argument of type {{argumentType}}',
+  },
+  'detect-new-buffer': {
+    found: 'Found new Buffer',
+  },
+  'detect-no-csrf-before-method-override': {
+    found: 'express.csrf() middleware found before express.methodOverride()',
+  },
+  'detect-non-literal-fs-filename': {
+    nonLiteral:
+      'Found {{fnName}} from package "{{packageName}}" with non literal argument at index {{indices}}',
+  },
+  'detect-non-literal-regexp': {
+    nonLiteral: 'Found non-literal argument to RegExp Constructor',
+  },
+  'detect-non-literal-require': {
+    nonLiteral: 'Found non-literal argument in require',
+  },
+  'detect-object-injection': {
+    variable: 'Variable Assigned to Object Injection Sink',
+    functionCall: 'Function Call Object Injection Sink',
+    generic: 'Generic Object Injection Sink',
+  },
+  'detect-possible-timing-attacks': {
+    found: 'Potential timing attack, {{side}} side: true',
+  },
+  'detect-pseudoRandomBytes': {
+    found: 'Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers',
+  },
+  'detect-unsafe-regex': {
+    literal: 'Unsafe Regular Expression',
+    newRegExp: 'Unsafe Regular Expression (new RegExp)',
+  },
+};
+
+const ruleDescriptions = {
+  'detect-bidi-characters':
+    'Detects trojan source attacks that employ unicode bidi attacks to inject malicious code.',
+  'detect-buffer-noassert': 'Detects calls to "buffer" with "noAssert" flag set.',
+  'detect-child-process': 'Detects instances of "child_process" & non-literal "exec()" calls.',
+  'detect-disable-mustache-escape':
+    'Detects "object.escapeMarkup = false", which can be used with some template engines to disable escaping of HTML entities.',
+  'detect-eval-with-expression':
+    'Detects "eval(variable)" which can allow an attacker to run arbitrary code inside your process.',
+  'detect-new-buffer':
+    'Detects instances of new Buffer(argument) where argument is any non-literal value.',
+  'detect-no-csrf-before-method-override':
+    'Detects Express "csrf" middleware setup before "method-override" middleware.',
+  'detect-non-literal-fs-filename':
+    'Detects variable in filename argument of "fs" calls, which might allow an attacker to access anything on your system.',
+  'detect-non-literal-regexp':
+    'Detects "RegExp(variable)", which might allow an attacker to DOS your server with a long-running regular expression.',
+  'detect-non-literal-require':
+    'Detects "require(variable)", which might allow an attacker to load and run arbitrary code, or access arbitrary files on disk.',
+  'detect-object-injection': 'Detects "variable[key]" as a left- or right-hand assignment operand.',
+  'detect-possible-timing-attacks':
+    'Detects insecure comparisons (`==`, `!=`, `!==` and `===`), which check input sequentially.',
+  'detect-pseudoRandomBytes':
+    'Detects if "pseudoRandomBytes()" is in use, which might not give you the randomness you need and expect.',
+  'detect-unsafe-regex':
+    'Detects potentially unsafe regular expressions, which may take a very long time to run, blocking the event loop.',
+};
+
+const implementedRuleNames = Object.freeze(implementedSecurityRuleNames());
+
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createSecurityRule(ruleName)]),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: {
+      name: `${PLUGIN_NAME}/recommended`,
+      plugins: [PLUGIN_NAME],
+      rules: Object.fromEntries(
+        implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'warn']),
+      ),
+    },
+    'recommended-legacy': {
+      plugins: [PLUGIN_NAME],
+      rules: Object.fromEntries(
+        implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'warn']),
+      ),
+    },
+  },
+});
+
+plugin.implementedSecurityRuleNames = implementedRuleNames;
+plugin.scanSecurity = scanSecurity;
+
+function createSecurityRule(ruleName) {
+  return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: ruleDescriptions[ruleName],
+        category: 'Possible Security Vulnerability',
+        recommended: true,
+        url: `${DOCS_BASE}#${ruleName}`,
+      },
+      messages: messages[ruleName],
+      schema: [],
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForContext(context)) {
+            if (diagnostic.ruleName !== ruleName) {
+              continue;
+            }
+            context.report({
+              messageId: diagnostic.messageId,
+              data: compactData(diagnostic.data),
+              loc: {
+                start: {
+                  line: diagnostic.loc.startLine,
+                  column: diagnostic.loc.startColumn,
+                },
+                end: {
+                  line: diagnostic.loc.endLine,
+                  column: diagnostic.loc.endColumn,
+                },
+              },
+            });
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.js';
+  const cached = diagnosticsCache.get(sourceCode);
+
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanSecurity(sourceText, filename);
+  diagnosticsCache.set(sourceCode, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function compactData(data) {
+  const out = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    if (value != null) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.implementedSecurityRuleNames = implementedRuleNames;
+module.exports.scanSecurity = scanSecurity;

--- a/npm/security/package.json
+++ b/npm/security/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-security",
+  "version": "0.0.0",
+  "description": "Rust-backed oxlint plugin port of eslint-plugin-security.",
+  "keywords": [
+    "eslint-plugin",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "rust",
+    "security"
+  ],
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/security"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_security",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/security/src/lib.rs
+++ b/npm/security/src/lib.rs
@@ -1,0 +1,96 @@
+//! NAPI boundary for the security oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticLoc, implemented_security_rule_names, scan_security,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec; core rule logic uses compact Rust data structures."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_security as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct DiagnosticData {
+        pub text: Option<String>,
+        pub method: Option<String>,
+        pub package_name: Option<String>,
+        pub fn_name: Option<String>,
+        pub indices: Option<String>,
+        pub side: Option<String>,
+        pub value: Option<String>,
+        pub argument_type: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub data: DiagnosticData,
+        pub loc: DiagnosticLoc,
+    }
+
+    #[napi]
+    pub fn implemented_security_rule_names() -> Vec<String> {
+        core::implemented_security_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_security(source_text: String, filename: String) -> Vec<Diagnostic> {
+        core::scan_security(&source_text, &filename)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                data: DiagnosticData {
+                    text: diagnostic.data.text.map(|value| value.as_str().to_owned()),
+                    method: diagnostic
+                        .data
+                        .method
+                        .map(|value| value.as_str().to_owned()),
+                    package_name: diagnostic
+                        .data
+                        .package_name
+                        .map(|value| value.as_str().to_owned()),
+                    fn_name: diagnostic
+                        .data
+                        .fn_name
+                        .map(|value| value.as_str().to_owned()),
+                    indices: diagnostic
+                        .data
+                        .indices
+                        .map(|value| value.as_str().to_owned()),
+                    side: diagnostic.data.side.map(|value| value.as_str().to_owned()),
+                    value: diagnostic.data.value.map(|value| value.as_str().to_owned()),
+                    argument_type: diagnostic
+                        .data
+                        .argument_type
+                        .map(|value| value.as_str().to_owned()),
+                },
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+            })
+            .collect()
+    }
+}

--- a/npm/security/test/api.test.mjs
+++ b/npm/security/test/api.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedSecurityRuleNames, scanSecurity } from '../api.js';
+
+describe('security native API', () => {
+  it('exposes all eslint-plugin-security rule names', () => {
+    expect(implementedSecurityRuleNames()).toEqual([
+      'detect-bidi-characters',
+      'detect-buffer-noassert',
+      'detect-child-process',
+      'detect-disable-mustache-escape',
+      'detect-eval-with-expression',
+      'detect-new-buffer',
+      'detect-no-csrf-before-method-override',
+      'detect-non-literal-fs-filename',
+      'detect-non-literal-regexp',
+      'detect-non-literal-require',
+      'detect-object-injection',
+      'detect-possible-timing-attacks',
+      'detect-pseudoRandomBytes',
+      'detect-unsafe-regex',
+    ]);
+  });
+
+  it('scans multiple security rules through one native call', () => {
+    const diagnostics = scanSecurity(
+      [
+        "var fs = require('fs');",
+        'fs.readFile(filename);',
+        'eval(input);',
+        'if (password === secret) {}',
+      ].join('\n'),
+      'fixture.js',
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'detect-non-literal-fs-filename',
+      'detect-eval-with-expression',
+      'detect-possible-timing-attacks',
+    ]);
+    expect(diagnostics[0].data).toMatchObject({
+      fnName: 'readFile',
+      packageName: 'fs',
+      indices: '0',
+    });
+  });
+
+  it('returns LSP-shaped locations from Rust', () => {
+    const diagnostics = scanSecurity('const a = "‮";\n', 'fixture.js');
+
+    expect(diagnostics).toMatchObject([
+      {
+        ruleName: 'detect-bidi-characters',
+        messageId: 'code',
+        loc: {
+          startLine: 1,
+          startColumn: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+      },
+    ]);
+  });
+});

--- a/npm/security/test/plugin.test.mjs
+++ b/npm/security/test/plugin.test.mjs
@@ -1,0 +1,450 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const readMethods = [
+  'readUInt8',
+  'readUInt16LE',
+  'readUInt16BE',
+  'readUInt32LE',
+  'readUInt32BE',
+  'readInt8',
+  'readInt16LE',
+  'readInt16BE',
+  'readInt32LE',
+  'readInt32BE',
+  'readFloatLE',
+  'readFloatBE',
+  'readDoubleLE',
+  'readDoubleBE',
+];
+
+const writeMethods = [
+  'writeUInt8',
+  'writeUInt16LE',
+  'writeUInt16BE',
+  'writeUInt32LE',
+  'writeUInt32BE',
+  'writeInt8',
+  'writeInt16LE',
+  'writeInt16BE',
+  'writeInt32LE',
+  'writeInt32BE',
+  'writeFloatLE',
+  'writeFloatBE',
+  'writeDoubleLE',
+  'writeDoubleBE',
+];
+
+const validCases = [
+  ['detect-bidi-characters', 'clean source', 'const accessLevel = "user";\n'],
+  ...readMethods.map((method) => [
+    'detect-buffer-noassert',
+    `${method} without noAssert`,
+    `a.${method}(0, false)`,
+  ]),
+  ...writeMethods.map((method) => [
+    'detect-buffer-noassert',
+    `${method} without noAssert`,
+    `a.${method}(0, 0, false)`,
+  ]),
+  ['detect-child-process', 'literal child_process exec', "child_process.exec('ls')"],
+  [
+    'detect-child-process',
+    'spawn import is allowed',
+    "import { spawn } from 'child_process'; spawn(str);",
+  ],
+  [
+    'detect-child-process',
+    'shadowed exec receiver is ignored',
+    "var foo = require('child_process'); function fn () { var foo = /hello/; foo.exec(str); }",
+  ],
+  [
+    'detect-child-process',
+    'static exec argument is allowed',
+    "var child_process = require('child_process'); var FOO = 'ls'; child_process.exec(FOO);",
+  ],
+  ['detect-disable-mustache-escape', 'bare escapeMarkup assignment', 'escapeMarkup = false'],
+  ['detect-eval-with-expression', 'literal eval', "eval('alert()')"],
+  ['detect-eval-with-expression', 'empty eval', 'eval()'],
+  ['detect-new-buffer', 'literal new Buffer', "var a = new Buffer('test')"],
+  [
+    'detect-no-csrf-before-method-override',
+    'methodOverride before csrf',
+    'express.methodOverride();express.csrf()',
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'literal fs filename',
+    "var fs = require('fs'); var a = fs.open('test')",
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'non-fs readFile receiver',
+    "var something = require('some'); var a = something.readFile(c);",
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'static path resolve',
+    "import fs from 'fs'; import path from 'path'; fs.readFileSync(path.resolve(__dirname, './index.html'));",
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'static dirname variable',
+    "import fs from 'fs'; import path from 'path'; const dirname = path.dirname(__filename); fs.readFileSync(path.resolve(dirname, './index.html'));",
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'static process cwd template',
+    "import fs from 'fs'; fs.readFileSync(`${process.cwd()}/path/to/foo.json`);",
+  ],
+  ['detect-non-literal-regexp', 'literal regexp constructor', "var a = new RegExp('ab+c', 'i')"],
+  [
+    'detect-non-literal-regexp',
+    'static regexp source variable',
+    "var source = 'ab+c'; var a = new RegExp(source, 'i')",
+  ],
+  ['detect-non-literal-require', 'literal require', "var a = require('b')"],
+  [
+    'detect-non-literal-require',
+    'static template require',
+    "const d = 'debounce'; var a = require(`lodash/${d}`)",
+  ],
+  ['detect-non-literal-require', 'dirname require', "const utils = require(__dirname + '/utils');"],
+  ['detect-object-injection', 'plain object', 'var a = {};'],
+  ['detect-possible-timing-attacks', 'non-secret comparison', 'if (age === 5) {}'],
+  ['detect-pseudoRandomBytes', 'randomBytes member', 'crypto.randomBytes'],
+  ['detect-unsafe-regex', 'safe regex literal', '/^d+1337d+$/'],
+  ['detect-unsafe-regex', 'safe RegExp constructor', "new RegExp('^d+1337d+$')"],
+];
+
+const invalidCases = [
+  [
+    'detect-bidi-characters',
+    'bidi in code',
+    'var accessLevel = "user‮ ⁦// Check⁩ ⁦";',
+    [
+      'Detected potential trojan source attack with unicode bidi introduced in this code: \'var accessLevel = "user‮ ⁦// Check⁩ ⁦";\'.',
+      'Detected potential trojan source attack with unicode bidi introduced in this code: \'var accessLevel = "user‮ ⁦// Check⁩ ⁦";\'.',
+      'Detected potential trojan source attack with unicode bidi introduced in this code: \'var accessLevel = "user‮ ⁦// Check⁩ ⁦";\'.',
+      'Detected potential trojan source attack with unicode bidi introduced in this code: \'var accessLevel = "user‮ ⁦// Check⁩ ⁦";\'.',
+    ],
+  ],
+  [
+    'detect-bidi-characters',
+    'bidi in comment',
+    '/*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */',
+    [
+      "Detected potential trojan source attack with unicode bidi introduced in this comment: '/*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */'.",
+      "Detected potential trojan source attack with unicode bidi introduced in this comment: '/*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */'.",
+      "Detected potential trojan source attack with unicode bidi introduced in this comment: '/*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */'.",
+      "Detected potential trojan source attack with unicode bidi introduced in this comment: '/*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */'.",
+    ],
+  ],
+  ...readMethods.map((method) => [
+    'detect-buffer-noassert',
+    `${method} with noAssert`,
+    `a.${method}(0, true)`,
+    [`Found Buffer.${method} with noAssert flag set true`],
+  ]),
+  ...writeMethods.map((method) => [
+    'detect-buffer-noassert',
+    `${method} with noAssert`,
+    `a.${method}(0, 0, true)`,
+    [`Found Buffer.${method} with noAssert flag set true`],
+  ]),
+  [
+    'detect-child-process',
+    'bare child_process require',
+    "require('child_process')",
+    ['Found require("child_process")'],
+  ],
+  [
+    'detect-child-process',
+    'node child_process require',
+    "require('node:child_process')",
+    ['Found require("node:child_process")'],
+  ],
+  [
+    'detect-child-process',
+    'child exec non-literal',
+    "var child = require('child_process'); child.exec(com)",
+    ['Found child_process.exec() with non Literal first argument'],
+  ],
+  [
+    'detect-child-process',
+    'default import child exec non-literal',
+    "import child from 'node:child_process'; child.exec(com)",
+    ['Found child_process.exec() with non Literal first argument'],
+  ],
+  [
+    'detect-child-process',
+    'destructured exec non-literal',
+    "const {exec} = require('child_process'); exec(str)",
+    ['Found child_process.exec() with non Literal first argument'],
+  ],
+  [
+    'detect-disable-mustache-escape',
+    'escapeMarkup false',
+    'a.escapeMarkup = false',
+    ['Markup escaping disabled.'],
+  ],
+  [
+    'detect-eval-with-expression',
+    'identifier eval',
+    'eval(a);',
+    ['eval with argument of type Identifier'],
+  ],
+  ['detect-new-buffer', 'new Buffer variable', 'var a = new Buffer(c)', ['Found new Buffer']],
+  [
+    'detect-no-csrf-before-method-override',
+    'csrf before methodOverride',
+    'express.csrf();express.methodOverride()',
+    ['express.csrf() middleware found before express.methodOverride()'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'fs open variable',
+    "var something = require('fs'); var a = something.open(c);",
+    ['Found open from package "fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'fs readFile alias',
+    "var one = require('node:fs').readFile; one(filename);",
+    ['Found readFile from package "node:fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'fs promises package',
+    "var something = require('fs/promises'); something.readFile(filename);",
+    ['Found readFile from package "fs/promises" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'fs-extra package',
+    "var something = require('fs-extra'); something.readFile(filename);",
+    ['Found readFile from package "fs-extra" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'destructured fs readFile',
+    "var { readFile: something } = require('fs'); something(filename)",
+    ['Found readFile from package "fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'imported fs readFile',
+    "import { readFile as something } from 'node:fs'; something(filename);",
+    ['Found readFile from package "node:fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'namespace fs readFile',
+    "import * as something from 'fs'; something.readFile(filename);",
+    ['Found readFile from package "fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'require fs promises member',
+    "var something = require('node:fs'); something.promises.readFile(filename)",
+    ['Found readFile from package "node:fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-fs-filename',
+    'template fs filename',
+    "var fs = require('fs'); fs.readFile(`template with ${filename}`);",
+    ['Found readFile from package "fs" with non literal argument at index 0'],
+  ],
+  [
+    'detect-non-literal-regexp',
+    'regexp variable',
+    "var a = new RegExp(c, 'i')",
+    ['Found non-literal argument to RegExp Constructor'],
+  ],
+  [
+    'detect-non-literal-require',
+    'require variable',
+    'var a = require(c)',
+    ['Found non-literal argument in require'],
+  ],
+  [
+    'detect-non-literal-require',
+    'require dynamic template',
+    'var a = require(`${c}`)',
+    ['Found non-literal argument in require'],
+  ],
+  [
+    'detect-object-injection',
+    'generic object injection',
+    'var a = {}; a[b] = 4',
+    ['Generic Object Injection Sink'],
+  ],
+  [
+    'detect-object-injection',
+    'function object injection',
+    'obj[key]()',
+    ['Function Call Object Injection Sink'],
+  ],
+  [
+    'detect-possible-timing-attacks',
+    'password left side',
+    "if (password === 'mypass') {}",
+    ['Potential timing attack, left side: true'],
+  ],
+  [
+    'detect-possible-timing-attacks',
+    'password right side',
+    "if ('mypass' === password) {}",
+    ['Potential timing attack, right side: true'],
+  ],
+  [
+    'detect-pseudoRandomBytes',
+    'pseudoRandomBytes member',
+    'crypto.pseudoRandomBytes',
+    ['Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers'],
+  ],
+  ['detect-unsafe-regex', 'unsafe regex literal', '/(x+x+)+y/', ['Unsafe Regular Expression']],
+  [
+    'detect-unsafe-regex',
+    'unsafe RegExp constructor',
+    "new RegExp('x+x+)+y')",
+    ['Unsafe Regular Expression (new RegExp)'],
+  ],
+];
+
+function runRule(ruleName, sourceText, filename = 'fixture.js') {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const rule = plugin.rules[ruleName];
+  const visitor = rule.createOnce({
+    filename,
+    options: [],
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function renderMessage(ruleName, report) {
+  const template = plugin.rules[ruleName].meta.messages[report.messageId];
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => report.data?.[key] ?? '');
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code) {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'security-plugin-'));
+
+  try {
+    const sourcePath = join(temp, 'fixture.js');
+    const configPath = join(temp, 'oxlint.config.jsonc');
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'security',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`security/${ruleName}`]: 'error',
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('security plugin shape', () => {
+  it('exports the security plugin surface', () => {
+    expect(plugin.meta?.name).toBe('security');
+    expect(plugin.implementedSecurityRuleNames).toEqual(Object.keys(plugin.rules));
+    expect(plugin.rules['detect-child-process'].meta.messages.execNonLiteral).toContain(
+      'child_process.exec',
+    );
+  });
+
+  it('ships upstream-compatible recommended configs', () => {
+    expect(plugin.configs.recommended.rules['security/detect-child-process']).toBe('warn');
+    expect(plugin.configs['recommended-legacy'].plugins).toEqual(['security']);
+  });
+});
+
+describe('security rules through direct Oxlint plugin adapter', () => {
+  it.each(validCases)('accepts %s: %s', (ruleName, _name, code) => {
+    expect(runRule(ruleName, code)).toEqual([]);
+  });
+
+  it.each(invalidCases)('reports %s: %s', (ruleName, _name, code, expectedMessages) => {
+    const reports = runRule(ruleName, code);
+
+    expect(reports.map((report) => renderMessage(ruleName, report))).toEqual(expectedMessages);
+  });
+});
+
+describe('security rules through oxlint jsPlugins', () => {
+  it('reports a native diagnostic through the CLI', () => {
+    const result = runOxlint('detect-non-literal-require', 'require(name);\n');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toMatchObject([
+      {
+        code: 'security(detect-non-literal-require)',
+        message: 'Found non-literal argument in require',
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/security:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/stylistic:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -222,6 +222,247 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-security",
+    "directory": "npm/security",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-security",
+      "version": "4.0.0",
+      "repository": "https://github.com/eslint-community/eslint-plugin-security",
+      "license": "Apache-2.0"
+    },
+    "status": "ported",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "detect-bidi-characters",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc source scan port of eslint-plugin-security/detect-bidi-characters; upstream-style code/comment cases covered in Vitest."
+      },
+      {
+        "name": "detect-buffer-noassert",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc AST port of eslint-plugin-security/detect-buffer-noassert; read/write noAssert method matrix covered in Vitest."
+      },
+      {
+        "name": "detect-child-process",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc import and require access-path port of eslint-plugin-security/detect-child-process; require/import/destructure/shadowing cases covered in Vitest."
+      },
+      {
+        "name": "detect-disable-mustache-escape",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc AST port of eslint-plugin-security/detect-disable-mustache-escape; upstream valid/invalid cases covered in Vitest."
+      },
+      {
+        "name": "detect-eval-with-expression",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc AST port of eslint-plugin-security/detect-eval-with-expression; upstream literal and identifier cases covered in Vitest."
+      },
+      {
+        "name": "detect-new-buffer",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc AST port of eslint-plugin-security/detect-new-buffer; upstream literal and non-literal constructor cases covered in Vitest."
+      },
+      {
+        "name": "detect-no-csrf-before-method-override",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc traversal-order port of eslint-plugin-security/detect-no-csrf-before-method-override; upstream order cases covered in Vitest."
+      },
+      {
+        "name": "detect-non-literal-fs-filename",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc import/require/static-expression port of eslint-plugin-security/detect-non-literal-fs-filename; fs/node:fs/fs-extra/import/destructure/promises/static path cases covered in Vitest."
+      },
+      {
+        "name": "detect-non-literal-regexp",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc static-expression port of eslint-plugin-security/detect-non-literal-regexp; upstream literal/static/dynamic cases covered in Vitest."
+      },
+      {
+        "name": "detect-non-literal-require",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc static-expression port of eslint-plugin-security/detect-non-literal-require; literal/template/__dirname/dynamic cases covered in Vitest."
+      },
+      {
+        "name": "detect-object-injection",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc computed-member port of eslint-plugin-security/detect-object-injection; generic and function-call sinks covered in Vitest."
+      },
+      {
+        "name": "detect-possible-timing-attacks",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc if/binary comparison port of eslint-plugin-security/detect-possible-timing-attacks; upstream left/right keyword cases covered in Vitest."
+      },
+      {
+        "name": "detect-pseudoRandomBytes",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc member-expression port of eslint-plugin-security/detect-pseudoRandomBytes; upstream valid/invalid cases covered in Vitest."
+      },
+      {
+        "name": "detect-unsafe-regex",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc regex-literal and RegExp constructor port of eslint-plugin-security/detect-unsafe-regex; safe and nested-quantifier cases covered in Vitest."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-stylistic",
     "directory": "npm/stylistic",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -17,6 +17,10 @@ const nativePackages = [
     binding: 'npm/eslint-comments/native.js',
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-security',
+    binding: 'npm/security/native.js',
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     binding: 'npm/stylistic/native.js',
   },

--- a/tools/tasks/security-audit.ts
+++ b/tools/tasks/security-audit.ts
@@ -17,7 +17,9 @@ type AuditJson = {
 const publishablePrefixes = [
   '@oxlint-plugins/oxlint-plugin-type-aware>',
   '@oxlint-plugins/oxlint-plugin-no-forbidden-identifiers>',
+  '@oxlint-plugins/oxlint-plugin-eslint-comments>',
   '@oxlint-plugins/oxlint-plugin-react-refresh>',
+  '@oxlint-plugins/oxlint-plugin-security>',
   '@oxlint-plugins/oxlint-plugin-stylistic>',
 ];
 

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -30,6 +30,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-security',
+    dir: 'npm/security',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     dir: 'npm/stylistic',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- port `eslint-plugin-security` v4.0.0 as `@oxlint-plugins/oxlint-plugin-security`
- implement all 14 security rules in Rust/Oxc with a thin Oxlint/NAPI adapter
- add native API, package metadata, publish readiness wiring, and 117 Vitest cases plus Rust tests

## Validation
- `vp exec pnpm run verify`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->