### PR TITLE
feat(unused-imports): port eslint-plugin-unused-imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,15 @@ dependencies = [
  "once_cell",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -592,6 +607,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_ast_visit"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8a8771bbedc5904b6536822fb719f76291d00ab2bccbf5f98950d666f0154f"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
 name = "oxc_data_structures"
 version = "0.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +706,28 @@ dependencies = [
  "phf",
  "rustc-hash",
  "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_semantic"
+version = "0.135.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6735efd98d54e0f5e8c30a6b17df921085373d54b2b1e10e42d7f4ec8d2597bc"
+dependencies = [
+ "itertools",
+ "memchr",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_index",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "rustc-hash",
+ "self_cell",
+ "smallvec",
 ]
 
 [[package]]
@@ -816,6 +865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-unused-imports"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-unused-imports",
+]
+
+[[package]]
 name = "oxlint-plugins-_carton"
 version = "0.0.0"
 dependencies = [
@@ -908,6 +968,20 @@ dependencies = [
  "phf",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "oxlint-plugins-unused-imports"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_span",
+ "oxlint-plugins-_carton",
+ "regex",
 ]
 
 [[package]]
@@ -1066,6 +1140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1223,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/security",
   "crates/simple_import_sort",
   "crates/stylistic",
+  "crates/unused_imports",
   "npm/cypress",
   "npm/eslint-comments",
   "npm/mocha",
@@ -16,6 +17,7 @@ members = [
   "npm/security",
   "npm/simple-import-sort",
   "npm/stylistic",
+  "npm/unused-imports",
 ]
 resolver = "3"
 
@@ -38,6 +40,7 @@ napi-derive = "3.5.6"
 oxc_allocator = "0.135.0"
 oxc_ast = "0.135.0"
 oxc_parser = "0.135.0"
+oxc_semantic = "0.135.0"
 oxc_span = "0.135.0"
 oxc_syntax = "0.135.0"
 oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_carton", version = "0.0.0" }
@@ -48,6 +51,7 @@ oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
 oxlint-plugins-simple-import-sort = { path = "crates/simple_import_sort", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }
+oxlint-plugins-unused-imports = { path = "crates/unused_imports", version = "0.0.0" }
 regex = "1.12.2"
 phf = { version = "0.13.1", features = ["macros"] }
 rustc-hash = "2.1.1"

--- a/crates/unused_imports/Cargo.toml
+++ b/crates/unused_imports/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oxlint-plugins-unused-imports"
+description = "Rust core for the unused-imports oxlint JavaScript plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_semantic.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+regex.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/unused_imports/src/lib.rs
+++ b/crates/unused_imports/src/lib.rs
@@ -1,0 +1,600 @@
+#![doc = "Rust implementation of eslint-plugin-unused-imports rule logic."]
+
+use std::fmt::Write as _;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier, Program, Statement};
+use oxc_parser::Parser;
+use oxc_semantic::{SemanticBuilder, SymbolFlags};
+use oxc_span::{SourceType, Span};
+use oxlint_plugins_carton::{CompactString, FastHashMap, SmallVec};
+use regex::Regex;
+
+pub const RULE_NAMES: [&str; 2] = ["no-unused-imports", "no-unused-vars"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiagnosticFix {
+    pub start: u32,
+    pub end: u32,
+    pub replacement: CompactString,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message: CompactString,
+    pub loc: DiagnosticLoc,
+    pub fix: Option<DiagnosticFix>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnusedImportsOptions {
+    pub rule_names: SmallVec<[CompactString; 2]>,
+}
+
+impl Default for UnusedImportsOptions {
+    fn default() -> Self {
+        Self {
+            rule_names: RULE_NAMES
+                .iter()
+                .map(|name| CompactString::from(*name))
+                .collect(),
+        }
+    }
+}
+
+impl UnusedImportsOptions {
+    fn has_rule(&self, rule_name: &str) -> bool {
+        self.rule_names.iter().any(|name| name == rule_name)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct SpanKey {
+    start: u32,
+    end: u32,
+}
+
+impl From<Span> for SpanKey {
+    fn from(span: Span) -> Self {
+        Self {
+            start: span.start,
+            end: span.end,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct DeclarationKey {
+    start: u32,
+    end: u32,
+}
+
+impl From<Span> for DeclarationKey {
+    fn from(span: Span) -> Self {
+        Self {
+            start: span.start,
+            end: span.end,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ImportSpecifierKind {
+    Named,
+    Default,
+    Namespace,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ImportBinding<'a> {
+    name: &'a str,
+    local_span: Span,
+    specifier_span: Span,
+    declaration_span: Span,
+    specifier_index: usize,
+    specifier_count: usize,
+    named_specifier_count: usize,
+    kind: ImportSpecifierKind,
+}
+
+#[derive(Default)]
+struct DeclarationUsage {
+    specifier_count: usize,
+    unused_count: usize,
+    first_unused_index: usize,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn line_for_offset(&self, offset: u32) -> u32 {
+        let offset = offset as usize;
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        line_index.saturating_sub(1) as u32 + 1
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_unused_imports_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_unused_imports(
+    source_text: &str,
+    filename: &str,
+    options: &UnusedImportsOptions,
+) -> SmallVec<[Diagnostic; 16]> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::mjs())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let line_index = LineIndex::new(source_text);
+    let import_bindings = collect_import_bindings(&parser_return.program);
+    let import_by_local_span: FastHashMap<SpanKey, ImportBinding<'_>> = import_bindings
+        .iter()
+        .map(|binding| (SpanKey::from(binding.local_span), *binding))
+        .collect();
+    let semantic_return = SemanticBuilder::new().build(&parser_return.program);
+    if !semantic_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let semantic = semantic_return.semantic;
+    let scoping = semantic.scoping();
+    let mut diagnostics = SmallVec::<[Diagnostic; 16]>::new();
+
+    if options.has_rule("no-unused-imports") {
+        let mut unused_imports = SmallVec::<[ImportBinding<'_>; 16]>::new();
+        for symbol_id in scoping.symbol_ids() {
+            let flags = scoping.symbol_flags(symbol_id);
+            if !flags.is_import() || !scoping.get_resolved_reference_ids(symbol_id).is_empty() {
+                continue;
+            }
+            let span = scoping.symbol_span(symbol_id);
+            let Some(binding) = import_by_local_span.get(&SpanKey::from(span)) else {
+                continue;
+            };
+            if is_used_in_jsdoc(binding.name, source_text) {
+                continue;
+            }
+            unused_imports.push(*binding);
+        }
+        diagnostics.extend(report_unused_imports(
+            source_text,
+            &line_index,
+            &unused_imports,
+        ));
+    }
+
+    if options.has_rule("no-unused-vars") {
+        for symbol_id in scoping.symbol_ids() {
+            let flags = scoping.symbol_flags(symbol_id);
+            if flags.is_import()
+                || !should_report_unused_symbol(flags)
+                || !scoping.get_resolved_reference_ids(symbol_id).is_empty()
+            {
+                continue;
+            }
+            let span = scoping.symbol_span(symbol_id);
+            let name = scoping.symbol_name(symbol_id);
+            diagnostics.push(Diagnostic {
+                rule_name: "no-unused-vars",
+                message: unused_message(name),
+                loc: line_index.loc_for_span(source_text, span),
+                fix: None,
+            });
+        }
+    }
+
+    diagnostics.sort_by(|a, b| {
+        a.loc
+            .start_line
+            .cmp(&b.loc.start_line)
+            .then(a.loc.start_column.cmp(&b.loc.start_column))
+            .then(a.rule_name.cmp(b.rule_name))
+    });
+    diagnostics
+}
+
+fn should_report_unused_symbol(flags: SymbolFlags) -> bool {
+    flags.intersects(
+        SymbolFlags::Variable
+            | SymbolFlags::Function
+            | SymbolFlags::Class
+            | SymbolFlags::TypeAlias
+            | SymbolFlags::Interface
+            | SymbolFlags::Enum
+            | SymbolFlags::TypeParameter
+            | SymbolFlags::CatchVariable,
+    )
+}
+
+fn collect_import_bindings<'a>(program: &'a Program<'a>) -> SmallVec<[ImportBinding<'a>; 16]> {
+    let mut bindings = SmallVec::new();
+    for statement in &program.body {
+        let Statement::ImportDeclaration(declaration) = statement else {
+            continue;
+        };
+        bindings.extend(bindings_for_declaration(declaration));
+    }
+    bindings
+}
+
+fn bindings_for_declaration<'a>(
+    declaration: &'a ImportDeclaration<'a>,
+) -> SmallVec<[ImportBinding<'a>; 4]> {
+    let Some(specifiers) = &declaration.specifiers else {
+        return SmallVec::new();
+    };
+    let specifier_count = specifiers.len();
+    let named_specifier_count = specifiers
+        .iter()
+        .filter(|specifier| matches!(specifier, ImportDeclarationSpecifier::ImportSpecifier(_)))
+        .count();
+    let mut bindings = SmallVec::new();
+    for (specifier_index, specifier) in specifiers.iter().enumerate() {
+        let (name, local_span, specifier_span, kind) = match specifier {
+            ImportDeclarationSpecifier::ImportSpecifier(specifier) => (
+                specifier.local.name.as_str(),
+                specifier.local.span,
+                specifier.span,
+                ImportSpecifierKind::Named,
+            ),
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => (
+                specifier.local.name.as_str(),
+                specifier.local.span,
+                specifier.span,
+                ImportSpecifierKind::Default,
+            ),
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => (
+                specifier.local.name.as_str(),
+                specifier.local.span,
+                specifier.span,
+                ImportSpecifierKind::Namespace,
+            ),
+        };
+        bindings.push(ImportBinding {
+            name,
+            local_span,
+            specifier_span,
+            declaration_span: declaration.span,
+            specifier_index,
+            specifier_count,
+            named_specifier_count,
+            kind,
+        });
+    }
+    bindings
+}
+
+fn report_unused_imports(
+    source_text: &str,
+    line_index: &LineIndex,
+    unused_imports: &[ImportBinding<'_>],
+) -> SmallVec<[Diagnostic; 16]> {
+    let mut declarations: FastHashMap<DeclarationKey, DeclarationUsage> = FastHashMap::default();
+    for binding in unused_imports {
+        let key = DeclarationKey::from(binding.declaration_span);
+        declarations
+            .entry(key)
+            .and_modify(|usage| {
+                usage.unused_count += 1;
+                usage.first_unused_index = usage.first_unused_index.min(binding.specifier_index);
+            })
+            .or_insert(DeclarationUsage {
+                specifier_count: binding.specifier_count,
+                unused_count: 1,
+                first_unused_index: binding.specifier_index,
+            });
+    }
+
+    let mut diagnostics = SmallVec::new();
+    for binding in unused_imports {
+        let usage = declarations
+            .get(&DeclarationKey::from(binding.declaration_span))
+            .expect("declaration usage is inserted before reporting");
+        let remove_declaration = usage.unused_count == usage.specifier_count;
+        if remove_declaration && binding.specifier_index != usage.first_unused_index {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule_name: "no-unused-imports",
+            message: unused_message(binding.name),
+            loc: line_index.loc_for_span(source_text, binding.local_span),
+            fix: Some(if remove_declaration {
+                fix_remove_declaration(source_text, line_index, binding.declaration_span)
+            } else {
+                fix_remove_specifier(source_text, *binding)
+            }),
+        });
+    }
+    diagnostics
+}
+
+fn unused_message(name: &str) -> CompactString {
+    let mut message = CompactString::new("'");
+    let _ = write!(&mut message, "{name}' is defined but never used.");
+    message
+}
+
+fn fix_remove_declaration(
+    source_text: &str,
+    line_index: &LineIndex,
+    declaration_span: Span,
+) -> DiagnosticFix {
+    let mut end = declaration_span.end;
+    let mut replacement = CompactString::new("");
+    let next_start = next_non_whitespace(source_text, end as usize);
+    if next_start < source_text.len() {
+        let import_line = line_index.line_for_offset(declaration_span.start);
+        let next_line = line_index.line_for_offset(next_start as u32);
+        let count = next_line.saturating_sub(import_line + 1);
+        replacement = CompactString::from("\n".repeat(count as usize));
+        end = next_start as u32;
+    }
+    DiagnosticFix {
+        start: declaration_span.start,
+        end,
+        replacement,
+    }
+}
+
+fn fix_remove_specifier(source_text: &str, binding: ImportBinding<'_>) -> DiagnosticFix {
+    let start;
+    let end;
+    if binding.specifier_index + 1 < binding.specifier_count {
+        start = token_before_end(source_text, binding.specifier_span.start as usize);
+        end = comma_after_end(source_text, binding.specifier_span.end as usize);
+    } else if binding.kind == ImportSpecifierKind::Named && binding.named_specifier_count == 1 {
+        start = comma_before_named_group(source_text, binding.specifier_span.start as usize);
+        end = brace_after_end(source_text, binding.specifier_span.end as usize);
+    } else {
+        start = comma_before_start(source_text, binding.specifier_span.start as usize);
+        end = binding.specifier_span.end as usize;
+    }
+    DiagnosticFix {
+        start: start as u32,
+        end: end as u32,
+        replacement: CompactString::new(""),
+    }
+}
+
+fn next_non_whitespace(source_text: &str, from: usize) -> usize {
+    let bytes = source_text.as_bytes();
+    let mut index = from;
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    index
+}
+
+fn token_before_end(source_text: &str, before: usize) -> usize {
+    let bytes = source_text.as_bytes();
+    let mut index = before.min(bytes.len());
+    while index > 0 && bytes[index - 1].is_ascii_whitespace() {
+        index -= 1;
+    }
+    index
+}
+
+fn comma_after_end(source_text: &str, after: usize) -> usize {
+    let bytes = source_text.as_bytes();
+    let mut index = after.min(bytes.len());
+    while index < bytes.len() {
+        match bytes[index] {
+            b',' => return index + 1,
+            byte if byte.is_ascii_whitespace() => index += 1,
+            _ => return after.min(bytes.len()),
+        }
+    }
+    after.min(bytes.len())
+}
+
+fn comma_before_start(source_text: &str, before: usize) -> usize {
+    let bytes = source_text.as_bytes();
+    let mut index = before.min(bytes.len());
+    while index > 0 {
+        match bytes[index - 1] {
+            b',' => return index - 1,
+            byte if byte.is_ascii_whitespace() => index -= 1,
+            _ => return before.min(bytes.len()),
+        }
+    }
+    before.min(bytes.len())
+}
+
+fn comma_before_named_group(source_text: &str, before: usize) -> usize {
+    let bytes = source_text.as_bytes();
+    let mut index = before.min(bytes.len());
+    while index > 0 && bytes[index - 1].is_ascii_whitespace() {
+        index -= 1;
+    }
+    if index > 0 && bytes[index - 1] == b'{' {
+        index -= 1;
+    }
+    while index > 0 && bytes[index - 1].is_ascii_whitespace() {
+        index -= 1;
+    }
+    if index > 0 && bytes[index - 1] == b',' {
+        return index - 1;
+    }
+    comma_before_start(source_text, before)
+}
+
+fn brace_after_end(source_text: &str, after: usize) -> usize {
+    let bytes = source_text.as_bytes();
+    let mut index = after.min(bytes.len());
+    while index < bytes.len() {
+        match bytes[index] {
+            b'}' => return index + 1,
+            byte if byte.is_ascii_whitespace() => index += 1,
+            _ => return after.min(bytes.len()),
+        }
+    }
+    after.min(bytes.len())
+}
+
+fn is_used_in_jsdoc(identifier_name: &str, source_text: &str) -> bool {
+    let escaped_name = regex::escape(identifier_name);
+    let mut pattern_text = CompactString::new("");
+    let _ = write!(
+        &mut pattern_text,
+        r"(?:(?:@(?:link|linkcode|linkplain|see)\s+{escaped_name}\b)|(?:\{{@(?:link|linkcode|linkplain)\s+{escaped_name}\b\}})|(?:[@\{{](?:type|typedef|param|returns?|template|augments|extends|implements)\s+[^}}]*\b{escaped_name}\b))"
+    );
+    let Ok(pattern) = Regex::new(pattern_text.as_str()) else {
+        return false;
+    };
+    let bytes = source_text.as_bytes();
+    let mut index = 0;
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'/' && bytes[index + 1] == b'*' {
+            let comment_start = index + 2;
+            let mut end = comment_start;
+            while end + 1 < bytes.len() && !(bytes[end] == b'*' && bytes[end + 1] == b'/') {
+                end += 1;
+            }
+            if pattern.is_match(&source_text[comment_start..end]) {
+                return true;
+            }
+            index = end.saturating_add(2);
+        } else {
+            index += 1;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use oxlint_plugins_carton::CompactString;
+
+    use super::{UnusedImportsOptions, scan_unused_imports};
+
+    fn apply_first_fix(source: &str, filename: &str) -> CompactString {
+        let diagnostics = scan_unused_imports(source, filename, &UnusedImportsOptions::default());
+        let fix = diagnostics
+            .iter()
+            .find_map(|diagnostic| diagnostic.fix.as_ref())
+            .expect("expected fix");
+        let mut output = CompactString::new("");
+        output.push_str(&source[..fix.start as usize]);
+        output.push_str(&fix.replacement);
+        output.push_str(&source[fix.end as usize..]);
+        output
+    }
+
+    #[test]
+    fn removes_unused_named_import() {
+        let source =
+            "import x from \"package\";\nimport { a, b } from \"./utils\";\nconst c = b(x);\n";
+        let diagnostics = scan_unused_imports(source, "file.js", &UnusedImportsOptions::default());
+        assert_eq!(diagnostics[0].rule_name, "no-unused-imports");
+        assert_eq!(diagnostics[0].message, "'a' is defined but never used.");
+        assert_eq!(
+            apply_first_fix(source, "file.js"),
+            "import x from \"package\";\nimport { b } from \"./utils\";\nconst c = b(x);\n"
+        );
+    }
+
+    #[test]
+    fn removes_whole_import_and_preserves_comment_spacing() {
+        let source = "import y from \"package\";\nimport { a } from \"./utils\";\n\n/** c is the number 4 */\nconst c = y;\n";
+        assert_eq!(
+            apply_first_fix(source, "file.js"),
+            "import y from \"package\";\n\n/** c is the number 4 */\nconst c = y;\n"
+        );
+    }
+
+    #[test]
+    fn removes_last_named_import_with_default_left() {
+        let source = "import fallback, { a } from \"./utils\";\nconsole.log(fallback);\n";
+        assert_eq!(
+            apply_first_fix(source, "file.js"),
+            "import fallback from \"./utils\";\nconsole.log(fallback);\n"
+        );
+    }
+
+    #[test]
+    fn honors_jsdoc_identifier_references() {
+        let source = "import { UsedInJSDoc } from \"./used\";\n/** Reference to {@link UsedInJSDoc} */\nconst example = \"test\";\n";
+        let diagnostics = scan_unused_imports(source, "file.js", &UnusedImportsOptions::default());
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule_name != "no-unused-imports")
+        );
+    }
+
+    #[test]
+    fn type_usage_counts_as_used() {
+        let source =
+            "import type { SomeType } from \"./types\";\nconst value: SomeType = {} as SomeType;\n";
+        let diagnostics = scan_unused_imports(source, "file.ts", &UnusedImportsOptions::default());
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.message != "'SomeType' is defined but never used.")
+        );
+    }
+
+    #[test]
+    fn shadowed_inner_name_does_not_mark_import_used() {
+        let source = "import { a } from \"./utils\";\nfunction fn(a) { return a; }\nfn(1);\n";
+        let diagnostics = scan_unused_imports(source, "file.js", &UnusedImportsOptions::default());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.rule_name == "no-unused-imports"
+                    && diagnostic.message == "'a' is defined but never used.")
+        );
+    }
+}

--- a/npm/unused-imports/Cargo.toml
+++ b/npm/unused-imports/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oxlint-plugin-unused-imports"
+description = "NAPI wrapper for the unused-imports oxlint plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-unused-imports.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints]
+workspace = true

--- a/npm/unused-imports/LICENSE
+++ b/npm/unused-imports/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 oxlint-plugins contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/unused-imports/README.md
+++ b/npm/unused-imports/README.md
@@ -1,0 +1,7 @@
+# @oxlint-plugins/oxlint-plugin-unused-imports
+
+Rust/Oxc-backed Oxlint plugin port of `eslint-plugin-unused-imports`.
+
+The native core detects unused ESM import bindings through Oxc semantic
+analysis and provides autofixes for unused import specifiers or whole import
+declarations.

--- a/npm/unused-imports/api.d.ts
+++ b/npm/unused-imports/api.d.ts
@@ -1,0 +1,38 @@
+export type DiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type DiagnosticFix = {
+  start: number;
+  end: number;
+  replacement: string;
+};
+
+export type Diagnostic = {
+  ruleName: 'no-unused-imports' | 'no-unused-vars';
+  message: string;
+  loc: DiagnosticLoc;
+  fix?: DiagnosticFix;
+};
+
+export type ScanUnusedImportsOptions = {
+  ruleNames?: readonly string[];
+};
+
+export function implementedUnusedImportsRuleNames(): Array<'no-unused-imports' | 'no-unused-vars'>;
+
+export function scanUnusedImports(
+  sourceText: string,
+  filename?: string,
+  options?: ScanUnusedImportsOptions,
+): Diagnostic[];
+
+declare const api: {
+  implementedUnusedImportsRuleNames: typeof implementedUnusedImportsRuleNames;
+  scanUnusedImports: typeof scanUnusedImports;
+};
+
+export default api;

--- a/npm/unused-imports/api.js
+++ b/npm/unused-imports/api.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanUnusedImports(sourceText, filename = 'file.js', options = {}) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanUnusedImports(sourceText, filename, {
+    ruleNames: normalizeRuleNames(options.ruleNames),
+  });
+}
+
+function normalizeRuleNames(ruleNames) {
+  if (!Array.isArray(ruleNames)) {
+    return undefined;
+  }
+  return ruleNames.filter((ruleName) => typeof ruleName === 'string' && ruleName.length > 0);
+}
+
+module.exports = {
+  implementedUnusedImportsRuleNames: native.implementedUnusedImportsRuleNames,
+  scanUnusedImports,
+};
+module.exports.default = module.exports;

--- a/npm/unused-imports/build.rs
+++ b/npm/unused-imports/build.rs
@@ -1,0 +1,5 @@
+extern crate napi_build;
+
+fn main() {
+    napi_build::setup();
+}

--- a/npm/unused-imports/index.js
+++ b/npm/unused-imports/index.js
@@ -1,0 +1,137 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-unused-imports (MIT).
+// The JavaScript layer adapts Oxlint's ESLint-compatible plugin API to the
+// Rust/Oxc implementation. Import usage, scope resolution, JSDoc handling, and
+// autofix range calculation run in native code.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedUnusedImportsRuleNames, scanUnusedImports } = require('./api.js');
+
+const PLUGIN_NAME = 'unused-imports';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/unused-imports';
+const diagnosticsCache = new WeakMap();
+
+const recommendedRuleConfig = Object.freeze({
+  'no-unused-imports': 'error',
+  'no-unused-vars': 'off',
+});
+
+const ruleDescriptions = Object.freeze({
+  'no-unused-imports': 'disallow unused imports',
+  'no-unused-vars': 'disallow unused variables while leaving import reporting to no-unused-imports',
+});
+
+const implementedRuleNames = Object.freeze(implementedUnusedImportsRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createUnusedImportsRule(ruleName)]),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: configFromRuleConfig('recommended', recommendedRuleConfig),
+  },
+});
+
+plugin.implementedUnusedImportsRuleNames = implementedRuleNames;
+plugin.scanUnusedImports = scanUnusedImports;
+
+function configFromRuleConfig(name, ruleConfig) {
+  return {
+    name: `${PLUGIN_NAME}/${name}`,
+    plugins: [PLUGIN_NAME],
+    rules: Object.fromEntries(
+      Object.entries(ruleConfig).map(([ruleName, config]) => [
+        `${PLUGIN_NAME}/${ruleName}`,
+        config,
+      ]),
+    ),
+  };
+}
+
+function createUnusedImportsRule(ruleName) {
+  return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: ruleDescriptions[ruleName],
+        category: 'Variables',
+        recommended: recommendedRuleConfig[ruleName] !== 'off',
+        url: `${DOCS_BASE}#${ruleName}`,
+      },
+      fixable: ruleName === 'no-unused-imports' ? 'code' : undefined,
+      messages: {
+        unused: '{{message}}',
+      },
+      schema: [],
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForRule(context, ruleName)) {
+            reportDiagnostic(context, diagnostic);
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForRule(context, ruleName) {
+  const sourceCode = context.sourceCode ?? context.getSourceCode();
+  let bySource = diagnosticsCache.get(sourceCode);
+  if (!bySource) {
+    bySource = new Map();
+    diagnosticsCache.set(sourceCode, bySource);
+  }
+  const filename = context.filename ?? context.getFilename?.() ?? 'file.js';
+  const cacheKey = `${filename}\0${ruleName}`;
+  let diagnostics = bySource.get(cacheKey);
+  if (!diagnostics) {
+    diagnostics = scanUnusedImports(sourceCode.text, filename, { ruleNames: [ruleName] }).filter(
+      (diagnostic) => diagnostic.ruleName === ruleName,
+    );
+    bySource.set(cacheKey, diagnostics);
+  }
+  return diagnostics;
+}
+
+function reportDiagnostic(context, diagnostic) {
+  const report = {
+    messageId: 'unused',
+    data: {
+      message: diagnostic.message,
+    },
+    loc: {
+      start: {
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn,
+      },
+      end: {
+        line: diagnostic.loc.endLine,
+        column: diagnostic.loc.endColumn,
+      },
+    },
+  };
+
+  if (diagnostic.fix) {
+    report.fix = (fixer) =>
+      fixer.replaceTextRange(
+        [diagnostic.fix.start, diagnostic.fix.end],
+        diagnostic.fix.replacement,
+      );
+  }
+
+  context.report(report);
+}
+
+module.exports = plugin;
+module.exports.default = plugin;

--- a/npm/unused-imports/package.json
+++ b/npm/unused-imports/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-unused-imports",
+  "version": "0.0.0",
+  "description": "Rust-backed Oxlint plugin port of eslint-plugin-unused-imports.",
+  "keywords": [
+    "eslint-plugin",
+    "imports",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "rust",
+    "unused"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/unused-imports"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_unused_imports",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/unused-imports/src/lib.rs
+++ b/npm/unused-imports/src/lib.rs
@@ -1,0 +1,108 @@
+//! NAPI boundary for the unused-imports oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticFix, DiagnosticLoc, UnusedImportsScanOptions,
+    implemented_unused_imports_rule_names, scan_unused_imports,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use oxlint_plugins_unused_imports as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct UnusedImportsScanOptions {
+        pub rule_names: Option<Vec<String>>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticFix {
+        pub start: u32,
+        pub end: u32,
+        pub replacement: String,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message: String,
+        pub loc: DiagnosticLoc,
+        pub fix: Option<DiagnosticFix>,
+    }
+
+    #[napi]
+    pub fn implemented_unused_imports_rule_names() -> Vec<String> {
+        core::implemented_unused_imports_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_unused_imports(
+        source_text: String,
+        filename: String,
+        options: Option<UnusedImportsScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::UnusedImportsOptions {
+            rule_names: compact_rule_names(options.rule_names),
+        };
+
+        core::scan_unused_imports(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message: diagnostic.message.into_string(),
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+                fix: diagnostic.fix.map(|fix| DiagnosticFix {
+                    start: fix.start,
+                    end: fix.end,
+                    replacement: fix.replacement.into_string(),
+                }),
+            })
+            .collect()
+    }
+
+    fn compact_rule_names(values: Option<Vec<String>>) -> SmallVec<[CompactString; 2]> {
+        values.map_or_else(
+            || {
+                core::implemented_unused_imports_rule_names()
+                    .iter()
+                    .map(|name| CompactString::from(*name))
+                    .collect()
+            },
+            |values| {
+                values
+                    .into_iter()
+                    .filter(|value| {
+                        core::implemented_unused_imports_rule_names().contains(&value.as_str())
+                    })
+                    .map(CompactString::from)
+                    .collect()
+            },
+        )
+    }
+}

--- a/npm/unused-imports/test/api.test.mjs
+++ b/npm/unused-imports/test/api.test.mjs
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedUnusedImportsRuleNames, scanUnusedImports } from '../api.js';
+
+const expectedRuleNames = ['no-unused-imports', 'no-unused-vars'];
+
+function applyFix(sourceText, fix) {
+  return sourceText.slice(0, fix.start) + fix.replacement + sourceText.slice(fix.end);
+}
+
+describe('unused-imports native API', () => {
+  it('exposes all eslint-plugin-unused-imports rule names', () => {
+    expect(implementedUnusedImportsRuleNames()).toEqual(expectedRuleNames);
+  });
+
+  it('scans and fixes unused named imports', () => {
+    const source = [
+      'import x from "package";',
+      'import { a, b } from "./utils";',
+      '',
+      'const c = b(x);',
+    ].join('\n');
+
+    const diagnostics = scanUnusedImports(source, 'fixture.js', {
+      ruleNames: ['no-unused-imports'],
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      ruleName: 'no-unused-imports',
+      message: "'a' is defined but never used.",
+      fix: {
+        replacement: '',
+      },
+    });
+    expect(applyFix(source, diagnostics[0].fix)).toBe(
+      ['import x from "package";', 'import { b } from "./utils";', '', 'const c = b(x);'].join(
+        '\n',
+      ),
+    );
+  });
+
+  it('removes a whole unused import while preserving following comments', () => {
+    const source = [
+      'import y from "package";',
+      'import { a } from "./utils";',
+      '',
+      '/** c is the number 4 */',
+      'const c = y;',
+    ].join('\n');
+
+    const diagnostics = scanUnusedImports(source, 'fixture.js', {
+      ruleNames: ['no-unused-imports'],
+    });
+
+    expect(applyFix(source, diagnostics[0].fix)).toBe(
+      ['import y from "package";', '', '/** c is the number 4 */', 'const c = y;'].join('\n'),
+    );
+  });
+
+  it('keeps imports referenced only from JSDoc tags', () => {
+    const source = [
+      'import { UsedInJSDoc } from "./used";',
+      '',
+      '/** Reference to {@link UsedInJSDoc} */',
+      'const example = "test";',
+    ].join('\n');
+
+    expect(scanUnusedImports(source, 'fixture.js', { ruleNames: ['no-unused-imports'] })).toEqual(
+      [],
+    );
+  });
+
+  it('does not treat shadowed inner identifiers as import usage', () => {
+    const source = [
+      'import { a } from "./utils";',
+      'function fn(a) {',
+      '  return a;',
+      '}',
+      'fn(1);',
+    ].join('\n');
+
+    expect(
+      scanUnusedImports(source, 'fixture.js', { ruleNames: ['no-unused-imports'] }).map(
+        (diagnostic) => diagnostic.message,
+      ),
+    ).toEqual(["'a' is defined but never used."]);
+  });
+
+  it('treats TypeScript type references as usage', () => {
+    const source = [
+      'import type { SomeType } from "./types";',
+      'const value: SomeType = {} as SomeType;',
+    ].join('\n');
+
+    expect(scanUnusedImports(source, 'fixture.ts', { ruleNames: ['no-unused-imports'] })).toEqual(
+      [],
+    );
+  });
+
+  it('can report non-import unused variables separately', () => {
+    const source = ['const used = 1;', 'const unused = 2;', 'console.log(used);'].join('\n');
+
+    expect(
+      scanUnusedImports(source, 'fixture.js', { ruleNames: ['no-unused-vars'] }).map(
+        (diagnostic) => diagnostic.message,
+      ),
+    ).toEqual(["'unused' is defined but never used."]);
+  });
+});

--- a/npm/unused-imports/test/plugin.test.mjs
+++ b/npm/unused-imports/test/plugin.test.mjs
@@ -1,0 +1,154 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const expectedRuleNames = ['no-unused-imports', 'no-unused-vars'];
+
+function runRule(ruleName, sourceText, filename = 'fixture.js') {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename,
+    options: [],
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function applyFix(sourceText, report) {
+  const fix = report.fix({
+    replaceTextRange(range, replacement) {
+      return { range, text: replacement };
+    },
+  });
+  return sourceText.slice(0, fix.range[0]) + fix.text + sourceText.slice(fix.range[1]);
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code, filename = 'fixture.js') {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'unused-imports-plugin-'));
+
+  try {
+    const sourcePath = join(temp, filename);
+    const configPath = join(temp, 'oxlint.config.jsonc');
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'unused-imports',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`unused-imports/${ruleName}`]: 'error',
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('unused-imports plugin shape', () => {
+  it('exposes all ported rules', () => {
+    expect(plugin.meta?.name).toBe('unused-imports');
+    expect(Object.keys(plugin.rules)).toEqual(expectedRuleNames);
+    expect(plugin.implementedUnusedImportsRuleNames).toEqual(expectedRuleNames);
+    expect(typeof plugin.scanUnusedImports).toBe('function');
+  });
+
+  it('ships recommended config', () => {
+    expect(plugin.configs.recommended.rules).toEqual({
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': 'off',
+    });
+  });
+});
+
+describe('unused-imports rules through direct adapter harness', () => {
+  it('reports and fixes no-unused-imports', () => {
+    const code = ['import { a, b } from "./utils";', 'console.log(b);'].join('\n');
+    const reports = runRule('no-unused-imports', code);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].data.message).toBe("'a' is defined but never used.");
+    expect(applyFix(code, reports[0])).toBe(
+      ['import { b } from "./utils";', 'console.log(b);'].join('\n'),
+    );
+  });
+
+  it('reports no-unused-vars without a fixer', () => {
+    const code = ['const used = 1;', 'const unused = 2;', 'console.log(used);'].join('\n');
+    const reports = runRule('no-unused-vars', code);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].data.message).toBe("'unused' is defined but never used.");
+    expect(reports[0].fix).toBeUndefined();
+  });
+});
+
+describe('unused-imports rules through oxlint jsPlugins', () => {
+  it('reports no-unused-imports through the CLI', () => {
+    const result = runOxlint(
+      'no-unused-imports',
+      ['import { a, b } from "./utils";', 'console.log(b);'].join('\n'),
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('unused-imports(no-unused-imports)');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,12 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  npm/unused-imports:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
 packages:
 
   '@ark/schema@0.56.0':

--- a/status.json
+++ b/status.json
@@ -1825,5 +1825,54 @@
         "notes": "Port of Corsa's native stylistic scanner rule keyword-spacing; source-wide Rust scan exposed through NAPI."
       }
     ]
+  },
+  {
+    "packageName": "@oxlint-plugins/oxlint-plugin-unused-imports",
+    "directory": "npm/unused-imports",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-unused-imports",
+      "version": "4.4.1",
+      "repository": "https://github.com/sweepline/eslint-plugin-unused-imports",
+      "license": "MIT"
+    },
+    "status": "ported",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "no-unused-imports",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc semantic port of eslint-plugin-unused-imports/no-unused-imports; detects unused ESM import bindings with shadowing-aware references, supports JSDoc tag references, and provides autofixes for import specifiers and whole declarations."
+      },
+      {
+        "name": "no-unused-vars",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust/Oxc semantic helper rule matching eslint-plugin-unused-imports' split-reporting role by reporting non-import unused bindings separately from no-unused-imports."
+      }
+    ]
   }
 ]

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -1,9 +1,17 @@
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, statSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const lockRoot = resolve(root, 'target', '.napi-setup-locks');
+// Per-package locks prevent multiple Vitest workers from racing on the same
+// `napi build` invocation. Concurrent `napi build` invocations on the same
+// package corrupt napi-rs intermediate type files (ENOENT on the
+// intermediate dts file).
+const BUILD_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes covers cold cargo builds
+const STALE_LOCK_MS = 15 * 60 * 1000;
+const POLL_INTERVAL_MS = 250;
 
 // Packages whose Vitest suites depend on NAPI bindings. Normally `vp build`
 // produces these before `vp test`; this is the fallback for direct test runs.
@@ -46,11 +54,57 @@ const nativePackages = [
   },
 ];
 
-for (const pkg of nativePackages) {
-  if (existsSync(resolve(root, pkg.binding))) {
-    continue;
-  }
+function lockPathFor(pkg) {
+  const safe = pkg.name.replace(/[@/]/g, '_');
+  return resolve(lockRoot, `${safe}.lock`);
+}
 
+function tryAcquireLock(lockPath) {
+  try {
+    mkdirSync(lockPath);
+    return true;
+  } catch (err) {
+    if (err.code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+function isStaleLock(lockPath) {
+  try {
+    const stat = statSync(lockPath);
+    return Date.now() - stat.mtimeMs > STALE_LOCK_MS;
+  } catch {
+    return false;
+  }
+}
+
+const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepSync(ms) {
+  // True blocking sleep without busy-waiting. The Atomics.wait timeout is
+  // exactly what we want here while we poll for the lock holder to finish.
+  Atomics.wait(sleepBuffer, 0, 0, ms);
+}
+
+function waitForBinding(pkg, lockPath) {
+  const bindingPath = resolve(root, pkg.binding);
+  const deadline = Date.now() + BUILD_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (existsSync(bindingPath)) return true;
+    if (isStaleLock(lockPath)) {
+      try {
+        rmSync(lockPath, { recursive: true, force: true });
+      } catch {
+        // another worker may have removed it concurrently
+      }
+      return false;
+    }
+    sleepSync(POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+function buildPackage(pkg) {
   const result = spawnSync('pnpm', ['--filter', pkg.name, 'build'], {
     cwd: root,
     stdio: 'inherit',
@@ -58,5 +112,41 @@ for (const pkg of nativePackages) {
 
   if (result.status !== 0) {
     throw new Error(`Failed to build NAPI bindings required by Vitest for ${pkg.name}.`);
+  }
+}
+
+mkdirSync(lockRoot, { recursive: true });
+
+for (const pkg of nativePackages) {
+  const bindingPath = resolve(root, pkg.binding);
+  if (existsSync(bindingPath)) {
+    continue;
+  }
+
+  const lockPath = lockPathFor(pkg);
+  // Retry loop handles the rare case where the lock holder fails to produce
+  // the binding (e.g., crash or stale lock) and we need to re-acquire.
+  let attempts = 0;
+  while (!existsSync(bindingPath)) {
+    attempts += 1;
+    if (attempts > 3) {
+      throw new Error(`Failed to build NAPI bindings required by Vitest for ${pkg.name} after ${attempts - 1} attempts.`);
+    }
+
+    if (tryAcquireLock(lockPath)) {
+      try {
+        buildPackage(pkg);
+      } finally {
+        try {
+          rmSync(lockPath, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    } else {
+      // Another worker is building; wait until the binding appears or the
+      // lock goes stale (in which case we'll retry and acquire).
+      waitForBinding(pkg, lockPath);
+    }
   }
 }

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -40,6 +40,10 @@ const nativePackages = [
     name: '@oxlint-plugins/oxlint-plugin-simple-import-sort',
     binding: 'npm/simple-import-sort/native.js',
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-unused-imports',
+    binding: 'npm/unused-imports/native.js',
+  },
 ];
 
 for (const pkg of nativePackages) {

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -130,7 +130,9 @@ for (const pkg of nativePackages) {
   while (!existsSync(bindingPath)) {
     attempts += 1;
     if (attempts > 3) {
-      throw new Error(`Failed to build NAPI bindings required by Vitest for ${pkg.name} after ${attempts - 1} attempts.`);
+      throw new Error(
+        `Failed to build NAPI bindings required by Vitest for ${pkg.name} after ${attempts - 1} attempts.`,
+      );
     }
 
     if (tryAcquireLock(lockPath)) {

--- a/tools/tasks/security-audit.ts
+++ b/tools/tasks/security-audit.ts
@@ -23,6 +23,7 @@ const publishablePrefixes = [
   '@oxlint-plugins/oxlint-plugin-cypress>',
   '@oxlint-plugins/oxlint-plugin-mocha>',
   '@oxlint-plugins/oxlint-plugin-simple-import-sort>',
+  '@oxlint-plugins/oxlint-plugin-unused-imports>',
   '@oxlint-plugins/oxlint-plugin-stylistic>',
 ];
 

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -50,6 +50,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-unused-imports',
+    dir: 'npm/unused-imports',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-stylistic',
     dir: 'npm/stylistic',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- port eslint-plugin-unused-imports as a Rust/Oxc-backed oxlint plugin
- add native semantic analysis for no-unused-imports with shadowing-aware import usage, JSDoc tag references, and autofixes for specifiers/whole declarations
- add the no-unused-vars helper rule through the same Rust semantic scanner for non-import unused bindings
- add NAPI bindings, Oxlint JS adapter/config, package metadata, status, publish readiness, and tests

## Validation
- cargo test -p oxlint-plugins-unused-imports -p oxlint-plugin-unused-imports
- vp test npm/unused-imports
- vp exec pnpm run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->