### PR TITLE
test(eslint-comments): verify oxlint integration

### DIFF
--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -53,16 +53,36 @@ function buildData(data) {
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+function locForContext(context, loc) {
+  if (!context.sourceCode?.isESTree) {
+    return loc;
+  }
+
+  return {
+    start: {
+      line: loc.start.line,
+      column: Math.max(0, loc.start.column),
+    },
+    end: {
+      line: loc.end.line,
+      column: Math.max(0, loc.end.column),
+    },
+  };
+}
+
 // Forward the diagnostics from a Rust scan to Oxlint. Diagnostic locations are
-// kept verbatim (including the upstream `column: -1` "whole line" sentinel).
+// kept verbatim in the upstream replay harness. Oxlint itself rejects the
+// upstream `column: -1` "whole line" sentinel, so clamp it only for Oxlint's
+// ESTree-compatible runtime.
 function reportDiagnostics(context, diagnostics) {
   for (const diagnostic of diagnostics) {
+    const loc = locForContext(context, {
+      start: { line: diagnostic.loc.startLine, column: diagnostic.loc.startColumn },
+      end: { line: diagnostic.loc.endLine, column: diagnostic.loc.endColumn },
+    });
     const descriptor = {
       messageId: diagnostic.messageId,
-      loc: {
-        start: { line: diagnostic.loc.startLine, column: diagnostic.loc.startColumn },
-        end: { line: diagnostic.loc.endLine, column: diagnostic.loc.endColumn },
-      },
+      loc,
     };
 
     const data = buildData(diagnostic.data);

--- a/npm/eslint-comments/test/oxlint.test.mjs
+++ b/npm/eslint-comments/test/oxlint.test.mjs
@@ -1,0 +1,121 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const invalidCases = [
+  ['no-unlimited-disable', '// eslint-disable-next-line\nalert(x);\n', 'Unexpected unlimited'],
+  ['no-use', '// eslint-disable-next-line no-alert\nalert(x);\n', 'Unexpected ESLint directive'],
+  [
+    'require-description',
+    '// eslint-disable-next-line no-alert\nalert(x);\n',
+    'Unexpected undescribed directive',
+  ],
+  [
+    'disable-enable-pair',
+    '/* eslint-disable no-alert */\nalert(x);\n',
+    "Requires 'eslint-enable' directive",
+  ],
+  [
+    'no-aggregating-enable',
+    '/* eslint-disable no-alert */\n/* eslint-disable no-console */\n/* eslint-enable */\n',
+    'affects 2 `eslint-disable` comments',
+  ],
+  [
+    'no-duplicate-disable',
+    '/* eslint-disable no-alert */\n/* eslint-disable no-alert */\n',
+    'has been disabled already',
+  ],
+  [
+    'no-unused-enable',
+    '/* eslint-enable no-alert */\n',
+    'is re-enabled but it has not been disabled',
+  ],
+  [
+    'no-restricted-disable',
+    '// eslint-disable-next-line no-alert\nalert(x);\n',
+    "Disabling 'no-alert' is not allowed",
+    ['error', 'no-alert'],
+  ],
+  [
+    'no-unused-disable',
+    '// eslint-disable-next-line no-alert\nconst x = 1;\n',
+    'Unused eslint-disable directive',
+  ],
+];
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code, ruleConfig = 'error') {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'eslint-comments-plugin-'));
+
+  try {
+    const sourcePath = join(temp, 'fixture.js');
+    const configPath = join(temp, 'oxlint.config.jsonc');
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'eslint-comments',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`eslint-comments/${ruleName}`]: ruleConfig,
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('eslint-comments rules through oxlint jsPlugins', () => {
+  it.each(invalidCases)('reports %s through the CLI', (ruleName, code, message, ruleConfig) => {
+    const result = runOxlint(ruleName, code, ruleConfig);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe(`eslint-comments(${String(ruleName)})`);
+    expect(result.diagnostics[0].message).toContain(message);
+  });
+});

--- a/status.json
+++ b/status.json
@@ -11,7 +11,7 @@
       "repository": "https://github.com/eslint-community/eslint-plugin-eslint-comments",
       "license": "MIT"
     },
-    "status": "in-progress",
+    "status": "ported",
     "typeAware": false,
     "rules": [
       {
@@ -26,7 +26,7 @@
           "insta": true,
           "vitest": true,
           "lsp": true,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-unlimited-disable; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -42,7 +42,7 @@
           "insta": true,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-use; supports the allow option; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -58,7 +58,7 @@
           "insta": true,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/require-description; supports the ignore option; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -74,7 +74,7 @@
           "insta": true,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/disable-enable-pair; supports the allowWholeFile option; shared disabled-area algorithm in Rust; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -90,7 +90,7 @@
           "insta": true,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-aggregating-enable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -106,7 +106,7 @@
           "insta": true,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-duplicate-disable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -122,7 +122,7 @@
           "insta": true,
           "vitest": true,
           "lsp": true,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-unused-enable; reuses the shared disabled-area algorithm; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -138,7 +138,7 @@
           "insta": true,
           "vitest": true,
           "lsp": true,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Port of @eslint-community/eslint-plugin-eslint-comments/no-restricted-disable; gitignore-style pattern matching in Rust; upstream RuleTester cases replayed via test/fixtures."
       },
@@ -154,7 +154,7 @@
           "insta": true,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
         "notes": "Deprecated upstream (use reportUnusedDisableDirectives). Approximation built on sourceCode.getDisableDirectives().problems; the upstream RuleTester suite needs the ESLint runtime, so the rule is covered by a synthetic-problem mechanism test (insta + Vitest) instead of the espree replay harness."
       }


### PR DESCRIPTION
## Summary

- Add Oxlint jsPlugins integration coverage for every eslint-comments rule.
- Clamp upstream column -1 directive locations only in Oxlint runtime so CLI reporting works while upstream replay tests keep their original locations.
- Mark eslint-comments status as ported with Oxlint integration coverage recorded for all rules.

## Validation

- vp exec pnpm run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->