### PR TITLE
test(regexp): broaden coverage for ported eslint-plugin-regexp rules

### DIFF
--- a/crates/e18e/src/lib.rs
+++ b/crates/e18e/src/lib.rs
@@ -24,10 +24,10 @@ use oxlint_plugins_carton::SmallVec;
 
 use crate::helpers::ban_dependency_diagnostic;
 use crate::scanner::Scanner;
+pub(crate) use crate::types::LineIndex;
 pub use crate::types::{
     BanDependency, Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, E18eOptions,
 };
-pub(crate) use crate::types::LineIndex;
 
 pub const RULE_NAMES: [&str; 25] = [
     "prefer-array-at",

--- a/crates/regexp/src/expressions.rs
+++ b/crates/regexp/src/expressions.rs
@@ -1,7 +1,9 @@
 //! Expression-level traversal for the regexp scanner. Split from the
 //! statement-level walker in `traversal.rs` to keep each file focused.
 
-use oxc_ast::ast::{Argument, AssignmentTarget, ChainElement, Expression, ObjectPropertyKind, PropertyKey};
+use oxc_ast::ast::{
+    Argument, AssignmentTarget, ChainElement, Expression, ObjectPropertyKind, PropertyKey,
+};
 
 use crate::helpers::array_element_expression;
 use crate::scanner::Scanner;

--- a/crates/regexp/src/scanner.rs
+++ b/crates/regexp/src/scanner.rs
@@ -13,12 +13,7 @@ pub(crate) struct Scanner<'a> {
 }
 
 impl<'a> Scanner<'a> {
-    pub(crate) fn report(
-        &mut self,
-        rule_name: &'static str,
-        message_id: &'static str,
-        span: Span,
-    ) {
+    pub(crate) fn report(&mut self, rule_name: &'static str, message_id: &'static str, span: Span) {
         self.report_with_data(rule_name, message_id, DiagnosticData::default(), span);
     }
 

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1,12 +1,39 @@
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
 
-use crate::{implemented_regexp_rule_names, scan_regexp};
+use crate::{
+    implemented_regexp_rule_names, scan_regexp,
+    types::{Diagnostic, DiagnosticData},
+};
 
 fn ids(source: &str) -> SmallVec<[(&'static str, &'static str); 8]> {
     scan_regexp(source, "fixture.js")
         .into_iter()
         .map(|diagnostic| (diagnostic.rule_name, diagnostic.message_id))
         .collect()
+}
+
+fn diagnostics(source: &str) -> SmallVec<[Diagnostic; 16]> {
+    scan_regexp(source, "fixture.js")
+}
+
+fn first_data(source: &str, rule_name: &'static str) -> DiagnosticData {
+    diagnostics(source)
+        .into_iter()
+        .find(|d| d.rule_name == rule_name)
+        .map(|d| d.data)
+        .expect("expected diagnostic for rule")
+}
+
+fn rule_ids_for(source: &str, rule_name: &'static str) -> SmallVec<[&'static str; 8]> {
+    diagnostics(source)
+        .into_iter()
+        .filter(|d| d.rule_name == rule_name)
+        .map(|d| d.message_id)
+        .collect()
+}
+
+fn rule_names_for(source: &str) -> SmallVec<[&'static str; 8]> {
+    ids(source).into_iter().map(|(name, _)| name).collect()
 }
 
 #[test]
@@ -29,60 +56,401 @@ fn exposes_initial_regexp_rule_names() {
 }
 
 #[test]
-fn scans_literal_pattern_rules() {
+fn ignores_non_regexp_callers() {
+    assert!(ids("const a = Foo('[]', 'u');").is_empty());
+    assert!(ids("const a = new Bar('[', 'u');").is_empty());
+    assert!(ids("const a = RegExp;").is_empty());
+}
+
+#[test]
+fn ignores_dynamic_constructor_arguments() {
+    // Non-literal pattern arguments cannot be statically analysed at all.
+    assert!(ids("const a = new RegExp(pattern, 'u');").is_empty());
+    assert!(ids("const a = RegExp();").is_empty());
+    // When the flags argument is non-literal we still scan the pattern and
+    // assume no `u`/`v` flag, which surfaces `require-unicode-regexp` only.
     assert_eq!(
-        ids("const a = /[]/u;").as_slice(),
-        &[("no-empty-character-class", "empty")]
-    );
-    assert_eq!(ids("const a = /()/u;").len(), 2);
-    assert_eq!(
-        ids("const a = /a|/u;").as_slice(),
-        &[("no-empty-alternative", "empty")]
-    );
-    assert_eq!(
-        ids("const a = /a{0}/u;").as_slice(),
-        &[("no-zero-quantifier", "unexpected")]
+        rule_names_for("const a = new RegExp('a', flags);").as_slice(),
+        &["require-unicode-regexp"]
     );
 }
 
 #[test]
-fn scans_constructor_patterns_and_flags() {
-    assert_eq!(
-        ids("const a = new RegExp('[]', 'u');").as_slice(),
-        &[("no-empty-character-class", "empty")]
-    );
-    assert_eq!(
-        ids("const a = new RegExp('[', 'u');").as_slice(),
-        &[("no-invalid-regexp", "error")]
-    );
-    assert_eq!(
-        ids("const a = new RegExp('a', 'gg');").as_slice(),
-        &[("no-invalid-regexp", "duplicateFlag")]
-    );
-    assert_eq!(
-        ids("const a = RegExp('a', 'vu');").as_slice(),
-        &[("no-invalid-regexp", "uvFlag")]
-    );
+fn parses_syntactically_invalid_module_safely() {
+    // Parser failure should yield no diagnostics rather than panic.
+    assert!(scan_regexp("const = ;", "fixture.js").is_empty());
+}
+
+mod no_invalid_regexp {
+    use super::*;
+
+    #[test]
+    fn accepts_well_formed_patterns() {
+        assert!(rule_ids_for("const a = /a+/u;", "no-invalid-regexp").is_empty());
+        assert!(
+            rule_ids_for("const a = new RegExp('a+', 'gimsu');", "no-invalid-regexp").is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('(?:a|b)+', 'v');",
+                "no-invalid-regexp"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn reports_unclosed_constructs() {
+        assert_eq!(
+            rule_ids_for("const a = new RegExp('[', 'u');", "no-invalid-regexp").as_slice(),
+            &["error"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = new RegExp('(?:', 'u');", "no-invalid-regexp").as_slice(),
+            &["error"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = new RegExp('\\\\u{', 'u');", "no-invalid-regexp").as_slice(),
+            &["error"]
+        );
+    }
+
+    #[test]
+    fn reports_duplicate_flags() {
+        let data = first_data("const a = new RegExp('a', 'gg');", "no-invalid-regexp");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("g"));
+
+        // Duplicate detection short-circuits before further checks.
+        assert_eq!(
+            ids("const a = new RegExp('a', 'ii');").as_slice(),
+            &[("no-invalid-regexp", "duplicateFlag")]
+        );
+    }
+
+    #[test]
+    fn reports_conflicting_u_and_v_flags() {
+        assert_eq!(
+            ids("const a = new RegExp('a', 'uv');").as_slice(),
+            &[("no-invalid-regexp", "uvFlag")]
+        );
+        assert_eq!(
+            ids("const a = RegExp('a', 'vu');").as_slice(),
+            &[("no-invalid-regexp", "uvFlag")]
+        );
+    }
+
+    #[test]
+    fn does_not_validate_literal_patterns() {
+        // Literal regexps are already parser-validated by the JS engine; we
+        // intentionally skip constructor-style validation for them.
+        assert!(rule_ids_for("const a = /a+/u;", "no-invalid-regexp").is_empty());
+    }
+}
+
+mod no_empty_character_class {
+    use super::*;
+
+    #[test]
+    fn reports_empty_classes_in_various_positions() {
+        assert_eq!(
+            rule_ids_for("const a = /[]/u;", "no-empty-character-class").as_slice(),
+            &["empty"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /abc[]def/u;", "no-empty-character-class").as_slice(),
+            &["empty"]
+        );
+        assert_eq!(
+            rule_ids_for(
+                "const a = new RegExp('[]', 'u');",
+                "no-empty-character-class"
+            )
+            .as_slice(),
+            &["empty"]
+        );
+    }
+
+    #[test]
+    fn accepts_non_empty_or_negated_classes() {
+        assert!(rule_ids_for("const a = /[a]/u;", "no-empty-character-class").is_empty());
+        assert!(rule_ids_for("const a = /[^]/u;", "no-empty-character-class").is_empty());
+        // A `]` escaped inside the class still has content.
+        assert!(rule_ids_for("const a = /[\\]]/u;", "no-empty-character-class").is_empty());
+    }
+}
+
+mod no_empty_group {
+    use super::*;
+
+    #[test]
+    fn reports_empty_non_capturing_groups() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:)/u;", "no-empty-group").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a(?:)b/u;", "no-empty-group").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn reports_empty_named_capturing_group_as_group_too() {
+        // Named capturing groups participate in both empty-group rules.
+        assert_eq!(
+            rule_ids_for("const a = /(?<name>)/u;", "no-empty-group").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_lookaround_groups() {
+        // Lookarounds are not checked for emptiness; they are valid even when empty.
+        assert!(rule_ids_for("const a = /(?=)/u;", "no-empty-group").is_empty());
+        assert!(rule_ids_for("const a = /(?!)/u;", "no-empty-group").is_empty());
+        assert!(rule_ids_for("const a = /(?<=)/u;", "no-empty-group").is_empty());
+        assert!(rule_ids_for("const a = /(?<!)/u;", "no-empty-group").is_empty());
+    }
+
+    #[test]
+    fn accepts_non_empty_groups() {
+        assert!(rule_ids_for("const a = /(?:a)/u;", "no-empty-group").is_empty());
+        assert!(rule_ids_for("const a = /(?:a|b)/u;", "no-empty-group").is_empty());
+    }
+}
+
+mod no_empty_capturing_group {
+    use super::*;
+
+    #[test]
+    fn reports_anonymous_and_named_empty_captures() {
+        assert!(
+            rule_ids_for("const a = /()/u;", "no-empty-capturing-group").contains(&"unexpected")
+        );
+        assert!(
+            rule_ids_for("const a = /(?<name>)/u;", "no-empty-capturing-group")
+                .contains(&"unexpected")
+        );
+        assert!(
+            rule_ids_for("const a = /a()b/u;", "no-empty-capturing-group").contains(&"unexpected")
+        );
+    }
+
+    #[test]
+    fn accepts_non_empty_captures() {
+        assert!(rule_ids_for("const a = /(a)/u;", "no-empty-capturing-group").is_empty());
+        assert!(rule_ids_for("const a = /(?<name>a)/u;", "no-empty-capturing-group").is_empty());
+    }
+}
+
+mod no_empty_alternative {
+    use super::*;
+
+    #[test]
+    fn reports_top_level_empty_alternatives() {
+        assert_eq!(
+            rule_ids_for("const a = /a|/u;", "no-empty-alternative").as_slice(),
+            &["empty"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /|a/u;", "no-empty-alternative").as_slice(),
+            &["empty"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a||b/u;", "no-empty-alternative").as_slice(),
+            &["empty"]
+        );
+    }
+
+    #[test]
+    fn reports_empty_alternatives_inside_groups() {
+        assert_eq!(
+            rule_ids_for("const a = /(a|)/u;", "no-empty-alternative").as_slice(),
+            &["empty"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|)/u;", "no-empty-alternative").as_slice(),
+            &["empty"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:|b)/u;", "no-empty-alternative").as_slice(),
+            &["empty"]
+        );
+    }
+
+    #[test]
+    fn accepts_filled_alternatives() {
+        assert!(rule_ids_for("const a = /a|b/u;", "no-empty-alternative").is_empty());
+        assert!(rule_ids_for("const a = /(?:a|b|c)/u;", "no-empty-alternative").is_empty());
+    }
+}
+
+mod no_zero_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_zero_braced_quantifiers() {
+        assert_eq!(
+            rule_ids_for("const a = /a{0}/u;", "no-zero-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a{0,0}/u;", "no-zero-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:abc){0}/u;", "no-zero-quantifier").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn accepts_quantifiers_with_a_nonzero_upper_bound() {
+        assert!(rule_ids_for("const a = /a{1}/u;", "no-zero-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{0,1}/u;", "no-zero-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{0,}/u;", "no-zero-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{2,5}/u;", "no-zero-quantifier").is_empty());
+    }
+}
+
+mod no_octal {
+    use super::*;
+
+    #[test]
+    fn reports_real_octal_escapes() {
+        let data = first_data("const a = /\\07/u;", "no-octal");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\07"));
+
+        let data = first_data("const a = /\\012/u;", "no-octal");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\012"));
+    }
+
+    #[test]
+    fn ignores_nul_and_non_octal_digits() {
+        // `\0` alone is the NUL escape, not an octal sequence.
+        assert!(rule_ids_for("const a = /\\0/u;", "no-octal").is_empty());
+        // `\08` is `\0` followed by literal `8` (which is not an octal digit).
+        assert!(rule_ids_for("const a = /\\08/u;", "no-octal").is_empty());
+    }
+}
+
+mod no_control_character {
+    use super::*;
+
+    #[test]
+    fn reports_hex_and_unicode_control_escapes() {
+        let data = first_data(
+            "const a = new RegExp('\\x01', 'u');",
+            "no-control-character",
+        );
+        assert_eq!(
+            data.char_text.as_ref().map(CompactString::as_str),
+            Some("U+0001")
+        );
+
+        let data = first_data(
+            "const a = new RegExp('\\u0002', 'u');",
+            "no-control-character",
+        );
+        assert_eq!(
+            data.char_text.as_ref().map(CompactString::as_str),
+            Some("U+0002")
+        );
+
+        let data = first_data(
+            "const a = new RegExp('\\u{3}', 'u');",
+            "no-control-character",
+        );
+        assert_eq!(
+            data.char_text.as_ref().map(CompactString::as_str),
+            Some("U+0003")
+        );
+    }
+
+    #[test]
+    fn accepts_named_or_printable_escapes() {
+        // Named escapes (`\t`, `\n`, `\r`) are NOT reported.
+        assert!(rule_ids_for("const a = /\\t/u;", "no-control-character").is_empty());
+        assert!(rule_ids_for("const a = /\\n/u;", "no-control-character").is_empty());
+        // Printable characters above U+001F are fine.
+        assert!(rule_ids_for("const a = /a/u;", "no-control-character").is_empty());
+        // `\u0041` ('A') is above the control range.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\u0041', 'u');",
+                "no-control-character"
+            )
+            .is_empty()
+        );
+    }
+}
+
+mod sort_flags {
+    use super::*;
+
+    #[test]
+    fn reports_unsorted_flags_with_data() {
+        let data = first_data("const a = /a/mi;", "sort-flags");
+        assert_eq!(data.flags.as_ref().map(CompactString::as_str), Some("mi"));
+        assert_eq!(
+            data.sorted_flags.as_ref().map(CompactString::as_str),
+            Some("im")
+        );
+    }
+
+    #[test]
+    fn accepts_already_sorted_or_empty_flags() {
+        assert!(rule_ids_for("const a = /a/gim;", "sort-flags").is_empty());
+        assert!(rule_ids_for("const a = /a/u;", "sort-flags").is_empty());
+        assert!(rule_ids_for("const a = /a/;", "sort-flags").is_empty());
+        assert!(rule_ids_for("const a = new RegExp('a');", "sort-flags").is_empty());
+    }
+}
+
+mod require_unicode_regexp {
+    use super::*;
+
+    #[test]
+    fn reports_when_neither_u_nor_v_is_present() {
+        assert_eq!(
+            rule_ids_for("const a = /a/;", "require-unicode-regexp").as_slice(),
+            &["require"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a/g;", "require-unicode-regexp").as_slice(),
+            &["require"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = new RegExp('a');", "require-unicode-regexp").as_slice(),
+            &["require"]
+        );
+    }
+
+    #[test]
+    fn accepts_u_or_v_flag() {
+        assert!(rule_ids_for("const a = /a/u;", "require-unicode-regexp").is_empty());
+        assert!(rule_ids_for("const a = /a/v;", "require-unicode-regexp").is_empty());
+        assert!(rule_ids_for("const a = /a/gu;", "require-unicode-regexp").is_empty());
+        assert!(
+            rule_ids_for("const a = new RegExp('a', 'u');", "require-unicode-regexp").is_empty()
+        );
+    }
 }
 
 #[test]
-fn scans_style_and_legacy_rules() {
+fn reports_multiple_rules_for_a_single_regex() {
+    // `/()/mi` triggers: empty group, empty capturing group, sort-flags, require-unicode-regexp.
+    let rules = rule_names_for("const a = /()/mi;");
+    assert!(rules.contains(&"no-empty-group"));
+    assert!(rules.contains(&"no-empty-capturing-group"));
+    assert!(rules.contains(&"sort-flags"));
+    assert!(rules.contains(&"require-unicode-regexp"));
+}
+
+#[test]
+fn reports_each_literal_independently() {
     assert_eq!(
-        ids("const a = /a/mi;").as_slice(),
-        &[
-            ("sort-flags", "sortFlags"),
-            ("require-unicode-regexp", "require"),
-        ]
-    );
-    assert_eq!(
-        ids("const a = /\\07/u;").as_slice(),
-        &[("no-octal", "unexpected")]
-    );
-    assert_eq!(
-        ids("const a = new RegExp('\\u{1}');").as_slice(),
-        &[
-            ("require-unicode-regexp", "require"),
-            ("no-control-character", "unexpected"),
-        ]
+        rule_names_for("const a = /[]/u; const b = /a|/u;").as_slice(),
+        &["no-empty-character-class", "no-empty-alternative"]
     );
 }

--- a/crates/simple_import_sort/src/items.rs
+++ b/crates/simple_import_sort/src/items.rs
@@ -8,8 +8,8 @@ use oxlint_plugins_carton::CompactString;
 use regex::Regex;
 
 use crate::scanner::span_text;
-use crate::specifiers::sort_import_specifiers_in_code;
 use crate::specifiers::sort_export_specifiers_in_code;
+use crate::specifiers::sort_import_specifiers_in_code;
 use crate::types::{EXPORT_STYLE, Item, SIDE_EFFECT_STYLE, SimpleImportSortOptions};
 
 pub(crate) fn item_from_import(

--- a/crates/simple_import_sort/src/scanner.rs
+++ b/crates/simple_import_sort/src/scanner.rs
@@ -10,7 +10,8 @@ use oxlint_plugins_carton::{CompactString, SmallVec};
 use crate::items::{item_from_all_export, item_from_import, item_from_named_export};
 use crate::specifiers::sort_export_specifiers_in_code;
 use crate::types::{
-    Diagnostic, DiagnosticFix, Item, LineIndex, RuleKind, SIDE_EFFECT_STYLE, SimpleImportSortOptions,
+    Diagnostic, DiagnosticFix, Item, LineIndex, RuleKind, SIDE_EFFECT_STYLE,
+    SimpleImportSortOptions,
 };
 
 pub(crate) fn scan_import_chunks(

--- a/crates/testing_library/src/helpers.rs
+++ b/crates/testing_library/src/helpers.rs
@@ -6,7 +6,10 @@ pub(crate) fn span_for(index: usize, len: usize) -> Span {
     Span::new(index as u32, (index + len) as u32)
 }
 
-pub(crate) fn find_all<'a>(source_text: &'a str, pattern: &'a str) -> impl Iterator<Item = usize> + 'a {
+pub(crate) fn find_all<'a>(
+    source_text: &'a str,
+    pattern: &'a str,
+) -> impl Iterator<Item = usize> + 'a {
     source_text.match_indices(pattern).map(|(index, _)| index)
 }
 

--- a/crates/unocss/src/lib.rs
+++ b/crates/unocss/src/lib.rs
@@ -18,9 +18,7 @@ use regex::Regex;
 use crate::scanner::Scanner;
 use crate::types::LineIndex;
 
-pub use crate::types::{
-    BlocklistEntry, Diagnostic, DiagnosticFix, DiagnosticLoc, UnocssOptions,
-};
+pub use crate::types::{BlocklistEntry, Diagnostic, DiagnosticFix, DiagnosticLoc, UnocssOptions};
 
 pub const RULE_NAMES: [&str; 4] = [
     "blocklist",

--- a/crates/unocss/src/scanner.rs
+++ b/crates/unocss/src/scanner.rs
@@ -14,9 +14,7 @@ use crate::tags::{
     IGNORED_ATTRIBUTIFY_ATTRIBUTES, find_tag_end, is_attr_name_part, is_identifier_part,
     is_identifier_start, skip_attribute_value,
 };
-use crate::types::{
-    Diagnostic, DiagnosticFix, LineIndex, LiteralSpan, ReportData, UnocssOptions,
-};
+use crate::types::{Diagnostic, DiagnosticFix, LineIndex, LiteralSpan, ReportData, UnocssOptions};
 
 pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,

--- a/crates/unocss/src/tests.rs
+++ b/crates/unocss/src/tests.rs
@@ -1,8 +1,6 @@
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
-use crate::{
-    BlocklistEntry, UnocssOptions, implemented_unocss_rule_names, scan_unocss,
-};
+use crate::{BlocklistEntry, UnocssOptions, implemented_unocss_rule_names, scan_unocss};
 
 #[test]
 fn exposes_all_rule_names() {

--- a/crates/unused_imports/src/lib.rs
+++ b/crates/unused_imports/src/lib.rs
@@ -17,9 +17,7 @@ use crate::fixers::{is_used_in_jsdoc, unused_message};
 use crate::scanner::{collect_import_bindings, report_unused_imports, should_report_unused_symbol};
 use crate::types::{ImportBinding, LineIndex, SpanKey};
 
-pub use crate::types::{
-    Diagnostic, DiagnosticFix, DiagnosticLoc, UnusedImportsOptions,
-};
+pub use crate::types::{Diagnostic, DiagnosticFix, DiagnosticLoc, UnusedImportsOptions};
 
 pub const RULE_NAMES: [&str; 2] = ["no-unused-imports", "no-unused-vars"];
 

--- a/crates/unused_imports/src/tests.rs
+++ b/crates/unused_imports/src/tests.rs
@@ -17,8 +17,7 @@ fn apply_first_fix(source: &str, filename: &str) -> CompactString {
 
 #[test]
 fn removes_unused_named_import() {
-    let source =
-        "import x from \"package\";\nimport { a, b } from \"./utils\";\nconst c = b(x);\n";
+    let source = "import x from \"package\";\nimport { a, b } from \"./utils\";\nconst c = b(x);\n";
     let diagnostics = scan_unused_imports(source, "file.js", &UnusedImportsOptions::default());
     assert_eq!(diagnostics[0].rule_name, "no-unused-imports");
     assert_eq!(diagnostics[0].message, "'a' is defined but never used.");

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -56,4 +56,30 @@ describe('regexp native API', () => {
       },
     });
   });
+
+  it('returns no diagnostics for clean sources', () => {
+    expect(scanRegexp('const re = /a+/u;\n', 'fixture.js')).toEqual([]);
+    expect(scanRegexp("const re = new RegExp('a', 'gimsu');\n", 'fixture.js')).toEqual([]);
+  });
+
+  it('returns no diagnostics when the source fails to parse', () => {
+    // Parser failure must not surface phantom diagnostics.
+    expect(scanRegexp('const = ;', 'fixture.js')).toEqual([]);
+  });
+
+  it('reports each literal separately', () => {
+    const diagnostics = scanRegexp('const a = /[]/u; const b = /a|/u;\n', 'fixture.js');
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'no-empty-character-class',
+      'no-empty-alternative',
+    ]);
+    expect(diagnostics[0].loc.startLine).toBe(1);
+    expect(diagnostics[1].loc.startLine).toBe(1);
+    expect(diagnostics[1].loc.startColumn).toBeGreaterThan(diagnostics[0].loc.startColumn);
+  });
+
+  it('ignores callers that are not RegExp', () => {
+    expect(scanRegexp("new Foo('[]', 'u');\n", 'fixture.js')).toEqual([]);
+    expect(scanRegexp("Bar('[', 'u');\n", 'fixture.js')).toEqual([]);
+  });
 });

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -12,36 +12,111 @@ const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = resolve(packageRoot, '../..');
 
 const validCases = [
+  // no-invalid-regexp
   ['no-invalid-regexp', 'valid constructor', "new RegExp('a+', 'u');\n"],
-  ['no-empty-character-class', 'non-empty class', 'const re = /[a]/u;\n'],
-  ['no-empty-group', 'non-empty group', 'const re = /(?:a)/u;\n'],
-  ['no-empty-capturing-group', 'non-empty capture', 'const re = /(a)/u;\n'],
-  ['no-empty-alternative', 'no empty alternative', 'const re = /a|b/u;\n'],
+  ['no-invalid-regexp', 'all valid flags', "new RegExp('a', 'gimsu');\n"],
+  ['no-invalid-regexp', 'unicode set flag', "new RegExp('[a]', 'v');\n"],
+  // no-empty-character-class
+  ['no-empty-character-class', 'single-char class', 'const re = /[a]/u;\n'],
+  ['no-empty-character-class', 'negated empty-looking class', 'const re = /[^]/u;\n'],
+  ['no-empty-character-class', 'class containing escaped bracket', 'const re = /[\\]]/u;\n'],
+  // no-empty-group
+  ['no-empty-group', 'non-capturing group with content', 'const re = /(?:a)/u;\n'],
+  ['no-empty-group', 'empty lookahead is allowed', 'const re = /(?=a)/u;\n'],
+  ['no-empty-group', 'empty negative lookahead is allowed', 'const re = /(?!a)/u;\n'],
+  // no-empty-capturing-group
+  ['no-empty-capturing-group', 'capture with content', 'const re = /(a)/u;\n'],
+  ['no-empty-capturing-group', 'named capture with content', 'const re = /(?<name>a)/u;\n'],
+  // no-empty-alternative
+  ['no-empty-alternative', 'simple alternation', 'const re = /a|b/u;\n'],
+  ['no-empty-alternative', 'alternation inside group', 'const re = /(?:a|b|c)/u;\n'],
+  // no-zero-quantifier
   ['no-zero-quantifier', 'positive quantifier', 'const re = /a{1}/u;\n'],
+  ['no-zero-quantifier', 'open upper bound', 'const re = /a{0,}/u;\n'],
+  ['no-zero-quantifier', 'positive range', 'const re = /a{2,5}/u;\n'],
+  // no-octal
   ['no-octal', 'nul escape only', 'const re = /\\0/u;\n'],
-  ['no-control-character', 'named control escape', 'const re = /\\t/u;\n'],
+  ['no-octal', 'nul followed by 8 (not octal)', 'const re = /\\08/u;\n'],
+  // no-control-character
+  ['no-control-character', 'named tab escape', 'const re = /\\t/u;\n'],
+  ['no-control-character', 'named newline escape', 'const re = /\\n/u;\n'],
+  ['no-control-character', 'printable hex escape', "const re = new RegExp('\\\\u0041', 'u');\n"],
+  // sort-flags
   ['sort-flags', 'sorted flags', 'const re = /a/im;\n'],
+  ['sort-flags', 'no flags', 'const re = /a/;\n'],
+  ['sort-flags', 'single flag', 'const re = /a/u;\n'],
+  // require-unicode-regexp
   ['require-unicode-regexp', 'unicode flag', 'const re = /a/u;\n'],
+  ['require-unicode-regexp', 'unicode set flag', 'const re = /a/v;\n'],
+  ['require-unicode-regexp', 'unicode with other flags', 'const re = /a/gu;\n'],
 ];
 
 const invalidCases = [
-  ['no-invalid-regexp', 'invalid constructor pattern', "new RegExp('[', 'u');\n", ['error']],
+  // no-invalid-regexp
+  ['no-invalid-regexp', 'unclosed character class', "new RegExp('[', 'u');\n", ['error']],
+  ['no-invalid-regexp', 'unclosed group', "new RegExp('(?:', 'u');\n", ['error']],
   ['no-invalid-regexp', 'duplicate flags', "new RegExp('a', 'gg');\n", ['duplicateFlag']],
-  ['no-invalid-regexp', 'u and v flags', "new RegExp('a', 'uv');\n", ['uvFlag']],
-  ['no-empty-character-class', 'empty character class', 'const re = /[]/u;\n', ['empty']],
-  ['no-empty-group', 'empty group', 'const re = /(?:)/u;\n', ['unexpected']],
-  ['no-empty-capturing-group', 'empty capturing group', 'const re = /()/u;\n', ['unexpected']],
+  ['no-invalid-regexp', 'duplicate i flags', "new RegExp('a', 'ii');\n", ['duplicateFlag']],
+  ['no-invalid-regexp', 'u and v flags together', "new RegExp('a', 'uv');\n", ['uvFlag']],
+  ['no-invalid-regexp', 'v and u flags together', "new RegExp('a', 'vu');\n", ['uvFlag']],
+  // no-empty-character-class
+  ['no-empty-character-class', 'standalone empty class', 'const re = /[]/u;\n', ['empty']],
+  ['no-empty-character-class', 'empty class between chars', 'const re = /abc[]def/u;\n', ['empty']],
+  [
+    'no-empty-character-class',
+    'empty class via constructor',
+    "const re = new RegExp('[]', 'u');\n",
+    ['empty'],
+  ],
+  // no-empty-group
+  ['no-empty-group', 'empty non-capturing group', 'const re = /(?:)/u;\n', ['unexpected']],
+  ['no-empty-group', 'empty group between chars', 'const re = /a(?:)b/u;\n', ['unexpected']],
+  // no-empty-capturing-group
+  ['no-empty-capturing-group', 'empty capture', 'const re = /()/u;\n', ['unexpected']],
+  ['no-empty-capturing-group', 'empty named capture', 'const re = /(?<name>)/u;\n', ['unexpected']],
+  // no-empty-alternative
   ['no-empty-alternative', 'trailing empty alternative', 'const re = /a|/u;\n', ['empty']],
+  ['no-empty-alternative', 'leading empty alternative', 'const re = /|a/u;\n', ['empty']],
+  ['no-empty-alternative', 'middle empty alternative', 'const re = /a||b/u;\n', ['empty']],
+  ['no-empty-alternative', 'empty alternative in group', 'const re = /(?:a|)/u;\n', ['empty']],
+  // no-zero-quantifier
   ['no-zero-quantifier', 'zero quantifier', 'const re = /a{0}/u;\n', ['unexpected']],
-  ['no-octal', 'octal escape', 'const re = /\\07/u;\n', ['unexpected']],
+  ['no-zero-quantifier', 'zero,zero quantifier', 'const re = /a{0,0}/u;\n', ['unexpected']],
+  ['no-zero-quantifier', 'zero quantifier on group', 'const re = /(?:abc){0}/u;\n', ['unexpected']],
+  // no-octal
+  ['no-octal', 'two-digit octal escape', 'const re = /\\07/u;\n', ['unexpected']],
+  ['no-octal', 'three-digit octal escape', 'const re = /\\012/u;\n', ['unexpected']],
+  // no-control-character
   [
     'no-control-character',
     'hex escaped control character',
     "const re = new RegExp('\\\\x01', 'u');\n",
     ['unexpected'],
   ],
+  [
+    'no-control-character',
+    'unicode escaped control character',
+    "const re = new RegExp('\\\\u0002', 'u');\n",
+    ['unexpected'],
+  ],
+  [
+    'no-control-character',
+    'curly unicode control character',
+    "const re = new RegExp('\\\\u{3}', 'u');\n",
+    ['unexpected'],
+  ],
+  // sort-flags
   ['sort-flags', 'unsorted flags', 'const re = /a/mi;\n', ['sortFlags']],
-  ['require-unicode-regexp', 'missing unicode flag', 'const re = /a/;\n', ['require']],
+  ['sort-flags', 'unsorted unicode flag', 'const re = /a/ug;\n', ['sortFlags']],
+  // require-unicode-regexp
+  ['require-unicode-regexp', 'no flags', 'const re = /a/;\n', ['require']],
+  ['require-unicode-regexp', 'only g flag', 'const re = /a/g;\n', ['require']],
+  [
+    'require-unicode-regexp',
+    'constructor without flags',
+    "const re = new RegExp('a');\n",
+    ['require'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {
@@ -168,6 +243,28 @@ describe('regexp rules through direct Oxlint plugin adapter', () => {
         runRule('no-control-character', "const re = new RegExp('\\\\x01', 'u');\n")[0],
       ),
     ).toBe('Unexpected control character U+0001.');
+    expect(
+      renderMessage(
+        'no-invalid-regexp',
+        runRule('no-invalid-regexp', "new RegExp('a', 'gg');\n")[0],
+      ),
+    ).toBe('Duplicate g flag.');
+  });
+
+  it('ignores non-RegExp callees with the same shape', () => {
+    expect(runRule('no-empty-character-class', "new Foo('[]', 'u');\n")).toEqual([]);
+    expect(runRule('no-invalid-regexp', "Bar('[', 'u');\n")).toEqual([]);
+  });
+
+  it('does not crash when constructor arguments are non-literal', () => {
+    expect(runRule('no-empty-character-class', "new RegExp(pattern, 'u');\n")).toEqual([]);
+    expect(runRule('no-invalid-regexp', 'new RegExp();\n')).toEqual([]);
+  });
+
+  it('reports each literal in a source independently', () => {
+    const reports = runRule('no-empty-character-class', 'const a = /[]/u; const b = /[]/u;\n');
+    expect(reports).toHaveLength(2);
+    expect(reports.every((report) => report.messageId === 'empty')).toBe(true);
   });
 });
 


### PR DESCRIPTION
PR #61 shipped each regexp rule with a single valid + invalid sample, so most edge paths in `pattern.rs`/`helpers.rs` were silently uncovered. This PR expands the Rust unit suite from 3 cases to 32 and the JS plugin suite from 24 to 71 so each ported rule actually exercises its real branches.

Highlights:
- `no-invalid-regexp`: unclosed class / group / `\u{`, duplicate flag short-circuit, `uv`/`vu` order, well-formed `gimsu` and `v` constructors, dynamic `flags` arg falling back to "no u/v" path.
- `no-empty-character-class`: `[]`, `abc[]def`, constructor form, `[^]` not empty, `[\]]` not empty.
- `no-empty-group` vs `no-empty-capturing-group`: anonymous, named, and mid-pattern empty captures plus the lookaround forms `(?=)`/`(?!)`/`(?<=)`/`(?<!)` that must stay silent.
- `no-empty-alternative`: leading, trailing, doubled `||`, and group-scoped variants.
- `no-zero-quantifier`: `{0}`, `{0,0}`, `(?:...){0}` vs `{0,}`, `{0,1}`, `{2,5}`.
- `no-octal`: `\07` / `\012` vs `\0` and `\08` (8 is not octal).
- `no-control-character`: `\x01`, `\u0002`, `\u{3}` vs named escapes (`\t`, `
`) and printable `\u0041`.
- `sort-flags` / `require-unicode-regexp`: empty/single/sorted flag combinations, constructor without flags.
- Plus message-rendering checks for the `duplicateFlag`, `sortFlags`, `no-octal`, and `no-control-character` templates, multi-rule fan-out on a single literal, and parser-failure paths that must produce zero diagnostics.

The two non-test diffs are `cargo fmt` adjustments to neighboring files in the crate; no rule behavior changes.

Verification: `cargo test -p oxlint-plugins-regexp` (32 passed), `vp test npm/regexp/test` (71 passed), `cargo clippy -p oxlint-plugins-regexp --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `vp lint npm/regexp`, `vp fmt --check npm/regexp`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->