### PR TITLE
feat(regexp): port eslint-plugin-regexp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-regexp"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-regexp",
+]
+
+[[package]]
 name = "oxlint-plugin-security"
 version = "0.0.0"
 dependencies = [
@@ -928,6 +938,18 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_parser",
+ "oxc_span",
+ "oxlint-plugins-_carton",
+]
+
+[[package]]
+name = "oxlint-plugins-regexp"
+version = "0.0.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_regular_expression",
  "oxc_span",
  "oxlint-plugins-_carton",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/eslint_comments",
   "crates/mocha",
   "crates/react_refresh",
+  "crates/regexp",
   "crates/security",
   "crates/simple_import_sort",
   "crates/stylistic",
@@ -14,6 +15,7 @@ members = [
   "npm/mocha",
   "npm/no-forbidden-identifiers",
   "npm/react-refresh",
+  "npm/regexp",
   "npm/security",
   "npm/simple-import-sort",
   "npm/stylistic",
@@ -40,6 +42,7 @@ napi-derive = "3.5.6"
 oxc_allocator = "0.135.0"
 oxc_ast = "0.135.0"
 oxc_parser = "0.135.0"
+oxc_regular_expression = "0.135.0"
 oxc_semantic = "0.135.0"
 oxc_span = "0.135.0"
 oxc_syntax = "0.135.0"
@@ -48,6 +51,7 @@ oxlint-plugins-cypress = { path = "crates/cypress", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }
 oxlint-plugins-mocha = { path = "crates/mocha", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
+oxlint-plugins-regexp = { path = "crates/regexp", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
 oxlint-plugins-simple-import-sort = { path = "crates/simple_import_sort", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }

--- a/crates/regexp/Cargo.toml
+++ b/crates/regexp/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "oxlint-plugins-regexp"
+description = "Rust core for the regexp oxlint JavaScript plugin."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_regular_expression.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -1,0 +1,1146 @@
+#![doc = "Rust implementation of selected eslint-plugin-regexp rule logic."]
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, AssignmentTarget, CallExpression, ChainElement, Class,
+    ClassElement, Declaration, ExportDefaultDeclarationKind, Expression, ForStatementInit,
+    ForStatementLeft, Function, FunctionBody, NewExpression, ObjectPropertyKind, PropertyKey,
+    RegExpLiteral, Statement, VariableDeclaration,
+};
+use oxc_parser::Parser;
+use oxc_regular_expression::{ConstructorParser, Options as RegExpOptions};
+use oxc_span::{SourceType, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub const RULE_NAMES: [&str; 10] = [
+    "no-invalid-regexp",
+    "no-empty-character-class",
+    "no-empty-group",
+    "no-empty-capturing-group",
+    "no-empty-alternative",
+    "no-zero-quantifier",
+    "no-octal",
+    "no-control-character",
+    "sort-flags",
+    "require-unicode-regexp",
+];
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub message: Option<CompactString>,
+    pub flag: Option<CompactString>,
+    pub flags: Option<CompactString>,
+    pub sorted_flags: Option<CompactString>,
+    pub expr: Option<CompactString>,
+    pub char_text: Option<CompactString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: DiagnosticData,
+    pub loc: DiagnosticLoc,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_regexp_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_regexp(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 16]> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::mjs())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let mut scanner = Scanner {
+        source_text,
+        line_index: LineIndex::new(source_text),
+        diagnostics: SmallVec::new(),
+    };
+    scanner.scan_program(&parser_return.program.body);
+    scanner.diagnostics
+}
+
+struct Scanner<'a> {
+    source_text: &'a str,
+    line_index: LineIndex,
+    diagnostics: SmallVec<[Diagnostic; 16]>,
+}
+
+impl<'a> Scanner<'a> {
+    fn report(&mut self, rule_name: &'static str, message_id: &'static str, span: Span) {
+        self.report_with_data(rule_name, message_id, DiagnosticData::default(), span);
+    }
+
+    fn report_with_data(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        data: DiagnosticData,
+        span: Span,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+
+    fn scan_program(&mut self, body: &'a [Statement<'a>]) {
+        for statement in body {
+            self.scan_statement(statement);
+        }
+    }
+
+    fn scan_statement(&mut self, statement: &'a Statement<'a>) {
+        match statement {
+            Statement::BlockStatement(block) => {
+                for statement in &block.body {
+                    self.scan_statement(statement);
+                }
+            }
+            Statement::ExpressionStatement(statement) => {
+                self.scan_expression(&statement.expression)
+            }
+            Statement::IfStatement(statement) => {
+                self.scan_expression(&statement.test);
+                self.scan_statement(&statement.consequent);
+                if let Some(alternate) = &statement.alternate {
+                    self.scan_statement(alternate);
+                }
+            }
+            Statement::ReturnStatement(statement) => {
+                if let Some(argument) = &statement.argument {
+                    self.scan_expression(argument);
+                }
+            }
+            Statement::ThrowStatement(statement) => self.scan_expression(&statement.argument),
+            Statement::WhileStatement(statement) => {
+                self.scan_expression(&statement.test);
+                self.scan_statement(&statement.body);
+            }
+            Statement::DoWhileStatement(statement) => {
+                self.scan_statement(&statement.body);
+                self.scan_expression(&statement.test);
+            }
+            Statement::ForStatement(statement) => {
+                if let Some(init) = &statement.init {
+                    self.scan_for_init(init);
+                }
+                if let Some(test) = &statement.test {
+                    self.scan_expression(test);
+                }
+                if let Some(update) = &statement.update {
+                    self.scan_expression(update);
+                }
+                self.scan_statement(&statement.body);
+            }
+            Statement::ForInStatement(statement) => {
+                self.scan_for_left(&statement.left);
+                self.scan_expression(&statement.right);
+                self.scan_statement(&statement.body);
+            }
+            Statement::ForOfStatement(statement) => {
+                self.scan_for_left(&statement.left);
+                self.scan_expression(&statement.right);
+                self.scan_statement(&statement.body);
+            }
+            Statement::SwitchStatement(statement) => {
+                self.scan_expression(&statement.discriminant);
+                for case in &statement.cases {
+                    if let Some(test) = &case.test {
+                        self.scan_expression(test);
+                    }
+                    for statement in &case.consequent {
+                        self.scan_statement(statement);
+                    }
+                }
+            }
+            Statement::TryStatement(statement) => {
+                for statement in &statement.block.body {
+                    self.scan_statement(statement);
+                }
+                if let Some(handler) = &statement.handler {
+                    for statement in &handler.body.body {
+                        self.scan_statement(statement);
+                    }
+                }
+                if let Some(finalizer) = &statement.finalizer {
+                    for statement in &finalizer.body {
+                        self.scan_statement(statement);
+                    }
+                }
+            }
+            Statement::LabeledStatement(statement) => self.scan_statement(&statement.body),
+            Statement::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            Statement::FunctionDeclaration(function) => self.scan_function(function),
+            Statement::ClassDeclaration(class) => self.scan_class(class),
+            Statement::ExportNamedDeclaration(declaration) => {
+                if let Some(declaration) = &declaration.declaration {
+                    self.scan_declaration(declaration);
+                }
+            }
+            Statement::ExportDefaultDeclaration(declaration) => match &declaration.declaration {
+                ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                    self.scan_function(function);
+                }
+                ExportDefaultDeclarationKind::ClassDeclaration(class) => self.scan_class(class),
+                _ => {
+                    if let Some(expression) = declaration.declaration.as_expression() {
+                        self.scan_expression(expression);
+                    }
+                }
+            },
+            _ => {}
+        }
+    }
+
+    fn scan_declaration(&mut self, declaration: &'a Declaration<'a>) {
+        match declaration {
+            Declaration::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            Declaration::FunctionDeclaration(function) => self.scan_function(function),
+            Declaration::ClassDeclaration(class) => self.scan_class(class),
+            _ => {}
+        }
+    }
+
+    fn scan_for_init(&mut self, init: &'a ForStatementInit<'a>) {
+        match init {
+            ForStatementInit::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            _ => {
+                if let Some(expression) = init.as_expression() {
+                    self.scan_expression(expression);
+                }
+            }
+        }
+    }
+
+    fn scan_for_left(&mut self, left: &'a ForStatementLeft<'a>) {
+        if let ForStatementLeft::VariableDeclaration(declaration) = left {
+            self.scan_variable_declaration(declaration);
+        }
+    }
+
+    fn scan_variable_declaration(&mut self, declaration: &'a VariableDeclaration<'a>) {
+        for declarator in &declaration.declarations {
+            if let Some(init) = &declarator.init {
+                self.scan_expression(init);
+            }
+        }
+    }
+
+    fn scan_function(&mut self, function: &'a Function<'a>) {
+        for param in &function.params.items {
+            if let Some(initializer) = &param.initializer {
+                self.scan_expression(initializer);
+            }
+        }
+        if let Some(body) = &function.body {
+            self.scan_function_body(body);
+        }
+    }
+
+    fn scan_function_body(&mut self, body: &'a FunctionBody<'a>) {
+        for statement in &body.statements {
+            self.scan_statement(statement);
+        }
+    }
+
+    fn scan_class(&mut self, class: &'a Class<'a>) {
+        if let Some(super_class) = &class.super_class {
+            self.scan_expression(super_class);
+        }
+        for element in &class.body.body {
+            match element {
+                ClassElement::StaticBlock(block) => {
+                    for statement in &block.body {
+                        self.scan_statement(statement);
+                    }
+                }
+                ClassElement::MethodDefinition(method) => self.scan_function(&method.value),
+                ClassElement::PropertyDefinition(property) => {
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value);
+                    }
+                }
+                ClassElement::AccessorProperty(property) => {
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value);
+                    }
+                }
+                ClassElement::TSIndexSignature(_) => {}
+            }
+        }
+    }
+
+    fn scan_expression(&mut self, expression: &'a Expression<'a>) {
+        match expression.get_inner_expression() {
+            Expression::RegExpLiteral(literal) => self.check_regexp_literal(literal),
+            Expression::CallExpression(call) => {
+                self.check_call_expression(call);
+                self.scan_expression(&call.callee);
+                for argument in &call.arguments {
+                    self.scan_argument(argument);
+                }
+            }
+            Expression::NewExpression(new_expression) => {
+                self.check_new_expression(new_expression);
+                self.scan_expression(&new_expression.callee);
+                for argument in &new_expression.arguments {
+                    self.scan_argument(argument);
+                }
+            }
+            Expression::AssignmentExpression(assignment) => {
+                self.scan_assignment_target(&assignment.left);
+                self.scan_expression(&assignment.right);
+            }
+            Expression::StaticMemberExpression(member) => self.scan_expression(&member.object),
+            Expression::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object);
+                self.scan_expression(&member.expression);
+            }
+            Expression::BinaryExpression(binary) => {
+                self.scan_expression(&binary.left);
+                self.scan_expression(&binary.right);
+            }
+            Expression::LogicalExpression(logical) => {
+                self.scan_expression(&logical.left);
+                self.scan_expression(&logical.right);
+            }
+            Expression::ConditionalExpression(conditional) => {
+                self.scan_expression(&conditional.test);
+                self.scan_expression(&conditional.consequent);
+                self.scan_expression(&conditional.alternate);
+            }
+            Expression::ArrayExpression(array) => {
+                for element in &array.elements {
+                    if let Some(expression) = array_element_expression(element) {
+                        self.scan_expression(expression);
+                    }
+                }
+            }
+            Expression::ObjectExpression(object) => {
+                for property in &object.properties {
+                    match property {
+                        ObjectPropertyKind::ObjectProperty(property) => {
+                            if property.computed {
+                                self.scan_property_key(&property.key);
+                            }
+                            self.scan_expression(&property.value);
+                        }
+                        ObjectPropertyKind::SpreadProperty(spread) => {
+                            self.scan_expression(&spread.argument);
+                        }
+                    }
+                }
+            }
+            Expression::TemplateLiteral(template) => {
+                for expression in &template.expressions {
+                    self.scan_expression(expression);
+                }
+            }
+            Expression::TaggedTemplateExpression(tagged) => {
+                self.scan_expression(&tagged.tag);
+                for expression in &tagged.quasi.expressions {
+                    self.scan_expression(expression);
+                }
+            }
+            Expression::FunctionExpression(function) => self.scan_function(function),
+            Expression::ArrowFunctionExpression(function) => {
+                for param in &function.params.items {
+                    if let Some(initializer) = &param.initializer {
+                        self.scan_expression(initializer);
+                    }
+                }
+                for statement in &function.body.statements {
+                    self.scan_statement(statement);
+                }
+            }
+            Expression::ClassExpression(class) => self.scan_class(class),
+            Expression::SequenceExpression(sequence) => {
+                for expression in &sequence.expressions {
+                    self.scan_expression(expression);
+                }
+            }
+            Expression::AwaitExpression(await_expression) => {
+                self.scan_expression(&await_expression.argument);
+            }
+            Expression::UnaryExpression(unary) => self.scan_expression(&unary.argument),
+            Expression::UpdateExpression(_) => {}
+            Expression::YieldExpression(yield_expression) => {
+                if let Some(argument) = &yield_expression.argument {
+                    self.scan_expression(argument);
+                }
+            }
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::CallExpression(call) => {
+                    self.check_call_expression(call);
+                    self.scan_expression(&call.callee);
+                    for argument in &call.arguments {
+                        self.scan_argument(argument);
+                    }
+                }
+                ChainElement::StaticMemberExpression(member) => {
+                    self.scan_expression(&member.object);
+                }
+                ChainElement::ComputedMemberExpression(member) => {
+                    self.scan_expression(&member.object);
+                    self.scan_expression(&member.expression);
+                }
+                ChainElement::PrivateFieldExpression(member) => {
+                    self.scan_expression(&member.object);
+                }
+                ChainElement::TSNonNullExpression(expression) => {
+                    self.scan_expression(&expression.expression);
+                }
+            },
+            _ => {}
+        }
+    }
+
+    fn scan_property_key(&mut self, key: &'a PropertyKey<'a>) {
+        if let Some(expression) = key.as_expression() {
+            self.scan_expression(expression);
+        }
+    }
+
+    fn scan_argument(&mut self, argument: &'a Argument<'a>) {
+        if let Some(expression) = argument.as_expression() {
+            self.scan_expression(expression);
+        } else if let Argument::SpreadElement(spread) = argument {
+            self.scan_expression(&spread.argument);
+        }
+    }
+
+    fn scan_assignment_target(&mut self, target: &'a AssignmentTarget<'a>) {
+        match target {
+            AssignmentTarget::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object);
+                self.scan_expression(&member.expression);
+            }
+            AssignmentTarget::StaticMemberExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            AssignmentTarget::PrivateFieldExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            AssignmentTarget::TSAsExpression(expression) => {
+                self.scan_expression(&expression.expression)
+            }
+            AssignmentTarget::TSSatisfiesExpression(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            AssignmentTarget::TSNonNullExpression(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            AssignmentTarget::TSTypeAssertion(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            _ => {}
+        }
+    }
+
+    fn check_call_expression(&mut self, call: &'a CallExpression<'a>) {
+        if call.callee.is_specific_id("RegExp") {
+            self.check_regexp_constructor(call.span, &call.arguments);
+        }
+    }
+
+    fn check_new_expression(&mut self, new_expression: &'a NewExpression<'a>) {
+        if new_expression.callee.is_specific_id("RegExp") {
+            self.check_regexp_constructor(new_expression.span, &new_expression.arguments);
+        }
+    }
+
+    fn check_regexp_literal(&mut self, literal: &'a RegExpLiteral<'a>) {
+        let pattern = literal.regex.pattern.text.as_str();
+        let flags = literal
+            .raw
+            .as_ref()
+            .and_then(|raw| raw.as_str().rsplit_once('/').map(|(_, flags)| flags))
+            .unwrap_or("");
+        self.check_regexp(pattern, flags, literal.span, false, None, None);
+    }
+
+    fn check_regexp_constructor(
+        &mut self,
+        span: Span,
+        arguments: &'a oxc_allocator::Vec<'a, Argument<'a>>,
+    ) {
+        let Some(pattern_argument) = arguments.first().and_then(Argument::as_expression) else {
+            return;
+        };
+        let Some((pattern, pattern_span)) = string_literal_value_with_span(pattern_argument) else {
+            return;
+        };
+        let flags = arguments
+            .get(1)
+            .and_then(Argument::as_expression)
+            .and_then(string_literal_value_with_span);
+        let flags_value = flags.map_or("", |(value, _)| value);
+        self.check_regexp(
+            pattern,
+            flags_value,
+            span,
+            true,
+            Some(pattern_span),
+            flags.map(|(_, span)| span),
+        );
+    }
+
+    fn check_regexp(
+        &mut self,
+        pattern: &str,
+        flags: &str,
+        span: Span,
+        is_constructor: bool,
+        pattern_span: Option<Span>,
+        flags_span: Option<Span>,
+    ) {
+        if let Some(flag) = duplicate_flag(flags) {
+            self.report_with_data(
+                "no-invalid-regexp",
+                "duplicateFlag",
+                DiagnosticData {
+                    flag: Some(CompactString::from(flag)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+            return;
+        }
+        if flags.contains('u') && flags.contains('v') {
+            self.report("no-invalid-regexp", "uvFlag", span);
+            return;
+        }
+        if let (true, Some(message)) = (
+            is_constructor,
+            self.constructor_parse_error(pattern_span, flags_span),
+        ) {
+            self.report_with_data(
+                "no-invalid-regexp",
+                "error",
+                DiagnosticData {
+                    message: Some(message),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+            return;
+        }
+
+        self.check_flag_style(flags, span);
+        self.check_pattern_rules(pattern, span);
+    }
+
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "Oxc regexp parser exposes display text; this allocation is only diagnostic data."
+    )]
+    fn constructor_parse_error(
+        &self,
+        pattern_span: Option<Span>,
+        flags_span: Option<Span>,
+    ) -> Option<CompactString> {
+        let pattern_span = pattern_span?;
+        let allocator = Allocator::default();
+        let parsed = ConstructorParser::new(
+            &allocator,
+            pattern_span.source_text(self.source_text),
+            flags_span.map(|span| span.source_text(self.source_text)),
+            RegExpOptions {
+                pattern_span_offset: pattern_span.start,
+                flags_span_offset: flags_span.map_or(0, |span| span.start),
+            },
+        )
+        .parse();
+        match parsed {
+            Ok(_) => None,
+            Err(error) => Some(CompactString::from(error.to_string().as_str())),
+        }
+    }
+
+    fn check_flag_style(&mut self, flags: &str, span: Span) {
+        let sorted_flags = sorted_flags(flags);
+        if flags != sorted_flags.as_str() {
+            self.report_with_data(
+                "sort-flags",
+                "sortFlags",
+                DiagnosticData {
+                    flags: Some(CompactString::from(flags)),
+                    sorted_flags: Some(sorted_flags),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if !flags.contains('u') && !flags.contains('v') {
+            self.report("require-unicode-regexp", "require", span);
+        }
+    }
+
+    fn check_pattern_rules(&mut self, pattern: &str, span: Span) {
+        let mut analysis = PatternAnalysis::new();
+        analysis.scan(pattern);
+
+        if analysis.has_empty_character_class {
+            self.report("no-empty-character-class", "empty", span);
+        }
+        if analysis.has_empty_group {
+            self.report("no-empty-group", "unexpected", span);
+        }
+        if analysis.has_empty_capturing_group {
+            self.report("no-empty-capturing-group", "unexpected", span);
+        }
+        if analysis.has_empty_alternative {
+            self.report("no-empty-alternative", "empty", span);
+        }
+        if analysis.has_zero_quantifier {
+            self.report("no-zero-quantifier", "unexpected", span);
+        }
+        if let Some(expr) = first_octal_escape(pattern) {
+            self.report_with_data(
+                "no-octal",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(expr)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(ch) = first_control_character(pattern) {
+            self.report_with_data(
+                "no-control-character",
+                "unexpected",
+                DiagnosticData {
+                    char_text: Some(mention_char(ch)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GroupState {
+    check_empty: bool,
+    capturing: bool,
+    seen_pipe: bool,
+    current_has_content: bool,
+}
+
+impl GroupState {
+    fn top_level() -> Self {
+        Self {
+            check_empty: false,
+            capturing: false,
+            seen_pipe: false,
+            current_has_content: false,
+        }
+    }
+
+    fn group(check_empty: bool, capturing: bool) -> Self {
+        Self {
+            check_empty,
+            capturing,
+            seen_pipe: false,
+            current_has_content: false,
+        }
+    }
+}
+
+#[derive(Default)]
+struct PatternAnalysis {
+    has_empty_character_class: bool,
+    has_empty_group: bool,
+    has_empty_capturing_group: bool,
+    has_empty_alternative: bool,
+    has_zero_quantifier: bool,
+}
+
+impl PatternAnalysis {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn scan(&mut self, pattern: &str) {
+        let bytes = pattern.as_bytes();
+        let mut groups = SmallVec::<[GroupState; 8]>::new();
+        groups.push(GroupState::top_level());
+        let mut index = 0;
+
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' => {
+                    self.mark_content(&mut groups);
+                    index = skip_escape(bytes, index);
+                }
+                b'[' => {
+                    let close = find_class_end(bytes, index);
+                    if let Some(close) = close {
+                        if close == index + 1 {
+                            self.has_empty_character_class = true;
+                        }
+                        self.mark_content(&mut groups);
+                        index = close + 1;
+                    } else {
+                        self.mark_content(&mut groups);
+                        index += 1;
+                    }
+                }
+                b'(' => {
+                    let (check_empty, capturing, next) = group_prefix(bytes, index);
+                    groups.push(GroupState::group(check_empty, capturing));
+                    index = next;
+                }
+                b')' => {
+                    if groups.len() > 1
+                        && let Some(group) = groups.pop()
+                    {
+                        if group.seen_pipe && !group.current_has_content {
+                            self.has_empty_alternative = true;
+                        }
+                        if group.check_empty && !group.seen_pipe && !group.current_has_content {
+                            self.has_empty_group = true;
+                            if group.capturing {
+                                self.has_empty_capturing_group = true;
+                            }
+                        }
+                        self.mark_content(&mut groups);
+                    }
+                    index += 1;
+                }
+                b'|' => {
+                    if let Some(group) = groups.last_mut() {
+                        if !group.current_has_content {
+                            self.has_empty_alternative = true;
+                        }
+                        group.seen_pipe = true;
+                        group.current_has_content = false;
+                    }
+                    index += 1;
+                }
+                b'{' if is_zero_quantifier(bytes, index) => {
+                    self.has_zero_quantifier = true;
+                    index += 1;
+                }
+                b'*' | b'+' | b'?' | b'{' | b'}' | b'^' | b'$' => {
+                    index += 1;
+                }
+                _ => {
+                    self.mark_content(&mut groups);
+                    index += 1;
+                }
+            }
+        }
+
+        if let Some(group) = groups.last()
+            && group.seen_pipe
+            && !group.current_has_content
+        {
+            self.has_empty_alternative = true;
+        }
+    }
+
+    fn mark_content(&self, groups: &mut SmallVec<[GroupState; 8]>) {
+        if let Some(group) = groups.last_mut() {
+            group.current_has_content = true;
+        }
+    }
+}
+
+fn array_element_expression<'a>(
+    element: &'a ArrayExpressionElement<'a>,
+) -> Option<&'a Expression<'a>> {
+    element.as_expression()
+}
+
+fn string_literal_value_with_span<'a>(expression: &'a Expression<'a>) -> Option<(&'a str, Span)> {
+    match expression.get_inner_expression() {
+        Expression::StringLiteral(literal) => Some((literal.value.as_str(), literal.span)),
+        _ => None,
+    }
+}
+
+fn duplicate_flag(flags: &str) -> Option<&str> {
+    let mut seen = [false; 128];
+    for (start, ch) in flags.char_indices() {
+        let code = ch as usize;
+        if code < seen.len() {
+            if seen[code] {
+                return Some(&flags[start..start + ch.len_utf8()]);
+            }
+            seen[code] = true;
+        }
+    }
+    None
+}
+
+fn sorted_flags(flags: &str) -> CompactString {
+    let mut chars = SmallVec::<[char; 8]>::new();
+    chars.extend(flags.chars());
+    chars.sort_unstable();
+    let mut out = CompactString::new("");
+    for ch in chars {
+        out.push(ch);
+    }
+    out
+}
+
+fn skip_escape(bytes: &[u8], index: usize) -> usize {
+    if index + 1 >= bytes.len() {
+        return index + 1;
+    }
+    match bytes[index + 1] {
+        b'u' if index + 2 < bytes.len() && bytes[index + 2] == b'{' => {
+            let mut cursor = index + 3;
+            while cursor < bytes.len() && bytes[cursor] != b'}' {
+                cursor += 1;
+            }
+            cursor.saturating_add(1).min(bytes.len())
+        }
+        b'u' => (index + 6).min(bytes.len()),
+        b'x' => (index + 4).min(bytes.len()),
+        _ => (index + 2).min(bytes.len()),
+    }
+}
+
+fn find_class_end(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut index = open + 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index = skip_escape(bytes, index),
+            b']' => return Some(index),
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+fn group_prefix(bytes: &[u8], open: usize) -> (bool, bool, usize) {
+    if bytes.get(open + 1) != Some(&b'?') {
+        return (true, true, open + 1);
+    }
+    match bytes.get(open + 2).copied() {
+        Some(b':') => (true, false, open + 3),
+        Some(b'=') | Some(b'!') => (false, false, open + 3),
+        Some(b'<') => {
+            if matches!(bytes.get(open + 3), Some(b'=') | Some(b'!')) {
+                (false, false, open + 4)
+            } else {
+                let mut cursor = open + 3;
+                while cursor < bytes.len() && bytes[cursor] != b'>' {
+                    cursor += 1;
+                }
+                (true, true, cursor.saturating_add(1).min(bytes.len()))
+            }
+        }
+        _ => (false, false, open + 2),
+    }
+}
+
+fn is_zero_quantifier(bytes: &[u8], open: usize) -> bool {
+    let mut cursor = open + 1;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+        cursor += 1;
+    }
+    if cursor == open + 1 {
+        return false;
+    }
+    let first = std::str::from_utf8(&bytes[open + 1..cursor]).unwrap_or("");
+    if first != "0" {
+        return false;
+    }
+    if bytes.get(cursor) == Some(&b'}') {
+        return true;
+    }
+    if bytes.get(cursor) != Some(&b',') {
+        return false;
+    }
+    cursor += 1;
+    let second_start = cursor;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+        cursor += 1;
+    }
+    if bytes.get(cursor) != Some(&b'}') {
+        return false;
+    }
+    if cursor == second_start {
+        return false;
+    }
+    std::str::from_utf8(&bytes[second_start..cursor]).unwrap_or("") == "0"
+}
+
+fn first_octal_escape(pattern: &str) -> Option<&str> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index + 2 < bytes.len() {
+        if bytes[index] == b'\\'
+            && bytes[index + 1] == b'0'
+            && matches!(bytes[index + 2], b'0'..=b'7')
+        {
+            let mut end = index + 3;
+            while end < bytes.len() && matches!(bytes[end], b'0'..=b'7') {
+                end += 1;
+            }
+            return Some(&pattern[index..end]);
+        }
+        index = if bytes[index] == b'\\' {
+            skip_escape(bytes, index)
+        } else {
+            index + 1
+        };
+    }
+    None
+}
+
+fn first_control_character(pattern: &str) -> Option<char> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            if let Some(ch) = escaped_control_character(bytes, index) {
+                return Some(ch);
+            }
+            index = skip_escape(bytes, index);
+            continue;
+        }
+
+        let Some(ch) = pattern[index..].chars().next() else {
+            break;
+        };
+        if ch <= '\u{1f}' {
+            return Some(ch);
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+fn escaped_control_character(bytes: &[u8], index: usize) -> Option<char> {
+    let code = match bytes.get(index + 1).copied()? {
+        b'x' if index + 3 < bytes.len() => {
+            u32::from((hex_value(bytes[index + 2])? << 4) | hex_value(bytes[index + 3])?)
+        }
+        b'u' if index + 2 < bytes.len() && bytes[index + 2] == b'{' => {
+            let mut cursor = index + 3;
+            let mut value = 0u32;
+            let mut saw_digit = false;
+            while cursor < bytes.len() && bytes[cursor] != b'}' {
+                value = (value << 4) | u32::from(hex_value(bytes[cursor])?);
+                saw_digit = true;
+                cursor += 1;
+            }
+            if !saw_digit || bytes.get(cursor) != Some(&b'}') {
+                return None;
+            }
+            value
+        }
+        b'u' if index + 5 < bytes.len() => {
+            let mut value = 0u32;
+            for byte in &bytes[index + 2..index + 6] {
+                value = (value << 4) | u32::from(hex_value(*byte)?);
+            }
+            value
+        }
+        _ => return None,
+    };
+    if code <= 0x1f {
+        char::from_u32(code)
+    } else {
+        None
+    }
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn mention_char(ch: char) -> CompactString {
+    let mut text = CompactString::new("U+");
+    let code = ch as u32;
+    let mut buf = [0u8; 6];
+    let mut value = code;
+    let mut cursor = buf.len();
+    if value == 0 {
+        cursor -= 1;
+        buf[cursor] = b'0';
+    } else {
+        while value > 0 {
+            cursor -= 1;
+            let digit = (value & 0xf) as u8;
+            buf[cursor] = if digit < 10 {
+                b'0' + digit
+            } else {
+                b'A' + (digit - 10)
+            };
+            value >>= 4;
+        }
+    }
+    for _ in 0..(4usize.saturating_sub(buf.len() - cursor)) {
+        text.push('0');
+    }
+    if let Ok(hex) = std::str::from_utf8(&buf[cursor..]) {
+        text.push_str(hex);
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use oxlint_plugins_carton::SmallVec;
+
+    use super::{implemented_regexp_rule_names, scan_regexp};
+
+    fn ids(source: &str) -> SmallVec<[(&'static str, &'static str); 8]> {
+        scan_regexp(source, "fixture.js")
+            .into_iter()
+            .map(|diagnostic| (diagnostic.rule_name, diagnostic.message_id))
+            .collect()
+    }
+
+    #[test]
+    fn exposes_initial_regexp_rule_names() {
+        assert_eq!(
+            implemented_regexp_rule_names(),
+            &[
+                "no-invalid-regexp",
+                "no-empty-character-class",
+                "no-empty-group",
+                "no-empty-capturing-group",
+                "no-empty-alternative",
+                "no-zero-quantifier",
+                "no-octal",
+                "no-control-character",
+                "sort-flags",
+                "require-unicode-regexp",
+            ]
+        );
+    }
+
+    #[test]
+    fn scans_literal_pattern_rules() {
+        assert_eq!(
+            ids("const a = /[]/u;").as_slice(),
+            &[("no-empty-character-class", "empty")]
+        );
+        assert_eq!(ids("const a = /()/u;").len(), 2);
+        assert_eq!(
+            ids("const a = /a|/u;").as_slice(),
+            &[("no-empty-alternative", "empty")]
+        );
+        assert_eq!(
+            ids("const a = /a{0}/u;").as_slice(),
+            &[("no-zero-quantifier", "unexpected")]
+        );
+    }
+
+    #[test]
+    fn scans_constructor_patterns_and_flags() {
+        assert_eq!(
+            ids("const a = new RegExp('[]', 'u');").as_slice(),
+            &[("no-empty-character-class", "empty")]
+        );
+        assert_eq!(
+            ids("const a = new RegExp('[', 'u');").as_slice(),
+            &[("no-invalid-regexp", "error")]
+        );
+        assert_eq!(
+            ids("const a = new RegExp('a', 'gg');").as_slice(),
+            &[("no-invalid-regexp", "duplicateFlag")]
+        );
+        assert_eq!(
+            ids("const a = RegExp('a', 'vu');").as_slice(),
+            &[("no-invalid-regexp", "uvFlag")]
+        );
+    }
+
+    #[test]
+    fn scans_style_and_legacy_rules() {
+        assert_eq!(
+            ids("const a = /a/mi;").as_slice(),
+            &[
+                ("sort-flags", "sortFlags"),
+                ("require-unicode-regexp", "require"),
+            ]
+        );
+        assert_eq!(
+            ids("const a = /\\07/u;").as_slice(),
+            &[("no-octal", "unexpected")]
+        );
+        assert_eq!(
+            ids("const a = new RegExp('\\u{1}');").as_slice(),
+            &[
+                ("require-unicode-regexp", "require"),
+                ("no-control-character", "unexpected"),
+            ]
+        );
+    }
+}

--- a/npm/regexp/Cargo.toml
+++ b/npm/regexp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "oxlint-plugin-regexp"
+description = "Rust-backed oxlint plugin port of eslint-plugin-regexp."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_regexp"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-regexp.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/npm/regexp/LICENSE
+++ b/npm/regexp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) oxlint-plugins contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/regexp/README.md
+++ b/npm/regexp/README.md
@@ -1,0 +1,3 @@
+# @oxlint-plugins/oxlint-plugin-regexp
+
+Rust-backed oxlint plugin port of selected `eslint-plugin-regexp` rules.

--- a/npm/regexp/api.d.ts
+++ b/npm/regexp/api.d.ts
@@ -1,0 +1,25 @@
+export type RegexpDiagnosticData = {
+  message?: string;
+  flag?: string;
+  flags?: string;
+  sortedFlags?: string;
+  expr?: string;
+  charText?: string;
+};
+
+export type RegexpDiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type RegexpDiagnostic = {
+  ruleName: string;
+  messageId: string;
+  data: RegexpDiagnosticData;
+  loc: RegexpDiagnosticLoc;
+};
+
+export function implementedRegexpRuleNames(): string[];
+export function scanRegexp(sourceText: string, filename?: string): RegexpDiagnostic[];

--- a/npm/regexp/api.js
+++ b/npm/regexp/api.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanRegexp(sourceText, filename = 'file.js') {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanRegexp(sourceText, filename);
+}
+
+module.exports = {
+  implementedRegexpRuleNames: native.implementedRegexpRuleNames,
+  scanRegexp,
+};
+module.exports.default = module.exports;

--- a/npm/regexp/build.rs
+++ b/npm/regexp/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -1,0 +1,233 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-regexp (MIT).
+// The JavaScript layer is only an Oxlint/NAPI adapter; parsing and the
+// implemented regular-expression checks run in Rust through Oxc.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedRegexpRuleNames, scanRegexp } = require('./api.js');
+
+const PLUGIN_NAME = 'regexp';
+const DOCS_BASE = 'https://github.com/ota-meshi/eslint-plugin-regexp/tree/master/docs/rules';
+const diagnosticsCache = new WeakMap();
+
+const messages = Object.freeze({
+  'no-invalid-regexp': {
+    error: '{{message}}',
+    duplicateFlag: 'Duplicate {{flag}} flag.',
+    uvFlag: "Regex 'u' and 'v' flags cannot be used together.",
+  },
+  'no-empty-character-class': {
+    empty: 'This character class matches no characters because it is empty.',
+    cannotMatchAny: 'This character class cannot match any characters.',
+  },
+  'no-empty-group': {
+    unexpected: 'Unexpected empty group.',
+  },
+  'no-empty-capturing-group': {
+    unexpected: 'Unexpected capture empty.',
+  },
+  'no-empty-alternative': {
+    empty: 'This empty alternative might be a mistake. If not, use a quantifier instead.',
+    suggest: 'Use a quantifier instead.',
+  },
+  'no-zero-quantifier': {
+    unexpected:
+      'Unexpected zero quantifier. The quantifier and its quantified element can be removed without affecting the pattern.',
+    withCapturingGroup:
+      'Unexpected zero quantifier. The quantifier and its quantified element do not affecting the pattern. Try to remove the elements but be careful because it contains at least one capturing group.',
+    remove: 'Remove this zero quantifier.',
+  },
+  'no-octal': {
+    unexpected: "Unexpected octal escape sequence '{{expr}}'.",
+    replaceHex: 'Replace the octal escape sequence with a hexadecimal escape sequence.',
+  },
+  'no-control-character': {
+    unexpected: 'Unexpected control character {{ char }}.',
+    escape: 'Use {{ escape }} instead.',
+  },
+  'sort-flags': {
+    sortFlags: "The flags '{{flags}}' should be in the order '{{sortedFlags}}'.",
+  },
+  'require-unicode-regexp': {
+    require: "Use the 'u' flag.",
+  },
+});
+
+const ruleDescriptions = Object.freeze({
+  'no-invalid-regexp': 'disallow invalid regular expression strings in `RegExp` constructors',
+  'no-empty-character-class': 'disallow character classes that match no characters',
+  'no-empty-group': 'disallow empty group',
+  'no-empty-capturing-group': 'disallow capturing group that captures empty.',
+  'no-empty-alternative': 'disallow alternatives without elements',
+  'no-zero-quantifier': 'disallow quantifiers with a maximum of zero',
+  'no-octal': 'disallow octal escape sequence',
+  'no-control-character': 'disallow control characters',
+  'sort-flags': 'require regex flags to be sorted',
+  'require-unicode-regexp': 'enforce the use of the `u` flag',
+});
+
+const ruleTypes = Object.freeze({
+  'no-invalid-regexp': 'problem',
+  'no-empty-character-class': 'suggestion',
+  'no-empty-group': 'suggestion',
+  'no-empty-capturing-group': 'suggestion',
+  'no-empty-alternative': 'problem',
+  'no-zero-quantifier': 'suggestion',
+  'no-octal': 'suggestion',
+  'no-control-character': 'suggestion',
+  'sort-flags': 'suggestion',
+  'require-unicode-regexp': 'suggestion',
+});
+
+const recommendedRuleConfig = Object.freeze({
+  'no-invalid-regexp': 'error',
+  'no-empty-character-class': 'error',
+  'no-empty-group': 'error',
+  'no-empty-capturing-group': 'error',
+  'no-empty-alternative': 'warn',
+  'no-zero-quantifier': 'error',
+  'sort-flags': 'error',
+});
+
+const implementedRuleNames = Object.freeze(implementedRegexpRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createRegexpRule(ruleName)]),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: configFromRuleConfig('recommended', recommendedRuleConfig),
+    all: configFromRuleConfig(
+      'all',
+      Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 'error'])),
+    ),
+  },
+});
+
+plugin.configs['flat/recommended'] = plugin.configs.recommended;
+plugin.configs['flat/all'] = plugin.configs.all;
+plugin.implementedRegexpRuleNames = implementedRuleNames;
+plugin.scanRegexp = scanRegexp;
+
+function configFromRuleConfig(name, ruleConfig) {
+  return {
+    name: `${PLUGIN_NAME}/${name}`,
+    plugins: [PLUGIN_NAME],
+    rules: Object.fromEntries(
+      Object.entries(ruleConfig).map(([ruleName, config]) => [
+        `${PLUGIN_NAME}/${ruleName}`,
+        config,
+      ]),
+    ),
+  };
+}
+
+function createRegexpRule(ruleName) {
+  return {
+    meta: {
+      type: ruleTypes[ruleName],
+      docs: {
+        description: ruleDescriptions[ruleName],
+        category: ruleCategory(ruleName),
+        recommended: Object.hasOwn(recommendedRuleConfig, ruleName),
+        url: `${DOCS_BASE}/${ruleName}.md`,
+      },
+      messages: messages[ruleName],
+      schema: [],
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForContext(context)) {
+            if (diagnostic.ruleName !== ruleName) {
+              continue;
+            }
+            context.report({
+              messageId: diagnostic.messageId,
+              data: compactData(diagnostic.data),
+              loc: {
+                start: {
+                  line: diagnostic.loc.startLine,
+                  column: diagnostic.loc.startColumn,
+                },
+                end: {
+                  line: diagnostic.loc.endLine,
+                  column: diagnostic.loc.endColumn,
+                },
+              },
+            });
+          }
+        },
+      };
+    },
+  };
+}
+
+function ruleCategory(ruleName) {
+  if (
+    ruleName === 'no-invalid-regexp' ||
+    ruleName === 'no-empty-character-class' ||
+    ruleName === 'no-empty-group' ||
+    ruleName === 'no-empty-alternative' ||
+    ruleName === 'no-control-character'
+  ) {
+    return 'Possible Errors';
+  }
+  if (ruleName === 'sort-flags') {
+    return 'Stylistic Issues';
+  }
+  return 'Best Practices';
+}
+
+function diagnosticsForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.js';
+  const cached = diagnosticsCache.get(sourceCode);
+
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanRegexp(sourceText, filename);
+  diagnosticsCache.set(sourceCode, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function compactData(data) {
+  const out = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    if (value != null) {
+      out[key] = value;
+    }
+  }
+  if (out.charText != null && out.char == null) {
+    out.char = out.charText;
+  }
+  return out;
+}
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.implementedRegexpRuleNames = implementedRuleNames;
+module.exports.scanRegexp = scanRegexp;

--- a/npm/regexp/package.json
+++ b/npm/regexp/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-regexp",
+  "version": "0.0.0",
+  "description": "Rust-backed oxlint plugin port of eslint-plugin-regexp.",
+  "keywords": [
+    "eslint-plugin",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "regexp",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/regexp"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_regexp",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/regexp/src/lib.rs
+++ b/npm/regexp/src/lib.rs
@@ -1,0 +1,86 @@
+//! NAPI boundary for the regexp oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticLoc, implemented_regexp_rule_names, scan_regexp,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec; core rule logic uses compact Rust data structures."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_regexp as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct DiagnosticData {
+        pub message: Option<String>,
+        pub flag: Option<String>,
+        pub flags: Option<String>,
+        pub sorted_flags: Option<String>,
+        pub expr: Option<String>,
+        pub char_text: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub data: DiagnosticData,
+        pub loc: DiagnosticLoc,
+    }
+
+    #[napi]
+    pub fn implemented_regexp_rule_names() -> Vec<String> {
+        core::implemented_regexp_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_regexp(source_text: String, filename: String) -> Vec<Diagnostic> {
+        core::scan_regexp(&source_text, &filename)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                data: DiagnosticData {
+                    message: diagnostic
+                        .data
+                        .message
+                        .map(|value| value.as_str().to_owned()),
+                    flag: diagnostic.data.flag.map(|value| value.as_str().to_owned()),
+                    flags: diagnostic.data.flags.map(|value| value.as_str().to_owned()),
+                    sorted_flags: diagnostic
+                        .data
+                        .sorted_flags
+                        .map(|value| value.as_str().to_owned()),
+                    expr: diagnostic.data.expr.map(|value| value.as_str().to_owned()),
+                    char_text: diagnostic
+                        .data
+                        .char_text
+                        .map(|value| value.as_str().to_owned()),
+                },
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+            })
+            .collect()
+    }
+}

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedRegexpRuleNames, scanRegexp } from '../api.js';
+
+describe('regexp native API', () => {
+  it('exposes the implemented eslint-plugin-regexp rule names', () => {
+    expect(implementedRegexpRuleNames()).toEqual([
+      'no-invalid-regexp',
+      'no-empty-character-class',
+      'no-empty-group',
+      'no-empty-capturing-group',
+      'no-empty-alternative',
+      'no-zero-quantifier',
+      'no-octal',
+      'no-control-character',
+      'sort-flags',
+      'require-unicode-regexp',
+    ]);
+  });
+
+  it('scans literals and constructors through one native call', () => {
+    const diagnostics = scanRegexp(
+      [
+        'const emptyClass = /[]/mi;',
+        "const invalid = new RegExp('[', 'u');",
+        "const control = new RegExp('\\\\x01', 'u');",
+      ].join('\n'),
+      'fixture.js',
+    );
+
+    expect(diagnostics.map((diagnostic) => [diagnostic.ruleName, diagnostic.messageId])).toEqual([
+      ['sort-flags', 'sortFlags'],
+      ['require-unicode-regexp', 'require'],
+      ['no-empty-character-class', 'empty'],
+      ['no-invalid-regexp', 'error'],
+      ['no-control-character', 'unexpected'],
+    ]);
+    expect(diagnostics[0].data).toMatchObject({
+      flags: 'mi',
+      sortedFlags: 'im',
+    });
+    expect(diagnostics[4].data.charText).toBe('U+0001');
+  });
+
+  it('returns LSP-shaped locations from Rust', () => {
+    const diagnostics = scanRegexp('const a = /a/mi;\n', 'fixture.js');
+
+    expect(diagnostics[0]).toMatchObject({
+      ruleName: 'sort-flags',
+      messageId: 'sortFlags',
+      loc: {
+        startLine: 1,
+        startColumn: 10,
+        endLine: 1,
+        endColumn: 15,
+      },
+    });
+  });
+});

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -1,0 +1,187 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+const validCases = [
+  ['no-invalid-regexp', 'valid constructor', "new RegExp('a+', 'u');\n"],
+  ['no-empty-character-class', 'non-empty class', 'const re = /[a]/u;\n'],
+  ['no-empty-group', 'non-empty group', 'const re = /(?:a)/u;\n'],
+  ['no-empty-capturing-group', 'non-empty capture', 'const re = /(a)/u;\n'],
+  ['no-empty-alternative', 'no empty alternative', 'const re = /a|b/u;\n'],
+  ['no-zero-quantifier', 'positive quantifier', 'const re = /a{1}/u;\n'],
+  ['no-octal', 'nul escape only', 'const re = /\\0/u;\n'],
+  ['no-control-character', 'named control escape', 'const re = /\\t/u;\n'],
+  ['sort-flags', 'sorted flags', 'const re = /a/im;\n'],
+  ['require-unicode-regexp', 'unicode flag', 'const re = /a/u;\n'],
+];
+
+const invalidCases = [
+  ['no-invalid-regexp', 'invalid constructor pattern', "new RegExp('[', 'u');\n", ['error']],
+  ['no-invalid-regexp', 'duplicate flags', "new RegExp('a', 'gg');\n", ['duplicateFlag']],
+  ['no-invalid-regexp', 'u and v flags', "new RegExp('a', 'uv');\n", ['uvFlag']],
+  ['no-empty-character-class', 'empty character class', 'const re = /[]/u;\n', ['empty']],
+  ['no-empty-group', 'empty group', 'const re = /(?:)/u;\n', ['unexpected']],
+  ['no-empty-capturing-group', 'empty capturing group', 'const re = /()/u;\n', ['unexpected']],
+  ['no-empty-alternative', 'trailing empty alternative', 'const re = /a|/u;\n', ['empty']],
+  ['no-zero-quantifier', 'zero quantifier', 'const re = /a{0}/u;\n', ['unexpected']],
+  ['no-octal', 'octal escape', 'const re = /\\07/u;\n', ['unexpected']],
+  [
+    'no-control-character',
+    'hex escaped control character',
+    "const re = new RegExp('\\\\x01', 'u');\n",
+    ['unexpected'],
+  ],
+  ['sort-flags', 'unsorted flags', 'const re = /a/mi;\n', ['sortFlags']],
+  ['require-unicode-regexp', 'missing unicode flag', 'const re = /a/;\n', ['require']],
+];
+
+function runRule(ruleName, sourceText, filename = 'fixture.js') {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const rule = plugin.rules[ruleName];
+  const visitor = rule.createOnce({
+    filename,
+    options: [],
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function renderMessage(ruleName, report) {
+  const template = plugin.rules[ruleName].meta.messages[report.messageId];
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => report.data?.[key] ?? '');
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code) {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'regexp-plugin-'));
+
+  try {
+    const sourcePath = join(temp, 'fixture.js');
+    const configPath = join(temp, 'oxlint.config.jsonc');
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'regexp',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`regexp/${ruleName}`]: 'error',
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('regexp plugin shape', () => {
+  it('exports the regexp plugin surface', () => {
+    expect(plugin.meta?.name).toBe('regexp');
+    expect(plugin.implementedRegexpRuleNames).toEqual(Object.keys(plugin.rules));
+    expect(plugin.rules['sort-flags'].meta.messages.sortFlags).toContain('{{sortedFlags}}');
+  });
+
+  it('ships upstream-compatible implemented configs', () => {
+    expect(plugin.configs.recommended.rules['regexp/no-empty-alternative']).toBe('warn');
+    expect(plugin.configs.recommended.rules['regexp/no-octal']).toBeUndefined();
+    expect(plugin.configs.all.rules['regexp/no-octal']).toBe('error');
+    expect(plugin.configs['flat/recommended']).toBe(plugin.configs.recommended);
+  });
+});
+
+describe('regexp rules through direct Oxlint plugin adapter', () => {
+  it.each(validCases)('accepts %s: %s', (ruleName, _name, code) => {
+    expect(runRule(ruleName, code)).toEqual([]);
+  });
+
+  it.each(invalidCases)('reports %s: %s', (ruleName, _name, code, expectedMessageIds) => {
+    const reports = runRule(ruleName, code);
+
+    expect(reports.map((report) => report.messageId)).toEqual(expectedMessageIds);
+  });
+
+  it('renders data-bearing upstream messages', () => {
+    expect(renderMessage('sort-flags', runRule('sort-flags', 'const re = /a/mi;\n')[0])).toBe(
+      "The flags 'mi' should be in the order 'im'.",
+    );
+    expect(renderMessage('no-octal', runRule('no-octal', 'const re = /\\07/u;\n')[0])).toBe(
+      "Unexpected octal escape sequence '\\07'.",
+    );
+    expect(
+      renderMessage(
+        'no-control-character',
+        runRule('no-control-character', "const re = new RegExp('\\\\x01', 'u');\n")[0],
+      ),
+    ).toBe('Unexpected control character U+0001.');
+  });
+});
+
+describe('regexp rules through oxlint jsPlugins', () => {
+  it('reports a native diagnostic through the CLI', () => {
+    const result = runOxlint('sort-flags', 'const re = /a/mi;\n');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toMatchObject([
+      {
+        code: 'regexp(sort-flags)',
+        message: "The flags 'mi' should be in the order 'im'.",
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/regexp:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/security:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -447,6 +447,183 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-regexp",
+    "directory": "npm/regexp",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-regexp",
+      "version": "3.1.0",
+      "repository": "https://github.com/ota-meshi/eslint-plugin-regexp",
+      "license": "MIT"
+    },
+    "status": "in-progress",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "no-invalid-regexp",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc RegExp constructor and flag validation port of eslint-plugin-regexp/no-invalid-regexp; duplicate flags, incompatible u/v flags, and constructor parse errors covered in Vitest."
+      },
+      {
+        "name": "no-empty-character-class",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-empty-character-class for empty character classes in literals and static RegExp constructors."
+      },
+      {
+        "name": "no-empty-group",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-empty-group for empty capturing and non-capturing groups."
+      },
+      {
+        "name": "no-empty-capturing-group",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-empty-capturing-group for empty capturing groups."
+      },
+      {
+        "name": "no-empty-alternative",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-empty-alternative for leading, trailing, and adjacent empty alternatives."
+      },
+      {
+        "name": "no-zero-quantifier",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-zero-quantifier for {0} and {0,0} quantifiers."
+      },
+      {
+        "name": "no-octal",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-octal for octal escape sequences beginning with \\0."
+      },
+      {
+        "name": "no-control-character",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust pattern scanner port of eslint-plugin-regexp/no-control-character for raw, escaped, or constructor-decoded control characters."
+      },
+      {
+        "name": "sort-flags",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc flag scanner port of eslint-plugin-regexp/sort-flags for RegExp literals and static RegExp constructors."
+      },
+      {
+        "name": "require-unicode-regexp",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc flag scanner port of eslint-plugin-regexp/require-unicode-regexp for regexps missing u or v flags."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-security",
     "directory": "npm/security",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -41,6 +41,10 @@ const nativePackages = [
     binding: 'npm/react-refresh/native.js',
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-regexp',
+    binding: 'npm/regexp/native.js',
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-mocha',
     binding: 'npm/mocha/native.js',
   },

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -30,6 +30,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-regexp',
+    dir: 'npm/regexp',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-security',
     dir: 'npm/security',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- add Rust/NAPI regexp package for selected eslint-plugin-regexp rules
- expose regexp Oxlint jsPlugin adapter with recommended/all configs
- cover native API, direct adapter, and oxlint CLI integration tests

## Verification
- corepack pnpm run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->