### PR TITLE
feat(eslint-markdown): port @eslint/markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-eslint-markdown"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-eslint-markdown",
+]
+
+[[package]]
 name = "oxlint-plugin-mocha"
 version = "0.0.0"
 dependencies = [
@@ -905,6 +916,15 @@ dependencies = [
  "insta",
  "oxlint-plugins-_carton",
  "phf",
+]
+
+[[package]]
+name = "oxlint-plugins-eslint-markdown"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxlint-plugins-_carton",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/_carton",
   "crates/cypress",
   "crates/eslint_comments",
+  "crates/eslint_markdown",
   "crates/mocha",
   "crates/react_refresh",
   "crates/security",
@@ -11,6 +12,7 @@ members = [
   "crates/unused_imports",
   "npm/cypress",
   "npm/eslint-comments",
+  "npm/eslint-markdown",
   "npm/mocha",
   "npm/no-forbidden-identifiers",
   "npm/react-refresh",
@@ -46,6 +48,7 @@ oxc_syntax = "0.135.0"
 oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_carton", version = "0.0.0" }
 oxlint-plugins-cypress = { path = "crates/cypress", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }
+oxlint-plugins-eslint-markdown = { path = "crates/eslint_markdown", version = "0.0.0" }
 oxlint-plugins-mocha = { path = "crates/mocha", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }

--- a/crates/eslint_markdown/Cargo.toml
+++ b/crates/eslint_markdown/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "oxlint-plugins-eslint-markdown"
+description = "Rust core for the @eslint/markdown oxlint JavaScript plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxlint-plugins-carton.workspace = true
+regex.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -1,0 +1,1773 @@
+#![doc = "Rust implementation of @eslint/markdown rule logic."]
+
+use oxlint_plugins_carton::{CompactString, FastHashMap, FastHashSet, SmallVec};
+use regex::Regex;
+
+pub const RULE_NAMES: [&str; 21] = [
+    "fenced-code-language",
+    "fenced-code-meta",
+    "heading-increment",
+    "no-bare-urls",
+    "no-duplicate-definitions",
+    "no-duplicate-headings",
+    "no-empty-definitions",
+    "no-empty-images",
+    "no-empty-links",
+    "no-html",
+    "no-invalid-label-refs",
+    "no-missing-atx-heading-space",
+    "no-missing-label-refs",
+    "no-missing-link-fragments",
+    "no-multiple-h1",
+    "no-reference-like-urls",
+    "no-reversed-media-syntax",
+    "no-space-in-emphasis",
+    "no-unused-definitions",
+    "require-alt-text",
+    "table-column-count",
+];
+
+const EMPHASIS_MARKERS: &[&str] = &["***", "**", "*", "___", "__", "_"];
+const EMPHASIS_AND_STRIKE_MARKERS: &[&str] = &["***", "**", "*", "___", "__", "_", "~~", "~"];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScanOptions {
+    pub rule_names: SmallVec<[CompactString; 21]>,
+    pub required_code_languages: SmallVec<[CompactString; 8]>,
+    pub fenced_code_meta_mode: MetaMode,
+    pub frontmatter_title: Option<CompactString>,
+    pub check_closed_headings: bool,
+    pub check_strikethrough: bool,
+    pub allowed_html: SmallVec<[CompactString; 8]>,
+    pub allowed_html_ignore_case: bool,
+    pub allow_labels: SmallVec<[CompactString; 8]>,
+    pub allow_definitions: SmallVec<[CompactString; 8]>,
+    pub allow_footnote_definitions: SmallVec<[CompactString; 8]>,
+    pub check_footnote_definitions: bool,
+    pub check_duplicate_headings_siblings_only: bool,
+    pub ignore_fragment_case: bool,
+    pub allow_fragment_pattern: Option<CompactString>,
+    pub check_missing_table_cells: bool,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            rule_names: SmallVec::new(),
+            required_code_languages: SmallVec::new(),
+            fenced_code_meta_mode: MetaMode::Always,
+            frontmatter_title: None,
+            check_closed_headings: false,
+            check_strikethrough: false,
+            allowed_html: SmallVec::new(),
+            allowed_html_ignore_case: false,
+            allow_labels: SmallVec::new(),
+            allow_definitions: {
+                let mut values = SmallVec::new();
+                values.push(CompactString::from("//"));
+                values
+            },
+            allow_footnote_definitions: SmallVec::new(),
+            check_footnote_definitions: true,
+            check_duplicate_headings_siblings_only: false,
+            ignore_fragment_case: true,
+            allow_fragment_pattern: None,
+            check_missing_table_cells: false,
+        }
+    }
+}
+
+impl ScanOptions {
+    fn is_enabled(&self, rule_name: &str) -> bool {
+        self.rule_names.is_empty() || self.rule_names.iter().any(|name| name == rule_name)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MetaMode {
+    #[default]
+    Always,
+    Never,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub lang: Option<CompactString>,
+    pub name: Option<CompactString>,
+    pub identifier: Option<CompactString>,
+    pub label: Option<CompactString>,
+    pub first_line: Option<u32>,
+    pub first_label: Option<CompactString>,
+    pub from_level: Option<u32>,
+    pub to_level: Option<u32>,
+    pub position: Option<CompactString>,
+    pub text: Option<CompactString>,
+    pub link_type: Option<CompactString>,
+    pub prefix: Option<CompactString>,
+    pub fragment: Option<CompactString>,
+    pub expected_cells: Option<u32>,
+    pub actual_cells: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiagnosticFix {
+    pub start: u32,
+    pub end: u32,
+    pub replacement: CompactString,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: DiagnosticData,
+    pub loc: DiagnosticLoc,
+    pub fix: Option<DiagnosticFix>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ByteSpan {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LineFact<'a> {
+    number: u32,
+    start: usize,
+    end: usize,
+    text: &'a str,
+    in_fence: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FenceFact {
+    marker_span: ByteSpan,
+    info_span: ByteSpan,
+    lang: Option<CompactString>,
+    meta: Option<CompactString>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HeadingFact {
+    depth: u8,
+    text: CompactString,
+    span: ByteSpan,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DefinitionFact {
+    identifier: CompactString,
+    label: CompactString,
+    url: CompactString,
+    span: ByteSpan,
+    is_footnote: bool,
+    line: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LinkFact {
+    is_image: bool,
+    label: CompactString,
+    url: CompactString,
+    span: ByteSpan,
+    url_span: ByteSpan,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LabelRefFact {
+    label: CompactString,
+    span: ByteSpan,
+    is_footnote: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HtmlTagFact {
+    name: CompactString,
+    span: ByteSpan,
+    raw: CompactString,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct MarkdownFacts<'a> {
+    lines: SmallVec<[LineFact<'a>; 64]>,
+    fences: SmallVec<[FenceFact; 8]>,
+    headings: SmallVec<[HeadingFact; 16]>,
+    definitions: SmallVec<[DefinitionFact; 16]>,
+    links: SmallVec<[LinkFact; 32]>,
+    label_refs: SmallVec<[LabelRefFact; 32]>,
+    html_tags: SmallVec<[HtmlTagFact; 16]>,
+    frontmatter_has_title: bool,
+}
+
+pub fn implemented_eslint_markdown_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_eslint_markdown(
+    source_text: &str,
+    options: &ScanOptions,
+) -> SmallVec<[Diagnostic; 32]> {
+    let line_index = LineIndex::new(source_text);
+    let facts = collect_facts(source_text, options);
+    let mut diagnostics = SmallVec::new();
+
+    if options.is_enabled("fenced-code-language") {
+        scan_fenced_code_language(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("fenced-code-meta") {
+        scan_fenced_code_meta(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("heading-increment") {
+        scan_heading_increment(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("no-bare-urls") {
+        scan_bare_urls(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("no-duplicate-definitions") {
+        scan_duplicate_definitions(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-duplicate-headings") {
+        scan_duplicate_headings(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-empty-definitions") {
+        scan_empty_definitions(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-empty-images") {
+        scan_empty_media(source_text, &line_index, &facts, true, &mut diagnostics);
+    }
+    if options.is_enabled("no-empty-links") {
+        scan_empty_media(source_text, &line_index, &facts, false, &mut diagnostics);
+    }
+    if options.is_enabled("no-html") {
+        scan_no_html(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-invalid-label-refs") {
+        scan_invalid_label_refs(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("no-missing-atx-heading-space") {
+        scan_missing_atx_heading_space(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-missing-label-refs") {
+        scan_missing_label_refs(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-missing-link-fragments") {
+        scan_missing_link_fragments(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-multiple-h1") {
+        scan_multiple_h1(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("no-reference-like-urls") {
+        scan_reference_like_urls(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("no-reversed-media-syntax") {
+        scan_reversed_media(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("no-space-in-emphasis") {
+        scan_space_in_emphasis(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("no-unused-definitions") {
+        scan_unused_definitions(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+    if options.is_enabled("require-alt-text") {
+        scan_require_alt_text(source_text, &line_index, &facts, &mut diagnostics);
+    }
+    if options.is_enabled("table-column-count") {
+        scan_table_column_count(source_text, &line_index, &facts, options, &mut diagnostics);
+    }
+
+    diagnostics
+}
+
+fn collect_facts<'a>(source_text: &'a str, options: &ScanOptions) -> MarkdownFacts<'a> {
+    let mut facts = MarkdownFacts::default();
+    collect_lines(source_text, &mut facts);
+    collect_frontmatter(
+        source_text,
+        &mut facts,
+        options.frontmatter_title.as_deref(),
+    );
+    collect_fences(source_text, &mut facts);
+    collect_headings(&mut facts);
+    collect_definitions(&mut facts);
+    collect_inline_links(source_text, &mut facts);
+    collect_html_tags(source_text, &mut facts);
+    facts
+}
+
+fn collect_lines<'a>(source_text: &'a str, facts: &mut MarkdownFacts<'a>) {
+    let bytes = source_text.as_bytes();
+    let mut start = 0usize;
+    let mut number = 1u32;
+    while start <= source_text.len() {
+        let mut end = start;
+        while end < source_text.len() && bytes[end] != b'\n' {
+            end += 1;
+        }
+        let text_end = if end > start && bytes[end.saturating_sub(1)] == b'\r' {
+            end - 1
+        } else {
+            end
+        };
+        let text = source_text.get(start..text_end).unwrap_or("");
+        facts.lines.push(LineFact {
+            number,
+            start,
+            end: text_end,
+            text,
+            in_fence: false,
+        });
+        if end == source_text.len() {
+            break;
+        }
+        start = end + 1;
+        number += 1;
+    }
+}
+
+fn collect_frontmatter(
+    source_text: &str,
+    facts: &mut MarkdownFacts<'_>,
+    frontmatter_title: Option<&str>,
+) {
+    if frontmatter_title == Some("") {
+        return;
+    }
+    let Some(first) = facts.lines.first() else {
+        return;
+    };
+    let marker = first.text.trim();
+    if !matches!(marker, "---" | "+++" | "{") {
+        return;
+    }
+    let title_pattern = frontmatter_title.and_then(|pattern| Regex::new(pattern).ok());
+    for line in facts.lines.iter().skip(1).take(32) {
+        let text = line.text.trim();
+        let matched_title = title_pattern
+            .as_ref()
+            .is_some_and(|pattern| pattern.is_match(text))
+            || (title_pattern.is_none()
+                && (text.starts_with("title")
+                    || text.starts_with("\"title\"")
+                    || text.starts_with("'title'")));
+        if matched_title {
+            facts.frontmatter_has_title = true;
+            return;
+        }
+        if text == marker || (marker == "{" && text == "}") {
+            return;
+        }
+    }
+    if title_pattern
+        .as_ref()
+        .is_some_and(|pattern| pattern.is_match(source_text))
+        || (title_pattern.is_none() && source_text.starts_with("title:"))
+    {
+        facts.frontmatter_has_title = true;
+    }
+}
+
+fn collect_fences(source_text: &str, facts: &mut MarkdownFacts<'_>) {
+    let mut open_marker: Option<(u8, usize)> = None;
+    for line in &mut facts.lines {
+        let (indent, trimmed) = split_indent(line.text);
+        if indent > 3 {
+            line.in_fence = open_marker.is_some();
+            continue;
+        }
+        let marker_byte = trimmed.as_bytes().first().copied();
+        let marker_len = trimmed
+            .bytes()
+            .take_while(|byte| Some(*byte) == marker_byte)
+            .count();
+        let is_fence = matches!(marker_byte, Some(b'`' | b'~')) && marker_len >= 3;
+        if let Some((open_byte, open_len)) = open_marker {
+            line.in_fence = true;
+            if is_fence && marker_byte == Some(open_byte) && marker_len >= open_len {
+                open_marker = None;
+            }
+            continue;
+        }
+        if !is_fence {
+            continue;
+        }
+
+        line.in_fence = true;
+        let marker_start = line.start + indent;
+        let marker_end = marker_start + marker_len;
+        let info_start = marker_end;
+        let info = source_text.get(info_start..line.end).unwrap_or("").trim();
+        let (lang, meta) = split_fence_info(info);
+        facts.fences.push(FenceFact {
+            marker_span: ByteSpan {
+                start: marker_start,
+                end: marker_end,
+            },
+            info_span: ByteSpan {
+                start: info_start,
+                end: line.end,
+            },
+            lang,
+            meta,
+        });
+        open_marker = marker_byte.map(|byte| (byte, marker_len));
+    }
+}
+
+fn collect_headings(facts: &mut MarkdownFacts<'_>) {
+    for line in &facts.lines {
+        if line.in_fence {
+            continue;
+        }
+        if let Some((depth, text)) = parse_atx_heading(line.text) {
+            facts.headings.push(HeadingFact {
+                depth,
+                text: CompactString::from(text),
+                span: ByteSpan {
+                    start: line.start,
+                    end: line.end,
+                },
+            });
+        }
+    }
+
+    for index in 1..facts.lines.len() {
+        let line = &facts.lines[index];
+        if line.in_fence {
+            continue;
+        }
+        let trimmed = line.text.trim();
+        let depth = if trimmed.chars().all(|ch| ch == '=') && trimmed.len() >= 3 {
+            Some(1)
+        } else if trimmed.chars().all(|ch| ch == '-') && trimmed.len() >= 3 {
+            Some(2)
+        } else {
+            None
+        };
+        let Some(depth) = depth else {
+            continue;
+        };
+        let prev = &facts.lines[index - 1];
+        if prev.text.trim().is_empty() || prev.in_fence {
+            continue;
+        }
+        facts.headings.push(HeadingFact {
+            depth,
+            text: CompactString::from(prev.text.trim()),
+            span: ByteSpan {
+                start: prev.start,
+                end: line.end,
+            },
+        });
+    }
+}
+
+fn collect_definitions(facts: &mut MarkdownFacts<'_>) {
+    for line in &facts.lines {
+        if line.in_fence {
+            continue;
+        }
+        let trimmed = line.text.trim_start();
+        let Some(rest) = trimmed.strip_prefix('[') else {
+            continue;
+        };
+        let is_footnote = rest.starts_with('^');
+        let label_start = usize::from(is_footnote);
+        let Some(close) = rest.find("]:") else {
+            continue;
+        };
+        let raw_label = &rest[label_start..close];
+        let url = rest[close + 2..].trim();
+        let label = CompactString::from(raw_label.trim());
+        let identifier = normalize_identifier(raw_label);
+        facts.definitions.push(DefinitionFact {
+            identifier,
+            label,
+            url: CompactString::from(trim_definition_url(url)),
+            span: ByteSpan {
+                start: line.start + (line.text.len() - trimmed.len()),
+                end: line.end,
+            },
+            is_footnote,
+            line: line.number,
+        });
+    }
+}
+
+fn collect_inline_links(source_text: &str, facts: &mut MarkdownFacts<'_>) {
+    let Ok(inline_link_re) = Regex::new(r"!?\[[^\]\n]*\]\([^\)\n]*\)") else {
+        return;
+    };
+    let Ok(label_ref_re) = Regex::new(r"!?\[[^\]\n]*\](?:\[[^\]\n]*\])?") else {
+        return;
+    };
+
+    for line in &facts.lines {
+        if line.in_fence || is_definition_line(line.text) {
+            continue;
+        }
+        for mat in inline_link_re.find_iter(line.text) {
+            let raw = mat.as_str();
+            if let Some(link) = parse_inline_link(raw, line.start + mat.start()) {
+                facts.links.push(link);
+            }
+        }
+        for mat in label_ref_re.find_iter(line.text) {
+            let absolute_start = line.start + mat.start();
+            let absolute_end = line.start + mat.end();
+            if source_text.get(absolute_end..absolute_end + 1) == Some("(") {
+                continue;
+            }
+            if let Some(label_ref) = parse_label_ref(mat.as_str(), absolute_start, absolute_end) {
+                facts.label_refs.push(label_ref);
+            }
+        }
+    }
+}
+
+fn collect_html_tags(source_text: &str, facts: &mut MarkdownFacts<'_>) {
+    let Ok(tag_re) = Regex::new(r#"(?is)<[a-z][a-z0-9-]*(?:\s[^>]*)?/?>"#) else {
+        return;
+    };
+    for mat in tag_re.find_iter(source_text) {
+        if in_fenced_range(facts, mat.start()) {
+            continue;
+        }
+        let raw = mat.as_str();
+        let name = html_tag_name(raw);
+        if name.is_empty() {
+            continue;
+        }
+        facts.html_tags.push(HtmlTagFact {
+            name,
+            span: ByteSpan {
+                start: mat.start(),
+                end: mat.end(),
+            },
+            raw: CompactString::from(raw),
+        });
+    }
+}
+
+fn scan_fenced_code_language(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for fence in &facts.fences {
+        let Some(lang) = &fence.lang else {
+            diagnostics.push(Diagnostic {
+                rule_name: "fenced-code-language",
+                message_id: "missingLanguage",
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, fence.marker_span),
+                fix: None,
+            });
+            continue;
+        };
+        if !options.required_code_languages.is_empty()
+            && !options
+                .required_code_languages
+                .iter()
+                .any(|value| value == lang)
+        {
+            diagnostics.push(Diagnostic {
+                rule_name: "fenced-code-language",
+                message_id: "disallowedLanguage",
+                data: DiagnosticData {
+                    lang: Some(lang.clone()),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, fence.info_span),
+                fix: None,
+            });
+        }
+    }
+}
+
+fn scan_fenced_code_meta(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for fence in &facts.fences {
+        match options.fenced_code_meta_mode {
+            MetaMode::Always => {
+                if fence.lang.is_some()
+                    && fence
+                        .meta
+                        .as_ref()
+                        .is_none_or(|meta| meta.trim().is_empty())
+                {
+                    diagnostics.push(Diagnostic {
+                        rule_name: "fenced-code-meta",
+                        message_id: "missingMetadata",
+                        data: DiagnosticData::default(),
+                        loc: line_index.loc_for_span(source_text, fence.info_span),
+                        fix: None,
+                    });
+                }
+            }
+            MetaMode::Never => {
+                if fence
+                    .meta
+                    .as_ref()
+                    .is_some_and(|meta| !meta.trim().is_empty())
+                {
+                    diagnostics.push(Diagnostic {
+                        rule_name: "fenced-code-meta",
+                        message_id: "disallowedMetadata",
+                        data: DiagnosticData::default(),
+                        loc: line_index.loc_for_span(source_text, fence.info_span),
+                        fix: None,
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn scan_heading_increment(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let mut last_depth = if facts.frontmatter_has_title { 1 } else { 0 };
+    let mut headings = facts.headings.iter().collect::<SmallVec<[_; 16]>>();
+    headings.sort_by_key(|heading| heading.span.start);
+    for heading in headings {
+        let depth = u32::from(heading.depth);
+        if last_depth > 0 && depth > last_depth + 1 {
+            diagnostics.push(Diagnostic {
+                rule_name: "heading-increment",
+                message_id: "skippedHeading",
+                data: DiagnosticData {
+                    from_level: Some(last_depth),
+                    to_level: Some(depth),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, heading.span),
+                fix: None,
+            });
+        }
+        last_depth = depth;
+    }
+}
+
+fn scan_bare_urls(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let Ok(url_re) =
+        Regex::new(r#"(?i)\b(?:https?://[^\s<>()]+|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})"#)
+    else {
+        return;
+    };
+    for line in &facts.lines {
+        if line.in_fence || line.text.starts_with("    ") || line.text.starts_with('\t') {
+            continue;
+        }
+        for mat in url_re.find_iter(line.text) {
+            let start = line.start + mat.start();
+            let mut end = line.start + mat.end();
+            while end > start
+                && source_text
+                    .as_bytes()
+                    .get(end - 1)
+                    .is_some_and(|byte| matches!(byte, b'.' | b',' | b';' | b':' | b'!' | b'?'))
+            {
+                end -= 1;
+            }
+            if end == start {
+                continue;
+            }
+            if is_inside_angle_autolink(source_text, start, end)
+                || is_inside_markdown_destination(&facts.links, start)
+                || is_inside_html_tag(&facts.html_tags, start)
+            {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                rule_name: "no-bare-urls",
+                message_id: "bareUrl",
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, ByteSpan { start, end }),
+                fix: Some(DiagnosticFix {
+                    start: utf16_offset(source_text, start),
+                    end: utf16_offset(source_text, end),
+                    replacement: {
+                        let mut out = CompactString::from("<");
+                        out.push_str(&source_text[start..end]);
+                        out.push('>');
+                        out
+                    },
+                }),
+            });
+        }
+    }
+}
+
+fn scan_duplicate_definitions(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let mut definitions = FastHashMap::<CompactString, &DefinitionFact>::default();
+    let mut footnotes = FastHashMap::<CompactString, &DefinitionFact>::default();
+    for definition in &facts.definitions {
+        if definition.is_footnote {
+            if !options.check_footnote_definitions
+                || is_allowed(&options.allow_footnote_definitions, &definition.identifier)
+            {
+                continue;
+            }
+            if let Some(first) = footnotes.get(&definition.identifier) {
+                diagnostics.push(definition_diagnostic(
+                    "no-duplicate-definitions",
+                    "duplicateFootnoteDefinition",
+                    source_text,
+                    line_index,
+                    definition,
+                    Some(first),
+                ));
+            } else {
+                footnotes.insert(definition.identifier.clone(), definition);
+            }
+        } else {
+            if is_allowed(&options.allow_definitions, &definition.identifier) {
+                continue;
+            }
+            if let Some(first) = definitions.get(&definition.identifier) {
+                diagnostics.push(definition_diagnostic(
+                    "no-duplicate-definitions",
+                    "duplicateDefinition",
+                    source_text,
+                    line_index,
+                    definition,
+                    Some(first),
+                ));
+            } else {
+                definitions.insert(definition.identifier.clone(), definition);
+            }
+        }
+    }
+}
+
+fn scan_duplicate_headings(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let mut all_seen = FastHashSet::<CompactString>::default();
+    let mut seen_by_parent = FastHashSet::<(usize, u8, CompactString)>::default();
+    let mut parent_stack = [0usize; 6];
+    let mut headings = facts.headings.iter().collect::<SmallVec<[_; 16]>>();
+    headings.sort_by_key(|heading| heading.span.start);
+    for (index, heading) in headings.into_iter().enumerate() {
+        let key = normalize_heading_text(heading.text.as_str());
+        let duplicate = if options.check_duplicate_headings_siblings_only {
+            let depth_index = usize::from(heading.depth.saturating_sub(1));
+            for value in parent_stack.iter_mut().skip(depth_index) {
+                *value = 0;
+            }
+            let parent_id = if depth_index == 0 {
+                0
+            } else {
+                parent_stack[depth_index - 1]
+            };
+            parent_stack[depth_index] = index + 1;
+            !seen_by_parent.insert((parent_id, heading.depth, key))
+        } else {
+            !all_seen.insert(key.clone())
+        };
+        if duplicate {
+            diagnostics.push(Diagnostic {
+                rule_name: "no-duplicate-headings",
+                message_id: "duplicateHeading",
+                data: DiagnosticData {
+                    text: Some(heading.text.clone()),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, heading.span),
+                fix: None,
+            });
+        }
+    }
+}
+
+fn scan_empty_definitions(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for definition in &facts.definitions {
+        if definition.is_footnote {
+            if options.check_footnote_definitions
+                && !is_allowed(&options.allow_footnote_definitions, &definition.identifier)
+                && definition.url.trim().is_empty()
+            {
+                diagnostics.push(definition_diagnostic(
+                    "no-empty-definitions",
+                    "emptyFootnoteDefinition",
+                    source_text,
+                    line_index,
+                    definition,
+                    None,
+                ));
+            }
+        } else if !is_allowed(&options.allow_definitions, &definition.identifier)
+            && (definition.url.trim().is_empty() || matches!(definition.url.as_str(), "#" | "<>"))
+        {
+            diagnostics.push(definition_diagnostic(
+                "no-empty-definitions",
+                "emptyDefinition",
+                source_text,
+                line_index,
+                definition,
+                None,
+            ));
+        }
+    }
+}
+
+fn scan_empty_media(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    images: bool,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for link in &facts.links {
+        if link.is_image != images {
+            continue;
+        }
+        if link.url.trim().is_empty() || link.url.trim() == "#" {
+            diagnostics.push(Diagnostic {
+                rule_name: if images {
+                    "no-empty-images"
+                } else {
+                    "no-empty-links"
+                },
+                message_id: if images { "emptyImage" } else { "emptyLink" },
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, link.span),
+                fix: None,
+            });
+        }
+    }
+}
+
+fn scan_no_html(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for tag in &facts.html_tags {
+        let normalized = if options.allowed_html_ignore_case {
+            lower(tag.name.as_str())
+        } else {
+            tag.name.clone()
+        };
+        if options.allowed_html.iter().any(|allowed| {
+            if options.allowed_html_ignore_case {
+                lower(allowed.as_str()) == normalized
+            } else {
+                allowed.as_str() == normalized.as_str()
+            }
+        }) {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule_name: "no-html",
+            message_id: "disallowedElement",
+            data: DiagnosticData {
+                name: Some(tag.name.clone()),
+                ..DiagnosticData::default()
+            },
+            loc: line_index.loc_for_span(source_text, tag.span),
+            fix: None,
+        });
+    }
+}
+
+fn scan_invalid_label_refs(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for label_ref in &facts.label_refs {
+        if label_ref.label.trim().is_empty() {
+            diagnostics.push(Diagnostic {
+                rule_name: "no-invalid-label-refs",
+                message_id: "invalidLabelRef",
+                data: DiagnosticData {
+                    label: Some(label_ref.label.clone()),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, label_ref.span),
+                fix: None,
+            });
+        }
+    }
+}
+
+fn scan_missing_atx_heading_space(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for line in &facts.lines {
+        if line.in_fence {
+            continue;
+        }
+        let (indent, trimmed) = split_indent(line.text);
+        if indent > 3 {
+            continue;
+        }
+        let hashes = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+        if (1..=6).contains(&hashes) {
+            let after = trimmed.as_bytes().get(hashes).copied();
+            if !matches!(after, Some(b' ' | b'\t' | b'#')) {
+                diagnostics.push(Diagnostic {
+                    rule_name: "no-missing-atx-heading-space",
+                    message_id: "missingSpace",
+                    data: DiagnosticData {
+                        position: Some(CompactString::from("after")),
+                        ..DiagnosticData::default()
+                    },
+                    loc: line_index.loc_for_span(
+                        source_text,
+                        ByteSpan {
+                            start: line.start + indent,
+                            end: line.start + indent + hashes + usize::from(after.is_some()),
+                        },
+                    ),
+                    fix: Some(DiagnosticFix {
+                        start: utf16_offset(source_text, line.start + indent + hashes),
+                        end: utf16_offset(source_text, line.start + indent + hashes),
+                        replacement: CompactString::from(" "),
+                    }),
+                });
+            }
+        }
+        if options.check_closed_headings && trimmed.ends_with('#') {
+            let before_last = trimmed.trim_end_matches('#').chars().last();
+            if before_last.is_some_and(|ch| !ch.is_whitespace()) {
+                let end = line.end;
+                let start =
+                    end.saturating_sub(trimmed.chars().rev().take_while(|ch| *ch == '#').count());
+                diagnostics.push(Diagnostic {
+                    rule_name: "no-missing-atx-heading-space",
+                    message_id: "missingSpace",
+                    data: DiagnosticData {
+                        position: Some(CompactString::from("before")),
+                        ..DiagnosticData::default()
+                    },
+                    loc: line_index.loc_for_span(source_text, ByteSpan { start, end }),
+                    fix: Some(DiagnosticFix {
+                        start: utf16_offset(source_text, start),
+                        end: utf16_offset(source_text, start),
+                        replacement: CompactString::from(" "),
+                    }),
+                });
+            }
+        }
+    }
+}
+
+fn scan_missing_label_refs(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let definitions = definition_ids(facts, false);
+    for label_ref in &facts.label_refs {
+        if label_ref.is_footnote || label_ref.label.trim().is_empty() {
+            continue;
+        }
+        let normalized = normalize_identifier(label_ref.label.as_str());
+        if definitions.contains(&normalized) || is_allowed(&options.allow_labels, &label_ref.label)
+        {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule_name: "no-missing-label-refs",
+            message_id: "notFound",
+            data: DiagnosticData {
+                label: Some(label_ref.label.clone()),
+                ..DiagnosticData::default()
+            },
+            loc: line_index.loc_for_span(source_text, label_ref.span),
+            fix: None,
+        });
+    }
+}
+
+fn scan_missing_link_fragments(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let mut ids = FastHashSet::<CompactString>::default();
+    let allow_fragment_pattern = options
+        .allow_fragment_pattern
+        .as_ref()
+        .filter(|pattern| !pattern.is_empty())
+        .and_then(|pattern| Regex::new(pattern.as_str()).ok());
+    ids.insert(CompactString::from("top"));
+    for heading in &facts.headings {
+        ids.insert(github_slug(heading.text.as_str()));
+    }
+    for tag in &facts.html_tags {
+        if let Some(id) =
+            html_attr(tag.raw.as_str(), "id").or_else(|| html_attr(tag.raw.as_str(), "name"))
+        {
+            ids.insert(if options.ignore_fragment_case {
+                lower(id)
+            } else {
+                CompactString::from(id)
+            });
+        }
+    }
+    for link in &facts.links {
+        let Some(fragment) = link.url.strip_prefix('#') else {
+            continue;
+        };
+        if fragment.is_empty() || is_github_line_ref(fragment) {
+            continue;
+        }
+        if allow_fragment_pattern
+            .as_ref()
+            .is_some_and(|pattern| pattern.is_match(fragment))
+        {
+            continue;
+        }
+        let normalized = if options.ignore_fragment_case {
+            lower(fragment)
+        } else {
+            CompactString::from(fragment)
+        };
+        if !ids.contains(&normalized) {
+            diagnostics.push(Diagnostic {
+                rule_name: "no-missing-link-fragments",
+                message_id: "invalidFragment",
+                data: DiagnosticData {
+                    fragment: Some(CompactString::from(fragment)),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, link.span),
+                fix: None,
+            });
+        }
+    }
+}
+
+fn scan_multiple_h1(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let mut count = u32::from(facts.frontmatter_has_title);
+    for heading in &facts.headings {
+        if heading.depth == 1 {
+            count += 1;
+            if count > 1 {
+                diagnostics.push(Diagnostic {
+                    rule_name: "no-multiple-h1",
+                    message_id: "multipleH1",
+                    data: DiagnosticData::default(),
+                    loc: line_index.loc_for_span(source_text, heading.span),
+                    fix: None,
+                });
+            }
+        }
+    }
+    for tag in &facts.html_tags {
+        if tag.name.eq_ignore_ascii_case("h1") {
+            count += 1;
+            if count > 1 {
+                diagnostics.push(Diagnostic {
+                    rule_name: "no-multiple-h1",
+                    message_id: "multipleH1",
+                    data: DiagnosticData::default(),
+                    loc: line_index.loc_for_span(source_text, tag.span),
+                    fix: None,
+                });
+            }
+        }
+    }
+}
+
+fn scan_reference_like_urls(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let definitions = definition_ids(facts, false);
+    for link in &facts.links {
+        let normalized = normalize_identifier(link.url.as_str());
+        if definitions.contains(&normalized) {
+            diagnostics.push(Diagnostic {
+                rule_name: "no-reference-like-urls",
+                message_id: "referenceLikeUrl",
+                data: DiagnosticData {
+                    link_type: Some(CompactString::from(if link.is_image {
+                        "image"
+                    } else {
+                        "link"
+                    })),
+                    prefix: Some(CompactString::from(if link.is_image { "!" } else { "" })),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, link.span),
+                fix: Some(DiagnosticFix {
+                    start: utf16_offset(source_text, link.span.start),
+                    end: utf16_offset(source_text, link.span.end),
+                    replacement: {
+                        let mut out = CompactString::new("");
+                        if link.is_image {
+                            out.push('!');
+                        }
+                        out.push('[');
+                        out.push_str(link.label.as_str());
+                        out.push_str("][");
+                        out.push_str(link.url.as_str());
+                        out.push(']');
+                        out
+                    },
+                }),
+            });
+        }
+    }
+}
+
+fn scan_reversed_media(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let Ok(reversed_re) = Regex::new(r"\(([^()\n]+)\)\[([^\]\n]+)\]") else {
+        return;
+    };
+    for line in &facts.lines {
+        if line.in_fence {
+            continue;
+        }
+        for captures in reversed_re.captures_iter(line.text) {
+            let Some(mat) = captures.get(0) else {
+                continue;
+            };
+            let label = captures.get(1).map(|value| value.as_str()).unwrap_or("");
+            let url = captures.get(2).map(|value| value.as_str()).unwrap_or("");
+            let start = line.start + mat.start();
+            let end = line.start + mat.end();
+            diagnostics.push(Diagnostic {
+                rule_name: "no-reversed-media-syntax",
+                message_id: "reversedSyntax",
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, ByteSpan { start, end }),
+                fix: Some(DiagnosticFix {
+                    start: utf16_offset(source_text, start),
+                    end: utf16_offset(source_text, end),
+                    replacement: {
+                        let mut out = CompactString::from("[");
+                        out.push_str(label);
+                        out.push_str("](");
+                        out.push_str(url);
+                        out.push(')');
+                        out
+                    },
+                }),
+            });
+        }
+    }
+}
+
+fn scan_space_in_emphasis(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let markers = if options.check_strikethrough {
+        EMPHASIS_AND_STRIKE_MARKERS
+    } else {
+        EMPHASIS_MARKERS
+    };
+    for line in &facts.lines {
+        if line.in_fence {
+            continue;
+        }
+        for marker in markers {
+            let mut search_start = 0;
+            while let Some(index) = line.text[search_start..].find(marker) {
+                let marker_start = search_start + index;
+                let marker_end = marker_start + marker.len();
+                let after = line.text.as_bytes().get(marker_end).copied();
+                let before = marker_start
+                    .checked_sub(1)
+                    .and_then(|idx| line.text.as_bytes().get(idx))
+                    .copied();
+                let violation =
+                    matches!(after, Some(b' ' | b'\t')) || matches!(before, Some(b' ' | b'\t'));
+                if violation {
+                    diagnostics.push(Diagnostic {
+                        rule_name: "no-space-in-emphasis",
+                        message_id: "spaceInEmphasis",
+                        data: DiagnosticData::default(),
+                        loc: line_index.loc_for_span(
+                            source_text,
+                            ByteSpan {
+                                start: line.start + marker_start,
+                                end: line.start + marker_end,
+                            },
+                        ),
+                        fix: None,
+                    });
+                }
+                search_start = marker_end;
+            }
+        }
+    }
+}
+
+fn scan_unused_definitions(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let used = used_label_ids(facts, false);
+    let used_footnotes = used_label_ids(facts, true);
+    for definition in &facts.definitions {
+        if definition.is_footnote {
+            if options.check_footnote_definitions
+                && !is_allowed(&options.allow_footnote_definitions, &definition.identifier)
+                && !used_footnotes.contains(&definition.identifier)
+            {
+                diagnostics.push(definition_diagnostic(
+                    "no-unused-definitions",
+                    "unusedFootnoteDefinition",
+                    source_text,
+                    line_index,
+                    definition,
+                    None,
+                ));
+            }
+        } else if !is_allowed(&options.allow_definitions, &definition.identifier)
+            && !used.contains(&definition.identifier)
+        {
+            diagnostics.push(definition_diagnostic(
+                "no-unused-definitions",
+                "unusedDefinition",
+                source_text,
+                line_index,
+                definition,
+                None,
+            ));
+        }
+    }
+}
+
+fn scan_require_alt_text(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for link in &facts.links {
+        if link.is_image && link.label.trim().is_empty() {
+            diagnostics.push(Diagnostic {
+                rule_name: "require-alt-text",
+                message_id: "altTextRequired",
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, link.span),
+                fix: None,
+            });
+        }
+    }
+    for tag in &facts.html_tags {
+        if !tag.name.eq_ignore_ascii_case("img") {
+            continue;
+        }
+        let alt = html_attr(tag.raw.as_str(), "alt");
+        let aria_hidden = html_attr(tag.raw.as_str(), "aria-hidden");
+        if aria_hidden.is_some_and(|value| value.eq_ignore_ascii_case("true")) {
+            continue;
+        }
+        if alt.is_none_or(|value| value.trim().is_empty()) {
+            diagnostics.push(Diagnostic {
+                rule_name: "require-alt-text",
+                message_id: "altTextRequired",
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, tag.span),
+                fix: None,
+            });
+        }
+    }
+}
+
+fn scan_table_column_count(
+    source_text: &str,
+    line_index: &LineIndex,
+    facts: &MarkdownFacts<'_>,
+    options: &ScanOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    for index in 1..facts.lines.len() {
+        let sep = &facts.lines[index];
+        if sep.in_fence || !looks_like_table_separator(sep.text) {
+            continue;
+        }
+        let header = &facts.lines[index - 1];
+        let expected = count_table_cells(header.text);
+        let mut row_index = index + 1;
+        while row_index < facts.lines.len() && facts.lines[row_index].text.contains('|') {
+            let row = &facts.lines[row_index];
+            if row.text.trim().is_empty() {
+                break;
+            }
+            let actual = count_table_cells(row.text);
+            if actual > expected || (options.check_missing_table_cells && actual < expected) {
+                diagnostics.push(Diagnostic {
+                    rule_name: "table-column-count",
+                    message_id: if actual > expected {
+                        "extraCells"
+                    } else {
+                        "missingCells"
+                    },
+                    data: DiagnosticData {
+                        expected_cells: Some(expected as u32),
+                        actual_cells: Some(actual as u32),
+                        ..DiagnosticData::default()
+                    },
+                    loc: line_index.loc_for_span(
+                        source_text,
+                        ByteSpan {
+                            start: row.start,
+                            end: row.end,
+                        },
+                    ),
+                    fix: None,
+                });
+            }
+            row_index += 1;
+        }
+    }
+}
+
+fn definition_diagnostic(
+    rule_name: &'static str,
+    message_id: &'static str,
+    source_text: &str,
+    line_index: &LineIndex,
+    definition: &DefinitionFact,
+    first: Option<&DefinitionFact>,
+) -> Diagnostic {
+    Diagnostic {
+        rule_name,
+        message_id,
+        data: DiagnosticData {
+            identifier: Some(definition.identifier.clone()),
+            label: Some(definition.label.clone()),
+            first_line: first.map(|definition| definition.line),
+            first_label: first.map(|definition| definition.label.clone()),
+            ..DiagnosticData::default()
+        },
+        loc: line_index.loc_for_span(source_text, definition.span),
+        fix: None,
+    }
+}
+
+fn definition_ids(facts: &MarkdownFacts<'_>, footnotes: bool) -> FastHashSet<CompactString> {
+    facts
+        .definitions
+        .iter()
+        .filter(|definition| definition.is_footnote == footnotes)
+        .map(|definition| definition.identifier.clone())
+        .collect()
+}
+
+fn used_label_ids(facts: &MarkdownFacts<'_>, footnotes: bool) -> FastHashSet<CompactString> {
+    facts
+        .label_refs
+        .iter()
+        .filter(|label_ref| label_ref.is_footnote == footnotes)
+        .map(|label_ref| normalize_identifier(label_ref.label.as_str()))
+        .collect()
+}
+
+fn is_allowed(values: &[CompactString], identifier: &CompactString) -> bool {
+    values
+        .iter()
+        .map(|value| normalize_identifier(value.as_str()))
+        .any(|value| value == *identifier)
+}
+
+fn split_indent(line: &str) -> (usize, &str) {
+    let indent = line.bytes().take_while(|byte| *byte == b' ').count();
+    (indent, &line[indent..])
+}
+
+fn split_fence_info(info: &str) -> (Option<CompactString>, Option<CompactString>) {
+    let trimmed = info.trim();
+    if trimmed.is_empty() {
+        return (None, None);
+    }
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let lang = parts
+        .next()
+        .filter(|part| !part.is_empty())
+        .map(CompactString::from);
+    let meta = parts
+        .next()
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(CompactString::from);
+    (lang, meta)
+}
+
+fn parse_atx_heading(line: &str) -> Option<(u8, &str)> {
+    let (indent, trimmed) = split_indent(line);
+    if indent > 3 {
+        return None;
+    }
+    let hashes = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    let after = trimmed.as_bytes().get(hashes).copied();
+    if !matches!(after, Some(b' ' | b'\t') | None) {
+        return None;
+    }
+    let mut text = trimmed[hashes..].trim();
+    if text.ends_with('#') {
+        text = text.trim_end_matches('#').trim_end();
+    }
+    Some((hashes as u8, text))
+}
+
+fn is_definition_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('[') && trimmed.contains("]:")
+}
+
+fn parse_inline_link(raw: &str, absolute_start: usize) -> Option<LinkFact> {
+    let is_image = raw.starts_with("!");
+    let label_open = usize::from(is_image);
+    let label_close = raw[label_open + 1..].find(']')? + label_open + 1;
+    let url_open = raw[label_close + 1..].find('(')? + label_close + 1;
+    let url_close = raw.rfind(')')?;
+    let label = &raw[label_open + 1..label_close];
+    let url = raw[url_open + 1..url_close].trim();
+    Some(LinkFact {
+        is_image,
+        label: CompactString::from(label),
+        url: CompactString::from(url.trim_matches(['<', '>'])),
+        span: ByteSpan {
+            start: absolute_start,
+            end: absolute_start + raw.len(),
+        },
+        url_span: ByteSpan {
+            start: absolute_start + url_open + 1,
+            end: absolute_start + url_close,
+        },
+    })
+}
+
+fn parse_label_ref(raw: &str, absolute_start: usize, absolute_end: usize) -> Option<LabelRefFact> {
+    let is_image = raw.starts_with('!');
+    let start = usize::from(is_image);
+    let first_close = raw[start + 1..].find(']')? + start + 1;
+    let is_footnote = raw[start + 1..].starts_with('^');
+    let label = if raw.as_bytes().get(first_close + 1) == Some(&b'[') {
+        let second_close = raw[first_close + 2..].find(']')? + first_close + 2;
+        &raw[first_close + 2..second_close]
+    } else {
+        &raw[start + 1..first_close]
+    };
+    Some(LabelRefFact {
+        label: CompactString::from(label.trim_start_matches('^')),
+        span: ByteSpan {
+            start: absolute_start,
+            end: absolute_end,
+        },
+        is_footnote,
+    })
+}
+
+fn trim_definition_url(url: &str) -> &str {
+    url.trim().trim_matches(['<', '>'])
+}
+
+fn normalize_identifier(value: &str) -> CompactString {
+    let mut out = CompactString::new("");
+    let mut previous_space = false;
+    for ch in value.trim().chars() {
+        if ch.is_whitespace() {
+            if !previous_space {
+                out.push(' ');
+                previous_space = true;
+            }
+        } else {
+            for lower in ch.to_lowercase() {
+                out.push(lower);
+            }
+            previous_space = false;
+        }
+    }
+    out
+}
+
+fn normalize_heading_text(value: &str) -> CompactString {
+    CompactString::from(value.trim())
+}
+
+fn lower(value: &str) -> CompactString {
+    let mut out = CompactString::new("");
+    for ch in value.chars() {
+        for lower in ch.to_lowercase() {
+            out.push(lower);
+        }
+    }
+    out
+}
+
+fn html_tag_name(raw: &str) -> CompactString {
+    let start = usize::from(raw.starts_with("</")) + 1;
+    let rest = raw.get(start..).unwrap_or("");
+    let end = rest
+        .find(|ch: char| ch.is_whitespace() || matches!(ch, '>' | '/'))
+        .unwrap_or(rest.len());
+    CompactString::from(&rest[..end])
+}
+
+fn html_attr<'a>(raw: &'a str, attr: &str) -> Option<&'a str> {
+    let mut search = raw;
+    while let Some(index) = find_ignore_ascii_case(search, attr) {
+        let after = &search[index + attr.len()..];
+        let trimmed = after.trim_start();
+        if !trimmed.starts_with('=') {
+            search = trimmed;
+            continue;
+        }
+        let value = trimmed[1..].trim_start();
+        if let Some(rest) = value.strip_prefix('"') {
+            return rest.split('"').next();
+        }
+        if let Some(rest) = value.strip_prefix('\'') {
+            return rest.split('\'').next();
+        }
+        return value
+            .split(|ch: char| ch.is_whitespace() || ch == '>')
+            .next();
+    }
+    None
+}
+
+fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
+fn in_fenced_range(facts: &MarkdownFacts<'_>, offset: usize) -> bool {
+    facts
+        .lines
+        .iter()
+        .any(|line| line.in_fence && offset >= line.start && offset <= line.end)
+}
+
+fn is_inside_angle_autolink(source_text: &str, start: usize, end: usize) -> bool {
+    source_text[..start].ends_with('<') && source_text[end..].starts_with('>')
+}
+
+fn is_inside_markdown_destination(links: &[LinkFact], offset: usize) -> bool {
+    links
+        .iter()
+        .any(|link| offset >= link.url_span.start && offset <= link.url_span.end)
+}
+
+fn is_inside_html_tag(tags: &[HtmlTagFact], offset: usize) -> bool {
+    tags.iter()
+        .any(|tag| offset >= tag.span.start && offset <= tag.span.end)
+}
+
+fn github_slug(value: &str) -> CompactString {
+    let mut out = CompactString::new("");
+    let mut previous_dash = false;
+    for ch in value.trim().chars() {
+        if ch.is_alphanumeric() {
+            for lower in ch.to_lowercase() {
+                out.push(lower);
+            }
+            previous_dash = false;
+        } else if (ch.is_whitespace() || ch == '-') && !previous_dash && !out.is_empty() {
+            out.push('-');
+            previous_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+fn is_github_line_ref(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix('L') else {
+        return false;
+    };
+    rest.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+}
+
+fn looks_like_table_separator(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.contains('|')
+        && trimmed
+            .chars()
+            .all(|ch| matches!(ch, '|' | '-' | ':' | ' ' | '\t'))
+        && trimmed.contains("---")
+}
+
+fn count_table_cells(line: &str) -> usize {
+    let trimmed = line.trim().trim_matches('|');
+    trimmed.split('|').count()
+}
+
+fn utf16_offset(source_text: &str, byte_offset: usize) -> u32 {
+    source_text[..byte_offset.min(source_text.len())]
+        .chars()
+        .map(char::len_utf16)
+        .sum::<usize>() as u32
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: ByteSpan) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: usize) -> (u32, u32) {
+        let offset = offset.min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RULE_NAMES, ScanOptions, scan_eslint_markdown};
+
+    #[test]
+    fn exposes_all_rule_names() {
+        assert_eq!(RULE_NAMES.len(), 21);
+        assert!(RULE_NAMES.contains(&"fenced-code-language"));
+        assert!(RULE_NAMES.contains(&"table-column-count"));
+    }
+
+    #[test]
+    fn scans_representative_rules() {
+        let source = [
+            "```",
+            "code",
+            "```",
+            "",
+            "# Title",
+            "### Skipped",
+            "# Title",
+            "",
+            "[foo]: #",
+            "[foo]: https://example.com",
+            "[missing][nope]",
+            "[empty]()",
+            "![](#)",
+            "(label)[https://example.com]",
+            "https://example.com",
+            "<div><img src=\"x\"></div>",
+            "| a | b |",
+            "| --- | --- |",
+            "| 1 | 2 | 3 |",
+        ]
+        .join("\n");
+        let diagnostics = scan_eslint_markdown(&source, &ScanOptions::default());
+        let rule_names: oxlint_plugins_carton::SmallVec<[&str; 24]> = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.rule_name)
+            .collect();
+
+        assert!(rule_names.contains(&"fenced-code-language"));
+        assert!(rule_names.contains(&"heading-increment"));
+        assert!(rule_names.contains(&"no-duplicate-headings"));
+        assert!(rule_names.contains(&"no-empty-definitions"));
+        assert!(rule_names.contains(&"no-empty-links"));
+        assert!(rule_names.contains(&"no-empty-images"));
+        assert!(rule_names.contains(&"no-reversed-media-syntax"));
+        assert!(rule_names.contains(&"no-bare-urls"));
+        assert!(rule_names.contains(&"no-html"));
+        assert!(rule_names.contains(&"require-alt-text"));
+        assert!(rule_names.contains(&"table-column-count"));
+    }
+}

--- a/npm/eslint-markdown/Cargo.toml
+++ b/npm/eslint-markdown/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oxlint-plugin-eslint-markdown"
+description = "NAPI wrapper for the @eslint/markdown oxlint plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-eslint-markdown.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints]
+workspace = true

--- a/npm/eslint-markdown/LICENSE
+++ b/npm/eslint-markdown/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 oxlint-plugins contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/eslint-markdown/README.md
+++ b/npm/eslint-markdown/README.md
@@ -1,0 +1,8 @@
+# @oxlint-plugins/oxlint-plugin-eslint-markdown
+
+Rust-backed Oxlint plugin port of `@eslint/markdown`.
+
+The native core scans Markdown source text and implements the upstream Markdown
+rules through a NAPI adapter. Oxlint 1.68 does not currently route `.md` files
+to `jsPlugins`, so integration coverage is limited to the direct ESLint
+compatible adapter and native API.

--- a/npm/eslint-markdown/api.d.ts
+++ b/npm/eslint-markdown/api.d.ts
@@ -1,0 +1,94 @@
+export type EslintMarkdownRuleName =
+  | 'fenced-code-language'
+  | 'fenced-code-meta'
+  | 'heading-increment'
+  | 'no-bare-urls'
+  | 'no-duplicate-definitions'
+  | 'no-duplicate-headings'
+  | 'no-empty-definitions'
+  | 'no-empty-images'
+  | 'no-empty-links'
+  | 'no-html'
+  | 'no-invalid-label-refs'
+  | 'no-missing-atx-heading-space'
+  | 'no-missing-label-refs'
+  | 'no-missing-link-fragments'
+  | 'no-multiple-h1'
+  | 'no-reference-like-urls'
+  | 'no-reversed-media-syntax'
+  | 'no-space-in-emphasis'
+  | 'no-unused-definitions'
+  | 'require-alt-text'
+  | 'table-column-count';
+
+export type DiagnosticData = {
+  lang?: string;
+  name?: string;
+  identifier?: string;
+  label?: string;
+  firstLine?: number;
+  firstLabel?: string;
+  fromLevel?: number;
+  toLevel?: number;
+  position?: string;
+  text?: string;
+  linkType?: string;
+  prefix?: string;
+  fragment?: string;
+  expectedCells?: number;
+  actualCells?: number;
+};
+
+export type DiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type DiagnosticFix = {
+  start: number;
+  end: number;
+  replacement: string;
+};
+
+export type Diagnostic = {
+  ruleName: EslintMarkdownRuleName;
+  messageId: string;
+  data: DiagnosticData;
+  loc: DiagnosticLoc;
+  fix?: DiagnosticFix;
+};
+
+export type ScanEslintMarkdownOptions = {
+  ruleNames?: readonly string[];
+  requiredCodeLanguages?: readonly string[];
+  fencedCodeMetaMode?: 'always' | 'never';
+  frontmatterTitle?: string;
+  checkClosedHeadings?: boolean;
+  checkStrikethrough?: boolean;
+  allowedHtml?: readonly string[];
+  allowedHtmlIgnoreCase?: boolean;
+  allowLabels?: readonly string[];
+  allowDefinitions?: readonly string[];
+  allowFootnoteDefinitions?: readonly string[];
+  checkFootnoteDefinitions?: boolean;
+  checkDuplicateHeadingsSiblingsOnly?: boolean;
+  ignoreFragmentCase?: boolean;
+  allowFragmentPattern?: string;
+  checkMissingTableCells?: boolean;
+};
+
+export function implementedEslintMarkdownRuleNames(): EslintMarkdownRuleName[];
+
+export function scanEslintMarkdown(
+  sourceText: string,
+  options?: ScanEslintMarkdownOptions,
+): Diagnostic[];
+
+declare const api: {
+  implementedEslintMarkdownRuleNames: typeof implementedEslintMarkdownRuleNames;
+  scanEslintMarkdown: typeof scanEslintMarkdown;
+};
+
+export default api;

--- a/npm/eslint-markdown/api.js
+++ b/npm/eslint-markdown/api.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanEslintMarkdown(sourceText, options = {}) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+
+  return native.scanEslintMarkdown(sourceText, normalizeOptions(options));
+}
+
+function normalizeOptions(options) {
+  if (!options || typeof options !== 'object') {
+    return {};
+  }
+
+  return {
+    ruleNames: normalizeStringList(options.ruleNames),
+    requiredCodeLanguages: normalizeStringList(options.requiredCodeLanguages),
+    fencedCodeMetaMode:
+      options.fencedCodeMetaMode === 'never' || options.fencedCodeMetaMode === 'always'
+        ? options.fencedCodeMetaMode
+        : undefined,
+    frontmatterTitle:
+      typeof options.frontmatterTitle === 'string' ? options.frontmatterTitle : undefined,
+    checkClosedHeadings: normalizeBoolean(options.checkClosedHeadings),
+    checkStrikethrough: normalizeBoolean(options.checkStrikethrough),
+    allowedHtml: normalizeStringList(options.allowedHtml),
+    allowedHtmlIgnoreCase: normalizeBoolean(options.allowedHtmlIgnoreCase),
+    allowLabels: normalizeStringList(options.allowLabels),
+    allowDefinitions: normalizeStringList(options.allowDefinitions),
+    allowFootnoteDefinitions: normalizeStringList(options.allowFootnoteDefinitions),
+    checkFootnoteDefinitions: normalizeBoolean(options.checkFootnoteDefinitions),
+    checkDuplicateHeadingsSiblingsOnly: normalizeBoolean(
+      options.checkDuplicateHeadingsSiblingsOnly,
+    ),
+    ignoreFragmentCase: normalizeBoolean(options.ignoreFragmentCase),
+    allowFragmentPattern:
+      typeof options.allowFragmentPattern === 'string' ? options.allowFragmentPattern : undefined,
+    checkMissingTableCells: normalizeBoolean(options.checkMissingTableCells),
+  };
+}
+
+function normalizeStringList(values) {
+  if (!Array.isArray(values)) {
+    return undefined;
+  }
+  return values.filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+function normalizeBoolean(value) {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+module.exports = {
+  implementedEslintMarkdownRuleNames: native.implementedEslintMarkdownRuleNames,
+  scanEslintMarkdown,
+};
+module.exports.default = module.exports;

--- a/npm/eslint-markdown/build.rs
+++ b/npm/eslint-markdown/build.rs
@@ -1,0 +1,5 @@
+extern crate napi_build;
+
+fn main() {
+    napi_build::setup();
+}

--- a/npm/eslint-markdown/index.js
+++ b/npm/eslint-markdown/index.js
@@ -1,0 +1,459 @@
+'use strict';
+
+// Oxlint plugin port of @eslint/markdown (MIT).
+// Markdown source scanning, rule option handling, and autofix range calculation
+// run in Rust through NAPI-RS. Oxlint 1.68 does not pass .md files to jsPlugins,
+// so this package exposes the adapter and native API while keeping CLI
+// integration disabled in status metadata.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedEslintMarkdownRuleNames, scanEslintMarkdown } = require('./api.js');
+
+const PLUGIN_NAME = 'markdown';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-markdown';
+const diagnosticsCache = new WeakMap();
+
+const recommendedRuleNames = Object.freeze([
+  'fenced-code-language',
+  'heading-increment',
+  'no-duplicate-definitions',
+  'no-empty-definitions',
+  'no-empty-images',
+  'no-empty-links',
+  'no-invalid-label-refs',
+  'no-missing-atx-heading-space',
+  'no-missing-label-refs',
+  'no-missing-link-fragments',
+  'no-multiple-h1',
+  'no-reference-like-urls',
+  'no-reversed-media-syntax',
+  'no-space-in-emphasis',
+  'no-unused-definitions',
+  'require-alt-text',
+  'table-column-count',
+]);
+
+const ruleDescriptions = Object.freeze({
+  'fenced-code-language': 'Require languages for fenced code blocks',
+  'fenced-code-meta': 'Require or disallow metadata for fenced code blocks',
+  'heading-increment': 'Enforce heading levels increment by one',
+  'no-bare-urls': 'Disallow bare URLs',
+  'no-duplicate-definitions': 'Disallow duplicate definitions',
+  'no-duplicate-headings': 'Disallow duplicate headings in the same document',
+  'no-empty-definitions': 'Disallow empty definitions',
+  'no-empty-images': 'Disallow empty images',
+  'no-empty-links': 'Disallow empty links',
+  'no-html': 'Disallow HTML tags',
+  'no-invalid-label-refs': 'Disallow invalid label references',
+  'no-missing-atx-heading-space': 'Require spaces around ATX heading hash characters',
+  'no-missing-label-refs': 'Disallow missing label references',
+  'no-missing-link-fragments': "Disallow link fragments that don't exist in the document",
+  'no-multiple-h1': 'Disallow multiple H1 headings in the same document',
+  'no-reference-like-urls': 'Disallow URLs that match defined reference identifiers',
+  'no-reversed-media-syntax': 'Disallow reversed link and image syntax',
+  'no-space-in-emphasis': 'Disallow spaces around emphasis markers',
+  'no-unused-definitions': 'Disallow unused definitions',
+  'require-alt-text': 'Require alternative text for images',
+  'table-column-count':
+    'Disallow data rows in a GitHub Flavored Markdown table from having more cells than the header row',
+});
+
+const ruleMessages = Object.freeze({
+  'fenced-code-language': {
+    missingLanguage: 'Missing code block language.',
+    disallowedLanguage: 'Code block language "{{lang}}" is not allowed.',
+  },
+  'fenced-code-meta': {
+    missingMetadata: 'Missing code block metadata.',
+    disallowedMetadata: 'Code block metadata is not allowed.',
+  },
+  'heading-increment': {
+    skippedHeading: 'Heading level skipped from {{fromLevel}} to {{toLevel}}.',
+  },
+  'no-bare-urls': {
+    bareUrl: 'Unexpected bare URL. Use autolink (<URL>) or link ([text](URL)) instead.',
+  },
+  'no-duplicate-definitions': {
+    duplicateDefinition:
+      'Unexpected duplicate definition `{{ identifier }}` (label: `{{ label }}`) found. First defined at line {{ firstLine }} (label: `{{ firstLabel }}`).',
+    duplicateFootnoteDefinition:
+      'Unexpected duplicate footnote definition `{{ identifier }}` (label: `{{ label }}`) found. First defined at line {{ firstLine }} (label: `{{ firstLabel }}`).',
+  },
+  'no-duplicate-headings': {
+    duplicateHeading: 'Duplicate heading "{{text}}" found.',
+  },
+  'no-empty-definitions': {
+    emptyDefinition: 'Unexpected empty definition `{{ identifier }}` (label: `{{ label }}`) found.',
+    emptyFootnoteDefinition:
+      'Unexpected empty footnote definition `{{ identifier }}` (label: `{{ label }}`) found.',
+  },
+  'no-empty-images': {
+    emptyImage: 'Unexpected empty image found.',
+  },
+  'no-empty-links': {
+    emptyLink: 'Unexpected empty link found.',
+  },
+  'no-html': {
+    disallowedElement: 'HTML element "{{name}}" is not allowed.',
+  },
+  'no-invalid-label-refs': {
+    invalidLabelRef: "Label reference '{{label}}' is invalid due to white space between [ and ].",
+  },
+  'no-missing-atx-heading-space': {
+    missingSpace: 'Missing space {{position}} hash(es) on ATX style heading.',
+  },
+  'no-missing-label-refs': {
+    notFound: "Label reference '{{label}}' not found.",
+  },
+  'no-missing-link-fragments': {
+    invalidFragment:
+      "Link fragment '#{{fragment}}' does not reference a heading or anchor in this document.",
+  },
+  'no-multiple-h1': {
+    multipleH1: 'Unexpected additional H1 heading found.',
+  },
+  'no-reference-like-urls': {
+    referenceLikeUrl:
+      "Unexpected resource {{type}} ('{{prefix}}[text](url)') with URL that matches a definition identifier. Use '[text][id]' syntax instead.",
+  },
+  'no-reversed-media-syntax': {
+    reversedSyntax: 'Unexpected reversed syntax found. Use [label](URL) syntax instead.',
+  },
+  'no-space-in-emphasis': {
+    spaceInEmphasis: 'Unexpected space around emphasis marker.',
+  },
+  'no-unused-definitions': {
+    unusedDefinition:
+      'Unexpected unused definition `{{ identifier }}` (label: `{{ label }}`) found.',
+    unusedFootnoteDefinition:
+      'Unexpected unused footnote definition `{{ identifier }}` (label: `{{ label }}`) found.',
+  },
+  'require-alt-text': {
+    altTextRequired: 'Alternative text for image is required.',
+  },
+  'table-column-count': {
+    extraCells:
+      'Table column count mismatch (Expected: {{expectedCells}}, Actual: {{actualCells}}), extra data starting here will be ignored.',
+    missingCells:
+      'Table column count mismatch (Expected: {{expectedCells}}, Actual: {{actualCells}}), row might be missing data.',
+  },
+});
+
+const fixableRules = Object.freeze({
+  'no-bare-urls': 'code',
+  'no-missing-atx-heading-space': 'whitespace',
+  'no-reference-like-urls': 'code',
+  'no-reversed-media-syntax': 'code',
+  'no-space-in-emphasis': 'whitespace',
+});
+
+const stringArraySchema = Object.freeze({
+  type: 'array',
+  items: { type: 'string' },
+  uniqueItems: true,
+});
+const definitionOptionsSchema = Object.freeze([
+  {
+    type: 'object',
+    properties: {
+      allowDefinitions: stringArraySchema,
+      allowFootnoteDefinitions: stringArraySchema,
+      checkFootnoteDefinitions: { type: 'boolean' },
+    },
+    additionalProperties: false,
+  },
+]);
+
+const ruleSchemas = Object.freeze({
+  'fenced-code-language': [
+    {
+      type: 'object',
+      properties: {
+        required: stringArraySchema,
+      },
+      additionalProperties: false,
+    },
+  ],
+  'fenced-code-meta': [{ enum: ['always', 'never'] }],
+  'heading-increment': [
+    {
+      type: 'object',
+      properties: {
+        frontmatterTitle: { type: 'string' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-duplicate-definitions': definitionOptionsSchema,
+  'no-duplicate-headings': [
+    {
+      type: 'object',
+      properties: {
+        checkSiblingsOnly: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-empty-definitions': definitionOptionsSchema,
+  'no-html': [
+    {
+      type: 'object',
+      properties: {
+        allowed: stringArraySchema,
+        allowedIgnoreCase: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-missing-atx-heading-space': [
+    {
+      type: 'object',
+      properties: {
+        checkClosedHeadings: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-missing-label-refs': [
+    {
+      type: 'object',
+      properties: {
+        allowLabels: stringArraySchema,
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-missing-link-fragments': [
+    {
+      type: 'object',
+      properties: {
+        ignoreCase: { type: 'boolean' },
+        allowPattern: { type: 'string' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-multiple-h1': [
+    {
+      type: 'object',
+      properties: {
+        frontmatterTitle: { type: 'string' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-space-in-emphasis': [
+    {
+      type: 'object',
+      properties: {
+        checkStrikethrough: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+  ],
+  'no-unused-definitions': definitionOptionsSchema,
+  'table-column-count': [
+    {
+      type: 'object',
+      properties: {
+        checkMissingCells: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+  ],
+});
+
+const implementedRuleNames = Object.freeze(implementedEslintMarkdownRuleNames());
+const recommendedRuleConfig = Object.freeze(
+  Object.fromEntries(
+    recommendedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
+  ),
+);
+const allRuleConfig = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
+  ),
+);
+
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createMarkdownRule(ruleName)]),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: '@eslint/markdown',
+    version: '8.0.2',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: configFromRuleConfig('recommended', recommendedRuleConfig),
+    all: configFromRuleConfig('all', allRuleConfig),
+  },
+});
+
+plugin.implementedEslintMarkdownRuleNames = implementedRuleNames;
+plugin.scanEslintMarkdown = scanEslintMarkdown;
+
+function configFromRuleConfig(name, ruleConfig) {
+  return {
+    name: `${PLUGIN_NAME}/${name}`,
+    plugins: [PLUGIN_NAME],
+    rules: { ...ruleConfig },
+  };
+}
+
+function createMarkdownRule(ruleName) {
+  return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: ruleDescriptions[ruleName],
+        recommended: recommendedRuleNames.includes(ruleName),
+        url: `${DOCS_BASE}#${ruleName}`,
+      },
+      fixable: fixableRules[ruleName],
+      messages: ruleMessages[ruleName],
+      schema: ruleSchemas[ruleName] ?? [],
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForRule(context, ruleName)) {
+            reportDiagnostic(context, diagnostic);
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForRule(context, ruleName) {
+  const sourceCode = context.sourceCode ?? context.getSourceCode();
+  let bySource = diagnosticsCache.get(sourceCode);
+  if (!bySource) {
+    bySource = new Map();
+    diagnosticsCache.set(sourceCode, bySource);
+  }
+
+  const scanOptions = optionsForRule(ruleName, context.options?.[0]);
+  const cacheKey = `${ruleName}\0${JSON.stringify(scanOptions)}`;
+  let diagnostics = bySource.get(cacheKey);
+  if (!diagnostics) {
+    diagnostics = scanEslintMarkdown(sourceCode.text, scanOptions).filter(
+      (diagnostic) => diagnostic.ruleName === ruleName,
+    );
+    bySource.set(cacheKey, diagnostics);
+  }
+
+  return diagnostics;
+}
+
+function optionsForRule(ruleName, rawOptions) {
+  const ruleOptions = rawOptions && typeof rawOptions === 'object' ? rawOptions : {};
+  const scanOptions = { ruleNames: [ruleName] };
+
+  switch (ruleName) {
+    case 'fenced-code-language':
+      scanOptions.requiredCodeLanguages = stringList(ruleOptions.required);
+      break;
+    case 'fenced-code-meta':
+      scanOptions.fencedCodeMetaMode = rawOptions === 'never' ? 'never' : 'always';
+      break;
+    case 'heading-increment':
+    case 'no-multiple-h1':
+      if (typeof ruleOptions.frontmatterTitle === 'string') {
+        scanOptions.frontmatterTitle = ruleOptions.frontmatterTitle;
+      }
+      break;
+    case 'no-duplicate-definitions':
+    case 'no-empty-definitions':
+    case 'no-unused-definitions':
+      scanOptions.allowDefinitions = stringList(ruleOptions.allowDefinitions);
+      scanOptions.allowFootnoteDefinitions = stringList(ruleOptions.allowFootnoteDefinitions);
+      scanOptions.checkFootnoteDefinitions = booleanOption(ruleOptions.checkFootnoteDefinitions);
+      break;
+    case 'no-duplicate-headings':
+      scanOptions.checkDuplicateHeadingsSiblingsOnly = booleanOption(ruleOptions.checkSiblingsOnly);
+      break;
+    case 'no-html':
+      scanOptions.allowedHtml = stringList(ruleOptions.allowed);
+      scanOptions.allowedHtmlIgnoreCase = booleanOption(ruleOptions.allowedIgnoreCase);
+      break;
+    case 'no-missing-atx-heading-space':
+      scanOptions.checkClosedHeadings = booleanOption(ruleOptions.checkClosedHeadings);
+      break;
+    case 'no-missing-label-refs':
+      scanOptions.allowLabels = stringList(ruleOptions.allowLabels);
+      break;
+    case 'no-missing-link-fragments':
+      scanOptions.ignoreFragmentCase = booleanOption(ruleOptions.ignoreCase);
+      if (typeof ruleOptions.allowPattern === 'string') {
+        scanOptions.allowFragmentPattern = ruleOptions.allowPattern;
+      }
+      break;
+    case 'no-space-in-emphasis':
+      scanOptions.checkStrikethrough = booleanOption(ruleOptions.checkStrikethrough);
+      break;
+    case 'table-column-count':
+      scanOptions.checkMissingTableCells = booleanOption(ruleOptions.checkMissingCells);
+      break;
+  }
+
+  return scanOptions;
+}
+
+function stringList(values) {
+  return Array.isArray(values)
+    ? values.filter((value) => typeof value === 'string' && value.length > 0)
+    : undefined;
+}
+
+function booleanOption(value) {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function dataForReport(data) {
+  const out = {};
+  for (const [key, value] of Object.entries(data ?? {})) {
+    if (value != null) {
+      out[key] = String(value);
+    }
+  }
+  if (out.linkType != null) {
+    out.type = out.linkType;
+  }
+  return out;
+}
+
+function reportDiagnostic(context, diagnostic) {
+  const report = {
+    messageId: diagnostic.messageId,
+    data: dataForReport(diagnostic.data),
+    loc: {
+      start: {
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn,
+      },
+      end: {
+        line: diagnostic.loc.endLine,
+        column: diagnostic.loc.endColumn,
+      },
+    },
+  };
+
+  if (diagnostic.fix) {
+    report.fix = (fixer) =>
+      fixer.replaceTextRange(
+        [diagnostic.fix.start, diagnostic.fix.end],
+        diagnostic.fix.replacement,
+      );
+  }
+
+  context.report(report);
+}
+
+module.exports = plugin;
+module.exports.default = plugin;

--- a/npm/eslint-markdown/package.json
+++ b/npm/eslint-markdown/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-eslint-markdown",
+  "version": "0.0.0",
+  "description": "Rust-backed Oxlint plugin port of @eslint/markdown.",
+  "keywords": [
+    "eslint-plugin",
+    "markdown",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/eslint-markdown"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_eslint_markdown",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/eslint-markdown/src/lib.rs
+++ b/npm/eslint-markdown/src/lib.rs
@@ -1,0 +1,219 @@
+//! NAPI boundary for the @eslint/markdown oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, EslintMarkdownScanOptions,
+    implemented_eslint_markdown_rule_names, scan_eslint_markdown,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use oxlint_plugins_eslint_markdown as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct EslintMarkdownScanOptions {
+        pub rule_names: Option<Vec<String>>,
+        pub required_code_languages: Option<Vec<String>>,
+        pub fenced_code_meta_mode: Option<String>,
+        pub frontmatter_title: Option<String>,
+        pub check_closed_headings: Option<bool>,
+        pub check_strikethrough: Option<bool>,
+        pub allowed_html: Option<Vec<String>>,
+        pub allowed_html_ignore_case: Option<bool>,
+        pub allow_labels: Option<Vec<String>>,
+        pub allow_definitions: Option<Vec<String>>,
+        pub allow_footnote_definitions: Option<Vec<String>>,
+        pub check_footnote_definitions: Option<bool>,
+        pub check_duplicate_headings_siblings_only: Option<bool>,
+        pub ignore_fragment_case: Option<bool>,
+        pub allow_fragment_pattern: Option<String>,
+        pub check_missing_table_cells: Option<bool>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct DiagnosticData {
+        pub lang: Option<String>,
+        pub name: Option<String>,
+        pub identifier: Option<String>,
+        pub label: Option<String>,
+        pub first_line: Option<u32>,
+        pub first_label: Option<String>,
+        pub from_level: Option<u32>,
+        pub to_level: Option<u32>,
+        pub position: Option<String>,
+        pub text: Option<String>,
+        pub link_type: Option<String>,
+        pub prefix: Option<String>,
+        pub fragment: Option<String>,
+        pub expected_cells: Option<u32>,
+        pub actual_cells: Option<u32>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticFix {
+        pub start: u32,
+        pub end: u32,
+        pub replacement: String,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub data: DiagnosticData,
+        pub loc: DiagnosticLoc,
+        pub fix: Option<DiagnosticFix>,
+    }
+
+    #[napi]
+    pub fn implemented_eslint_markdown_rule_names() -> Vec<String> {
+        core::implemented_eslint_markdown_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_eslint_markdown(
+        source_text: String,
+        options: Option<EslintMarkdownScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let core_options = to_core_options(options.unwrap_or_default());
+        core::scan_eslint_markdown(&source_text, &core_options)
+            .into_iter()
+            .map(to_diagnostic)
+            .collect()
+    }
+
+    fn to_core_options(options: EslintMarkdownScanOptions) -> core::ScanOptions {
+        let default_rule_names = options.rule_names.is_none();
+        let mut core_options = core::ScanOptions {
+            rule_names: compact_known_rule_names(options.rule_names),
+            required_code_languages: compact_list(options.required_code_languages),
+            fenced_code_meta_mode: match options.fenced_code_meta_mode.as_deref() {
+                Some("never") => core::MetaMode::Never,
+                _ => core::MetaMode::Always,
+            },
+            frontmatter_title: options.frontmatter_title.map(CompactString::from),
+            check_closed_headings: options.check_closed_headings.unwrap_or(false),
+            check_strikethrough: options.check_strikethrough.unwrap_or(false),
+            allowed_html: compact_list(options.allowed_html),
+            allowed_html_ignore_case: options.allowed_html_ignore_case.unwrap_or(false),
+            allow_labels: compact_list(options.allow_labels),
+            allow_definitions: defaulted_list(options.allow_definitions, &["//"]),
+            allow_footnote_definitions: compact_list(options.allow_footnote_definitions),
+            check_footnote_definitions: options.check_footnote_definitions.unwrap_or(true),
+            check_duplicate_headings_siblings_only: options
+                .check_duplicate_headings_siblings_only
+                .unwrap_or(false),
+            ignore_fragment_case: options.ignore_fragment_case.unwrap_or(true),
+            allow_fragment_pattern: options.allow_fragment_pattern.map(CompactString::from),
+            check_missing_table_cells: options.check_missing_table_cells.unwrap_or(false),
+        };
+
+        if core_options.rule_names.is_empty() && default_rule_names {
+            core_options.rule_names = core::implemented_eslint_markdown_rule_names()
+                .iter()
+                .map(|name| CompactString::from(*name))
+                .collect();
+        }
+
+        core_options
+    }
+
+    fn to_diagnostic(diagnostic: core::Diagnostic) -> Diagnostic {
+        Diagnostic {
+            rule_name: diagnostic.rule_name.to_owned(),
+            message_id: diagnostic.message_id.to_owned(),
+            data: DiagnosticData {
+                lang: diagnostic.data.lang.map(CompactString::into_string),
+                name: diagnostic.data.name.map(CompactString::into_string),
+                identifier: diagnostic.data.identifier.map(CompactString::into_string),
+                label: diagnostic.data.label.map(CompactString::into_string),
+                first_line: diagnostic.data.first_line,
+                first_label: diagnostic.data.first_label.map(CompactString::into_string),
+                from_level: diagnostic.data.from_level,
+                to_level: diagnostic.data.to_level,
+                position: diagnostic.data.position.map(CompactString::into_string),
+                text: diagnostic.data.text.map(CompactString::into_string),
+                link_type: diagnostic.data.link_type.map(CompactString::into_string),
+                prefix: diagnostic.data.prefix.map(CompactString::into_string),
+                fragment: diagnostic.data.fragment.map(CompactString::into_string),
+                expected_cells: diagnostic.data.expected_cells,
+                actual_cells: diagnostic.data.actual_cells,
+            },
+            loc: DiagnosticLoc {
+                start_line: diagnostic.loc.start_line,
+                start_column: diagnostic.loc.start_column,
+                end_line: diagnostic.loc.end_line,
+                end_column: diagnostic.loc.end_column,
+            },
+            fix: diagnostic.fix.map(|fix| DiagnosticFix {
+                start: fix.start,
+                end: fix.end,
+                replacement: fix.replacement.into_string(),
+            }),
+        }
+    }
+
+    fn compact_known_rule_names(values: Option<Vec<String>>) -> SmallVec<[CompactString; 21]> {
+        values.map_or_else(SmallVec::new, |values| {
+            values
+                .into_iter()
+                .filter(|value| {
+                    core::implemented_eslint_markdown_rule_names().contains(&value.as_str())
+                })
+                .map(CompactString::from)
+                .collect()
+        })
+    }
+
+    fn compact_list(values: Option<Vec<String>>) -> SmallVec<[CompactString; 8]> {
+        values.map_or_else(SmallVec::new, |values| {
+            values
+                .into_iter()
+                .filter(|value| !value.is_empty())
+                .map(CompactString::from)
+                .collect()
+        })
+    }
+
+    fn defaulted_list(
+        values: Option<Vec<String>>,
+        default_values: &[&str],
+    ) -> SmallVec<[CompactString; 8]> {
+        values.map_or_else(
+            || {
+                default_values
+                    .iter()
+                    .map(|value| CompactString::from(*value))
+                    .collect()
+            },
+            |values| {
+                values
+                    .into_iter()
+                    .filter(|value| !value.is_empty())
+                    .map(CompactString::from)
+                    .collect()
+            },
+        )
+    }
+}

--- a/npm/eslint-markdown/test/api.test.mjs
+++ b/npm/eslint-markdown/test/api.test.mjs
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedEslintMarkdownRuleNames, scanEslintMarkdown } from '../api.js';
+
+const expectedRuleNames = [
+  'fenced-code-language',
+  'fenced-code-meta',
+  'heading-increment',
+  'no-bare-urls',
+  'no-duplicate-definitions',
+  'no-duplicate-headings',
+  'no-empty-definitions',
+  'no-empty-images',
+  'no-empty-links',
+  'no-html',
+  'no-invalid-label-refs',
+  'no-missing-atx-heading-space',
+  'no-missing-label-refs',
+  'no-missing-link-fragments',
+  'no-multiple-h1',
+  'no-reference-like-urls',
+  'no-reversed-media-syntax',
+  'no-space-in-emphasis',
+  'no-unused-definitions',
+  'require-alt-text',
+  'table-column-count',
+];
+
+function applyFix(sourceText, fix) {
+  return sourceText.slice(0, fix.start) + fix.replacement + sourceText.slice(fix.end);
+}
+
+describe('@eslint/markdown native API', () => {
+  it('exposes all ported rule names', () => {
+    expect(implementedEslintMarkdownRuleNames()).toEqual(expectedRuleNames);
+  });
+
+  it('scans representative Markdown for all implemented rules', () => {
+    const source = [
+      '---',
+      'title: Example',
+      '---',
+      '',
+      '```',
+      'plain',
+      '```',
+      '',
+      '```js',
+      'console.log(1);',
+      '```',
+      '',
+      '#Title',
+      '# Before',
+      '### Skipped',
+      '# Title',
+      '# Title',
+      '',
+      '[foo]: #',
+      '[foo]: https://example.com',
+      '[ref]: https://example.com',
+      '[unused]: https://example.com',
+      '[missing][nope]',
+      '[empty]()',
+      '![](#)',
+      '[resource](ref)',
+      '[broken](#missing)',
+      '(label)[https://example.com]',
+      'https://example.com',
+      '* spaced *',
+      '[ ][]',
+      '<div><img src="x"></div>',
+      '',
+      '| a | b |',
+      '| --- | --- |',
+      '| 1 | 2 | 3 |',
+    ].join('\n');
+
+    const ruleNames = new Set(scanEslintMarkdown(source).map((diagnostic) => diagnostic.ruleName));
+
+    expect([...ruleNames].sort()).toEqual([...expectedRuleNames].sort());
+  });
+
+  it('supports fenced-code-language required language options', () => {
+    const diagnostics = scanEslintMarkdown('```ts\nlet value = 1;\n```', {
+      ruleNames: ['fenced-code-language'],
+      requiredCodeLanguages: ['js'],
+    });
+
+    expect(diagnostics).toMatchObject([
+      {
+        ruleName: 'fenced-code-language',
+        messageId: 'disallowedLanguage',
+        data: { lang: 'ts' },
+      },
+    ]);
+  });
+
+  it('fixes bare URLs as autolinks', () => {
+    const source = 'See https://example.com/path.';
+    const diagnostics = scanEslintMarkdown(source, { ruleNames: ['no-bare-urls'] });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(applyFix(source, diagnostics[0].fix)).toBe('See <https://example.com/path>.');
+  });
+
+  it('honors HTML allow lists and fragment allow patterns', () => {
+    expect(
+      scanEslintMarkdown('<div id="ok">x</div>\n[figure](#figure-1)', {
+        ruleNames: ['no-html', 'no-missing-link-fragments'],
+        allowedHtml: ['DIV'],
+        allowedHtmlIgnoreCase: true,
+        allowFragmentPattern: '^figure-',
+      }),
+    ).toEqual([]);
+  });
+
+  it('can disable frontmatter H1 detection through frontmatterTitle', () => {
+    expect(
+      scanEslintMarkdown('---\ntitle: Example\n---\n# Title', {
+        ruleNames: ['no-multiple-h1'],
+        frontmatterTitle: '',
+      }),
+    ).toEqual([]);
+  });
+
+  it('can check missing table cells when configured', () => {
+    const source = ['| a | b |', '| --- | --- |', '| 1 |'].join('\n');
+
+    expect(
+      scanEslintMarkdown(source, {
+        ruleNames: ['table-column-count'],
+        checkMissingTableCells: true,
+      }),
+    ).toMatchObject([
+      {
+        ruleName: 'table-column-count',
+        messageId: 'missingCells',
+        data: { expectedCells: 2, actualCells: 1 },
+      },
+    ]);
+  });
+});

--- a/npm/eslint-markdown/test/plugin.test.mjs
+++ b/npm/eslint-markdown/test/plugin.test.mjs
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const expectedRuleNames = [
+  'fenced-code-language',
+  'fenced-code-meta',
+  'heading-increment',
+  'no-bare-urls',
+  'no-duplicate-definitions',
+  'no-duplicate-headings',
+  'no-empty-definitions',
+  'no-empty-images',
+  'no-empty-links',
+  'no-html',
+  'no-invalid-label-refs',
+  'no-missing-atx-heading-space',
+  'no-missing-label-refs',
+  'no-missing-link-fragments',
+  'no-multiple-h1',
+  'no-reference-like-urls',
+  'no-reversed-media-syntax',
+  'no-space-in-emphasis',
+  'no-unused-definitions',
+  'require-alt-text',
+  'table-column-count',
+];
+
+function runRule(ruleName, sourceText, options = []) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    options,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function applyFix(sourceText, report) {
+  const fix = report.fix({
+    replaceTextRange(range, replacement) {
+      return { range, text: replacement };
+    },
+  });
+  return sourceText.slice(0, fix.range[0]) + fix.text + sourceText.slice(fix.range[1]);
+}
+
+describe('@eslint/markdown plugin shape', () => {
+  it('exposes all ported rules and native helpers', () => {
+    expect(plugin.meta?.name).toBe('@eslint/markdown');
+    expect(Object.keys(plugin.rules)).toEqual(expectedRuleNames);
+    expect(plugin.implementedEslintMarkdownRuleNames).toEqual(expectedRuleNames);
+    expect(typeof plugin.scanEslintMarkdown).toBe('function');
+  });
+
+  it('ships recommended and all configs', () => {
+    expect(plugin.configs.recommended.rules['markdown/fenced-code-language']).toBe('error');
+    expect(plugin.configs.recommended.rules['markdown/fenced-code-meta']).toBeUndefined();
+    expect(plugin.configs.all.rules['markdown/fenced-code-meta']).toBe('error');
+    expect(Object.keys(plugin.configs.all.rules)).toHaveLength(expectedRuleNames.length);
+  });
+});
+
+describe('@eslint/markdown rules through direct adapter harness', () => {
+  it('reports and fixes missing ATX heading spaces', () => {
+    const source = '###Heading';
+    const reports = runRule('no-missing-atx-heading-space', source);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      messageId: 'missingSpace',
+      data: { position: 'after' },
+    });
+    expect(applyFix(source, reports[0])).toBe('### Heading');
+  });
+
+  it('maps rule options before scanning', () => {
+    expect(
+      runRule('no-html', '<DIV>x</DIV>', [{ allowed: ['div'], allowedIgnoreCase: true }]),
+    ).toEqual([]);
+    expect(runRule('fenced-code-meta', '```js title="x"\n```', ['never'])).toMatchObject([
+      { messageId: 'disallowedMetadata' },
+    ]);
+  });
+
+  it('reports table column counts with interpolated data', () => {
+    const reports = runRule(
+      'table-column-count',
+      ['| a | b |', '| --- | --- |', '| 1 | 2 | 3 |'].join('\n'),
+    );
+
+    expect(reports).toMatchObject([
+      {
+        messageId: 'extraCells',
+        data: { expectedCells: '2', actualCells: '3' },
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,12 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
 
+  npm/eslint-markdown:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/mocha:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -161,6 +161,359 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-eslint-markdown",
+    "directory": "npm/eslint-markdown",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "@eslint/markdown",
+      "version": "8.0.2",
+      "repository": "https://github.com/eslint/markdown",
+      "license": "MIT"
+    },
+    "status": "ported",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "fenced-code-language",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/fenced-code-language with required language options; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "fenced-code-meta",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/fenced-code-meta with always/never mode; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "heading-increment",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/heading-increment with frontmatterTitle handling; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-bare-urls",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-bare-urls with autolink fixes; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-duplicate-definitions",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-duplicate-definitions with definition and footnote allow options; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-duplicate-headings",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-duplicate-headings with siblings-only mode; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-empty-definitions",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-empty-definitions with definition and footnote allow options; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-empty-images",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-empty-images; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-empty-links",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-empty-links; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-html",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-html with allowed and allowedIgnoreCase options; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-invalid-label-refs",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-invalid-label-refs; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-missing-atx-heading-space",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-missing-atx-heading-space with whitespace fixes and checkClosedHeadings; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-missing-label-refs",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-missing-label-refs with allowLabels; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-missing-link-fragments",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-missing-link-fragments with heading/HTML anchor collection, ignoreCase, and allowPattern; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-multiple-h1",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-multiple-h1 with frontmatterTitle handling; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-reference-like-urls",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-reference-like-urls with reference-style fixes; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-reversed-media-syntax",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-reversed-media-syntax with link syntax fixes; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-space-in-emphasis",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-space-in-emphasis with checkStrikethrough; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "no-unused-definitions",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/no-unused-definitions with definition and footnote allow options; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "require-alt-text",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/require-alt-text for Markdown images and HTML img tags; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      },
+      {
+        "name": "table-column-count",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Rust source scanner port of @eslint/markdown/table-column-count with checkMissingCells; covered by native API and direct adapter Vitest tests. Oxlint 1.68 does not route .md files to jsPlugins."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-no-forbidden-identifiers",
     "directory": "npm/no-forbidden-identifiers",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -25,6 +25,10 @@ const nativePackages = [
     binding: 'npm/eslint-comments/native.js',
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-eslint-markdown',
+    binding: 'npm/eslint-markdown/native.js',
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-security',
     binding: 'npm/security/native.js',
   },

--- a/tools/tasks/security-audit.ts
+++ b/tools/tasks/security-audit.ts
@@ -18,6 +18,7 @@ const publishablePrefixes = [
   '@oxlint-plugins/oxlint-plugin-type-aware>',
   '@oxlint-plugins/oxlint-plugin-no-forbidden-identifiers>',
   '@oxlint-plugins/oxlint-plugin-eslint-comments>',
+  '@oxlint-plugins/oxlint-plugin-eslint-markdown>',
   '@oxlint-plugins/oxlint-plugin-react-refresh>',
   '@oxlint-plugins/oxlint-plugin-security>',
   '@oxlint-plugins/oxlint-plugin-cypress>',

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -25,6 +25,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-eslint-markdown',
+    dir: 'npm/eslint-markdown',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-react-refresh',
     dir: 'npm/react-refresh',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- add a Rust/NAPI-backed @eslint/markdown package with all 21 upstream Markdown rules exposed through the markdown plugin namespace
- add native API and direct adapter Vitest coverage for representative diagnostics, fixes, configs, and options
- register the package in workspace status, security audit, publish-readiness checks, Cargo, and pnpm metadata

## Verification
- corepack pnpm run verify

## Notes
- Oxlint 1.68 does not route .md files to jsPlugins, so status.json records oxlintIntegration: false for these rules while native/API and direct adapter tests cover the port.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->