### PR TITLE
feat(mocha): port eslint-plugin-mocha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +750,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-mocha"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-mocha",
+]
+
+[[package]]
 name = "oxlint-plugin-no-forbidden-identifiers"
 version = "0.0.0"
 dependencies = [
@@ -814,6 +834,19 @@ dependencies = [
  "insta",
  "oxlint-plugins-_carton",
  "phf",
+]
+
+[[package]]
+name = "oxlint-plugins-mocha"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxlint-plugins-_carton",
+ "regex",
 ]
 
 [[package]]
@@ -943,10 +976,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,13 @@ members = [
   "crates/_carton",
   "crates/cypress",
   "crates/eslint_comments",
+  "crates/mocha",
   "crates/react_refresh",
   "crates/security",
   "crates/stylistic",
   "npm/cypress",
   "npm/eslint-comments",
+  "npm/mocha",
   "npm/no-forbidden-identifiers",
   "npm/react-refresh",
   "npm/security",
@@ -39,9 +41,11 @@ oxc_syntax = "0.135.0"
 oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_carton", version = "0.0.0" }
 oxlint-plugins-cypress = { path = "crates/cypress", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }
+oxlint-plugins-mocha = { path = "crates/mocha", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }
+regex = "1.12.2"
 phf = { version = "0.13.1", features = ["macros"] }
 rustc-hash = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/mocha/Cargo.toml
+++ b/crates/mocha/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "oxlint-plugins-mocha"
+description = "Rust core for the mocha oxlint JavaScript plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+regex.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/mocha/src/lib.rs
+++ b/crates/mocha/src/lib.rs
@@ -1,0 +1,1727 @@
+#![doc = "Rust implementation of eslint-plugin-mocha rule logic."]
+
+use std::fmt::{Arguments, Write as _};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, ArrowFunctionExpression, BindingPattern, CallExpression,
+    ChainElement, Class, ClassElement, ConditionalExpression, Declaration,
+    ExportDefaultDeclarationKind, Expression, Function, FunctionBody, PropertyKey, Statement,
+    StaticMemberExpression,
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+use oxlint_plugins_carton::{CompactString, FastHashMap, SmallVec};
+use regex::Regex;
+
+pub const RULE_NAMES: [&str; 24] = [
+    "consistent-interface",
+    "consistent-spacing-between-blocks",
+    "handle-done-callback",
+    "max-top-level-suites",
+    "no-async-suite",
+    "no-empty-title",
+    "no-exclusive-tests",
+    "no-exports",
+    "no-global-tests",
+    "no-hooks",
+    "no-hooks-for-single-case",
+    "no-identical-title",
+    "no-mocha-arrows",
+    "no-nested-tests",
+    "no-pending-tests",
+    "no-return-and-callback",
+    "no-return-from-async",
+    "no-setup-in-describe",
+    "no-sibling-hooks",
+    "no-synchronous-tests",
+    "no-top-level-hooks",
+    "prefer-arrow-callback",
+    "valid-suite-title",
+    "valid-test-title",
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message: CompactString,
+    pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MochaOptions {
+    pub consistent_interface: CompactString,
+    pub max_top_level_suites_limit: u32,
+    pub handle_done_ignore_pending: bool,
+    pub no_hooks_allowed: SmallVec<[CompactString; 4]>,
+    pub no_hooks_for_single_case_allowed: SmallVec<[CompactString; 4]>,
+    pub no_synchronous_allowed: SmallVec<[CompactString; 3]>,
+    pub no_empty_title_message: Option<CompactString>,
+    pub valid_suite_title_pattern: Option<CompactString>,
+    pub valid_suite_title_message: Option<CompactString>,
+    pub valid_test_title_pattern: Option<CompactString>,
+    pub valid_test_title_message: Option<CompactString>,
+    pub prefer_arrow_allow_named_functions: bool,
+    pub prefer_arrow_allow_unbound_this: bool,
+}
+
+impl Default for MochaOptions {
+    fn default() -> Self {
+        let mut no_synchronous_allowed = SmallVec::new();
+        no_synchronous_allowed.push("async".into());
+        no_synchronous_allowed.push("callback".into());
+        no_synchronous_allowed.push("promise".into());
+        Self {
+            consistent_interface: "BDD".into(),
+            max_top_level_suites_limit: 1,
+            handle_done_ignore_pending: false,
+            no_hooks_allowed: SmallVec::new(),
+            no_hooks_for_single_case_allowed: SmallVec::new(),
+            no_synchronous_allowed,
+            no_empty_title_message: None,
+            valid_suite_title_pattern: None,
+            valid_suite_title_message: None,
+            valid_test_title_pattern: None,
+            valid_test_title_message: None,
+            prefer_arrow_allow_named_functions: false,
+            prefer_arrow_allow_unbound_this: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EntityType {
+    Suite,
+    TestCase,
+    Hook,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MochaInterface {
+    Bdd,
+    Tdd,
+}
+
+impl MochaInterface {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Bdd => "BDD",
+            Self::Tdd => "TDD",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Modifier {
+    Pending,
+    Exclusive,
+}
+
+#[derive(Clone, Copy)]
+struct Callback<'a> {
+    span: Span,
+    body: CallbackBody<'a>,
+    async_function: bool,
+    arrow: bool,
+    named_function: bool,
+    params_len: usize,
+    first_param_name: Option<&'a str>,
+}
+
+#[derive(Clone, Copy)]
+enum CallbackBody<'a> {
+    Function(&'a FunctionBody<'a>),
+}
+
+#[derive(Clone)]
+struct Entity<'a> {
+    name: CompactString,
+    entity_type: EntityType,
+    interface: MochaInterface,
+    modifier: Option<Modifier>,
+    span: Span,
+    title: Option<CompactString>,
+    callback: Option<Callback<'a>>,
+}
+
+#[derive(Default)]
+struct Layer {
+    suite_titles: FastHashMap<CompactString, Span>,
+    test_titles: FastHashMap<CompactString, Span>,
+    hook_names: FastHashMap<CompactString, Span>,
+    hooks: SmallVec<[(CompactString, Span); 4]>,
+    test_count: u32,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_mocha_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_mocha(
+    source_text: &str,
+    filename: &str,
+    options: &MochaOptions,
+) -> SmallVec<[Diagnostic; 16]> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::mjs())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let valid_suite_regex = options
+        .valid_suite_title_pattern
+        .as_ref()
+        .and_then(|pattern| Regex::new(pattern.as_str()).ok());
+    let valid_test_regex = options
+        .valid_test_title_pattern
+        .as_ref()
+        .and_then(|pattern| Regex::new(pattern.as_str()).ok());
+    let mut scanner = Scanner {
+        source_text,
+        line_index: LineIndex::new(source_text),
+        diagnostics: SmallVec::new(),
+        options,
+        valid_suite_regex,
+        valid_test_regex,
+        layers: SmallVec::new(),
+        suite_depth: 0,
+        test_depth: 0,
+        top_level_suites: 0,
+        has_test_entity: false,
+        export_spans: SmallVec::new(),
+    };
+    scanner.layers.push(Layer::default());
+    scanner.scan_statement_list(&parser_return.program.body, ContextKind::Program, true);
+    scanner.finish_program();
+    scanner.diagnostics
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ContextKind {
+    Program,
+    SuiteCallback,
+    TestCallback,
+    HookCallback,
+    Other,
+}
+
+struct Scanner<'a> {
+    source_text: &'a str,
+    line_index: LineIndex,
+    diagnostics: SmallVec<[Diagnostic; 16]>,
+    options: &'a MochaOptions,
+    valid_suite_regex: Option<Regex>,
+    valid_test_regex: Option<Regex>,
+    layers: SmallVec<[Layer; 8]>,
+    suite_depth: u32,
+    test_depth: u32,
+    top_level_suites: u32,
+    has_test_entity: bool,
+    export_spans: SmallVec<[Span; 8]>,
+}
+
+impl<'a> Scanner<'a> {
+    fn report(&mut self, rule_name: &'static str, message: impl Into<CompactString>, span: Span) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message: message.into(),
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+
+    fn finish_program(&mut self) {
+        if self.has_test_entity {
+            let spans = self.export_spans.clone();
+            for span in spans {
+                self.report("no-exports", "Unexpected export from a test file", span);
+            }
+        }
+    }
+
+    fn scan_statement_list(
+        &mut self,
+        statements: &'a [Statement<'a>],
+        context: ContextKind,
+        direct_spacing_scope: bool,
+    ) {
+        let mut previous_end_line = None;
+        for statement in statements {
+            if direct_spacing_scope {
+                if let Some(entity_span) = direct_statement_mocha_span(statement)
+                    && let Some(end_line) = previous_end_line
+                {
+                    let (start_line, _) = self
+                        .line_index
+                        .position_for_offset(self.source_text, entity_span.start);
+                    if start_line.saturating_sub(end_line) < 2 {
+                        self.report(
+                            "consistent-spacing-between-blocks",
+                            "Expected line break before this statement.",
+                            entity_span,
+                        );
+                    }
+                }
+                previous_end_line = Some(
+                    self.line_index
+                        .position_for_offset(self.source_text, statement.span().end)
+                        .0,
+                );
+            }
+            self.scan_statement(statement, context);
+        }
+    }
+
+    fn scan_statement(&mut self, statement: &'a Statement<'a>, context: ContextKind) {
+        match statement {
+            Statement::ExpressionStatement(statement) => {
+                self.scan_expression(&statement.expression, context);
+            }
+            Statement::BlockStatement(block) => {
+                self.scan_statement_list(&block.body, context, false);
+            }
+            Statement::IfStatement(statement) => {
+                self.scan_expression(&statement.test, context);
+                self.scan_statement(&statement.consequent, context);
+                if let Some(alternate) = &statement.alternate {
+                    self.scan_statement(alternate, context);
+                }
+            }
+            Statement::ReturnStatement(statement) => {
+                if let Some(argument) = &statement.argument {
+                    self.scan_expression(argument, context);
+                }
+            }
+            Statement::ThrowStatement(statement) => {
+                self.scan_expression(&statement.argument, context);
+            }
+            Statement::VariableDeclaration(declaration) => {
+                for declarator in &declaration.declarations {
+                    if let Some(init) = &declarator.init {
+                        self.scan_expression(init, context);
+                    }
+                }
+            }
+            Statement::FunctionDeclaration(function) => {
+                self.scan_function(function);
+            }
+            Statement::ClassDeclaration(class) => {
+                self.scan_class(class);
+            }
+            Statement::ExportNamedDeclaration(declaration) => {
+                self.export_spans.push(declaration.span);
+                if let Some(declaration) = &declaration.declaration {
+                    self.scan_declaration(declaration, context);
+                }
+            }
+            Statement::ExportDefaultDeclaration(declaration) => {
+                self.export_spans.push(declaration.span);
+                match &declaration.declaration {
+                    ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                        self.scan_function(function);
+                    }
+                    ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+                        self.scan_class(class);
+                    }
+                    declaration => {
+                        if let Some(expression) = declaration.as_expression() {
+                            self.scan_expression(expression, context);
+                        }
+                    }
+                }
+            }
+            Statement::ExportAllDeclaration(declaration) => {
+                self.export_spans.push(declaration.span);
+            }
+            Statement::WhileStatement(statement) => {
+                self.scan_expression(&statement.test, context);
+                self.scan_statement(&statement.body, context);
+            }
+            Statement::DoWhileStatement(statement) => {
+                self.scan_statement(&statement.body, context);
+                self.scan_expression(&statement.test, context);
+            }
+            Statement::ForStatement(statement) => {
+                if let Some(test) = &statement.test {
+                    self.scan_expression(test, context);
+                }
+                if let Some(update) = &statement.update {
+                    self.scan_expression(update, context);
+                }
+                self.scan_statement(&statement.body, context);
+            }
+            Statement::ForInStatement(statement) => {
+                self.scan_expression(&statement.right, context);
+                self.scan_statement(&statement.body, context);
+            }
+            Statement::ForOfStatement(statement) => {
+                self.scan_expression(&statement.right, context);
+                self.scan_statement(&statement.body, context);
+            }
+            Statement::SwitchStatement(statement) => {
+                self.scan_expression(&statement.discriminant, context);
+                for case in &statement.cases {
+                    if let Some(test) = &case.test {
+                        self.scan_expression(test, context);
+                    }
+                    self.scan_statement_list(&case.consequent, context, false);
+                }
+            }
+            Statement::TryStatement(statement) => {
+                self.scan_statement_list(&statement.block.body, context, false);
+                if let Some(handler) = &statement.handler {
+                    self.scan_statement_list(&handler.body.body, context, false);
+                }
+                if let Some(finalizer) = &statement.finalizer {
+                    self.scan_statement_list(&finalizer.body, context, false);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_declaration(&mut self, declaration: &'a Declaration<'a>, context: ContextKind) {
+        match declaration {
+            Declaration::VariableDeclaration(declaration) => {
+                for declarator in &declaration.declarations {
+                    if let Some(init) = &declarator.init {
+                        self.scan_expression(init, context);
+                    }
+                }
+            }
+            Declaration::FunctionDeclaration(function) => self.scan_function(function),
+            Declaration::ClassDeclaration(class) => self.scan_class(class),
+            _ => {}
+        }
+    }
+
+    fn scan_expression(&mut self, expression: &'a Expression<'a>, context: ContextKind) {
+        match expression.get_inner_expression() {
+            Expression::CallExpression(call) => {
+                self.scan_call_expression(call, context);
+            }
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::CallExpression(call) => self.scan_call_expression(call, context),
+                ChainElement::StaticMemberExpression(member) => {
+                    self.scan_static_member_expression(member, context);
+                }
+                _ => {}
+            },
+            Expression::StaticMemberExpression(member) => {
+                self.scan_static_member_expression(member, context);
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object, context);
+                self.scan_expression(&member.expression, context);
+            }
+            Expression::ArrowFunctionExpression(function) => {
+                self.scan_arrow_function(function);
+            }
+            Expression::FunctionExpression(function) => {
+                self.scan_function(function);
+            }
+            Expression::ObjectExpression(expression) => {
+                for property in &expression.properties {
+                    if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) = property {
+                        if property.computed {
+                            self.scan_property_key(&property.key, context);
+                        }
+                        self.scan_expression(&property.value, context);
+                    }
+                }
+            }
+            Expression::ArrayExpression(expression) => {
+                for element in &expression.elements {
+                    self.scan_array_element(element, context);
+                }
+            }
+            Expression::AwaitExpression(expression) => {
+                self.scan_expression(&expression.argument, context);
+            }
+            Expression::UnaryExpression(expression) => {
+                self.scan_expression(&expression.argument, context);
+            }
+            Expression::BinaryExpression(expression) => {
+                self.scan_expression(&expression.left, context);
+                self.scan_expression(&expression.right, context);
+            }
+            Expression::LogicalExpression(expression) => {
+                self.scan_expression(&expression.left, context);
+                self.scan_expression(&expression.right, context);
+            }
+            Expression::ConditionalExpression(expression) => {
+                self.scan_conditional_expression(expression, context);
+            }
+            Expression::AssignmentExpression(expression) => {
+                self.scan_expression(&expression.right, context);
+            }
+            Expression::SequenceExpression(expression) => {
+                for expression in &expression.expressions {
+                    self.scan_expression(expression, context);
+                }
+            }
+            Expression::TemplateLiteral(template) => {
+                for expression in &template.expressions {
+                    self.scan_expression(expression, context);
+                }
+            }
+            Expression::TaggedTemplateExpression(expression) => {
+                self.scan_expression(&expression.tag, context);
+                for expression in &expression.quasi.expressions {
+                    self.scan_expression(expression, context);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_array_element(
+        &mut self,
+        element: &'a ArrayExpressionElement<'a>,
+        context: ContextKind,
+    ) {
+        match element {
+            ArrayExpressionElement::CallExpression(call) => {
+                self.scan_call_expression(call, context)
+            }
+            ArrayExpressionElement::StaticMemberExpression(member) => {
+                self.scan_static_member_expression(member, context);
+            }
+            ArrayExpressionElement::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object, context);
+                self.scan_expression(&member.expression, context);
+            }
+            ArrayExpressionElement::ArrowFunctionExpression(function) => {
+                self.scan_arrow_function(function);
+            }
+            ArrayExpressionElement::FunctionExpression(function) => self.scan_function(function),
+            ArrayExpressionElement::ArrayExpression(expression) => {
+                for element in &expression.elements {
+                    self.scan_array_element(element, context);
+                }
+            }
+            ArrayExpressionElement::ObjectExpression(expression) => {
+                for property in &expression.properties {
+                    if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) = property {
+                        self.scan_expression(&property.value, context);
+                    }
+                }
+            }
+            ArrayExpressionElement::ConditionalExpression(expression) => {
+                self.scan_conditional_expression(expression, context);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_argument(&mut self, argument: &'a Argument<'a>, context: ContextKind) {
+        match argument {
+            Argument::CallExpression(call) => self.scan_call_expression(call, context),
+            Argument::StaticMemberExpression(member) => {
+                self.scan_static_member_expression(member, context)
+            }
+            Argument::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object, context);
+                self.scan_expression(&member.expression, context);
+            }
+            Argument::ArrowFunctionExpression(function) => self.scan_arrow_function(function),
+            Argument::FunctionExpression(function) => self.scan_function(function),
+            Argument::ArrayExpression(expression) => {
+                for element in &expression.elements {
+                    self.scan_array_element(element, context);
+                }
+            }
+            Argument::ObjectExpression(expression) => {
+                for property in &expression.properties {
+                    if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) = property {
+                        self.scan_expression(&property.value, context);
+                    }
+                }
+            }
+            Argument::ConditionalExpression(expression) => {
+                self.scan_conditional_expression(expression, context);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_property_key(&mut self, key: &'a PropertyKey<'a>, context: ContextKind) {
+        match key {
+            PropertyKey::CallExpression(call) => self.scan_call_expression(call, context),
+            PropertyKey::StaticMemberExpression(member) => {
+                self.scan_static_member_expression(member, context)
+            }
+            PropertyKey::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object, context);
+                self.scan_expression(&member.expression, context);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_conditional_expression(
+        &mut self,
+        expression: &'a ConditionalExpression<'a>,
+        context: ContextKind,
+    ) {
+        self.scan_expression(&expression.test, context);
+        self.scan_expression(&expression.consequent, context);
+        self.scan_expression(&expression.alternate, context);
+    }
+
+    fn scan_static_member_expression(
+        &mut self,
+        member: &'a StaticMemberExpression<'a>,
+        context: ContextKind,
+    ) {
+        self.scan_expression(&member.object, context);
+    }
+
+    fn scan_call_expression(&mut self, call: &'a CallExpression<'a>, context: ContextKind) {
+        if let Some(entity) = self.entity_for_call(call) {
+            self.handle_entity(&entity);
+            self.scan_entity_callback(&entity);
+        } else {
+            if context == ContextKind::SuiteCallback && !is_suite_config_call(call) {
+                self.report(
+                    "no-setup-in-describe",
+                    "Unexpected function call in describe block.",
+                    call.span,
+                );
+            }
+            self.scan_expression(&call.callee, context);
+            for argument in &call.arguments {
+                self.scan_argument(argument, context);
+            }
+        }
+    }
+
+    fn scan_function(&mut self, function: &'a Function<'a>) {
+        if let Some(body) = &function.body {
+            self.scan_statement_list(&body.statements, ContextKind::Other, false);
+        }
+    }
+
+    fn scan_arrow_function(&mut self, function: &'a ArrowFunctionExpression<'a>) {
+        self.scan_statement_list(&function.body.statements, ContextKind::Other, false);
+    }
+
+    fn scan_class(&mut self, class: &'a Class<'a>) {
+        for element in &class.body.body {
+            match element {
+                ClassElement::StaticBlock(block) => {
+                    self.scan_statement_list(&block.body, ContextKind::Other, false);
+                }
+                ClassElement::MethodDefinition(method) => {
+                    self.scan_function(&method.value);
+                }
+                ClassElement::PropertyDefinition(property) => {
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value, ContextKind::Other);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn handle_entity(&mut self, entity: &Entity<'a>) {
+        self.has_test_entity = true;
+        if entity.interface.as_str() != self.options.consistent_interface.as_str() {
+            self.report(
+                "consistent-interface",
+                compact_format(format_args!(
+                    "Unexpected use of {} interface instead of {}",
+                    entity.interface.as_str(),
+                    self.options.consistent_interface
+                )),
+                entity.span,
+            );
+        }
+
+        if entity.entity_type == EntityType::Suite && self.suite_depth == 0 {
+            self.top_level_suites += 1;
+            if self.top_level_suites == self.options.max_top_level_suites_limit + 1 {
+                self.report(
+                    "max-top-level-suites",
+                    compact_format(format_args!(
+                        "The number of top-level suites is more than {}.",
+                        self.options.max_top_level_suites_limit
+                    )),
+                    entity.span,
+                );
+            }
+        }
+
+        match entity.entity_type {
+            EntityType::Suite => self.check_suite(entity),
+            EntityType::TestCase => self.check_test_case(entity),
+            EntityType::Hook => self.check_hook(entity),
+        }
+
+        if let Some(callback) = entity.callback {
+            self.check_callback(entity, callback);
+        } else if entity.entity_type == EntityType::TestCase
+            && entity.modifier != Some(Modifier::Pending)
+        {
+            self.report(
+                "no-pending-tests",
+                "Unexpected pending mocha test.",
+                entity.span,
+            );
+        }
+    }
+
+    fn check_suite(&mut self, entity: &Entity<'a>) {
+        if entity.modifier == Some(Modifier::Exclusive) {
+            self.report(
+                "no-exclusive-tests",
+                "Unexpected exclusive mocha test.",
+                entity.span,
+            );
+        }
+        if entity.modifier == Some(Modifier::Pending) {
+            self.report(
+                "no-pending-tests",
+                "Unexpected pending mocha test.",
+                entity.span,
+            );
+        }
+        let invalid_suite_title = self.valid_suite_regex.as_ref().is_some_and(|pattern| {
+            entity
+                .title
+                .as_ref()
+                .is_some_and(|title| !pattern.is_match(title.as_str()))
+        });
+        self.check_title(
+            "valid-suite-title",
+            entity,
+            invalid_suite_title,
+            self.options.valid_suite_title_message.clone(),
+            "Invalid \"",
+        );
+        self.check_empty_title(entity);
+        if let Some(title) = &entity.title {
+            let current = self.layers.last_mut().expect("root layer exists");
+            if current.suite_titles.contains_key(title.as_str()) {
+                self.report(
+                    "no-identical-title",
+                    compact_format(format_args!(
+                        "Unexpected use of duplicate Mocha title `{title}`"
+                    )),
+                    entity.span,
+                );
+            } else {
+                current.suite_titles.insert(title.clone(), entity.span);
+            }
+        }
+    }
+
+    fn check_test_case(&mut self, entity: &Entity<'a>) {
+        if self.test_depth > 0 {
+            self.report(
+                "no-nested-tests",
+                "Unexpected test nested inside another test.",
+                entity.span,
+            );
+        }
+        if self.suite_depth == 0 {
+            self.report(
+                "no-global-tests",
+                "Unexpected global mocha test.",
+                entity.span,
+            );
+        }
+        if entity.modifier == Some(Modifier::Exclusive) {
+            self.report(
+                "no-exclusive-tests",
+                "Unexpected exclusive mocha test.",
+                entity.span,
+            );
+        }
+        if entity.modifier == Some(Modifier::Pending) {
+            self.report(
+                "no-pending-tests",
+                "Unexpected pending mocha test.",
+                entity.span,
+            );
+        }
+        let invalid_test_title = self.valid_test_regex.as_ref().is_some_and(|pattern| {
+            entity
+                .title
+                .as_ref()
+                .is_some_and(|title| !pattern.is_match(title.as_str()))
+        });
+        self.check_title(
+            "valid-test-title",
+            entity,
+            invalid_test_title,
+            self.options.valid_test_title_message.clone(),
+            "Invalid \"",
+        );
+        self.check_empty_title(entity);
+        let current = self.layers.last_mut().expect("root layer exists");
+        current.test_count += 1;
+        if let Some(title) = &entity.title {
+            if current.test_titles.contains_key(title.as_str()) {
+                self.report(
+                    "no-identical-title",
+                    compact_format(format_args!(
+                        "Unexpected use of duplicate Mocha title `{title}`"
+                    )),
+                    entity.span,
+                );
+            } else {
+                current.test_titles.insert(title.clone(), entity.span);
+            }
+        }
+    }
+
+    fn check_hook(&mut self, entity: &Entity<'a>) {
+        if self.suite_depth == 0 {
+            self.report(
+                "no-top-level-hooks",
+                compact_format(format_args!(
+                    "Unexpected use of Mocha `{}` hook outside of a test suite",
+                    display_call_name(entity.name.as_str())
+                )),
+                entity.span,
+            );
+        }
+        if !self
+            .options
+            .no_hooks_allowed
+            .iter()
+            .any(|allowed| allowed.as_str() == entity.name.as_str())
+        {
+            self.report(
+                "no-hooks",
+                compact_format(format_args!(
+                    "Unexpected use of Mocha `{}` hook",
+                    display_call_name(entity.name.as_str())
+                )),
+                entity.span,
+            );
+        }
+        let current = self.layers.last_mut().expect("root layer exists");
+        current.hooks.push((entity.name.clone(), entity.span));
+        if current.hook_names.contains_key(entity.name.as_str()) {
+            self.report(
+                "no-sibling-hooks",
+                compact_format(format_args!(
+                    "Unexpected use of duplicate Mocha `{}` hook",
+                    display_call_name(entity.name.as_str())
+                )),
+                entity.span,
+            );
+        } else {
+            current.hook_names.insert(entity.name.clone(), entity.span);
+        }
+    }
+
+    fn check_callback(&mut self, entity: &Entity<'a>, callback: Callback<'a>) {
+        if entity.entity_type == EntityType::Suite && callback.async_function {
+            self.report(
+                "no-async-suite",
+                compact_format(format_args!(
+                    "Unexpected async function in {}",
+                    display_call_name(entity.name.as_str())
+                )),
+                callback.span,
+            );
+        }
+        if callback.arrow {
+            self.report(
+                "no-mocha-arrows",
+                "Unexpected arrow function.",
+                callback.span,
+            );
+        } else if !self.callback_is_allowed_function_callback(callback) {
+            self.report(
+                "prefer-arrow-callback",
+                "Unexpected function expression.",
+                callback.span,
+            );
+        }
+        if matches!(entity.entity_type, EntityType::TestCase | EntityType::Hook) {
+            if let Some(param) = callback.first_param_name
+                && !(entity.modifier == Some(Modifier::Pending)
+                    && self.options.handle_done_ignore_pending)
+                && !callback_body_calls_identifier(callback.body, param)
+            {
+                self.report(
+                    "handle-done-callback",
+                    compact_format(format_args!("Expected \"{param}\" callback to be handled.")),
+                    callback.span,
+                );
+            }
+            if callback.first_param_name.is_some() && callback_body_returns_value(callback.body) {
+                self.report(
+                    "no-return-and-callback",
+                    "Unexpected use of `return` in a test with callback",
+                    callback.span,
+                );
+            }
+            if callback.async_function && callback_body_returns_value(callback.body) {
+                self.report(
+                    "no-return-from-async",
+                    "Unexpected use of `return` in a test with an async function",
+                    callback.span,
+                );
+            }
+            if self.callback_is_synchronous(callback) {
+                self.report(
+                    "no-synchronous-tests",
+                    "Unexpected synchronous test.",
+                    callback.span,
+                );
+            }
+        }
+    }
+
+    fn callback_is_synchronous(&self, callback: Callback<'a>) -> bool {
+        let mut async_used = false;
+        for method in &self.options.no_synchronous_allowed {
+            match method.as_str() {
+                "async" if callback.async_function => async_used = true,
+                "callback" if callback.params_len == 1 => async_used = true,
+                "promise" if callback_body_returns_promise(callback.body) => async_used = true,
+                _ => {}
+            }
+        }
+        !async_used
+    }
+
+    fn callback_is_allowed_function_callback(&self, callback: Callback<'a>) -> bool {
+        (self.options.prefer_arrow_allow_named_functions && callback.named_function)
+            || (self.options.prefer_arrow_allow_unbound_this
+                && callback_body_contains_this(callback.body))
+    }
+
+    fn check_empty_title(&mut self, entity: &Entity<'a>) {
+        let empty = entity
+            .title
+            .as_ref()
+            .is_none_or(|title| title.trim().is_empty());
+        if empty {
+            self.report(
+                "no-empty-title",
+                self.options
+                    .no_empty_title_message
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_else(|| "Unexpected empty test description.".into()),
+                entity.span,
+            );
+        }
+    }
+
+    fn check_title(
+        &mut self,
+        rule_name: &'static str,
+        entity: &Entity<'a>,
+        invalid_title: bool,
+        custom_message: Option<CompactString>,
+        default_prefix: &str,
+    ) {
+        if !invalid_title {
+            return;
+        };
+        self.report(
+            rule_name,
+            custom_message.unwrap_or_else(|| {
+                compact_format(format_args!(
+                    "{default_prefix}{}\" description found.",
+                    display_call_name(entity.name.as_str())
+                ))
+            }),
+            entity.span,
+        );
+    }
+
+    fn scan_entity_callback(&mut self, entity: &Entity<'a>) {
+        let Some(callback) = entity.callback else {
+            return;
+        };
+        match entity.entity_type {
+            EntityType::Suite => {
+                self.suite_depth += 1;
+                self.layers.push(Layer::default());
+                self.scan_callback_body(callback.body, ContextKind::SuiteCallback);
+                let layer = self.layers.pop().expect("suite layer exists");
+                if layer.test_count == 1 {
+                    for (hook_name, span) in layer.hooks {
+                        if !self
+                            .options
+                            .no_hooks_for_single_case_allowed
+                            .iter()
+                            .any(|allowed| allowed.as_str() == hook_name.as_str())
+                        {
+                            self.report(
+                                "no-hooks-for-single-case",
+                                compact_format(format_args!(
+                                    "Unexpected use of Mocha `{}` hook for a single test case",
+                                    display_call_name(hook_name.as_str())
+                                )),
+                                span,
+                            );
+                        }
+                    }
+                }
+                self.suite_depth = self.suite_depth.saturating_sub(1);
+            }
+            EntityType::TestCase => {
+                self.test_depth += 1;
+                self.scan_callback_body(callback.body, ContextKind::TestCallback);
+                self.test_depth = self.test_depth.saturating_sub(1);
+            }
+            EntityType::Hook => {
+                self.scan_callback_body(callback.body, ContextKind::HookCallback);
+            }
+        }
+    }
+
+    fn scan_callback_body(&mut self, body: CallbackBody<'a>, context: ContextKind) {
+        match body {
+            CallbackBody::Function(body) => self.scan_statement_list(
+                &body.statements,
+                context,
+                context == ContextKind::SuiteCallback,
+            ),
+        }
+    }
+
+    fn entity_for_call(&self, call: &'a CallExpression<'a>) -> Option<Entity<'a>> {
+        let path = call_path(call)?;
+        let (name, entity_type, interface, modifier) = classify_mocha_path(&path)?;
+        Some(Entity {
+            name: CompactString::from(name),
+            entity_type,
+            interface,
+            modifier,
+            span: call.span,
+            title: call
+                .arguments
+                .first()
+                .and_then(argument_string_value)
+                .map(CompactString::from),
+            callback: call.arguments.last().and_then(callback_from_argument),
+        })
+    }
+}
+
+fn direct_statement_mocha_span(statement: &Statement<'_>) -> Option<Span> {
+    match statement {
+        Statement::ExpressionStatement(statement) => {
+            direct_expression_mocha_span(&statement.expression)
+        }
+        _ => None,
+    }
+}
+
+fn direct_expression_mocha_span(expression: &Expression<'_>) -> Option<Span> {
+    match expression.get_inner_expression() {
+        Expression::CallExpression(call) => {
+            if call_path(call)
+                .as_deref()
+                .and_then(classify_mocha_path)
+                .is_some()
+            {
+                return Some(call.span);
+            }
+            direct_expression_mocha_span(&call.callee)
+                .or_else(|| call.arguments.iter().find_map(direct_argument_mocha_span))
+        }
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(call) => {
+                if call_path(call)
+                    .as_deref()
+                    .and_then(classify_mocha_path)
+                    .is_some()
+                {
+                    Some(call.span)
+                } else {
+                    direct_expression_mocha_span(&call.callee)
+                }
+            }
+            ChainElement::StaticMemberExpression(member) => {
+                direct_expression_mocha_span(&member.object)
+            }
+            _ => None,
+        },
+        Expression::StaticMemberExpression(member) => direct_expression_mocha_span(&member.object),
+        Expression::ComputedMemberExpression(member) => {
+            direct_expression_mocha_span(&member.object)
+        }
+        _ => None,
+    }
+}
+
+fn direct_argument_mocha_span(argument: &Argument<'_>) -> Option<Span> {
+    match argument {
+        Argument::CallExpression(call) => {
+            if call_path(call)
+                .as_deref()
+                .and_then(classify_mocha_path)
+                .is_some()
+            {
+                Some(call.span)
+            } else {
+                direct_expression_mocha_span(&call.callee)
+            }
+        }
+        Argument::StaticMemberExpression(member) => direct_expression_mocha_span(&member.object),
+        Argument::ComputedMemberExpression(member) => direct_expression_mocha_span(&member.object),
+        _ => None,
+    }
+}
+
+fn compact_format(args: Arguments<'_>) -> CompactString {
+    let mut message = CompactString::new("");
+    let _ = message.write_fmt(args);
+    message
+}
+
+fn display_call_name(name: &str) -> CompactString {
+    compact_format(format_args!("{name}()"))
+}
+
+fn classify_mocha_path(
+    path: &[&str],
+) -> Option<(&'static str, EntityType, MochaInterface, Option<Modifier>)> {
+    let first = *path.first()?;
+    let last = *path.last()?;
+    let modifier = if last == "only" {
+        Some(Modifier::Exclusive)
+    } else if last == "skip" {
+        Some(Modifier::Pending)
+    } else {
+        None
+    };
+    let base = if path.len() == 1 || (modifier.is_some() && path.len() == 2) {
+        first
+    } else {
+        return None;
+    };
+
+    match base {
+        "describe" => Some(("describe", EntityType::Suite, MochaInterface::Bdd, modifier)),
+        "context" => Some(("context", EntityType::Suite, MochaInterface::Bdd, modifier)),
+        "suite" => Some(("suite", EntityType::Suite, MochaInterface::Tdd, modifier)),
+        "it" => Some(("it", EntityType::TestCase, MochaInterface::Bdd, modifier)),
+        "specify" => Some((
+            "specify",
+            EntityType::TestCase,
+            MochaInterface::Bdd,
+            modifier,
+        )),
+        "test" => Some(("test", EntityType::TestCase, MochaInterface::Tdd, modifier)),
+        "before" | "after" | "beforeEach" | "afterEach" => {
+            let hook = match base {
+                "before" => "before",
+                "after" => "after",
+                "beforeEach" => "beforeEach",
+                _ => "afterEach",
+            };
+            Some((hook, EntityType::Hook, MochaInterface::Bdd, None))
+        }
+        "suiteSetup" | "suiteTeardown" | "setup" | "teardown" => {
+            let hook = match base {
+                "suiteSetup" => "suiteSetup",
+                "suiteTeardown" => "suiteTeardown",
+                "setup" => "setup",
+                _ => "teardown",
+            };
+            Some((hook, EntityType::Hook, MochaInterface::Tdd, None))
+        }
+        "xdescribe" => Some((
+            "xdescribe",
+            EntityType::Suite,
+            MochaInterface::Bdd,
+            Some(Modifier::Pending),
+        )),
+        "xcontext" => Some((
+            "xcontext",
+            EntityType::Suite,
+            MochaInterface::Bdd,
+            Some(Modifier::Pending),
+        )),
+        "xit" => Some((
+            "xit",
+            EntityType::TestCase,
+            MochaInterface::Bdd,
+            Some(Modifier::Pending),
+        )),
+        "xspecify" => Some((
+            "xspecify",
+            EntityType::TestCase,
+            MochaInterface::Bdd,
+            Some(Modifier::Pending),
+        )),
+        _ => None,
+    }
+}
+
+fn call_path<'a>(call: &'a CallExpression<'a>) -> Option<SmallVec<[&'a str; 3]>> {
+    let mut path = SmallVec::new();
+    collect_callee_path(call.callee.get_inner_expression(), &mut path)?;
+    Some(path)
+}
+
+fn collect_callee_path<'a>(
+    expression: &'a Expression<'a>,
+    path: &mut SmallVec<[&'a str; 3]>,
+) -> Option<()> {
+    match expression.get_inner_expression() {
+        Expression::Identifier(identifier) => {
+            path.push(identifier.name.as_str());
+            Some(())
+        }
+        Expression::StaticMemberExpression(member) => {
+            collect_callee_path(&member.object, path)?;
+            path.push(member.property.name.as_str());
+            Some(())
+        }
+        _ => None,
+    }
+}
+
+fn callback_from_argument<'a>(argument: &'a Argument<'a>) -> Option<Callback<'a>> {
+    match argument {
+        Argument::FunctionExpression(function) => {
+            let body = function.body.as_deref()?;
+            Some(Callback {
+                span: function.span,
+                body: CallbackBody::Function(body),
+                async_function: function.r#async,
+                arrow: false,
+                named_function: function.id.is_some(),
+                params_len: function.params.items.len(),
+                first_param_name: function
+                    .params
+                    .items
+                    .first()
+                    .and_then(|param| binding_identifier_name(&param.pattern)),
+            })
+        }
+        Argument::ArrowFunctionExpression(function) => Some(Callback {
+            span: function.span,
+            body: CallbackBody::Function(&function.body),
+            async_function: function.r#async,
+            arrow: true,
+            named_function: false,
+            params_len: function.params.items.len(),
+            first_param_name: function
+                .params
+                .items
+                .first()
+                .and_then(|param| binding_identifier_name(&param.pattern)),
+        }),
+        _ => None,
+    }
+}
+
+fn binding_identifier_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn argument_string_value<'a>(argument: &'a Argument<'a>) -> Option<&'a str> {
+    match argument {
+        Argument::StringLiteral(literal) => Some(literal.value.as_str()),
+        Argument::TemplateLiteral(template) if template.expressions.is_empty() => template
+            .quasis
+            .first()
+            .and_then(|quasi| quasi.value.cooked.as_ref())
+            .map(|value| value.as_str()),
+        _ => None,
+    }
+}
+
+fn is_suite_config_call(call: &CallExpression<'_>) -> bool {
+    let Expression::StaticMemberExpression(member) = call.callee.get_inner_expression() else {
+        return false;
+    };
+    matches!(
+        member.object.get_inner_expression(),
+        Expression::ThisExpression(_)
+    ) && matches!(
+        member.property.name.as_str(),
+        "timeout" | "slow" | "retries"
+    )
+}
+
+fn callback_body_calls_identifier(body: CallbackBody<'_>, name: &str) -> bool {
+    match body {
+        CallbackBody::Function(body) => body
+            .statements
+            .iter()
+            .any(|statement| statement_calls_identifier(statement, name)),
+    }
+}
+
+fn callback_body_returns_value(body: CallbackBody<'_>) -> bool {
+    match body {
+        CallbackBody::Function(body) => body.statements.iter().any(statement_returns_value),
+    }
+}
+
+fn callback_body_returns_promise(body: CallbackBody<'_>) -> bool {
+    match body {
+        CallbackBody::Function(body) => body.statements.iter().any(|statement| {
+            matches!(statement, Statement::ReturnStatement(statement) if statement.argument.as_ref().is_some_and(non_literal_expression))
+        }),
+    }
+}
+
+fn callback_body_contains_this(body: CallbackBody<'_>) -> bool {
+    match body {
+        CallbackBody::Function(body) => body.statements.iter().any(statement_contains_this),
+    }
+}
+
+fn statement_returns_value(statement: &Statement<'_>) -> bool {
+    match statement {
+        Statement::ReturnStatement(statement) => statement.argument.is_some(),
+        Statement::BlockStatement(block) => block.body.iter().any(statement_returns_value),
+        Statement::IfStatement(statement) => {
+            statement_returns_value(&statement.consequent)
+                || statement
+                    .alternate
+                    .as_ref()
+                    .is_some_and(|alternate| statement_returns_value(alternate))
+        }
+        _ => false,
+    }
+}
+
+fn non_literal_expression(expression: &Expression<'_>) -> bool {
+    !matches!(
+        expression.get_inner_expression(),
+        Expression::NullLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::RegExpLiteral(_)
+    )
+}
+
+fn statement_contains_this(statement: &Statement<'_>) -> bool {
+    match statement {
+        Statement::ExpressionStatement(statement) => {
+            expression_contains_this(&statement.expression)
+        }
+        Statement::BlockStatement(block) => block.body.iter().any(statement_contains_this),
+        Statement::ReturnStatement(statement) => statement
+            .argument
+            .as_ref()
+            .is_some_and(expression_contains_this),
+        Statement::IfStatement(statement) => {
+            expression_contains_this(&statement.test)
+                || statement_contains_this(&statement.consequent)
+                || statement
+                    .alternate
+                    .as_ref()
+                    .is_some_and(|alternate| statement_contains_this(alternate))
+        }
+        Statement::ThrowStatement(statement) => expression_contains_this(&statement.argument),
+        Statement::VariableDeclaration(declaration) => {
+            declaration.declarations.iter().any(|declarator| {
+                declarator
+                    .init
+                    .as_ref()
+                    .is_some_and(expression_contains_this)
+            })
+        }
+        Statement::WhileStatement(statement) => {
+            expression_contains_this(&statement.test) || statement_contains_this(&statement.body)
+        }
+        Statement::DoWhileStatement(statement) => {
+            statement_contains_this(&statement.body) || expression_contains_this(&statement.test)
+        }
+        Statement::ForStatement(statement) => {
+            statement
+                .test
+                .as_ref()
+                .is_some_and(expression_contains_this)
+                || statement
+                    .update
+                    .as_ref()
+                    .is_some_and(expression_contains_this)
+                || statement_contains_this(&statement.body)
+        }
+        Statement::ForInStatement(statement) => {
+            expression_contains_this(&statement.right) || statement_contains_this(&statement.body)
+        }
+        Statement::ForOfStatement(statement) => {
+            expression_contains_this(&statement.right) || statement_contains_this(&statement.body)
+        }
+        Statement::SwitchStatement(statement) => {
+            expression_contains_this(&statement.discriminant)
+                || statement.cases.iter().any(|case| {
+                    case.test.as_ref().is_some_and(expression_contains_this)
+                        || case.consequent.iter().any(statement_contains_this)
+                })
+        }
+        Statement::TryStatement(statement) => {
+            statement.block.body.iter().any(statement_contains_this)
+                || statement
+                    .handler
+                    .as_ref()
+                    .is_some_and(|handler| handler.body.body.iter().any(statement_contains_this))
+                || statement
+                    .finalizer
+                    .as_ref()
+                    .is_some_and(|finalizer| finalizer.body.iter().any(statement_contains_this))
+        }
+        _ => false,
+    }
+}
+
+fn expression_contains_this(expression: &Expression<'_>) -> bool {
+    match expression.get_inner_expression() {
+        Expression::ThisExpression(_) => true,
+        Expression::CallExpression(call) => {
+            expression_contains_this(&call.callee)
+                || call.arguments.iter().any(argument_contains_this)
+        }
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(call) => {
+                expression_contains_this(&call.callee)
+                    || call.arguments.iter().any(argument_contains_this)
+            }
+            ChainElement::StaticMemberExpression(member) => {
+                expression_contains_this(&member.object)
+            }
+            ChainElement::ComputedMemberExpression(member) => {
+                expression_contains_this(&member.object)
+                    || expression_contains_this(&member.expression)
+            }
+            _ => false,
+        },
+        Expression::StaticMemberExpression(member) => expression_contains_this(&member.object),
+        Expression::ComputedMemberExpression(member) => {
+            expression_contains_this(&member.object) || expression_contains_this(&member.expression)
+        }
+        Expression::UnaryExpression(expression) => expression_contains_this(&expression.argument),
+        Expression::AwaitExpression(expression) => expression_contains_this(&expression.argument),
+        Expression::BinaryExpression(expression) => {
+            expression_contains_this(&expression.left)
+                || expression_contains_this(&expression.right)
+        }
+        Expression::LogicalExpression(expression) => {
+            expression_contains_this(&expression.left)
+                || expression_contains_this(&expression.right)
+        }
+        Expression::ConditionalExpression(expression) => {
+            expression_contains_this(&expression.test)
+                || expression_contains_this(&expression.consequent)
+                || expression_contains_this(&expression.alternate)
+        }
+        Expression::AssignmentExpression(expression) => expression_contains_this(&expression.right),
+        Expression::SequenceExpression(expression) => {
+            expression.expressions.iter().any(expression_contains_this)
+        }
+        Expression::TemplateLiteral(template) => {
+            template.expressions.iter().any(expression_contains_this)
+        }
+        Expression::TaggedTemplateExpression(expression) => {
+            expression_contains_this(&expression.tag)
+                || expression
+                    .quasi
+                    .expressions
+                    .iter()
+                    .any(expression_contains_this)
+        }
+        Expression::ArrayExpression(expression) => {
+            expression.elements.iter().any(array_element_contains_this)
+        }
+        Expression::ObjectExpression(expression) => expression.properties.iter().any(|property| {
+            if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) = property {
+                (property.computed && property_key_contains_this(&property.key))
+                    || expression_contains_this(&property.value)
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    }
+}
+
+fn argument_contains_this(argument: &Argument<'_>) -> bool {
+    match argument {
+        Argument::CallExpression(call) => {
+            expression_contains_this(&call.callee)
+                || call.arguments.iter().any(argument_contains_this)
+        }
+        Argument::StaticMemberExpression(member) => expression_contains_this(&member.object),
+        Argument::ComputedMemberExpression(member) => {
+            expression_contains_this(&member.object) || expression_contains_this(&member.expression)
+        }
+        Argument::ArrayExpression(expression) => {
+            expression.elements.iter().any(array_element_contains_this)
+        }
+        Argument::ObjectExpression(expression) => expression.properties.iter().any(|property| {
+            if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) = property {
+                expression_contains_this(&property.value)
+            } else {
+                false
+            }
+        }),
+        Argument::ConditionalExpression(expression) => {
+            expression_contains_this(&expression.test)
+                || expression_contains_this(&expression.consequent)
+                || expression_contains_this(&expression.alternate)
+        }
+        _ => false,
+    }
+}
+
+fn array_element_contains_this(element: &ArrayExpressionElement<'_>) -> bool {
+    match element {
+        ArrayExpressionElement::CallExpression(call) => {
+            expression_contains_this(&call.callee)
+                || call.arguments.iter().any(argument_contains_this)
+        }
+        ArrayExpressionElement::StaticMemberExpression(member) => {
+            expression_contains_this(&member.object)
+        }
+        ArrayExpressionElement::ComputedMemberExpression(member) => {
+            expression_contains_this(&member.object) || expression_contains_this(&member.expression)
+        }
+        ArrayExpressionElement::ArrayExpression(expression) => {
+            expression.elements.iter().any(array_element_contains_this)
+        }
+        ArrayExpressionElement::ObjectExpression(expression) => {
+            expression.properties.iter().any(|property| {
+                if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) = property {
+                    expression_contains_this(&property.value)
+                } else {
+                    false
+                }
+            })
+        }
+        ArrayExpressionElement::ConditionalExpression(expression) => {
+            expression_contains_this(&expression.test)
+                || expression_contains_this(&expression.consequent)
+                || expression_contains_this(&expression.alternate)
+        }
+        _ => false,
+    }
+}
+
+fn property_key_contains_this(key: &PropertyKey<'_>) -> bool {
+    match key {
+        PropertyKey::CallExpression(call) => {
+            expression_contains_this(&call.callee)
+                || call.arguments.iter().any(argument_contains_this)
+        }
+        PropertyKey::StaticMemberExpression(member) => expression_contains_this(&member.object),
+        PropertyKey::ComputedMemberExpression(member) => {
+            expression_contains_this(&member.object) || expression_contains_this(&member.expression)
+        }
+        _ => false,
+    }
+}
+
+fn statement_calls_identifier(statement: &Statement<'_>, name: &str) -> bool {
+    match statement {
+        Statement::ExpressionStatement(statement) => {
+            expression_calls_identifier(&statement.expression, name)
+        }
+        Statement::BlockStatement(block) => block
+            .body
+            .iter()
+            .any(|statement| statement_calls_identifier(statement, name)),
+        Statement::ReturnStatement(statement) => statement
+            .argument
+            .as_ref()
+            .is_some_and(|argument| expression_calls_identifier(argument, name)),
+        Statement::IfStatement(statement) => {
+            expression_calls_identifier(&statement.test, name)
+                || statement_calls_identifier(&statement.consequent, name)
+                || statement
+                    .alternate
+                    .as_ref()
+                    .is_some_and(|alternate| statement_calls_identifier(alternate, name))
+        }
+        _ => false,
+    }
+}
+
+fn expression_calls_identifier(expression: &Expression<'_>, name: &str) -> bool {
+    match expression.get_inner_expression() {
+        Expression::CallExpression(call) => {
+            matches!(call.callee.get_inner_expression(), Expression::Identifier(identifier) if identifier.name.as_str() == name)
+                || call
+                    .arguments
+                    .iter()
+                    .any(|argument| argument_calls_identifier(argument, name))
+        }
+        Expression::StaticMemberExpression(member) => {
+            expression_calls_identifier(&member.object, name)
+        }
+        Expression::ComputedMemberExpression(member) => {
+            expression_calls_identifier(&member.object, name)
+                || expression_calls_identifier(&member.expression, name)
+        }
+        Expression::BinaryExpression(expression) => {
+            expression_calls_identifier(&expression.left, name)
+                || expression_calls_identifier(&expression.right, name)
+        }
+        Expression::LogicalExpression(expression) => {
+            expression_calls_identifier(&expression.left, name)
+                || expression_calls_identifier(&expression.right, name)
+        }
+        Expression::ConditionalExpression(expression) => {
+            expression_calls_identifier(&expression.test, name)
+                || expression_calls_identifier(&expression.consequent, name)
+                || expression_calls_identifier(&expression.alternate, name)
+        }
+        _ => false,
+    }
+}
+
+fn argument_calls_identifier(argument: &Argument<'_>, name: &str) -> bool {
+    match argument {
+        Argument::CallExpression(call) => {
+            matches!(call.callee.get_inner_expression(), Expression::Identifier(identifier) if identifier.name.as_str() == name)
+        }
+        Argument::Identifier(identifier) => identifier.name.as_str() == name,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MochaOptions, scan_mocha};
+
+    fn rule_names(source_text: &str) -> oxlint_plugins_carton::SmallVec<[&'static str; 16]> {
+        scan_mocha(source_text, "fixture.test.js", &MochaOptions::default())
+            .into_iter()
+            .map(|diagnostic| diagnostic.rule_name)
+            .collect()
+    }
+
+    #[test]
+    fn scans_core_mocha_rules() {
+        let rules = rule_names(
+            r#"
+            beforeEach(function () {});
+            it("global", function () {});
+            describe.only("", async function () {
+              before(function (done) {});
+              before(function () {});
+              it("works", function (done) { return fetch("/"); });
+              it("works", () => {});
+              it.skip("later");
+              it("async return", async function () { return fetch("/"); });
+              it("nested", function () { it("bad", function () {}); });
+              helper();
+            });
+            describe("single", function () {
+              before(function () {});
+              it("one", function (done) { done(); });
+            });
+            suite("tdd", function () { test("bad", function () {}); });
+            export const value = 1;
+            "#,
+        );
+
+        assert!(rules.contains(&"consistent-spacing-between-blocks"));
+        assert!(rules.contains(&"no-top-level-hooks"));
+        assert!(rules.contains(&"no-hooks"));
+        assert!(rules.contains(&"no-exclusive-tests"));
+        assert!(rules.contains(&"no-empty-title"));
+        assert!(rules.contains(&"no-async-suite"));
+        assert!(rules.contains(&"handle-done-callback"));
+        assert!(rules.contains(&"no-sibling-hooks"));
+        assert!(rules.contains(&"no-return-and-callback"));
+        assert!(rules.contains(&"no-return-from-async"));
+        assert!(rules.contains(&"no-mocha-arrows"));
+        assert!(rules.contains(&"no-pending-tests"));
+        assert!(rules.contains(&"no-global-tests"));
+        assert!(rules.contains(&"no-hooks-for-single-case"));
+        assert!(rules.contains(&"no-nested-tests"));
+        assert!(rules.contains(&"no-setup-in-describe"));
+        assert!(rules.contains(&"no-synchronous-tests"));
+        assert!(rules.contains(&"consistent-interface"));
+        assert!(rules.contains(&"no-exports"));
+    }
+
+    #[test]
+    fn scans_title_rules_with_options() {
+        let options = MochaOptions {
+            valid_suite_title_pattern: Some("^Suite".into()),
+            valid_test_title_pattern: Some("^should".into()),
+            ..MochaOptions::default()
+        };
+        let rules = scan_mocha(
+            r#"
+            describe("bad suite", function () {
+              it("bad test", function () {});
+            });
+            "#,
+            "fixture.test.js",
+            &options,
+        )
+        .into_iter()
+        .map(|diagnostic| diagnostic.rule_name)
+        .collect::<oxlint_plugins_carton::SmallVec<[&'static str; 8]>>();
+
+        assert!(rules.contains(&"valid-suite-title"));
+        assert!(rules.contains(&"valid-test-title"));
+    }
+}

--- a/npm/mocha/Cargo.toml
+++ b/npm/mocha/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "oxlint-plugin-mocha"
+description = "Rust-backed oxlint plugin port of eslint-plugin-mocha."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_mocha"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-mocha.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/npm/mocha/LICENSE
+++ b/npm/mocha/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 eslint-plugin-mocha contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/mocha/README.md
+++ b/npm/mocha/README.md
@@ -1,0 +1,33 @@
+# @oxlint-plugins/oxlint-plugin-mocha
+
+Rust-backed Oxlint plugin port of `eslint-plugin-mocha`.
+
+The JavaScript layer is an Oxlint/NAPI adapter. Rule parsing and Mocha AST checks
+run in Rust through Oxc.
+
+## Rules
+
+- `mocha/consistent-interface`
+- `mocha/consistent-spacing-between-blocks`
+- `mocha/handle-done-callback`
+- `mocha/max-top-level-suites`
+- `mocha/no-async-suite`
+- `mocha/no-empty-title`
+- `mocha/no-exclusive-tests`
+- `mocha/no-exports`
+- `mocha/no-global-tests`
+- `mocha/no-hooks`
+- `mocha/no-hooks-for-single-case`
+- `mocha/no-identical-title`
+- `mocha/no-mocha-arrows`
+- `mocha/no-nested-tests`
+- `mocha/no-pending-tests`
+- `mocha/no-return-and-callback`
+- `mocha/no-return-from-async`
+- `mocha/no-setup-in-describe`
+- `mocha/no-sibling-hooks`
+- `mocha/no-synchronous-tests`
+- `mocha/no-top-level-hooks`
+- `mocha/prefer-arrow-callback`
+- `mocha/valid-suite-title`
+- `mocha/valid-test-title`

--- a/npm/mocha/api.d.ts
+++ b/npm/mocha/api.d.ts
@@ -1,0 +1,35 @@
+export type MochaDiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type MochaDiagnostic = {
+  ruleName: string;
+  message: string;
+  loc: MochaDiagnosticLoc;
+};
+
+export type MochaScanOptions = {
+  consistentInterface?: string;
+  maxTopLevelSuitesLimit?: number;
+  handleDoneIgnorePending?: boolean;
+  noHooksAllowed?: string[];
+  noHooksForSingleCaseAllowed?: string[];
+  noSynchronousAllowed?: string[];
+  noEmptyTitleMessage?: string;
+  validSuiteTitlePattern?: string;
+  validSuiteTitleMessage?: string;
+  validTestTitlePattern?: string;
+  validTestTitleMessage?: string;
+  preferArrowAllowNamedFunctions?: boolean;
+  preferArrowAllowUnboundThis?: boolean;
+};
+
+export function implementedMochaRuleNames(): string[];
+export function scanMocha(
+  sourceText: string,
+  filename?: string,
+  options?: MochaScanOptions,
+): MochaDiagnostic[];

--- a/npm/mocha/api.js
+++ b/npm/mocha/api.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const native = require('./native.js');
+
+function implementedMochaRuleNames() {
+  return native.implementedMochaRuleNames();
+}
+
+function scanMocha(sourceText, filename = 'file.js', options = {}) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+
+  return native.scanMocha(sourceText, filename, normalizeOptions(options));
+}
+
+function normalizeOptions(options) {
+  const raw = options && typeof options === 'object' ? options : {};
+  return {
+    consistentInterface: normalizeString(raw.consistentInterface),
+    maxTopLevelSuitesLimit:
+      typeof raw.maxTopLevelSuitesLimit === 'number' ? raw.maxTopLevelSuitesLimit : undefined,
+    handleDoneIgnorePending: raw.handleDoneIgnorePending === true,
+    noHooksAllowed: normalizeStringArray(raw.noHooksAllowed),
+    noHooksForSingleCaseAllowed: normalizeStringArray(raw.noHooksForSingleCaseAllowed),
+    noSynchronousAllowed: Array.isArray(raw.noSynchronousAllowed)
+      ? normalizeStringArray(raw.noSynchronousAllowed)
+      : undefined,
+    noEmptyTitleMessage: normalizeString(raw.noEmptyTitleMessage),
+    validSuiteTitlePattern: normalizeString(raw.validSuiteTitlePattern),
+    validSuiteTitleMessage: normalizeString(raw.validSuiteTitleMessage),
+    validTestTitlePattern: normalizeString(raw.validTestTitlePattern),
+    validTestTitleMessage: normalizeString(raw.validTestTitleMessage),
+    preferArrowAllowNamedFunctions: raw.preferArrowAllowNamedFunctions === true,
+    preferArrowAllowUnboundThis: raw.preferArrowAllowUnboundThis !== false,
+  };
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function normalizeStringArray(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+module.exports = {
+  implementedMochaRuleNames,
+  scanMocha,
+};
+module.exports.default = module.exports;

--- a/npm/mocha/build.rs
+++ b/npm/mocha/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/mocha/index.js
+++ b/npm/mocha/index.js
@@ -1,0 +1,420 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-mocha (MIT).
+// The JavaScript layer is only an Oxlint/NAPI adapter; parsing, Mocha call
+// classification, suite tracking, and rule checks run in Rust through Oxc.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedMochaRuleNames, scanMocha } = require('./api.js');
+
+const PLUGIN_NAME = 'mocha';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/mocha';
+const diagnosticsCache = new WeakMap();
+
+const commonGlobals = Object.freeze({
+  after: false,
+  afterEach: false,
+  before: false,
+  beforeEach: false,
+  context: false,
+  describe: false,
+  it: false,
+  setup: false,
+  specify: false,
+  suite: false,
+  suiteSetup: false,
+  suiteTeardown: false,
+  teardown: false,
+  test: false,
+  xcontext: false,
+  xdescribe: false,
+  xit: false,
+  xspecify: false,
+});
+
+const allRuleConfig = Object.freeze({
+  'handle-done-callback': 'error',
+  'max-top-level-suites': 'error',
+  'no-async-suite': 'error',
+  'no-exclusive-tests': 'error',
+  'no-exports': 'error',
+  'no-global-tests': 'error',
+  'no-hooks': 'error',
+  'no-hooks-for-single-case': 'error',
+  'no-identical-title': 'error',
+  'no-mocha-arrows': 'error',
+  'no-nested-tests': 'error',
+  'no-pending-tests': 'error',
+  'no-return-and-callback': 'error',
+  'no-return-from-async': 'error',
+  'no-setup-in-describe': 'error',
+  'no-sibling-hooks': 'error',
+  'no-synchronous-tests': 'error',
+  'no-top-level-hooks': 'error',
+  'prefer-arrow-callback': 'error',
+  'consistent-spacing-between-blocks': 'error',
+  'consistent-interface': ['error', { interface: 'BDD' }],
+  'valid-suite-title': 'error',
+  'valid-test-title': 'error',
+  'no-empty-title': 'error',
+});
+
+const recommendedRuleConfig = Object.freeze({
+  'handle-done-callback': 'error',
+  'max-top-level-suites': ['error', { limit: 1 }],
+  'no-async-suite': 'error',
+  'no-exclusive-tests': 'warn',
+  'no-exports': 'error',
+  'no-global-tests': 'error',
+  'no-hooks': 'off',
+  'no-hooks-for-single-case': 'off',
+  'no-identical-title': 'error',
+  'no-mocha-arrows': 'error',
+  'no-nested-tests': 'error',
+  'no-pending-tests': 'warn',
+  'no-return-and-callback': 'error',
+  'no-return-from-async': 'off',
+  'no-setup-in-describe': 'error',
+  'no-sibling-hooks': 'error',
+  'no-synchronous-tests': 'off',
+  'no-top-level-hooks': 'warn',
+  'prefer-arrow-callback': 'off',
+  'valid-suite-title': 'off',
+  'valid-test-title': 'off',
+  'no-empty-title': 'error',
+  'consistent-spacing-between-blocks': 'error',
+});
+
+const ruleDescriptions = Object.freeze({
+  'consistent-interface': 'enforce consistent use of Mocha interfaces',
+  'consistent-spacing-between-blocks': 'require consistent spacing between Mocha blocks',
+  'handle-done-callback': 'require callback-based async tests to handle the callback',
+  'max-top-level-suites': 'enforce a maximum number of top-level suites',
+  'no-async-suite': 'disallow async functions passed to suites',
+  'no-empty-title': 'disallow empty test descriptions',
+  'no-exclusive-tests': 'disallow exclusive Mocha tests',
+  'no-exports': 'disallow exports from test files',
+  'no-global-tests': 'disallow global tests',
+  'no-hooks': 'disallow hooks',
+  'no-hooks-for-single-case': 'disallow hooks for suites with a single test',
+  'no-identical-title': 'disallow duplicate suite or test titles in the same scope',
+  'no-mocha-arrows': 'disallow arrow callbacks in Mocha tests',
+  'no-nested-tests': 'disallow tests nested inside tests',
+  'no-pending-tests': 'disallow pending tests',
+  'no-return-and-callback': 'disallow returning in a test or hook that uses a callback',
+  'no-return-from-async': 'disallow returning from async tests or hooks',
+  'no-setup-in-describe': 'disallow setup calls in describe blocks',
+  'no-sibling-hooks': 'disallow duplicate sibling hooks',
+  'no-synchronous-tests': 'disallow synchronous tests',
+  'no-top-level-hooks': 'disallow top-level hooks',
+  'prefer-arrow-callback': 'prefer arrow callbacks in Mocha tests',
+  'valid-suite-title': 'require suite titles to match a configured pattern',
+  'valid-test-title': 'require test titles to match a configured pattern',
+});
+
+const ruleTypes = Object.freeze({
+  'consistent-interface': 'problem',
+  'consistent-spacing-between-blocks': 'suggestion',
+  'handle-done-callback': 'problem',
+  'max-top-level-suites': 'suggestion',
+  'no-async-suite': 'problem',
+  'no-empty-title': 'suggestion',
+  'no-exclusive-tests': 'problem',
+  'no-exports': 'problem',
+  'no-global-tests': 'problem',
+  'no-hooks': 'suggestion',
+  'no-hooks-for-single-case': 'suggestion',
+  'no-identical-title': 'problem',
+  'no-mocha-arrows': 'problem',
+  'no-nested-tests': 'problem',
+  'no-pending-tests': 'problem',
+  'no-return-and-callback': 'problem',
+  'no-return-from-async': 'problem',
+  'no-setup-in-describe': 'problem',
+  'no-sibling-hooks': 'problem',
+  'no-synchronous-tests': 'suggestion',
+  'no-top-level-hooks': 'problem',
+  'prefer-arrow-callback': 'suggestion',
+  'valid-suite-title': 'suggestion',
+  'valid-test-title': 'suggestion',
+});
+
+const implementedRuleNames = Object.freeze(implementedMochaRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, createMochaRule(ruleName)])),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    all: configFromRuleConfig('all', allRuleConfig),
+    recommended: configFromRuleConfig('recommended', recommendedRuleConfig),
+  },
+});
+
+plugin.implementedMochaRuleNames = implementedRuleNames;
+plugin.scanMocha = scanMocha;
+
+function configFromRuleConfig(name, ruleConfig) {
+  return {
+    name: `${PLUGIN_NAME}/${name}`,
+    plugins: [PLUGIN_NAME],
+    languageOptions: {
+      globals: commonGlobals,
+    },
+    rules: Object.fromEntries(
+      Object.entries(ruleConfig).map(([ruleName, config]) => [
+        `${PLUGIN_NAME}/${ruleName}`,
+        config,
+      ]),
+    ),
+  };
+}
+
+function createMochaRule(ruleName) {
+  const meta = {
+    type: ruleTypes[ruleName],
+    docs: {
+      description: ruleDescriptions[ruleName],
+      category: 'Possible Errors',
+      recommended: recommendedRuleConfig[ruleName] !== 'off',
+      url: `${DOCS_BASE}#${ruleName}`,
+    },
+    messages: {
+      unexpected: '{{message}}',
+    },
+    schema: schemaForRule(ruleName),
+  };
+
+  return {
+    meta,
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForRule(context, ruleName)) {
+            reportDiagnostic(context, diagnostic);
+          }
+        },
+      };
+    },
+  };
+}
+
+function schemaForRule(ruleName) {
+  if (ruleName === 'consistent-interface') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          interface: { type: 'string', enum: ['BDD', 'TDD'], default: 'BDD' },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'max-top-level-suites') {
+    return [
+      {
+        type: 'object',
+        properties: { limit: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'handle-done-callback') {
+    return [
+      {
+        type: 'object',
+        properties: { ignorePending: { type: 'boolean', default: false } },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'no-hooks' || ruleName === 'no-hooks-for-single-case') {
+    return [
+      {
+        type: 'object',
+        properties: { allow: { type: 'array', items: { type: 'string' } } },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'no-synchronous-tests') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          allowed: {
+            type: 'array',
+            items: { type: 'string', enum: ['async', 'callback', 'promise'] },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'no-empty-title') {
+    return [
+      {
+        type: 'object',
+        properties: { message: { type: 'string' } },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'valid-suite-title' || ruleName === 'valid-test-title') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          pattern: { type: 'string' },
+          message: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'prefer-arrow-callback') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          allowNamedFunctions: { type: 'boolean', default: false },
+          allowUnboundThis: { type: 'boolean', default: true },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  return [];
+}
+
+function diagnosticsForRule(context, ruleName) {
+  return diagnosticsForContext(context, scanOptionsForRule(context, ruleName)).filter(
+    (diagnostic) => diagnostic.ruleName === ruleName,
+  );
+}
+
+function diagnosticsForContext(context, options) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.js';
+  const key = JSON.stringify(options);
+  let sourceCache = diagnosticsCache.get(sourceCode);
+
+  if (!sourceCache) {
+    sourceCache = new Map();
+    diagnosticsCache.set(sourceCode, sourceCache);
+  }
+
+  const cached = sourceCache.get(key);
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanMocha(sourceText, filename, options);
+  sourceCache.set(key, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function scanOptionsForRule(context, ruleName) {
+  const options =
+    context.options?.[0] && typeof context.options[0] === 'object' ? context.options[0] : {};
+  const scanOptions = {
+    consistentInterface:
+      ruleName === 'consistent-interface' ? normalizeInterface(options.interface) : 'BDD',
+    maxTopLevelSuitesLimit:
+      ruleName === 'max-top-level-suites' && Number.isInteger(options.limit) ? options.limit : 1,
+    handleDoneIgnorePending: ruleName === 'handle-done-callback' && options.ignorePending === true,
+    noHooksAllowed: ruleName === 'no-hooks' ? normalizeHookNames(options.allow) : [],
+    noHooksForSingleCaseAllowed:
+      ruleName === 'no-hooks-for-single-case' ? normalizeHookNames(options.allow) : [],
+    noEmptyTitleMessage:
+      ruleName === 'no-empty-title' && typeof options.message === 'string'
+        ? options.message
+        : undefined,
+    validSuiteTitlePattern:
+      ruleName === 'valid-suite-title' && typeof options.pattern === 'string'
+        ? options.pattern
+        : undefined,
+    validSuiteTitleMessage:
+      ruleName === 'valid-suite-title' && typeof options.message === 'string'
+        ? options.message
+        : undefined,
+    validTestTitlePattern:
+      ruleName === 'valid-test-title'
+        ? typeof options.pattern === 'string'
+          ? options.pattern
+          : '^should'
+        : undefined,
+    validTestTitleMessage:
+      ruleName === 'valid-test-title' && typeof options.message === 'string'
+        ? options.message
+        : undefined,
+    preferArrowAllowNamedFunctions:
+      ruleName === 'prefer-arrow-callback' && options.allowNamedFunctions === true,
+    preferArrowAllowUnboundThis:
+      ruleName !== 'prefer-arrow-callback' || options.allowUnboundThis !== false,
+  };
+
+  if (ruleName === 'no-synchronous-tests' && Array.isArray(options.allowed)) {
+    scanOptions.noSynchronousAllowed = options.allowed.filter((method) =>
+      ['async', 'callback', 'promise'].includes(method),
+    );
+  }
+
+  return scanOptions;
+}
+
+function normalizeInterface(value) {
+  return value === 'TDD' ? 'TDD' : 'BDD';
+}
+
+function normalizeHookNames(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .filter((value) => typeof value === 'string' && value.length > 0)
+    .map((value) => (value.endsWith('()') ? value.slice(0, -2) : value));
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function reportDiagnostic(context, diagnostic) {
+  context.report({
+    messageId: 'unexpected',
+    data: {
+      message: diagnostic.message,
+    },
+    loc: {
+      start: {
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn,
+      },
+      end: {
+        line: diagnostic.loc.endLine,
+        column: diagnostic.loc.endColumn,
+      },
+    },
+  });
+}
+
+module.exports = plugin;
+module.exports.default = plugin;

--- a/npm/mocha/package.json
+++ b/npm/mocha/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-mocha",
+  "version": "0.0.0",
+  "description": "Rust-backed Oxlint plugin port of eslint-plugin-mocha.",
+  "keywords": [
+    "eslint-plugin",
+    "mocha",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/mocha"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_mocha",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/mocha/src/lib.rs
+++ b/npm/mocha/src/lib.rs
@@ -1,0 +1,134 @@
+//! NAPI boundary for the mocha oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticLoc, MochaScanOptions, implemented_mocha_rule_names, scan_mocha,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use oxlint_plugins_mocha as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct MochaScanOptions {
+        pub consistent_interface: Option<String>,
+        pub max_top_level_suites_limit: Option<u32>,
+        pub handle_done_ignore_pending: Option<bool>,
+        pub no_hooks_allowed: Option<Vec<String>>,
+        pub no_hooks_for_single_case_allowed: Option<Vec<String>>,
+        pub no_synchronous_allowed: Option<Vec<String>>,
+        pub no_empty_title_message: Option<String>,
+        pub valid_suite_title_pattern: Option<String>,
+        pub valid_suite_title_message: Option<String>,
+        pub valid_test_title_pattern: Option<String>,
+        pub valid_test_title_message: Option<String>,
+        pub prefer_arrow_allow_named_functions: Option<bool>,
+        pub prefer_arrow_allow_unbound_this: Option<bool>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message: String,
+        pub loc: DiagnosticLoc,
+    }
+
+    #[napi]
+    pub fn implemented_mocha_rule_names() -> Vec<String> {
+        core::implemented_mocha_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_mocha(
+        source_text: String,
+        filename: String,
+        options: Option<MochaScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let default_options = core::MochaOptions::default();
+        let core_options = core::MochaOptions {
+            consistent_interface: option_compact_string(options.consistent_interface)
+                .unwrap_or(default_options.consistent_interface),
+            max_top_level_suites_limit: options
+                .max_top_level_suites_limit
+                .unwrap_or(default_options.max_top_level_suites_limit),
+            handle_done_ignore_pending: options
+                .handle_done_ignore_pending
+                .unwrap_or(default_options.handle_done_ignore_pending),
+            no_hooks_allowed: compact_strings4(options.no_hooks_allowed.unwrap_or_default()),
+            no_hooks_for_single_case_allowed: compact_strings4(
+                options.no_hooks_for_single_case_allowed.unwrap_or_default(),
+            ),
+            no_synchronous_allowed: options
+                .no_synchronous_allowed
+                .map(compact_strings3)
+                .unwrap_or(default_options.no_synchronous_allowed),
+            no_empty_title_message: option_compact_string(options.no_empty_title_message),
+            valid_suite_title_pattern: option_compact_string(options.valid_suite_title_pattern),
+            valid_suite_title_message: option_compact_string(options.valid_suite_title_message),
+            valid_test_title_pattern: option_compact_string(options.valid_test_title_pattern),
+            valid_test_title_message: option_compact_string(options.valid_test_title_message),
+            prefer_arrow_allow_named_functions: options
+                .prefer_arrow_allow_named_functions
+                .unwrap_or(default_options.prefer_arrow_allow_named_functions),
+            prefer_arrow_allow_unbound_this: options
+                .prefer_arrow_allow_unbound_this
+                .unwrap_or(default_options.prefer_arrow_allow_unbound_this),
+        };
+
+        core::scan_mocha(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message: diagnostic.message.into_string(),
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+            })
+            .collect()
+    }
+
+    fn option_compact_string(value: Option<String>) -> Option<CompactString> {
+        value
+            .filter(|value| !value.is_empty())
+            .map(CompactString::from)
+    }
+
+    fn compact_strings3(values: Vec<String>) -> SmallVec<[CompactString; 3]> {
+        values
+            .into_iter()
+            .filter(|value| !value.is_empty())
+            .map(CompactString::from)
+            .collect()
+    }
+
+    fn compact_strings4(values: Vec<String>) -> SmallVec<[CompactString; 4]> {
+        values
+            .into_iter()
+            .filter(|value| !value.is_empty())
+            .map(CompactString::from)
+            .collect()
+    }
+}

--- a/npm/mocha/test/api.test.mjs
+++ b/npm/mocha/test/api.test.mjs
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedMochaRuleNames, scanMocha } from '../api.js';
+
+const expectedRuleNames = [
+  'consistent-interface',
+  'consistent-spacing-between-blocks',
+  'handle-done-callback',
+  'max-top-level-suites',
+  'no-async-suite',
+  'no-empty-title',
+  'no-exclusive-tests',
+  'no-exports',
+  'no-global-tests',
+  'no-hooks',
+  'no-hooks-for-single-case',
+  'no-identical-title',
+  'no-mocha-arrows',
+  'no-nested-tests',
+  'no-pending-tests',
+  'no-return-and-callback',
+  'no-return-from-async',
+  'no-setup-in-describe',
+  'no-sibling-hooks',
+  'no-synchronous-tests',
+  'no-top-level-hooks',
+  'prefer-arrow-callback',
+  'valid-suite-title',
+  'valid-test-title',
+];
+
+describe('mocha native API', () => {
+  it('exposes all eslint-plugin-mocha rule names', () => {
+    expect(implementedMochaRuleNames()).toEqual(expectedRuleNames);
+  });
+
+  it('scans multiple Mocha rules through one native call', () => {
+    const diagnostics = scanMocha(
+      [
+        'before(function () {});',
+        'it("global", function () {});',
+        'describe.only("", async function () {',
+        '  before(function (done) {});',
+        '  before(function () {});',
+        '  it("works", function (done) { return fetch("/"); });',
+        '  it("works", () => {});',
+        '  it.skip("later");',
+        '  it("async return", async function () { return fetch("/"); });',
+        '  it("nested", function () { it("bad", function () {}); });',
+        '  helper();',
+        '});',
+        'suite("tdd", function () { test("bad", function () {}); });',
+        'export const value = 1;',
+      ].join('\n'),
+      'fixture.test.js',
+    );
+
+    expect(new Set(diagnostics.map((diagnostic) => diagnostic.ruleName))).toEqual(
+      new Set([
+        'consistent-spacing-between-blocks',
+        'consistent-interface',
+        'handle-done-callback',
+        'max-top-level-suites',
+        'no-async-suite',
+        'no-empty-title',
+        'no-exclusive-tests',
+        'no-exports',
+        'no-global-tests',
+        'no-hooks',
+        'no-identical-title',
+        'no-mocha-arrows',
+        'no-nested-tests',
+        'no-pending-tests',
+        'no-return-and-callback',
+        'no-return-from-async',
+        'no-setup-in-describe',
+        'no-sibling-hooks',
+        'no-synchronous-tests',
+        'no-top-level-hooks',
+        'prefer-arrow-callback',
+      ]),
+    );
+  });
+
+  it('passes rule options to Rust', () => {
+    const diagnostics = scanMocha(
+      [
+        'describe("bad suite", function () {',
+        '  before(function () {});',
+        '  it("bad test", function () { this.timeout(1000); });',
+        '});',
+      ].join('\n'),
+      'fixture.test.js',
+      {
+        noHooksAllowed: ['before'],
+        validSuiteTitlePattern: '^Suite',
+        validTestTitlePattern: '^should',
+      },
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toContain('valid-suite-title');
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toContain('valid-test-title');
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).not.toContain('no-hooks');
+  });
+
+  it('honors prefer-arrow allowUnboundThis', () => {
+    const diagnostics = scanMocha(
+      'it("bad test", function () { this.timeout(1000); });\n',
+      'fixture.test.js',
+      {
+        preferArrowAllowUnboundThis: true,
+      },
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).not.toContain(
+      'prefer-arrow-callback',
+    );
+  });
+});

--- a/npm/mocha/test/plugin.test.mjs
+++ b/npm/mocha/test/plugin.test.mjs
@@ -1,0 +1,339 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const expectedRuleNames = [
+  'consistent-interface',
+  'consistent-spacing-between-blocks',
+  'handle-done-callback',
+  'max-top-level-suites',
+  'no-async-suite',
+  'no-empty-title',
+  'no-exclusive-tests',
+  'no-exports',
+  'no-global-tests',
+  'no-hooks',
+  'no-hooks-for-single-case',
+  'no-identical-title',
+  'no-mocha-arrows',
+  'no-nested-tests',
+  'no-pending-tests',
+  'no-return-and-callback',
+  'no-return-from-async',
+  'no-setup-in-describe',
+  'no-sibling-hooks',
+  'no-synchronous-tests',
+  'no-top-level-hooks',
+  'prefer-arrow-callback',
+  'valid-suite-title',
+  'valid-test-title',
+];
+
+const invalidCases = [
+  [
+    'consistent-interface',
+    'TDD call while BDD is required',
+    'suite("x", function () {});\n',
+    ['Unexpected use of TDD interface instead of BDD'],
+    [{ interface: 'BDD' }],
+  ],
+  [
+    'consistent-spacing-between-blocks',
+    'adjacent tests',
+    'describe("x", function () {\n  it("one", function () {});\n  it("two", function () {});\n});\n',
+    ['Expected line break before this statement.'],
+  ],
+  [
+    'handle-done-callback',
+    'unused done callback',
+    'it("x", function (done) {});\n',
+    ['Expected "done" callback to be handled.'],
+  ],
+  [
+    'max-top-level-suites',
+    'two top-level suites',
+    'describe("a", function () {});\ndescribe("b", function () {});\n',
+    ['The number of top-level suites is more than 1.'],
+  ],
+  [
+    'no-async-suite',
+    'async suite callback',
+    'describe("x", async function () {});\n',
+    ['Unexpected async function in describe()'],
+  ],
+  [
+    'no-empty-title',
+    'empty title',
+    'it("", function () {});\n',
+    ['Unexpected empty test description.'],
+  ],
+  [
+    'no-exclusive-tests',
+    'only modifier',
+    'it.only("x", function () {});\n',
+    ['Unexpected exclusive mocha test.'],
+  ],
+  [
+    'no-exports',
+    'export in test file',
+    'it("x", function () {});\nexport const value = 1;\n',
+    ['Unexpected export from a test file'],
+  ],
+  [
+    'no-global-tests',
+    'top-level test',
+    'it("x", function () {});\n',
+    ['Unexpected global mocha test.'],
+  ],
+  [
+    'no-hooks',
+    'hook inside suite',
+    'describe("x", function () {\n  before(function () {});\n  it("a", function () {});\n  it("b", function () {});\n});\n',
+    ['Unexpected use of Mocha `before()` hook'],
+  ],
+  [
+    'no-hooks-for-single-case',
+    'single test suite hook',
+    'describe("x", function () {\n  before(function () {});\n  it("a", function () {});\n});\n',
+    ['Unexpected use of Mocha `before()` hook for a single test case'],
+  ],
+  [
+    'no-identical-title',
+    'duplicate test titles',
+    'describe("x", function () {\n  it("a", function () {});\n  it("a", function () {});\n});\n',
+    ['Unexpected use of duplicate Mocha title `a`'],
+  ],
+  ['no-mocha-arrows', 'arrow callback', 'it("x", () => {});\n', ['Unexpected arrow function.']],
+  [
+    'no-nested-tests',
+    'nested test',
+    'it("x", function () { it("y", function () {}); });\n',
+    ['Unexpected test nested inside another test.'],
+  ],
+  ['no-pending-tests', 'skip modifier', 'it.skip("x");\n', ['Unexpected pending mocha test.']],
+  [
+    'no-return-and-callback',
+    'return with callback',
+    'it("x", function (done) { return fetch("/"); });\n',
+    ['Unexpected use of `return` in a test with callback'],
+  ],
+  [
+    'no-return-from-async',
+    'return from async',
+    'it("x", async function () { return fetch("/"); });\n',
+    ['Unexpected use of `return` in a test with an async function'],
+  ],
+  [
+    'no-setup-in-describe',
+    'setup call in suite',
+    'describe("x", function () {\n  helper();\n  it("a", function () {});\n});\n',
+    ['Unexpected function call in describe block.'],
+  ],
+  [
+    'no-sibling-hooks',
+    'duplicate hooks',
+    'describe("x", function () {\n  before(function () {});\n  before(function () {});\n  it("a", function () {});\n});\n',
+    ['Unexpected use of duplicate Mocha `before()` hook'],
+  ],
+  [
+    'no-synchronous-tests',
+    'sync test',
+    'it("x", function () {});\n',
+    ['Unexpected synchronous test.'],
+  ],
+  [
+    'no-top-level-hooks',
+    'top-level hook',
+    'before(function () {});\n',
+    ['Unexpected use of Mocha `before()` hook outside of a test suite'],
+  ],
+  [
+    'prefer-arrow-callback',
+    'function callback',
+    'it("x", function () { doThing(); });\n',
+    ['Unexpected function expression.'],
+  ],
+  [
+    'valid-suite-title',
+    'bad suite title',
+    'describe("bad", function () {});\n',
+    ['Invalid "describe()" description found.'],
+    [{ pattern: '^Suite' }],
+  ],
+  [
+    'valid-test-title',
+    'bad test title',
+    'it("bad", function () {});\n',
+    ['Invalid "it()" description found.'],
+    [{ pattern: '^should' }],
+  ],
+];
+
+function runRule(ruleName, sourceText, options = [], filename = 'fixture.test.js') {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename,
+    options,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function renderMessage(ruleName, report) {
+  return plugin.rules[ruleName].meta.messages[report.messageId].replace(
+    '{{message}}',
+    report.data.message,
+  );
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code, options) {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'mocha-plugin-'));
+
+  try {
+    const sourcePath = join(temp, 'fixture.test.js');
+    const configPath = join(temp, 'oxlint.config.jsonc');
+    const ruleConfig = options == null ? 'error' : ['error', options];
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'mocha',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`mocha/${ruleName}`]: ruleConfig,
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('mocha plugin shape', () => {
+  it('exposes all ported rules', () => {
+    expect(plugin.meta?.name).toBe('mocha');
+    expect(Object.keys(plugin.rules)).toEqual(expectedRuleNames);
+    expect(plugin.implementedMochaRuleNames).toEqual(expectedRuleNames);
+    expect(typeof plugin.scanMocha).toBe('function');
+  });
+
+  it('ships upstream-compatible configs', () => {
+    expect(plugin.configs.recommended.rules).toMatchObject({
+      'mocha/handle-done-callback': 'error',
+      'mocha/max-top-level-suites': ['error', { limit: 1 }],
+      'mocha/no-exclusive-tests': 'warn',
+      'mocha/no-hooks': 'off',
+      'mocha/no-return-from-async': 'off',
+      'mocha/consistent-spacing-between-blocks': 'error',
+    });
+    expect(plugin.configs.all.rules['mocha/consistent-interface']).toEqual([
+      'error',
+      { interface: 'BDD' },
+    ]);
+    expect(plugin.configs.recommended.languageOptions.globals).toMatchObject({
+      describe: false,
+      it: false,
+      beforeEach: false,
+    });
+  });
+});
+
+describe('mocha rules through direct adapter harness', () => {
+  it.each(invalidCases)('reports %s: %s', (ruleName, _name, code, messages, options = []) => {
+    const reports = runRule(ruleName, code, options);
+
+    expect(reports.map((report) => renderMessage(ruleName, report))).toEqual(messages);
+  });
+
+  it('honors selected rule options', () => {
+    expect(
+      runRule('no-hooks', 'describe("x", function () { before(function () {}); });', [
+        { allow: ['before()'] },
+      ]),
+    ).toEqual([]);
+    expect(
+      runRule('handle-done-callback', 'it.skip("x", function (done) {});', [
+        { ignorePending: true },
+      ]),
+    ).toEqual([]);
+    expect(
+      runRule('prefer-arrow-callback', 'it("x", function named() {});', [
+        { allowNamedFunctions: true },
+      ]),
+    ).toEqual([]);
+    expect(
+      runRule('prefer-arrow-callback', 'it("x", function () { this.timeout(1000); });'),
+    ).toEqual([]);
+  });
+});
+
+describe('mocha rules through oxlint jsPlugins', () => {
+  it.each(invalidCases)(
+    'reports %s through the CLI: %s',
+    (ruleName, _name, code, _messages, options = []) => {
+      const actualRuleName = /** @type {string} */ (ruleName);
+      const result = runOxlint(actualRuleName, code, options[0]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0].code).toBe(`mocha(${actualRuleName})`);
+    },
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,12 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
 
+  npm/mocha:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/no-forbidden-identifiers:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -688,6 +688,407 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-mocha",
+    "directory": "npm/mocha",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-mocha",
+      "version": "10.4.0",
+      "repository": "https://github.com/lo1tuma/eslint-plugin-mocha",
+      "license": "MIT"
+    },
+    "status": "ported",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "consistent-interface",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/consistent-interface; BDD/TDD interface checks and options covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "consistent-spacing-between-blocks",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/consistent-spacing-between-blocks; diagnostic behavior is implemented, while upstream autofix is intentionally not exposed until native fix ranges are added."
+      },
+      {
+        "name": "handle-done-callback",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/handle-done-callback; callback usage and ignorePending option covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "max-top-level-suites",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/max-top-level-suites; limit option covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-async-suite",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-async-suite; diagnostic behavior is implemented, while upstream autofix is intentionally not exposed until native fix ranges are added."
+      },
+      {
+        "name": "no-empty-title",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-empty-title; custom message option covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-exclusive-tests",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-exclusive-tests; only modifier cases covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-exports",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-exports; export declarations in files with Mocha tests covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-global-tests",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-global-tests; top-level test cases covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-hooks",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-hooks; allow option covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-hooks-for-single-case",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-hooks-for-single-case; single-test suite hook tracking and allow option covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-identical-title",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-identical-title; duplicate suite/test title tracking covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-mocha-arrows",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-mocha-arrows; diagnostic behavior is implemented, while upstream autofix is intentionally not exposed until native fix ranges are added."
+      },
+      {
+        "name": "no-nested-tests",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-nested-tests; nested test callback tracking covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-pending-tests",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-pending-tests; skip and callback-less test cases covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-return-and-callback",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-return-and-callback; callback plus return cases covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-return-from-async",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-return-from-async; async callback returns covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-setup-in-describe",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-setup-in-describe; suite callback setup calls covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-sibling-hooks",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-sibling-hooks; duplicate hook tracking covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-synchronous-tests",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-synchronous-tests; allowed async method option covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "no-top-level-hooks",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/no-top-level-hooks; top-level hook calls covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "prefer-arrow-callback",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/prefer-arrow-callback; allowNamedFunctions and allowUnboundThis options covered in Vitest and oxlint jsPlugins; upstream autofix is intentionally not exposed until native fix ranges are added."
+      },
+      {
+        "name": "valid-suite-title",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/valid-suite-title; pattern and message options covered in Vitest and oxlint jsPlugins."
+      },
+      {
+        "name": "valid-test-title",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-mocha/valid-test-title; pattern and message options covered in Vitest and oxlint jsPlugins."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-stylistic",
     "directory": "npm/stylistic",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -32,6 +32,10 @@ const nativePackages = [
     name: '@oxlint-plugins/oxlint-plugin-react-refresh',
     binding: 'npm/react-refresh/native.js',
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-mocha',
+    binding: 'npm/mocha/native.js',
+  },
 ];
 
 for (const pkg of nativePackages) {

--- a/tools/tasks/security-audit.ts
+++ b/tools/tasks/security-audit.ts
@@ -21,6 +21,7 @@ const publishablePrefixes = [
   '@oxlint-plugins/oxlint-plugin-react-refresh>',
   '@oxlint-plugins/oxlint-plugin-security>',
   '@oxlint-plugins/oxlint-plugin-cypress>',
+  '@oxlint-plugins/oxlint-plugin-mocha>',
   '@oxlint-plugins/oxlint-plugin-stylistic>',
 ];
 

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -40,6 +40,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-mocha',
+    dir: 'npm/mocha',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     dir: 'npm/stylistic',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- add a Rust/Oxc core implementation for eslint-plugin-mocha rule scanning
- expose @oxlint-plugins/oxlint-plugin-mocha through NAPI and the eslint-compatible JS adapter
- cover all 24 ported Mocha rules with native API tests and oxlint jsPlugins integration tests
- register the package in workspace metadata, publish-readiness checks, security audit scope, and status.json

## Validation
- vp test npm/mocha
- cargo test -p oxlint-plugins-mocha -p oxlint-plugin-mocha
- vp exec pnpm run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->