### PR TITLE
feat(react-hooks): port rules-of-hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-react-hooks"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-react-hooks",
+]
+
+[[package]]
 name = "oxlint-plugin-react-refresh"
 version = "0.0.0"
 dependencies = [
@@ -1015,6 +1025,17 @@ dependencies = [
  "oxc_span",
  "oxlint-plugins-_carton",
  "regex",
+]
+
+[[package]]
+name = "oxlint-plugins-react-hooks"
+version = "0.0.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxlint-plugins-_carton",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/eslint_markdown",
   "crates/mocha",
   "crates/playwright",
+  "crates/react_hooks",
   "crates/react_refresh",
   "crates/regexp",
   "crates/security",
@@ -22,6 +23,7 @@ members = [
   "npm/mocha",
   "npm/no-forbidden-identifiers",
   "npm/playwright",
+  "npm/react-hooks",
   "npm/react-refresh",
   "npm/regexp",
   "npm/security",
@@ -63,6 +65,7 @@ oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0
 oxlint-plugins-eslint-markdown = { path = "crates/eslint_markdown", version = "0.0.0" }
 oxlint-plugins-mocha = { path = "crates/mocha", version = "0.0.0" }
 oxlint-plugins-playwright = { path = "crates/playwright", version = "0.0.0" }
+oxlint-plugins-react-hooks = { path = "crates/react_hooks", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
 oxlint-plugins-regexp = { path = "crates/regexp", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }

--- a/crates/react_hooks/Cargo.toml
+++ b/crates/react_hooks/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "oxlint-plugins-react-hooks"
+description = "Rust core for the react-hooks oxlint JavaScript plugin."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/react_hooks/src/lib.rs
+++ b/crates/react_hooks/src/lib.rs
@@ -1,0 +1,915 @@
+#![doc = "Rust implementation of eslint-plugin-react-hooks rule logic."]
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, ArrowFunctionExpression, AssignmentTarget, BindingPattern,
+    CallExpression, ChainElement, Class, ClassElement, Declaration, ExportDefaultDeclarationKind,
+    Expression, ForStatementInit, ForStatementLeft, Function, FunctionBody, ObjectPropertyKind,
+    PropertyKey, Statement, VariableDeclaration,
+};
+use oxc_parser::Parser;
+use oxc_span::{SourceType, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub const RULE_NAMES: [&str; 1] = ["rules-of-hooks"];
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub hook: Option<CompactString>,
+    pub function_name: Option<CompactString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: DiagnosticData,
+    pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Debug)]
+struct FunctionFrame {
+    name: Option<CompactString>,
+    valid_scope: bool,
+    inside_valid_scope: bool,
+    async_function: bool,
+    in_class: bool,
+    conditional_depth: u32,
+    loop_depth: u32,
+    try_depth: u32,
+    possible_early_return: bool,
+}
+
+#[derive(Clone, Debug)]
+struct HookCall {
+    name: CompactString,
+    span: Span,
+    is_use: bool,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_react_hooks_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn is_react_component_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_uppercase()
+}
+
+pub fn is_hook_name(name: &str) -> bool {
+    if name == "use" {
+        return true;
+    }
+
+    let Some(rest) = name.strip_prefix("use") else {
+        return false;
+    };
+    let Some(next) = rest.chars().next() else {
+        return false;
+    };
+    next.is_ascii_uppercase() || next.is_ascii_digit()
+}
+
+pub fn scan_react_hooks(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 16]> {
+    let allocator = Allocator::default();
+    let source_type = source_type_for_filename(filename);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let mut scanner = Scanner {
+        source_text,
+        line_index: LineIndex::new(source_text),
+        diagnostics: SmallVec::new(),
+        frames: SmallVec::new(),
+        class_depth: 0,
+    };
+    scanner.scan_statement_list(&parser_return.program.body);
+    scanner.diagnostics
+}
+
+fn source_type_for_filename(filename: &str) -> SourceType {
+    if filename.ends_with(".tsx") {
+        SourceType::tsx()
+    } else if filename.ends_with(".jsx") {
+        SourceType::jsx()
+    } else {
+        SourceType::from_path(Path::new(filename))
+            .unwrap_or_else(|_| SourceType::mjs())
+            .with_module(true)
+    }
+}
+
+struct Scanner<'a> {
+    source_text: &'a str,
+    line_index: LineIndex,
+    diagnostics: SmallVec<[Diagnostic; 16]>,
+    frames: SmallVec<[FunctionFrame; 8]>,
+    class_depth: u32,
+}
+
+impl<'a> Scanner<'a> {
+    fn scan_statement_list(&mut self, statements: &'a [Statement<'a>]) {
+        for statement in statements {
+            self.scan_statement(statement);
+        }
+    }
+
+    fn scan_statement(&mut self, statement: &'a Statement<'a>) {
+        match statement {
+            Statement::BlockStatement(block) => {
+                self.scan_statement_list(&block.body);
+            }
+            Statement::ExpressionStatement(statement) => {
+                self.scan_expression(&statement.expression);
+            }
+            Statement::IfStatement(statement) => {
+                self.scan_expression(&statement.test);
+                self.with_conditional(|scanner| scanner.scan_statement(&statement.consequent));
+                if let Some(alternate) = &statement.alternate {
+                    self.with_conditional(|scanner| scanner.scan_statement(alternate));
+                }
+            }
+            Statement::ReturnStatement(statement) => {
+                if self
+                    .current_frame()
+                    .is_some_and(|frame| frame.conditional_depth > 0)
+                    && let Some(frame) = self.current_frame_mut()
+                {
+                    frame.possible_early_return = true;
+                }
+                if let Some(argument) = &statement.argument {
+                    self.scan_expression(argument);
+                }
+            }
+            Statement::ThrowStatement(statement) => {
+                self.scan_expression(&statement.argument);
+            }
+            Statement::WhileStatement(statement) => {
+                self.scan_expression(&statement.test);
+                self.with_loop(|scanner| scanner.scan_statement(&statement.body));
+            }
+            Statement::DoWhileStatement(statement) => {
+                self.with_loop(|scanner| scanner.scan_statement(&statement.body));
+                self.scan_expression(&statement.test);
+            }
+            Statement::ForStatement(statement) => {
+                if let Some(init) = &statement.init {
+                    self.scan_for_init(init);
+                }
+                self.with_loop(|scanner| {
+                    if let Some(test) = &statement.test {
+                        scanner.scan_expression(test);
+                    }
+                    if let Some(update) = &statement.update {
+                        scanner.scan_expression(update);
+                    }
+                    scanner.scan_statement(&statement.body);
+                });
+            }
+            Statement::ForInStatement(statement) => {
+                self.scan_for_left(&statement.left);
+                self.scan_expression(&statement.right);
+                self.with_loop(|scanner| scanner.scan_statement(&statement.body));
+            }
+            Statement::ForOfStatement(statement) => {
+                self.scan_for_left(&statement.left);
+                self.scan_expression(&statement.right);
+                self.with_loop(|scanner| scanner.scan_statement(&statement.body));
+            }
+            Statement::SwitchStatement(statement) => {
+                self.scan_expression(&statement.discriminant);
+                for case in &statement.cases {
+                    if let Some(test) = &case.test {
+                        self.scan_expression(test);
+                    }
+                    self.with_conditional(|scanner| scanner.scan_statement_list(&case.consequent));
+                }
+            }
+            Statement::TryStatement(statement) => {
+                self.with_try(|scanner| scanner.scan_statement_list(&statement.block.body));
+                if let Some(handler) = &statement.handler {
+                    self.with_try(|scanner| scanner.scan_statement_list(&handler.body.body));
+                }
+                if let Some(finalizer) = &statement.finalizer {
+                    self.with_try(|scanner| scanner.scan_statement_list(&finalizer.body));
+                }
+            }
+            Statement::LabeledStatement(statement) => {
+                self.scan_statement(&statement.body);
+            }
+            Statement::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            Statement::FunctionDeclaration(function) => {
+                self.scan_function(function, function_name(function), false);
+            }
+            Statement::ClassDeclaration(class) => {
+                self.scan_class(class);
+            }
+            Statement::ExportNamedDeclaration(declaration) => {
+                if let Some(declaration) = &declaration.declaration {
+                    self.scan_declaration(declaration);
+                }
+            }
+            Statement::ExportDefaultDeclaration(declaration) => match &declaration.declaration {
+                ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                    self.scan_function(function, function_name(function), false);
+                }
+                ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+                    self.scan_class(class);
+                }
+                _ => {
+                    if let Some(expression) = declaration.declaration.as_expression() {
+                        self.scan_expression(expression);
+                    }
+                }
+            },
+            _ => {}
+        }
+    }
+
+    fn scan_declaration(&mut self, declaration: &'a Declaration<'a>) {
+        match declaration {
+            Declaration::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            Declaration::FunctionDeclaration(function) => {
+                self.scan_function(function, function_name(function), false);
+            }
+            Declaration::ClassDeclaration(class) => {
+                self.scan_class(class);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_for_init(&mut self, init: &'a ForStatementInit<'a>) {
+        match init {
+            ForStatementInit::VariableDeclaration(declaration) => {
+                self.scan_variable_declaration(declaration);
+            }
+            _ => {
+                if let Some(expression) = init.as_expression() {
+                    self.scan_expression(expression);
+                }
+            }
+        }
+    }
+
+    fn scan_for_left(&mut self, left: &'a ForStatementLeft<'a>) {
+        if let ForStatementLeft::VariableDeclaration(declaration) = left {
+            self.scan_variable_declaration(declaration);
+        }
+    }
+
+    fn scan_variable_declaration(&mut self, declaration: &'a VariableDeclaration<'a>) {
+        for declarator in &declaration.declarations {
+            let name = binding_pattern_name(&declarator.id);
+            if let Some(init) = &declarator.init {
+                if let Expression::ArrowFunctionExpression(function) = init.get_inner_expression() {
+                    self.scan_arrow_function(function, name, false);
+                } else if let Expression::FunctionExpression(function) = init.get_inner_expression()
+                {
+                    self.scan_function(function, name.or_else(|| function_name(function)), false);
+                } else {
+                    self.scan_expression(init);
+                }
+            }
+        }
+    }
+
+    fn scan_expression(&mut self, expression: &'a Expression<'a>) {
+        match expression.get_inner_expression() {
+            Expression::CallExpression(call) => {
+                self.scan_call_expression(call);
+            }
+            Expression::NewExpression(new_expression) => {
+                self.scan_expression(&new_expression.callee);
+                for argument in &new_expression.arguments {
+                    self.scan_argument(argument, false);
+                }
+            }
+            Expression::AssignmentExpression(assignment) => {
+                self.scan_assignment_target(&assignment.left);
+                let name = assignment_target_name(&assignment.left);
+                if let Expression::ArrowFunctionExpression(function) =
+                    assignment.right.get_inner_expression()
+                {
+                    self.scan_arrow_function(function, name, false);
+                } else if let Expression::FunctionExpression(function) =
+                    assignment.right.get_inner_expression()
+                {
+                    self.scan_function(function, name.or_else(|| function_name(function)), false);
+                } else {
+                    self.scan_expression(&assignment.right);
+                }
+            }
+            Expression::StaticMemberExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object);
+                self.scan_expression(&member.expression);
+            }
+            Expression::PrivateFieldExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            Expression::BinaryExpression(binary) => {
+                self.scan_expression(&binary.left);
+                self.scan_expression(&binary.right);
+            }
+            Expression::LogicalExpression(logical) => {
+                self.scan_expression(&logical.left);
+                self.with_conditional(|scanner| scanner.scan_expression(&logical.right));
+            }
+            Expression::ConditionalExpression(conditional) => {
+                self.scan_expression(&conditional.test);
+                self.with_conditional(|scanner| {
+                    scanner.scan_expression(&conditional.consequent);
+                    scanner.scan_expression(&conditional.alternate);
+                });
+            }
+            Expression::ArrayExpression(array) => {
+                for element in &array.elements {
+                    self.scan_array_element(element);
+                }
+            }
+            Expression::ObjectExpression(object) => {
+                for property in &object.properties {
+                    match property {
+                        ObjectPropertyKind::ObjectProperty(property) => {
+                            if property.computed {
+                                self.scan_property_key(&property.key);
+                            }
+                            self.scan_expression(&property.value);
+                        }
+                        ObjectPropertyKind::SpreadProperty(spread) => {
+                            self.scan_expression(&spread.argument);
+                        }
+                    }
+                }
+            }
+            Expression::TemplateLiteral(template) => {
+                for expression in &template.expressions {
+                    self.scan_expression(expression);
+                }
+            }
+            Expression::TaggedTemplateExpression(tagged) => {
+                self.scan_expression(&tagged.tag);
+                for expression in &tagged.quasi.expressions {
+                    self.scan_expression(expression);
+                }
+            }
+            Expression::FunctionExpression(function) => {
+                self.scan_function(function, function_name(function), false);
+            }
+            Expression::ArrowFunctionExpression(function) => {
+                self.scan_arrow_function(function, None, false);
+            }
+            Expression::ClassExpression(class) => {
+                self.scan_class(class);
+            }
+            Expression::SequenceExpression(sequence) => {
+                for expression in &sequence.expressions {
+                    self.scan_expression(expression);
+                }
+            }
+            Expression::AwaitExpression(await_expression) => {
+                self.scan_expression(&await_expression.argument);
+            }
+            Expression::UnaryExpression(unary) => {
+                self.scan_expression(&unary.argument);
+            }
+            Expression::UpdateExpression(_) => {}
+            Expression::YieldExpression(yield_expression) => {
+                if let Some(argument) = &yield_expression.argument {
+                    self.scan_expression(argument);
+                }
+            }
+            Expression::ChainExpression(chain) => {
+                self.scan_chain_element(&chain.expression);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_call_expression(&mut self, call: &'a CallExpression<'a>) {
+        if let Some(hook_call) = self.hook_call(call) {
+            self.report_hook_call(&hook_call);
+        }
+
+        self.scan_expression(&call.callee);
+        for (index, argument) in call.arguments.iter().enumerate() {
+            self.scan_argument(
+                argument,
+                index == 0 && is_component_callback_callee(&call.callee),
+            );
+        }
+    }
+
+    fn scan_argument(&mut self, argument: &'a Argument<'a>, special_component_callback: bool) {
+        match argument {
+            Argument::FunctionExpression(function) => {
+                self.scan_function(
+                    function,
+                    function_name(function),
+                    special_component_callback,
+                );
+            }
+            Argument::ArrowFunctionExpression(function) => {
+                self.scan_arrow_function(function, None, special_component_callback);
+            }
+            Argument::SpreadElement(spread) => {
+                self.scan_expression(&spread.argument);
+            }
+            _ => {
+                if let Some(expression) = argument.as_expression() {
+                    self.scan_expression(expression);
+                }
+            }
+        }
+    }
+
+    fn scan_array_element(&mut self, element: &'a ArrayExpressionElement<'a>) {
+        match element {
+            ArrayExpressionElement::SpreadElement(spread) => {
+                self.scan_expression(&spread.argument);
+            }
+            _ => {
+                if let Some(expression) = element.as_expression() {
+                    self.scan_expression(expression);
+                }
+            }
+        }
+    }
+
+    fn scan_property_key(&mut self, key: &'a PropertyKey<'a>) {
+        if let Some(expression) = key.as_expression() {
+            self.scan_expression(expression);
+        }
+    }
+
+    fn scan_assignment_target(&mut self, target: &'a AssignmentTarget<'a>) {
+        match target {
+            AssignmentTarget::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object);
+                self.scan_expression(&member.expression);
+            }
+            AssignmentTarget::StaticMemberExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            AssignmentTarget::PrivateFieldExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            AssignmentTarget::TSAsExpression(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            AssignmentTarget::TSSatisfiesExpression(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            AssignmentTarget::TSNonNullExpression(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            AssignmentTarget::TSTypeAssertion(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+            _ => {}
+        }
+    }
+
+    fn scan_chain_element(&mut self, element: &'a ChainElement<'a>) {
+        match element {
+            ChainElement::CallExpression(call) => {
+                self.scan_call_expression(call);
+            }
+            ChainElement::StaticMemberExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            ChainElement::ComputedMemberExpression(member) => {
+                self.scan_expression(&member.object);
+                self.scan_expression(&member.expression);
+            }
+            ChainElement::PrivateFieldExpression(member) => {
+                self.scan_expression(&member.object);
+            }
+            ChainElement::TSNonNullExpression(expression) => {
+                self.scan_expression(&expression.expression);
+            }
+        }
+    }
+
+    fn scan_function(
+        &mut self,
+        function: &'a Function<'a>,
+        name: Option<&'a str>,
+        special_component_callback: bool,
+    ) {
+        let Some(body) = function.body.as_deref() else {
+            return;
+        };
+        self.enter_function(
+            name,
+            function.r#async,
+            self.class_depth > 0,
+            special_component_callback,
+            body,
+        );
+    }
+
+    fn scan_arrow_function(
+        &mut self,
+        function: &'a ArrowFunctionExpression<'a>,
+        name: Option<&'a str>,
+        special_component_callback: bool,
+    ) {
+        self.enter_function(
+            name,
+            function.r#async,
+            self.class_depth > 0,
+            special_component_callback,
+            &function.body,
+        );
+    }
+
+    fn enter_function(
+        &mut self,
+        name: Option<&'a str>,
+        async_function: bool,
+        in_class: bool,
+        special_component_callback: bool,
+        body: &'a FunctionBody<'a>,
+    ) {
+        let valid_scope = special_component_callback
+            || name.is_some_and(|name| is_react_component_name(name) || is_hook_name(name));
+        let inside_valid_scope = valid_scope
+            || self
+                .current_frame()
+                .is_some_and(FunctionFrame::is_inside_valid_scope);
+        self.frames.push(FunctionFrame {
+            name: name.map(CompactString::from),
+            valid_scope,
+            inside_valid_scope,
+            async_function,
+            in_class,
+            conditional_depth: 0,
+            loop_depth: 0,
+            try_depth: 0,
+            possible_early_return: false,
+        });
+        self.scan_statement_list(&body.statements);
+        let _ = self.frames.pop();
+    }
+
+    fn scan_class(&mut self, class: &'a Class<'a>) {
+        if let Some(super_class) = &class.super_class {
+            self.scan_expression(super_class);
+        }
+
+        self.class_depth += 1;
+        for element in &class.body.body {
+            match element {
+                ClassElement::StaticBlock(block) => {
+                    self.scan_statement_list(&block.body);
+                }
+                ClassElement::MethodDefinition(method) => {
+                    self.scan_function(&method.value, method_name(&method.key), false);
+                }
+                ClassElement::PropertyDefinition(property) => {
+                    if property.computed {
+                        self.scan_property_key(&property.key);
+                    }
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value);
+                    }
+                }
+                ClassElement::AccessorProperty(property) => {
+                    if property.computed {
+                        self.scan_property_key(&property.key);
+                    }
+                    if let Some(value) = &property.value {
+                        self.scan_expression(value);
+                    }
+                }
+                ClassElement::TSIndexSignature(_) => {}
+            }
+        }
+        self.class_depth = self.class_depth.saturating_sub(1);
+    }
+
+    fn hook_call(&self, call: &'a CallExpression<'a>) -> Option<HookCall> {
+        match call.callee.get_inner_expression() {
+            Expression::Identifier(identifier) if is_hook_name(identifier.name.as_str()) => {
+                Some(HookCall {
+                    name: CompactString::from(identifier.name.as_str()),
+                    span: identifier.span,
+                    is_use: identifier.name == "use",
+                })
+            }
+            Expression::StaticMemberExpression(member)
+                if is_hook_name(member.property.name.as_str())
+                    && object_is_pascal_case_identifier(&member.object) =>
+            {
+                Some(HookCall {
+                    name: self.compact_text(member.span),
+                    span: member.span,
+                    is_use: member.property.name == "use",
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn report_hook_call(&mut self, hook_call: &HookCall) {
+        let Some(frame) = self.current_frame() else {
+            if self.class_depth > 0 {
+                self.report("class", hook_call, None);
+            } else {
+                self.report("topLevel", hook_call, None);
+            }
+            return;
+        };
+
+        let message_id = if hook_call.is_use && frame.try_depth > 0 {
+            Some("tryCatch")
+        } else if !hook_call.is_use && frame.loop_depth > 0 {
+            Some("loop")
+        } else if frame.in_class {
+            Some("class")
+        } else if !frame.valid_scope {
+            if frame.is_inside_valid_scope() {
+                Some("callback")
+            } else if frame.name.is_some() {
+                Some("invalidFunction")
+            } else {
+                Some("callback")
+            }
+        } else if !hook_call.is_use && frame.async_function {
+            Some("async")
+        } else if !hook_call.is_use && (frame.conditional_depth > 0 || frame.possible_early_return)
+        {
+            Some("conditional")
+        } else {
+            None
+        };
+
+        if let Some(message_id) = message_id {
+            let function_name = frame.name.as_ref().cloned();
+            self.report(message_id, hook_call, function_name);
+        }
+    }
+
+    fn report(
+        &mut self,
+        message_id: &'static str,
+        hook_call: &HookCall,
+        function_name: Option<CompactString>,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name: "rules-of-hooks",
+            message_id,
+            data: DiagnosticData {
+                hook: Some(hook_call.name.clone()),
+                function_name,
+            },
+            loc: self
+                .line_index
+                .loc_for_span(self.source_text, hook_call.span),
+        });
+    }
+
+    fn compact_text(&self, span: Span) -> CompactString {
+        let start = span.start as usize;
+        let end = span.end as usize;
+        self.source_text
+            .get(start..end)
+            .map_or_else(|| CompactString::from("React Hook"), CompactString::from)
+    }
+
+    fn with_conditional(&mut self, f: impl FnOnce(&mut Self)) {
+        if let Some(frame) = self.current_frame_mut() {
+            frame.conditional_depth += 1;
+        }
+        f(self);
+        if let Some(frame) = self.current_frame_mut() {
+            frame.conditional_depth = frame.conditional_depth.saturating_sub(1);
+        }
+    }
+
+    fn with_loop(&mut self, f: impl FnOnce(&mut Self)) {
+        if let Some(frame) = self.current_frame_mut() {
+            frame.loop_depth += 1;
+        }
+        f(self);
+        if let Some(frame) = self.current_frame_mut() {
+            frame.loop_depth = frame.loop_depth.saturating_sub(1);
+        }
+    }
+
+    fn with_try(&mut self, f: impl FnOnce(&mut Self)) {
+        if let Some(frame) = self.current_frame_mut() {
+            frame.try_depth += 1;
+        }
+        f(self);
+        if let Some(frame) = self.current_frame_mut() {
+            frame.try_depth = frame.try_depth.saturating_sub(1);
+        }
+    }
+
+    fn current_frame(&self) -> Option<&FunctionFrame> {
+        self.frames.last()
+    }
+
+    fn current_frame_mut(&mut self) -> Option<&mut FunctionFrame> {
+        self.frames.last_mut()
+    }
+}
+
+impl FunctionFrame {
+    fn is_inside_valid_scope(&self) -> bool {
+        self.valid_scope || self.inside_valid_scope
+    }
+}
+
+fn binding_pattern_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn function_name<'a>(function: &'a Function<'a>) -> Option<&'a str> {
+    function
+        .id
+        .as_ref()
+        .map(|identifier| identifier.name.as_str())
+}
+
+fn method_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::PrivateIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn assignment_target_name<'a>(target: &'a AssignmentTarget<'a>) -> Option<&'a str> {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(identifier) => Some(identifier.name.as_str()),
+        AssignmentTarget::StaticMemberExpression(member) => Some(member.property.name.as_str()),
+        _ => None,
+    }
+}
+
+fn object_is_pascal_case_identifier(expression: &Expression<'_>) -> bool {
+    matches!(
+        expression.get_inner_expression(),
+        Expression::Identifier(identifier) if is_react_component_name(identifier.name.as_str())
+    )
+}
+
+fn is_component_callback_callee(expression: &Expression<'_>) -> bool {
+    match expression.get_inner_expression() {
+        Expression::Identifier(identifier) => {
+            matches!(identifier.name.as_str(), "forwardRef" | "memo")
+        }
+        Expression::StaticMemberExpression(member) => {
+            matches!(
+                member.object.get_inner_expression(),
+                Expression::Identifier(identifier) if identifier.name == "React"
+            ) && matches!(member.property.name.as_str(), "forwardRef" | "memo")
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_hook_name, is_react_component_name, scan_react_hooks};
+
+    fn message_ids(source_text: &str) -> oxlint_plugins_carton::SmallVec<[&'static str; 16]> {
+        scan_react_hooks(source_text, "Component.tsx")
+            .into_iter()
+            .map(|diagnostic| diagnostic.message_id)
+            .collect()
+    }
+
+    #[test]
+    fn classifies_component_and_hook_names() {
+        let cases = [
+            ("Component", true, false),
+            ("CMS", true, false),
+            ("useState", false, true),
+            ("use2", false, true),
+            ("use", false, true),
+            ("use_state", false, false),
+            ("component", false, false),
+        ];
+
+        for (name, component, hook) in cases {
+            assert_eq!(is_react_component_name(name), component);
+            assert_eq!(is_hook_name(name), hook);
+        }
+    }
+
+    #[test]
+    fn scans_rules_of_hooks_categories() {
+        let cases = [
+            ("useState();\n", &["topLevel"][..]),
+            (
+                "function normal() { useState(); }\n",
+                &["invalidFunction"][..],
+            ),
+            (
+                "function Component() { items.map(() => { useState(); }); }\n",
+                &["callback"][..],
+            ),
+            (
+                "function Component() { if (cond) { useState(); } }\n",
+                &["conditional"][..],
+            ),
+            (
+                "function Component() { if (cond) return null; useState(); }\n",
+                &["conditional"][..],
+            ),
+            (
+                "function Component() { while (cond) { useState(); } }\n",
+                &["loop"][..],
+            ),
+            (
+                "async function Component() { useState(); }\n",
+                &["async"][..],
+            ),
+            (
+                "class App extends React.Component { render() { useState(); } }\n",
+                &["class"][..],
+            ),
+            (
+                "function Component() { try { use(resource); } catch (error) {} }\n",
+                &["tryCatch"][..],
+            ),
+            (
+                "function Component() { if (cond) { use(resource); } }\n",
+                &[][..],
+            ),
+        ];
+
+        for (source_text, expected) in cases {
+            assert_eq!(message_ids(source_text).as_slice(), expected);
+        }
+    }
+}

--- a/npm/react-hooks/Cargo.toml
+++ b/npm/react-hooks/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "oxlint-plugin-react-hooks"
+description = "Rust-backed oxlint plugin port of eslint-plugin-react-hooks."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_react_hooks"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-react-hooks.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/npm/react-hooks/LICENSE
+++ b/npm/react-hooks/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/react-hooks/README.md
+++ b/npm/react-hooks/README.md
@@ -1,0 +1,3 @@
+# @oxlint-plugins/oxlint-plugin-react-hooks
+
+Rust-backed oxlint plugin port of selected `eslint-plugin-react-hooks` rules.

--- a/npm/react-hooks/api.d.ts
+++ b/npm/react-hooks/api.d.ts
@@ -1,0 +1,23 @@
+export type ReactHooksDiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type ReactHooksDiagnosticData = {
+  hook?: string | null;
+  functionName?: string | null;
+};
+
+export type ReactHooksDiagnostic = {
+  ruleName: string;
+  messageId: string;
+  data: ReactHooksDiagnosticData;
+  loc: ReactHooksDiagnosticLoc;
+};
+
+export function implementedReactHooksRuleNames(): string[];
+export function isHookName(name: string): boolean;
+export function isReactComponentName(name: string): boolean;
+export function scanReactHooks(sourceText: string, filename?: string): ReactHooksDiagnostic[];

--- a/npm/react-hooks/api.js
+++ b/npm/react-hooks/api.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanReactHooks(sourceText, filename = 'file.jsx') {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanReactHooks(sourceText, filename);
+}
+
+module.exports = {
+  implementedReactHooksRuleNames: native.implementedReactHooksRuleNames,
+  isHookName: native.isHookName,
+  isReactComponentName: native.isReactComponentName,
+  scanReactHooks,
+};
+module.exports.default = module.exports;

--- a/npm/react-hooks/build.rs
+++ b/npm/react-hooks/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/react-hooks/index.js
+++ b/npm/react-hooks/index.js
@@ -1,0 +1,172 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-react-hooks (MIT).
+// The JavaScript layer is only an Oxlint/NAPI adapter; the rules-of-hooks
+// classification runs in Rust through Oxc.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedReactHooksRuleNames, scanReactHooks } = require('./api.js');
+
+const PLUGIN_NAME = 'react-hooks';
+const DOCS_BASE = 'https://react.dev/reference/eslint-plugin-react-hooks/lints';
+const diagnosticsCache = new WeakMap();
+
+const messages = {
+  'rules-of-hooks': {
+    async: 'React Hook "{{hook}}" cannot be called in an async function.',
+    loop: 'React Hook "{{hook}}" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.',
+    conditional:
+      'React Hook "{{hook}}" is called conditionally. React Hooks must be called in the exact same order in every component render.',
+    class:
+      'React Hook "{{hook}}" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.',
+    invalidFunction:
+      'React Hook "{{hook}}" is called in function "{{functionName}}" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".',
+    topLevel:
+      'React Hook "{{hook}}" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.',
+    callback:
+      'React Hook "{{hook}}" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.',
+    tryCatch: 'React Hook "{{hook}}" cannot be called in a try/catch block.',
+  },
+};
+
+const ruleDescriptions = {
+  'rules-of-hooks': 'enforces the Rules of Hooks',
+};
+
+const implementedRuleNames = Object.freeze(implementedReactHooksRuleNames());
+
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createReactHooksRule(ruleName)]),
+  ),
+);
+
+const recommendedRules = Object.freeze({
+  [`${PLUGIN_NAME}/rules-of-hooks`]: 'error',
+});
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  configs: {
+    recommended: {
+      name: `${PLUGIN_NAME}/recommended`,
+      plugins: [PLUGIN_NAME],
+      rules: recommendedRules,
+    },
+    'recommended-latest': {
+      name: `${PLUGIN_NAME}/recommended-latest`,
+      plugins: [PLUGIN_NAME],
+      rules: recommendedRules,
+    },
+    all: {
+      name: `${PLUGIN_NAME}/all`,
+      plugins: [PLUGIN_NAME],
+      rules: recommendedRules,
+    },
+  },
+});
+
+plugin.configs.flat = {
+  recommended: {
+    name: `${PLUGIN_NAME}/flat/recommended`,
+    plugins: {
+      [PLUGIN_NAME]: plugin,
+    },
+    rules: recommendedRules,
+  },
+  'recommended-latest': {
+    name: `${PLUGIN_NAME}/flat/recommended-latest`,
+    plugins: {
+      [PLUGIN_NAME]: plugin,
+    },
+    rules: recommendedRules,
+  },
+};
+
+plugin.implementedReactHooksRuleNames = implementedRuleNames;
+plugin.scanReactHooks = scanReactHooks;
+
+function createReactHooksRule(ruleName) {
+  return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: ruleDescriptions[ruleName],
+        recommended: true,
+        url: `${DOCS_BASE}/${ruleName}`,
+      },
+      messages: messages[ruleName],
+      schema: [],
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForContext(context)) {
+            if (diagnostic.ruleName !== ruleName) {
+              continue;
+            }
+            context.report({
+              messageId: diagnostic.messageId,
+              data: compactData(diagnostic.data),
+              loc: {
+                start: {
+                  line: diagnostic.loc.startLine,
+                  column: diagnostic.loc.startColumn,
+                },
+                end: {
+                  line: diagnostic.loc.endLine,
+                  column: diagnostic.loc.endColumn,
+                },
+              },
+            });
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.jsx';
+  const cached = diagnosticsCache.get(sourceCode);
+
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanReactHooks(sourceText, filename);
+  diagnosticsCache.set(sourceCode, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function compactData(data) {
+  const out = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    if (value != null) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.implementedReactHooksRuleNames = implementedRuleNames;
+module.exports.scanReactHooks = scanReactHooks;

--- a/npm/react-hooks/package.json
+++ b/npm/react-hooks/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-react-hooks",
+  "version": "0.0.0",
+  "description": "Rust-backed oxlint plugin port of eslint-plugin-react-hooks.",
+  "keywords": [
+    "eslint-plugin",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "react-hooks",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/react-hooks"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_react_hooks",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/react-hooks/src/lib.rs
+++ b/npm/react-hooks/src/lib.rs
@@ -1,0 +1,83 @@
+//! NAPI boundary for the react-hooks oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticLoc, implemented_react_hooks_rule_names, is_hook_name,
+    is_react_component_name, scan_react_hooks,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI and proc macros require String/Vec/Option; values are converted before leaving the boundary."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_react_hooks as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct DiagnosticData {
+        pub hook: Option<String>,
+        pub function_name: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub data: DiagnosticData,
+        pub loc: DiagnosticLoc,
+    }
+
+    #[napi]
+    pub fn implemented_react_hooks_rule_names() -> Vec<String> {
+        core::implemented_react_hooks_rule_names()
+            .iter()
+            .map(|rule| (*rule).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn is_react_component_name(name: String) -> bool {
+        core::is_react_component_name(&name)
+    }
+
+    #[napi]
+    pub fn is_hook_name(name: String) -> bool {
+        core::is_hook_name(&name)
+    }
+
+    #[napi]
+    pub fn scan_react_hooks(source_text: String, filename: String) -> Vec<Diagnostic> {
+        core::scan_react_hooks(&source_text, &filename)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                data: DiagnosticData {
+                    hook: diagnostic.data.hook.map(|value| value.as_str().to_owned()),
+                    function_name: diagnostic
+                        .data
+                        .function_name
+                        .map(|value| value.as_str().to_owned()),
+                },
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+            })
+            .collect()
+    }
+}

--- a/npm/react-hooks/test/api.test.mjs
+++ b/npm/react-hooks/test/api.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  implementedReactHooksRuleNames,
+  isHookName,
+  isReactComponentName,
+  scanReactHooks,
+} from '../api.js';
+
+describe('react-hooks native api', () => {
+  it('exposes the implemented rule set', () => {
+    expect(implementedReactHooksRuleNames()).toEqual(['rules-of-hooks']);
+  });
+
+  it('classifies component and hook names like upstream', () => {
+    expect(isReactComponentName('Component')).toBe(true);
+    expect(isReactComponentName('CMS')).toBe(true);
+    expect(isReactComponentName('component')).toBe(false);
+    expect(isReactComponentName('useState')).toBe(false);
+
+    expect(isHookName('use')).toBe(true);
+    expect(isHookName('useState')).toBe(true);
+    expect(isHookName('use2')).toBe(true);
+    expect(isHookName('use_state')).toBe(false);
+    expect(isHookName('reuseState')).toBe(false);
+  });
+
+  it('runs the rules-of-hooks scan in native code', () => {
+    const diagnostics = scanReactHooks(
+      [
+        'function Component() {',
+        '  if (cond) { useState(); }',
+        '}',
+        'function normal() {',
+        '  useEffect(() => {});',
+        '}',
+        'function ComponentTwo() {',
+        '  try { use(resource); } catch (err) {}',
+        '}',
+      ].join('\n'),
+      'Component.tsx',
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.messageId)).toEqual([
+      'conditional',
+      'invalidFunction',
+      'tryCatch',
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'rules-of-hooks',
+      'rules-of-hooks',
+      'rules-of-hooks',
+    ]);
+    expect(diagnostics[0].data.hook).toBe('useState');
+    expect(diagnostics[1].data.functionName).toBe('normal');
+    expect(diagnostics[2].data.hook).toBe('use');
+  });
+
+  it('returns LSP-shaped source locations', () => {
+    expect(scanReactHooks('useState();\n', 'Component.tsx')[0].loc).toEqual({
+      startLine: 1,
+      startColumn: 0,
+      endLine: 1,
+      endColumn: 8,
+    });
+  });
+});

--- a/npm/react-hooks/test/plugin.test.mjs
+++ b/npm/react-hooks/test/plugin.test.mjs
@@ -1,0 +1,203 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+const pluginAlias = 'react-hooks-js';
+const ruleName = 'rules-of-hooks';
+const fullRuleName = `${pluginAlias}/${ruleName}`;
+const canonicalRuleName = `react-hooks/${ruleName}`;
+
+const validCases = [
+  {
+    name: 'function component calls hooks at top level',
+    filename: 'Component.tsx',
+    code: 'function Component() { useState(); React.useEffect(() => {}); }\n',
+  },
+  {
+    name: 'custom hook calls hooks at top level',
+    filename: 'Hook.tsx',
+    code: 'function useThing() { useMemo(() => 1, []); }\n',
+  },
+  {
+    name: 'React memo callback is a component scope',
+    filename: 'Memo.tsx',
+    code: 'const Component = React.memo(() => { useState(); });\n',
+  },
+  {
+    name: 'forwardRef callback is a component scope',
+    filename: 'ForwardRef.tsx',
+    code: 'const Fancy = forwardRef(function Fancy(props, ref) { useImperativeHandle(ref, () => ({})); });\n',
+  },
+  {
+    name: 'React use can be conditional and looped',
+    filename: 'Use.tsx',
+    code: 'function Component() { if (cond) { use(resource); } for (const item of items) { use(item); } }\n',
+  },
+];
+
+const invalidCases = [
+  {
+    name: 'top-level hook',
+    filename: 'TopLevel.tsx',
+    code: 'useState();\n',
+    messageIds: ['topLevel'],
+  },
+  {
+    name: 'invalid function name',
+    filename: 'InvalidFunction.tsx',
+    code: 'function normal() { useState(); }\n',
+    messageIds: ['invalidFunction'],
+  },
+  {
+    name: 'callback inside component',
+    filename: 'Callback.tsx',
+    code: 'function Component() { items.map(() => { useState(); }); }\n',
+    messageIds: ['callback'],
+  },
+  {
+    name: 'conditional hook',
+    filename: 'Conditional.tsx',
+    code: 'function Component() { if (cond) { useState(); } }\n',
+    messageIds: ['conditional'],
+  },
+  {
+    name: 'early return before hook',
+    filename: 'EarlyReturn.tsx',
+    code: 'function Component() { if (cond) return null; useState(); }\n',
+    messageIds: ['conditional'],
+  },
+  {
+    name: 'hook in loop',
+    filename: 'Loop.tsx',
+    code: 'function Component() { while (cond) { useState(); } }\n',
+    messageIds: ['loop'],
+  },
+  {
+    name: 'hook in async component',
+    filename: 'Async.tsx',
+    code: 'async function Component() { useState(); }\n',
+    messageIds: ['async'],
+  },
+  {
+    name: 'hook in class component',
+    filename: 'Class.tsx',
+    code: 'class App extends React.Component { render() { useState(); } }\n',
+    messageIds: ['class'],
+  },
+  {
+    name: 'React use inside try/catch',
+    filename: 'TryCatch.tsx',
+    code: 'function Component() { try { use(resource); } catch (err) {} }\n',
+    messageIds: ['tryCatch'],
+  },
+];
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint({ filename, code }) {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'react-hooks-plugin-'));
+
+  try {
+    const sourcePath = join(temp, filename);
+    const configPath = join(temp, 'oxlint.config.jsonc');
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: pluginAlias,
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [fullRuleName]: 'error',
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('react-hooks plugin shape', () => {
+  it('exposes rules-of-hooks and implemented configs only', () => {
+    expect(plugin.meta?.name).toBe('react-hooks');
+    expect(Object.keys(plugin.rules)).toEqual(['rules-of-hooks']);
+    expect(plugin.rules[ruleName].meta.messages.conditional).toContain('called conditionally');
+    expect(typeof plugin.rules[ruleName].createOnce).toBe('function');
+
+    expect(plugin.configs.recommended.rules).toEqual({
+      [canonicalRuleName]: 'error',
+    });
+    expect(plugin.configs['recommended-latest'].rules).toEqual({
+      [canonicalRuleName]: 'error',
+    });
+    expect(plugin.configs.flat.recommended.plugins['react-hooks']).toBe(plugin);
+  });
+});
+
+describe('react-hooks rules-of-hooks through oxlint jsPlugins', () => {
+  it.each(validCases)('accepts $name', (fixture) => {
+    const result = runOxlint(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(invalidCases)('reports $name', (fixture) => {
+    const result = runOxlint(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
+      fixture.messageIds.map(() => 'react-hooks-js(rules-of-hooks)'),
+    );
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual(
+      fixture.messageIds.map((messageId) =>
+        plugin.rules[ruleName].meta.messages[messageId]
+          .replace('{{hook}}', messageId === 'tryCatch' ? 'use' : 'useState')
+          .replace('{{functionName}}', 'normal'),
+      ),
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/react-hooks:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/react-refresh:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -1184,6 +1184,39 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-react-hooks",
+    "directory": "npm/react-hooks",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-react-hooks",
+      "version": "7.1.1",
+      "repository": "https://github.com/facebook/react",
+      "license": "MIT"
+    },
+    "status": "in-progress",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "rules-of-hooks",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc scope and control-flow port of eslint-plugin-react-hooks/rules-of-hooks; covers component and hook scopes, memo/forwardRef callbacks, loops, conditionals, early returns, async functions, class methods, nested callbacks, top-level calls, and React use() try/catch handling."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-react-refresh",
     "directory": "npm/react-refresh",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -57,6 +57,10 @@ const nativePackages = [
     binding: 'npm/regexp/native.js',
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-react-hooks',
+    binding: 'npm/react-hooks/native.js',
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-mocha',
     binding: 'npm/mocha/native.js',
   },

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -45,6 +45,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-react-hooks',
+    dir: 'npm/react-hooks',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-security',
     dir: 'npm/security',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- add a Rust/Oxc implementation of eslint-plugin-react-hooks rules-of-hooks
- expose @oxlint-plugins/oxlint-plugin-react-hooks through NAPI and the JS plugin adapter
- cover native API, Rust unit, Vitest, and oxlint jsPlugins CLI cases

## Verification
- corepack pnpm run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->