### PR TITLE
feat(simple-import-sort): port eslint-plugin-simple-import-sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-simple-import-sort"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-simple-import-sort",
+]
+
+[[package]]
 name = "oxlint-plugin-stylistic"
 version = "0.0.0"
 dependencies = [
@@ -872,6 +883,19 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxlint-plugins-_carton",
+]
+
+[[package]]
+name = "oxlint-plugins-simple-import-sort"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxlint-plugins-_carton",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/mocha",
   "crates/react_refresh",
   "crates/security",
+  "crates/simple_import_sort",
   "crates/stylistic",
   "npm/cypress",
   "npm/eslint-comments",
@@ -13,6 +14,7 @@ members = [
   "npm/no-forbidden-identifiers",
   "npm/react-refresh",
   "npm/security",
+  "npm/simple-import-sort",
   "npm/stylistic",
 ]
 resolver = "3"
@@ -44,6 +46,7 @@ oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0
 oxlint-plugins-mocha = { path = "crates/mocha", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
+oxlint-plugins-simple-import-sort = { path = "crates/simple_import_sort", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }
 regex = "1.12.2"
 phf = { version = "0.13.1", features = ["macros"] }

--- a/crates/simple_import_sort/Cargo.toml
+++ b/crates/simple_import_sort/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "oxlint-plugins-simple-import-sort"
+description = "Rust core for the simple-import-sort oxlint JavaScript plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+regex.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/simple_import_sort/src/lib.rs
+++ b/crates/simple_import_sort/src/lib.rs
@@ -1,0 +1,682 @@
+#![doc = "Rust implementation of eslint-plugin-simple-import-sort rule logic."]
+
+use std::cmp::Ordering;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    ExportAllDeclaration, ExportNamedDeclaration, ExportSpecifier, ImportDeclaration,
+    ImportDeclarationSpecifier, ImportOrExportKind, ModuleExportName, Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::{SourceType, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use regex::Regex;
+
+pub const RULE_NAMES: [&str; 2] = ["exports", "imports"];
+
+const SIDE_EFFECT_STYLE: u8 = 0;
+const EXPORT_STYLE: u8 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiagnosticFix {
+    pub start: u32,
+    pub end: u32,
+    pub replacement: CompactString,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub loc: DiagnosticLoc,
+    pub fix: Option<DiagnosticFix>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SimpleImportSortOptions {
+    pub import_groups: SmallVec<[SmallVec<[CompactString; 4]>; 8]>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuleKind {
+    Imports,
+    Exports,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Item {
+    span: Span,
+    code: CompactString,
+    source_original: CompactString,
+    source_key: CompactString,
+    kind_rank: u8,
+    style: u8,
+    index: usize,
+    outer_group: usize,
+    inner_group: usize,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_simple_import_sort_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_simple_import_sort(
+    source_text: &str,
+    filename: &str,
+    options: &SimpleImportSortOptions,
+) -> SmallVec<[Diagnostic; 8]> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::mjs())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let line_index = LineIndex::new(source_text);
+    let mut diagnostics = SmallVec::new();
+    scan_import_chunks(
+        source_text,
+        &line_index,
+        &parser_return.program.body,
+        options,
+        &mut diagnostics,
+    );
+    scan_export_chunks(
+        source_text,
+        &line_index,
+        &parser_return.program.body,
+        &mut diagnostics,
+    );
+    diagnostics
+}
+
+fn scan_import_chunks(
+    source_text: &str,
+    line_index: &LineIndex,
+    statements: &[Statement<'_>],
+    options: &SimpleImportSortOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+) {
+    let mut chunk: SmallVec<[Item; 16]> = SmallVec::new();
+    for statement in statements {
+        if let Statement::ImportDeclaration(declaration) = statement {
+            let index = chunk.len();
+            chunk.push(item_from_import(source_text, declaration, options, index));
+        } else {
+            report_chunk(
+                source_text,
+                line_index,
+                &chunk,
+                RuleKind::Imports,
+                diagnostics,
+            );
+            chunk.clear();
+        }
+    }
+    report_chunk(
+        source_text,
+        line_index,
+        &chunk,
+        RuleKind::Imports,
+        diagnostics,
+    );
+}
+
+fn scan_export_chunks(
+    source_text: &str,
+    line_index: &LineIndex,
+    statements: &[Statement<'_>],
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+) {
+    let mut chunk: SmallVec<[Item; 16]> = SmallVec::new();
+    for statement in statements {
+        match statement {
+            Statement::ExportNamedDeclaration(declaration)
+                if declaration.source.is_some() && declaration.declaration.is_none() =>
+            {
+                let index = chunk.len();
+                chunk.push(item_from_named_export(source_text, declaration, index));
+            }
+            Statement::ExportAllDeclaration(declaration) => {
+                let index = chunk.len();
+                chunk.push(item_from_all_export(source_text, declaration, index));
+            }
+            Statement::ExportNamedDeclaration(declaration)
+                if declaration.source.is_none()
+                    && declaration.declaration.is_none()
+                    && declaration.specifiers.len() > 1 =>
+            {
+                report_chunk(
+                    source_text,
+                    line_index,
+                    &chunk,
+                    RuleKind::Exports,
+                    diagnostics,
+                );
+                chunk.clear();
+                report_named_export_specifiers(source_text, line_index, declaration, diagnostics);
+            }
+            _ => {
+                report_chunk(
+                    source_text,
+                    line_index,
+                    &chunk,
+                    RuleKind::Exports,
+                    diagnostics,
+                );
+                chunk.clear();
+            }
+        }
+    }
+    report_chunk(
+        source_text,
+        line_index,
+        &chunk,
+        RuleKind::Exports,
+        diagnostics,
+    );
+}
+
+fn report_chunk(
+    source_text: &str,
+    line_index: &LineIndex,
+    chunk: &[Item],
+    rule_kind: RuleKind,
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+) {
+    if chunk.is_empty() {
+        return;
+    }
+    let sorted = print_sorted_chunk(chunk, guess_newline(source_text));
+    let start = chunk.first().expect("chunk has first item").span.start;
+    let end = chunk.last().expect("chunk has last item").span.end;
+    let original = source_text
+        .get(start as usize..end as usize)
+        .unwrap_or_default();
+    if original == sorted.as_str() {
+        return;
+    }
+    diagnostics.push(Diagnostic {
+        rule_name: match rule_kind {
+            RuleKind::Imports => "imports",
+            RuleKind::Exports => "exports",
+        },
+        message_id: "sort",
+        loc: line_index.loc_for_span(source_text, Span::new(start, end)),
+        fix: Some(DiagnosticFix {
+            start,
+            end,
+            replacement: sorted,
+        }),
+    });
+}
+
+fn report_named_export_specifiers(
+    source_text: &str,
+    line_index: &LineIndex,
+    declaration: &ExportNamedDeclaration<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+) {
+    let original = span_text(source_text, declaration.span);
+    let sorted = sort_export_specifiers_in_code(source_text, original, &declaration.specifiers);
+    if sorted.as_str() == original {
+        return;
+    }
+    diagnostics.push(Diagnostic {
+        rule_name: "exports",
+        message_id: "sort",
+        loc: line_index.loc_for_span(source_text, declaration.span),
+        fix: Some(DiagnosticFix {
+            start: declaration.span.start,
+            end: declaration.span.end,
+            replacement: sorted,
+        }),
+    });
+}
+
+fn item_from_import(
+    source_text: &str,
+    declaration: &ImportDeclaration<'_>,
+    options: &SimpleImportSortOptions,
+    index: usize,
+) -> Item {
+    let original = declaration.source.value.as_str();
+    let source_original = CompactString::from(original);
+    let source_key = source_sort_key(original);
+    let kind_rank = kind_rank(declaration.import_kind);
+    let style = import_style(declaration);
+    let code = sort_import_specifiers_in_code(
+        source_text,
+        span_text(source_text, declaration.span),
+        declaration,
+    );
+    let (outer_group, inner_group) = import_group(style, kind_rank, original, options);
+    Item {
+        span: declaration.span,
+        code,
+        source_original,
+        source_key,
+        kind_rank,
+        style,
+        index,
+        outer_group,
+        inner_group,
+    }
+}
+
+fn item_from_named_export(
+    source_text: &str,
+    declaration: &ExportNamedDeclaration<'_>,
+    index: usize,
+) -> Item {
+    let original = declaration
+        .source
+        .as_ref()
+        .expect("export-from declaration has source")
+        .value
+        .as_str();
+    Item {
+        span: declaration.span,
+        code: sort_export_specifiers_in_code(
+            source_text,
+            span_text(source_text, declaration.span),
+            &declaration.specifiers,
+        ),
+        source_original: CompactString::from(original),
+        source_key: source_sort_key(original),
+        kind_rank: kind_rank(declaration.export_kind),
+        style: EXPORT_STYLE,
+        index,
+        outer_group: 0,
+        inner_group: 0,
+    }
+}
+
+fn item_from_all_export(
+    source_text: &str,
+    declaration: &ExportAllDeclaration<'_>,
+    index: usize,
+) -> Item {
+    let original = declaration.source.value.as_str();
+    Item {
+        span: declaration.span,
+        code: CompactString::from(span_text(source_text, declaration.span)),
+        source_original: CompactString::from(original),
+        source_key: source_sort_key(original),
+        kind_rank: kind_rank(declaration.export_kind),
+        style: EXPORT_STYLE,
+        index,
+        outer_group: 0,
+        inner_group: 0,
+    }
+}
+
+fn print_sorted_chunk(items: &[Item], newline: &str) -> CompactString {
+    let mut sorted: SmallVec<[Item; 16]> = items.iter().cloned().collect();
+    sorted.sort_by(compare_items);
+
+    let mut out = CompactString::new("");
+    let mut previous_outer_group = None;
+    for item in sorted {
+        if !out.is_empty() {
+            out.push_str(newline);
+            if previous_outer_group.is_some_and(|group| group != item.outer_group) {
+                out.push_str(newline);
+            }
+        }
+        out.push_str(item.code.as_str());
+        previous_outer_group = Some(item.outer_group);
+    }
+    out
+}
+
+fn compare_items(a: &Item, b: &Item) -> Ordering {
+    a.outer_group
+        .cmp(&b.outer_group)
+        .then(a.inner_group.cmp(&b.inner_group))
+        .then_with(|| {
+            if a.style == SIDE_EFFECT_STYLE && b.style == SIDE_EFFECT_STYLE {
+                a.index.cmp(&b.index)
+            } else if a.style == SIDE_EFFECT_STYLE {
+                Ordering::Less
+            } else if b.style == SIDE_EFFECT_STYLE {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        })
+        .then(a.source_key.cmp(&b.source_key))
+        .then(a.source_original.cmp(&b.source_original))
+        .then(a.kind_rank.cmp(&b.kind_rank))
+        .then(a.style.cmp(&b.style))
+        .then(a.index.cmp(&b.index))
+}
+
+fn import_style(declaration: &ImportDeclaration<'_>) -> u8 {
+    let Some(specifiers) = &declaration.specifiers else {
+        return SIDE_EFFECT_STYLE;
+    };
+    let Some(first) = specifiers.first() else {
+        return 3;
+    };
+    match first {
+        ImportDeclarationSpecifier::ImportNamespaceSpecifier(_) => 1,
+        ImportDeclarationSpecifier::ImportDefaultSpecifier(_) => 2,
+        ImportDeclarationSpecifier::ImportSpecifier(_) => 3,
+    }
+}
+
+fn import_group(
+    style: u8,
+    kind_rank: u8,
+    original: &str,
+    options: &SimpleImportSortOptions,
+) -> (usize, usize) {
+    if options.import_groups.is_empty() {
+        if style == SIDE_EFFECT_STYLE {
+            return (0, 0);
+        }
+        if original.starts_with("node:") {
+            return (1, 0);
+        }
+        if is_package_source(original) {
+            return (2, 0);
+        }
+        if original.starts_with('.') {
+            return (4, 0);
+        }
+        return (3, 0);
+    }
+
+    let match_source = import_match_source(style, kind_rank, original);
+    let mut best: Option<(usize, usize, usize)> = None;
+    for (outer_index, group) in options.import_groups.iter().enumerate() {
+        for (inner_index, pattern) in group.iter().enumerate() {
+            let Ok(regex) = Regex::new(pattern.as_str()) else {
+                continue;
+            };
+            let Some(matched) = regex.find(match_source.as_str()) else {
+                continue;
+            };
+            let len = matched.end().saturating_sub(matched.start());
+            if best.is_none_or(|(_, _, best_len)| len > best_len) {
+                best = Some((outer_index, inner_index, len));
+            }
+        }
+    }
+    best.map(|(outer, inner, _)| (outer, inner))
+        .unwrap_or((options.import_groups.len(), 0))
+}
+
+fn import_match_source(style: u8, kind_rank: u8, original: &str) -> CompactString {
+    let mut source = CompactString::new("");
+    if style == SIDE_EFFECT_STYLE {
+        source.push('\0');
+    }
+    source.push_str(original);
+    if kind_rank == 0 {
+        source.push('\0');
+    }
+    source
+}
+
+fn is_package_source(source: &str) -> bool {
+    let Some(first) = source.chars().next() else {
+        return false;
+    };
+    first == '@' || first == '_' || first.is_ascii_alphanumeric()
+}
+
+fn source_sort_key(source: &str) -> CompactString {
+    let mut out = CompactString::new("");
+    let mut normalized = CompactString::from(source);
+    if normalized.chars().all(|ch| ch == '.' || ch == '/') && normalized.ends_with('.') {
+        normalized.push('/');
+    }
+    if normalized.chars().all(|ch| ch == '.' || ch == '/') && normalized.ends_with('/') {
+        normalized.push(',');
+    }
+    for ch in normalized.chars() {
+        match ch {
+            '.' => out.push('_'),
+            '/' => out.push('-'),
+            '_' => out.push('.'),
+            '-' => out.push('/'),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn kind_rank(kind: ImportOrExportKind) -> u8 {
+    match kind {
+        ImportOrExportKind::Type => 0,
+        ImportOrExportKind::Value => 1,
+    }
+}
+
+fn sort_import_specifiers_in_code(
+    source_text: &str,
+    original: &str,
+    declaration: &ImportDeclaration<'_>,
+) -> CompactString {
+    let Some(specifiers) = &declaration.specifiers else {
+        return CompactString::from(original);
+    };
+    let mut named: SmallVec<[(CompactString, CompactString, u8, CompactString); 8]> =
+        SmallVec::new();
+    for specifier in specifiers {
+        if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+            named.push((
+                module_name(&specifier.imported),
+                CompactString::from(specifier.local.name.as_str()),
+                kind_rank(specifier.import_kind),
+                CompactString::from(span_text(source_text, specifier.span)),
+            ));
+        }
+    }
+    if named.len() <= 1 {
+        return CompactString::from(original);
+    }
+    named.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
+    replace_braced_specifiers(original, named.iter().map(|item| item.3.as_str()))
+}
+
+fn sort_export_specifiers_in_code(
+    source_text: &str,
+    original: &str,
+    specifiers: &[ExportSpecifier<'_>],
+) -> CompactString {
+    if specifiers.len() <= 1 {
+        return CompactString::from(original);
+    }
+    let mut named: SmallVec<[(CompactString, CompactString, u8, CompactString); 8]> =
+        SmallVec::new();
+    for specifier in specifiers {
+        named.push((
+            module_name(&specifier.exported),
+            module_name(&specifier.local),
+            kind_rank(specifier.export_kind),
+            CompactString::from(span_text(source_text, specifier.span)),
+        ));
+    }
+    named.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
+    replace_braced_specifiers(original, named.iter().map(|item| item.3.as_str()))
+}
+
+fn replace_braced_specifiers<'a>(
+    original: &str,
+    sorted_specifiers: impl Iterator<Item = &'a str>,
+) -> CompactString {
+    let Some(open) = original.find('{') else {
+        return CompactString::from(original);
+    };
+    let Some(close) = original.rfind('}') else {
+        return CompactString::from(original);
+    };
+    if close <= open {
+        return CompactString::from(original);
+    }
+    let mut out = CompactString::new("");
+    out.push_str(&original[..open + 1]);
+    out.push(' ');
+    for (index, specifier) in sorted_specifiers.enumerate() {
+        if index > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(specifier.trim());
+    }
+    out.push(' ');
+    out.push_str(&original[close..]);
+    out
+}
+
+fn module_name(name: &ModuleExportName<'_>) -> CompactString {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => {
+            CompactString::from(identifier.name.as_str())
+        }
+        ModuleExportName::IdentifierReference(identifier) => {
+            CompactString::from(identifier.name.as_str())
+        }
+        ModuleExportName::StringLiteral(literal) => CompactString::from(literal.value.as_str()),
+    }
+}
+
+fn guess_newline(source_text: &str) -> &str {
+    if source_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+fn span_text(source_text: &str, span: Span) -> &str {
+    source_text
+        .get(span.start as usize..span.end as usize)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SimpleImportSortOptions, scan_simple_import_sort};
+
+    #[test]
+    fn sorts_import_chunks_and_specifiers() {
+        let source = [
+            "import z from 'z';",
+            "import { beta, alpha as renamed } from 'pkg';",
+            "import fs from 'node:fs';",
+            "import './setup';",
+            "import local from './local';",
+        ]
+        .join("\n");
+        let diagnostics =
+            scan_simple_import_sort(&source, "fixture.js", &SimpleImportSortOptions::default());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule_name, "imports");
+        assert_eq!(
+            diagnostics[0]
+                .fix
+                .as_ref()
+                .expect("fix")
+                .replacement
+                .as_str(),
+            [
+                "import './setup';",
+                "",
+                "import fs from 'node:fs';",
+                "",
+                "import { alpha as renamed, beta } from 'pkg';",
+                "import z from 'z';",
+                "",
+                "import local from './local';",
+            ]
+            .join("\n")
+        );
+    }
+
+    #[test]
+    fn sorts_export_chunks_and_local_specifiers() {
+        let source = [
+            "export { zed } from 'z';",
+            "export * from 'a';",
+            "export { d, a as c, b };",
+        ]
+        .join("\n");
+        let diagnostics =
+            scan_simple_import_sort(&source, "fixture.js", &SimpleImportSortOptions::default());
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].rule_name, "exports");
+        assert_eq!(
+            diagnostics[0]
+                .fix
+                .as_ref()
+                .expect("fix")
+                .replacement
+                .as_str(),
+            ["export * from 'a';", "export { zed } from 'z';"].join("\n")
+        );
+        assert_eq!(
+            diagnostics[1]
+                .fix
+                .as_ref()
+                .expect("fix")
+                .replacement
+                .as_str(),
+            "export { b, a as c, d };"
+        );
+    }
+}

--- a/npm/simple-import-sort/Cargo.toml
+++ b/npm/simple-import-sort/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oxlint-plugin-simple-import-sort"
+description = "NAPI wrapper for the simple-import-sort oxlint plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-simple-import-sort.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints]
+workspace = true

--- a/npm/simple-import-sort/LICENSE
+++ b/npm/simple-import-sort/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 oxlint-plugins contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/simple-import-sort/README.md
+++ b/npm/simple-import-sort/README.md
@@ -1,0 +1,13 @@
+# @oxlint-plugins/oxlint-plugin-simple-import-sort
+
+Rust-backed Oxlint plugin port of `eslint-plugin-simple-import-sort`.
+
+## Rules
+
+- `simple-import-sort/imports`
+- `simple-import-sort/exports`
+
+The native implementation sorts import/export chunks and named specifiers and
+returns autofix ranges through the Oxlint JavaScript plugin adapter. It covers
+the common module-sorting path; the upstream plugin's exhaustive comment
+printer is not duplicated yet.

--- a/npm/simple-import-sort/api.d.ts
+++ b/npm/simple-import-sort/api.d.ts
@@ -1,0 +1,30 @@
+export type DiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type DiagnosticFix = {
+  start: number;
+  end: number;
+  replacement: string;
+};
+
+export type Diagnostic = {
+  ruleName: string;
+  messageId: string;
+  loc: DiagnosticLoc;
+  fix?: DiagnosticFix;
+};
+
+export type SimpleImportSortScanOptions = {
+  importGroups?: string[][];
+};
+
+export function implementedSimpleImportSortRuleNames(): string[];
+export function scanSimpleImportSort(
+  sourceText: string,
+  filename?: string,
+  options?: SimpleImportSortScanOptions,
+): Diagnostic[];

--- a/npm/simple-import-sort/api.js
+++ b/npm/simple-import-sort/api.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanSimpleImportSort(sourceText, filename = 'file.js', options = {}) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanSimpleImportSort(sourceText, filename, {
+    importGroups: normalizeGroups(options.importGroups),
+  });
+}
+
+function normalizeGroups(groups) {
+  if (!Array.isArray(groups)) {
+    return undefined;
+  }
+  return groups
+    .filter(Array.isArray)
+    .map((group) => group.filter((value) => typeof value === 'string' && value.length > 0))
+    .filter((group) => group.length > 0);
+}
+
+module.exports = {
+  implementedSimpleImportSortRuleNames: native.implementedSimpleImportSortRuleNames,
+  scanSimpleImportSort,
+};
+module.exports.default = module.exports;

--- a/npm/simple-import-sort/build.rs
+++ b/npm/simple-import-sort/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/simple-import-sort/index.js
+++ b/npm/simple-import-sort/index.js
@@ -1,0 +1,177 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-simple-import-sort (MIT).
+// Parsing, import/export chunk discovery, sort decisions, and fix ranges run in
+// Rust through Oxc. The JS layer only adapts Oxlint plugin APIs.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedSimpleImportSortRuleNames, scanSimpleImportSort } = require('./api.js');
+
+const PLUGIN_NAME = 'simple-import-sort';
+const DOCS_BASE =
+  'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/simple-import-sort';
+const diagnosticsCache = new WeakMap();
+
+const messages = Object.freeze({
+  imports: {
+    sort: 'Run autofix to sort these imports!',
+  },
+  exports: {
+    sort: 'Run autofix to sort these exports!',
+  },
+});
+
+const ruleDescriptions = Object.freeze({
+  imports: 'automatically sort imports',
+  exports: 'automatically sort exports',
+});
+
+const implementedRuleNames = Object.freeze(implementedSimpleImportSortRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createSimpleImportSortRule(ruleName)]),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: {
+      name: `${PLUGIN_NAME}/recommended`,
+      plugins: [PLUGIN_NAME],
+      rules: {
+        [`${PLUGIN_NAME}/imports`]: 'error',
+        [`${PLUGIN_NAME}/exports`]: 'error',
+      },
+    },
+  },
+});
+
+plugin.implementedSimpleImportSortRuleNames = implementedRuleNames;
+plugin.scanSimpleImportSort = scanSimpleImportSort;
+
+function createSimpleImportSortRule(ruleName) {
+  return {
+    meta: {
+      type: 'layout',
+      docs: {
+        description: ruleDescriptions[ruleName],
+        category: 'Stylistic Issues',
+        recommended: true,
+        url: `${DOCS_BASE}#${ruleName}`,
+      },
+      fixable: 'code',
+      messages: messages[ruleName],
+      schema: schemaForRule(ruleName),
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForRule(context, ruleName)) {
+            reportDiagnostic(context, diagnostic);
+          }
+        },
+      };
+    },
+  };
+}
+
+function schemaForRule(ruleName) {
+  if (ruleName !== 'imports') {
+    return [];
+  }
+  return [
+    {
+      type: 'object',
+      properties: {
+        groups: {
+          type: 'array',
+          items: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+  ];
+}
+
+function diagnosticsForRule(context, ruleName) {
+  return diagnosticsForContext(context, scanOptionsForRule(context, ruleName)).filter(
+    (diagnostic) => diagnostic.ruleName === ruleName,
+  );
+}
+
+function diagnosticsForContext(context, options) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.js';
+  const key = JSON.stringify(options);
+  let sourceCache = diagnosticsCache.get(sourceCode);
+
+  if (!sourceCache) {
+    sourceCache = new Map();
+    diagnosticsCache.set(sourceCode, sourceCache);
+  }
+
+  const cached = sourceCache.get(key);
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanSimpleImportSort(sourceText, filename, options);
+  sourceCache.set(key, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function scanOptionsForRule(context, ruleName) {
+  const options =
+    context.options?.[0] && typeof context.options[0] === 'object' ? context.options[0] : {};
+  return {
+    importGroups:
+      ruleName === 'imports' && Array.isArray(options.groups) ? options.groups : undefined,
+  };
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function reportDiagnostic(context, diagnostic) {
+  context.report({
+    messageId: diagnostic.messageId,
+    loc: {
+      start: {
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn,
+      },
+      end: {
+        line: diagnostic.loc.endLine,
+        column: diagnostic.loc.endColumn,
+      },
+    },
+    fix: diagnostic.fix
+      ? (fixer) =>
+          fixer.replaceTextRange(
+            [diagnostic.fix.start, diagnostic.fix.end],
+            diagnostic.fix.replacement,
+          )
+      : undefined,
+  });
+}
+
+module.exports = plugin;
+module.exports.default = plugin;

--- a/npm/simple-import-sort/package.json
+++ b/npm/simple-import-sort/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-simple-import-sort",
+  "version": "0.0.0",
+  "description": "Rust-backed Oxlint plugin port of eslint-plugin-simple-import-sort.",
+  "keywords": [
+    "eslint-plugin",
+    "import-sort",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/simple-import-sort"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_simple_import_sort",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/simple-import-sort/src/lib.rs
+++ b/npm/simple-import-sort/src/lib.rs
@@ -1,0 +1,102 @@
+//! NAPI boundary for the simple-import-sort oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticFix, DiagnosticLoc, SimpleImportSortScanOptions,
+    implemented_simple_import_sort_rule_names, scan_simple_import_sort,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use oxlint_plugins_simple_import_sort as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct SimpleImportSortScanOptions {
+        pub import_groups: Option<Vec<Vec<String>>>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticFix {
+        pub start: u32,
+        pub end: u32,
+        pub replacement: String,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub loc: DiagnosticLoc,
+        pub fix: Option<DiagnosticFix>,
+    }
+
+    #[napi]
+    pub fn implemented_simple_import_sort_rule_names() -> Vec<String> {
+        core::implemented_simple_import_sort_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_simple_import_sort(
+        source_text: String,
+        filename: String,
+        options: Option<SimpleImportSortScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::SimpleImportSortOptions {
+            import_groups: compact_groups(options.import_groups.unwrap_or_default()),
+        };
+
+        core::scan_simple_import_sort(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+                fix: diagnostic.fix.map(|fix| DiagnosticFix {
+                    start: fix.start,
+                    end: fix.end,
+                    replacement: fix.replacement.into_string(),
+                }),
+            })
+            .collect()
+    }
+
+    fn compact_groups(values: Vec<Vec<String>>) -> SmallVec<[SmallVec<[CompactString; 4]>; 8]> {
+        values
+            .into_iter()
+            .filter_map(|group| {
+                let group: SmallVec<[CompactString; 4]> = group
+                    .into_iter()
+                    .filter(|value| !value.is_empty())
+                    .map(CompactString::from)
+                    .collect();
+                (!group.is_empty()).then_some(group)
+            })
+            .collect()
+    }
+}

--- a/npm/simple-import-sort/test/api.test.mjs
+++ b/npm/simple-import-sort/test/api.test.mjs
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedSimpleImportSortRuleNames, scanSimpleImportSort } from '../api.js';
+
+const expectedRuleNames = ['exports', 'imports'];
+
+describe('simple-import-sort native API', () => {
+  it('exposes all eslint-plugin-simple-import-sort rule names', () => {
+    expect(implementedSimpleImportSortRuleNames()).toEqual(expectedRuleNames);
+  });
+
+  it('scans and fixes import chunks', () => {
+    const source = [
+      "import z from 'z';",
+      "import { beta, alpha as renamed } from 'pkg';",
+      "import fs from 'node:fs';",
+      "import './setup';",
+      "import local from './local';",
+    ].join('\n');
+
+    const diagnostics = scanSimpleImportSort(source, 'fixture.js');
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      ruleName: 'imports',
+      messageId: 'sort',
+      fix: {
+        start: 0,
+        replacement: [
+          "import './setup';",
+          '',
+          "import fs from 'node:fs';",
+          '',
+          "import { alpha as renamed, beta } from 'pkg';",
+          "import z from 'z';",
+          '',
+          "import local from './local';",
+        ].join('\n'),
+      },
+    });
+  });
+
+  it('scans and fixes export chunks and local specifiers', () => {
+    const source = [
+      "export { zed } from 'z';",
+      "export * from 'a';",
+      'export { d, a as c, b };',
+    ].join('\n');
+
+    const diagnostics = scanSimpleImportSort(source, 'fixture.js');
+
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual(['exports', 'exports']);
+    expect(diagnostics[0].fix.replacement).toBe(
+      ["export * from 'a';", "export { zed } from 'z';"].join('\n'),
+    );
+    expect(diagnostics[1].fix.replacement).toBe('export { b, a as c, d };');
+  });
+
+  it('honors custom import groups', () => {
+    const source = ["import rel from './rel';", "import pkg from 'pkg';"].join('\n');
+    const diagnostics = scanSimpleImportSort(source, 'fixture.js', {
+      importGroups: [['^\\.'], ['^@?\\w']],
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].fix.replacement).toBe(
+      ["import rel from './rel';", '', "import pkg from 'pkg';"].join('\n'),
+    );
+  });
+});

--- a/npm/simple-import-sort/test/plugin.test.mjs
+++ b/npm/simple-import-sort/test/plugin.test.mjs
@@ -1,0 +1,192 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const expectedRuleNames = ['exports', 'imports'];
+
+const invalidCases = [
+  [
+    'imports',
+    'sorts import chunks and specifiers',
+    [
+      "import z from 'z';",
+      "import { beta, alpha as renamed } from 'pkg';",
+      "import fs from 'node:fs';",
+      "import './setup';",
+      "import local from './local';",
+    ].join('\n'),
+    [
+      "import './setup';",
+      '',
+      "import fs from 'node:fs';",
+      '',
+      "import { alpha as renamed, beta } from 'pkg';",
+      "import z from 'z';",
+      '',
+      "import local from './local';",
+    ].join('\n'),
+  ],
+  [
+    'exports',
+    'sorts export chunks',
+    ["export { zed } from 'z';", "export * from 'a';"].join('\n'),
+    ["export * from 'a';", "export { zed } from 'z';"].join('\n'),
+  ],
+  [
+    'exports',
+    'sorts local export specifiers',
+    'const d = 1, a = 1, b = 1;\nexport { d, a as c, b };',
+    'const d = 1, a = 1, b = 1;\nexport { b, a as c, d };',
+  ],
+];
+
+function runRule(ruleName, sourceText, options = [], filename = 'fixture.js') {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename,
+    options,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function applyFix(sourceText, report) {
+  const fix = report.fix({
+    replaceTextRange(range, replacement) {
+      return { range, text: replacement };
+    },
+  });
+  return sourceText.slice(0, fix.range[0]) + fix.text + sourceText.slice(fix.range[1]);
+}
+
+function renderMessage(ruleName, report) {
+  return plugin.rules[ruleName].meta.messages[report.messageId];
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code, options) {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'simple-import-sort-plugin-'));
+
+  try {
+    const sourcePath = join(temp, 'fixture.js');
+    const configPath = join(temp, 'oxlint.config.jsonc');
+    const ruleConfig = options == null ? 'error' : ['error', options];
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'simple-import-sort',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`simple-import-sort/${ruleName}`]: ruleConfig,
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('simple-import-sort plugin shape', () => {
+  it('exposes all ported rules', () => {
+    expect(plugin.meta?.name).toBe('simple-import-sort');
+    expect(Object.keys(plugin.rules)).toEqual(expectedRuleNames);
+    expect(plugin.implementedSimpleImportSortRuleNames).toEqual(expectedRuleNames);
+    expect(typeof plugin.scanSimpleImportSort).toBe('function');
+  });
+
+  it('ships recommended config', () => {
+    expect(plugin.configs.recommended.rules).toEqual({
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
+    });
+  });
+});
+
+describe('simple-import-sort rules through direct adapter harness', () => {
+  it.each(invalidCases)('reports %s: %s', (ruleName, _name, code, fixed) => {
+    const reports = runRule(ruleName, code);
+
+    expect(reports.map((report) => renderMessage(ruleName, report))).toEqual([
+      plugin.rules[ruleName].meta.messages.sort,
+    ]);
+    expect(applyFix(code, reports[0])).toBe(fixed);
+  });
+
+  it('honors selected import groups', () => {
+    const code = ["import rel from './rel';", "import pkg from 'pkg';"].join('\n');
+    const reports = runRule('imports', code, [{ groups: [['^\\.'], ['^@?\\w']] }]);
+
+    expect(reports).toHaveLength(1);
+    expect(applyFix(code, reports[0])).toBe(
+      ["import rel from './rel';", '', "import pkg from 'pkg';"].join('\n'),
+    );
+  });
+});
+
+describe('simple-import-sort rules through oxlint jsPlugins', () => {
+  it.each(invalidCases)('reports %s through the CLI: %s', (ruleName, _name, code) => {
+    const actualRuleName = /** @type {string} */ (ruleName);
+    const result = runOxlint(actualRuleName, code);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe(`simple-import-sort(${actualRuleName})`);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/simple-import-sort:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/stylistic:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -1089,6 +1089,55 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-simple-import-sort",
+    "directory": "npm/simple-import-sort",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-simple-import-sort",
+      "version": "13.0.0",
+      "repository": "https://github.com/lydell/eslint-plugin-simple-import-sort",
+      "license": "MIT"
+    },
+    "status": "ported",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "imports",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-simple-import-sort/imports; import chunk sorting, default/custom groups, named specifier sorting, NAPI fixes, and oxlint jsPlugins integration are covered in Vitest. The first port does not duplicate upstream's exhaustive comment-preserving printer."
+      },
+      {
+        "name": "exports",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc port of eslint-plugin-simple-import-sort/exports; export-from chunk sorting, local named export specifier sorting, NAPI fixes, and oxlint jsPlugins integration are covered in Vitest. The first port does not duplicate upstream's exhaustive comment-preserving printer."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-stylistic",
     "directory": "npm/stylistic",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -36,6 +36,10 @@ const nativePackages = [
     name: '@oxlint-plugins/oxlint-plugin-mocha',
     binding: 'npm/mocha/native.js',
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-simple-import-sort',
+    binding: 'npm/simple-import-sort/native.js',
+  },
 ];
 
 for (const pkg of nativePackages) {

--- a/tools/tasks/security-audit.ts
+++ b/tools/tasks/security-audit.ts
@@ -22,6 +22,7 @@ const publishablePrefixes = [
   '@oxlint-plugins/oxlint-plugin-security>',
   '@oxlint-plugins/oxlint-plugin-cypress>',
   '@oxlint-plugins/oxlint-plugin-mocha>',
+  '@oxlint-plugins/oxlint-plugin-simple-import-sort>',
   '@oxlint-plugins/oxlint-plugin-stylistic>',
 ];
 

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -45,6 +45,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-simple-import-sort',
+    dir: 'npm/simple-import-sort',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     dir: 'npm/stylistic',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- add a Rust/Oxc core implementation for eslint-plugin-simple-import-sort imports and exports
- expose @oxlint-plugins/oxlint-plugin-simple-import-sort through NAPI and the Oxlint JS adapter
- return autofix ranges for import/export chunks and named specifier sorting
- register package metadata for publish readiness, security audit, native test setup, and status.json

## Validation
- cargo test -p oxlint-plugins-simple-import-sort -p oxlint-plugin-simple-import-sort
- vp test npm/simple-import-sort
- vp exec pnpm run verify

## Notes
- This first Rust port covers the common chunk/specifier sorting path. It does not yet duplicate upstream's exhaustive comment-preserving printer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->