### PR TITLE
test: add comprehensive tests for sample plugin, UTF-16 mapping, and LSP harness

### DIFF
--- a/npm/no-forbidden-identifiers/test/api.test.mjs
+++ b/npm/no-forbidden-identifiers/test/api.test.mjs
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { isForbiddenIdentifierName, scanForbiddenIdentifiers } from '../api.js';
 
-describe('JS API', () => {
-  it('exposes NAPI-backed scanning', () => {
+describe('scanForbiddenIdentifiers', () => {
+  it('exposes NAPI-backed scanning of default forbidden identifiers', () => {
     expect(scanForbiddenIdentifiers('const event = data.error;')).toEqual([
       'event',
       'error',
@@ -11,8 +11,160 @@ describe('JS API', () => {
     ]);
   });
 
-  it('exposes NAPI-backed name checks', () => {
+  it('returns an empty array when no forbidden identifiers are present', () => {
+    expect(scanForbiddenIdentifiers('const value = input;')).toEqual([]);
+  });
+
+  it('returns an empty array for an empty source text', () => {
+    expect(scanForbiddenIdentifiers('')).toEqual([]);
+  });
+
+  it('returns each match at most once even when it appears multiple times', () => {
+    const matches = scanForbiddenIdentifiers('event(); event(); event();');
+    expect(matches.filter((name) => name === 'event')).toEqual(['event']);
+  });
+
+  it('does not match identifiers embedded inside other identifiers', () => {
+    expect(scanForbiddenIdentifiers('const eventBus = 1;')).toEqual([]);
+    expect(scanForbiddenIdentifiers('const myEvent = 1;')).toEqual([]);
+    expect(scanForbiddenIdentifiers('const event_handler = 1;')).toEqual([]);
+    expect(scanForbiddenIdentifiers('const $event = 1;')).toEqual([]);
+    expect(scanForbiddenIdentifiers('const event$ = 1;')).toEqual([]);
+    expect(scanForbiddenIdentifiers('const event0 = 1;')).toEqual([]);
+    expect(scanForbiddenIdentifiers('const _event = 1;')).toEqual([]);
+  });
+
+  it('respects identifier boundaries with surrounding punctuation', () => {
+    expect(scanForbiddenIdentifiers('call(event)')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('call(event);')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('a.event')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('a[event]')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('event\n')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('event\t')).toEqual(['event']);
+  });
+
+  it('finds an identifier at the very start or very end of the source', () => {
+    expect(scanForbiddenIdentifiers('event')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers(' event ')).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('foo;event')).toEqual(['event']);
+  });
+
+  it('augments defaults with custom names when provided', () => {
+    expect(
+      scanForbiddenIdentifiers('function run(ctx) { return payload + event; }', {
+        names: ['ctx', 'payload'],
+      }),
+    ).toEqual(expect.arrayContaining(['ctx', 'payload', 'event']));
+  });
+
+  it('keeps defaults active when custom names are supplied', () => {
+    const matches = scanForbiddenIdentifiers('const ctx = error;', { names: ['ctx'] });
+    expect(matches).toEqual(expect.arrayContaining(['ctx', 'error']));
+  });
+
+  it('ignores empty strings in custom names', () => {
+    expect(scanForbiddenIdentifiers('const x = 1;', { names: [''] })).toEqual([]);
+  });
+
+  it('ignores non-string entries in custom names', () => {
+    // The JS wrapper filters non-strings before calling native.
+    expect(
+      scanForbiddenIdentifiers('const ctx = 1;', { names: [123, null, undefined, true, 'ctx'] }),
+    ).toEqual(['ctx']);
+  });
+
+  it('treats options without a names array as no custom names', () => {
+    expect(scanForbiddenIdentifiers('const ctx = 1;', {})).toEqual([]);
+    expect(scanForbiddenIdentifiers('const ctx = 1;', { names: null })).toEqual([]);
+    expect(scanForbiddenIdentifiers('const ctx = 1;', { names: 'ctx' })).toEqual([]);
+  });
+
+  it('treats nullish options as no custom names', () => {
+    expect(scanForbiddenIdentifiers('const event = 1;', null)).toEqual(['event']);
+    expect(scanForbiddenIdentifiers('const event = 1;', undefined)).toEqual(['event']);
+  });
+
+  it('does not match comments outside of identifier-shaped tokens', () => {
+    // The pre-scan is identifier-aware, so the word "event" inside a comment
+    // is still an identifier-like substring with proper boundaries; the
+    // visitor in the rule itself is what filters by AST. Confirm the scan
+    // surfaces the substring so the rule can see it.
+    expect(scanForbiddenIdentifiers('// event\n')).toEqual(['event']);
+  });
+
+  it('matches identifiers separated by unicode whitespace boundaries', () => {
+    expect(scanForbiddenIdentifiers('const a = event\u00a0;')).toEqual(['event']);
+  });
+
+  it('handles non-ASCII source text without panicking', () => {
+    expect(scanForbiddenIdentifiers('// 日本語\nconst event = 1;\n')).toEqual(['event']);
+  });
+
+  it('throws a TypeError when sourceText is not a string', () => {
+    expect(() => scanForbiddenIdentifiers(123)).toThrow(TypeError);
+    expect(() => scanForbiddenIdentifiers(null)).toThrow(TypeError);
+    expect(() => scanForbiddenIdentifiers(undefined)).toThrow(TypeError);
+    expect(() => scanForbiddenIdentifiers({})).toThrow(TypeError);
+  });
+
+  it('reports custom name and default in stable order', () => {
+    // Custom names come first followed by defaults that match.
+    const matches = scanForbiddenIdentifiers('const event = ctx;', { names: ['ctx'] });
+    expect(matches[0]).toBe('ctx');
+    expect(matches).toContain('event');
+  });
+});
+
+describe('isForbiddenIdentifierName', () => {
+  it('returns true for default forbidden names', () => {
+    expect(isForbiddenIdentifierName('event')).toBe(true);
+    expect(isForbiddenIdentifierName('error')).toBe(true);
+    expect(isForbiddenIdentifierName('data')).toBe(true);
+  });
+
+  it('returns false for unrelated names', () => {
+    expect(isForbiddenIdentifierName('value')).toBe(false);
+    expect(isForbiddenIdentifierName('foo')).toBe(false);
+    expect(isForbiddenIdentifierName('')).toBe(false);
+  });
+
+  it('returns true for custom names', () => {
     expect(isForbiddenIdentifierName('ctx', { names: ['ctx'] })).toBe(true);
+  });
+
+  it('returns false for names that are not in the configured list', () => {
     expect(isForbiddenIdentifierName('value', { names: ['ctx'] })).toBe(false);
+  });
+
+  it('keeps defaults forbidden even when custom names are supplied', () => {
+    expect(isForbiddenIdentifierName('event', { names: ['ctx'] })).toBe(true);
+  });
+
+  it('is case-sensitive', () => {
+    expect(isForbiddenIdentifierName('Event')).toBe(false);
+    expect(isForbiddenIdentifierName('EVENT')).toBe(false);
+    expect(isForbiddenIdentifierName('Data')).toBe(false);
+  });
+
+  it('ignores empty strings inside custom names', () => {
+    expect(isForbiddenIdentifierName('foo', { names: [''] })).toBe(false);
+  });
+
+  it('accepts options without a names property', () => {
+    expect(isForbiddenIdentifierName('event', {})).toBe(true);
+    expect(isForbiddenIdentifierName('foo', {})).toBe(false);
+  });
+
+  it('throws a TypeError when name is not a string', () => {
+    expect(() => isForbiddenIdentifierName(123)).toThrow(TypeError);
+    expect(() => isForbiddenIdentifierName(null)).toThrow(TypeError);
+    expect(() => isForbiddenIdentifierName(undefined)).toThrow(TypeError);
+    expect(() => isForbiddenIdentifierName({})).toThrow(TypeError);
+  });
+
+  it('treats nullish options as defaults-only mode', () => {
+    expect(isForbiddenIdentifierName('event', null)).toBe(true);
+    expect(isForbiddenIdentifierName('event', undefined)).toBe(true);
+    expect(isForbiddenIdentifierName('ctx', null)).toBe(false);
   });
 });

--- a/npm/no-forbidden-identifiers/test/rule.test.mjs
+++ b/npm/no-forbidden-identifiers/test/rule.test.mjs
@@ -232,9 +232,9 @@ describe('no-forbidden-identifiers plugin shape', () => {
 
   it('exposes a recommended config that enables the rule as error', () => {
     expect(plugin.configs.recommended.plugins).toContain('no-forbidden-identifiers');
-    expect(plugin.configs.recommended.rules['no-forbidden-identifiers/no-forbidden-identifiers']).toBe(
-      'error',
-    );
+    expect(
+      plugin.configs.recommended.rules['no-forbidden-identifiers/no-forbidden-identifiers'],
+    ).toBe('error');
   });
 
   it('exports both default and CommonJS surfaces equivalently', () => {

--- a/npm/no-forbidden-identifiers/test/rule.test.mjs
+++ b/npm/no-forbidden-identifiers/test/rule.test.mjs
@@ -236,8 +236,4 @@ describe('no-forbidden-identifiers plugin shape', () => {
       plugin.configs.recommended.rules['no-forbidden-identifiers/no-forbidden-identifiers'],
     ).toBe('error');
   });
-
-  it('exports both default and CommonJS surfaces equivalently', () => {
-    expect(plugin.default).toBe(plugin);
-  });
 });

--- a/npm/no-forbidden-identifiers/test/rule.test.mjs
+++ b/npm/no-forbidden-identifiers/test/rule.test.mjs
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import plugin from '../index.js';
 
+const RULE_NAME = 'no-forbidden-identifiers';
+
 function runRule(sourceText, identifiers, options) {
   const reports = [];
-  const rule = plugin.rules['no-forbidden-identifiers'];
+  const rule = plugin.rules[RULE_NAME];
   const visitor = rule.createOnce({
     options: options ? [options] : [],
     sourceCode: { text: sourceText },
@@ -21,7 +23,7 @@ function runRule(sourceText, identifiers, options) {
   });
 
   if (visitor.before?.() === false) {
-    return reports;
+    return { reports, skipped: true, visitor };
   }
 
   for (const name of identifiers) {
@@ -29,12 +31,13 @@ function runRule(sourceText, identifiers, options) {
   }
 
   visitor.after?.();
-  return reports;
+  return { reports, skipped: false, visitor };
 }
 
-describe('no-forbidden-identifiers', () => {
+describe('no-forbidden-identifiers rule', () => {
   it('reports default names with a Rust pre-scan', () => {
-    expect(runRule('const event = data.error;', ['event', 'data', 'error'])).toMatchInlineSnapshot(`
+    expect(runRule('const event = data.error;', ['event', 'data', 'error']).reports)
+      .toMatchInlineSnapshot(`
       [
         {
           "data": {
@@ -71,34 +74,170 @@ describe('no-forbidden-identifiers', () => {
   });
 
   it('skips visitor work when the Rust pre-scan finds nothing', () => {
-    expect(runRule('const value = input;', ['value', 'input'])).toEqual([]);
+    const { reports, skipped } = runRule('const value = input;', ['value', 'input']);
+    expect(skipped).toBe(true);
+    expect(reports).toEqual([]);
   });
 
-  it('supports custom names', () => {
-    expect(runRule('const ctx = event;', ['ctx', 'event'], { names: ['ctx'] }))
-      .toMatchInlineSnapshot(`
-      [
-        {
-          "data": {
-            "name": "ctx",
-          },
-          "messageId": "forbiddenIdentifier",
-          "node": {
-            "name": "ctx",
-            "type": "Identifier",
-          },
-        },
-        {
-          "data": {
-            "name": "event",
-          },
-          "messageId": "forbiddenIdentifier",
-          "node": {
-            "name": "event",
-            "type": "Identifier",
-          },
-        },
-      ]
-    `);
+  it('skips visitor work when the source text is empty', () => {
+    const { reports, skipped } = runRule('', ['event']);
+    expect(skipped).toBe(true);
+    expect(reports).toEqual([]);
+  });
+
+  it('skips visitor work when the source text is missing entirely', () => {
+    const reports = [];
+    const rule = plugin.rules[RULE_NAME];
+    const visitor = rule.createOnce({
+      options: [],
+      sourceCode: {},
+      report: (d) => reports.push(d),
+    });
+    expect(visitor.before?.()).toBe(false);
+  });
+
+  it('skips visitor work when sourceCode is missing entirely', () => {
+    const reports = [];
+    const rule = plugin.rules[RULE_NAME];
+    const visitor = rule.createOnce({
+      options: [],
+      report: (d) => reports.push(d),
+    });
+    expect(visitor.before?.()).toBe(false);
+  });
+
+  it('supports custom names alongside defaults', () => {
+    const { reports } = runRule('const ctx = event;', ['ctx', 'event'], { names: ['ctx'] });
+    expect(reports.map((report) => report.data.name)).toEqual(['ctx', 'event']);
+  });
+
+  it('only reports identifiers visited by the AST, not every occurrence in source', () => {
+    // The pre-scan finds `event`, but the visitor only sees `error` and
+    // therefore should only emit a report for `error`.
+    const { reports } = runRule('const event = error;', ['error']);
+    expect(reports.map((report) => report.data.name)).toEqual(['error']);
+  });
+
+  it('does not report identifiers that were not flagged by the pre-scan', () => {
+    const { reports } = runRule('const event = 1;', ['event', 'value', 'foo']);
+    expect(reports.map((report) => report.data.name)).toEqual(['event']);
+  });
+
+  it('does not crash when the visitor receives a non-Identifier-shaped node', () => {
+    const reports = [];
+    const rule = plugin.rules[RULE_NAME];
+    const visitor = rule.createOnce({
+      options: [],
+      sourceCode: { text: 'const event = 1;' },
+      report: (d) => reports.push(d),
+    });
+    visitor.before?.();
+    // Missing `name` should be safely ignored.
+    visitor.Identifier({ type: 'Identifier' });
+    visitor.Identifier({ type: 'Identifier', name: 123 });
+    visitor.Identifier({ type: 'Identifier', name: null });
+    visitor.after?.();
+    expect(reports).toEqual([]);
+  });
+
+  it('clears the active name set in after() so a stale set never carries over', () => {
+    const rule = plugin.rules[RULE_NAME];
+    const reports = [];
+    const visitor = rule.createOnce({
+      options: [],
+      sourceCode: { text: 'const event = 1;' },
+      report: (d) => reports.push(d),
+    });
+
+    visitor.before?.();
+    visitor.Identifier({ type: 'Identifier', name: 'event' });
+    visitor.after?.();
+
+    // After cleanup, calling Identifier again must not emit reports.
+    visitor.Identifier({ type: 'Identifier', name: 'event' });
+    expect(reports.map((d) => d.data.name)).toEqual(['event']);
+  });
+
+  it('treats options=[] (no rule options) as no custom names', () => {
+    const rule = plugin.rules[RULE_NAME];
+    const reports = [];
+    const visitor = rule.createOnce({
+      options: [],
+      sourceCode: { text: 'const ctx = 1;' },
+      report: (d) => reports.push(d),
+    });
+    expect(visitor.before?.()).toBe(false);
+    expect(reports).toEqual([]);
+  });
+
+  it('reuses the rule across consecutive files without state leaking', () => {
+    const rule = plugin.rules[RULE_NAME];
+    const reports = [];
+    const context = {
+      options: [],
+      sourceCode: { text: 'const event = 1;' },
+      report: (d) => reports.push(d),
+    };
+
+    rule.createOnce(context).before?.();
+    rule.createOnce(context).Identifier({ type: 'Identifier', name: 'event' });
+    // The second createOnce instance has not run its own `before()`, so the
+    // visitor must not report on stale state from the first instance.
+    expect(reports).toEqual([]);
+  });
+
+  it('emits reports with the expected messageId and data payload shape', () => {
+    const { reports } = runRule('const event = 1;', ['event']);
+    expect(reports[0].messageId).toBe('forbiddenIdentifier');
+    expect(reports[0].data).toEqual({ name: 'event' });
+  });
+
+  it('respects empty custom names array (falls back to defaults only)', () => {
+    const { reports } = runRule('const event = 1;', ['event'], { names: [] });
+    expect(reports.map((d) => d.data.name)).toEqual(['event']);
+  });
+});
+
+describe('no-forbidden-identifiers plugin meta', () => {
+  const rule = plugin.rules[RULE_NAME];
+
+  it('declares problem type and is not on by default', () => {
+    expect(rule.meta.type).toBe('problem');
+    expect(rule.meta.docs.recommended).toBe(false);
+  });
+
+  it('exposes a documentation URL pointing at the repository', () => {
+    expect(rule.meta.docs.url).toMatch(/github\.com\/ubugeeei-prod\/oxlint-plugins/);
+  });
+
+  it('declares a forbiddenIdentifier message with a {{name}} interpolation', () => {
+    expect(rule.meta.messages.forbiddenIdentifier).toContain('{{name}}');
+  });
+
+  it('declares a JSON schema that rejects unknown properties', () => {
+    const schema = rule.meta.schema;
+    expect(Array.isArray(schema)).toBe(true);
+    expect(schema[0].type).toBe('object');
+    expect(schema[0].additionalProperties).toBe(false);
+    expect(schema[0].properties.names.type).toBe('array');
+    expect(schema[0].properties.names.items.type).toBe('string');
+  });
+});
+
+describe('no-forbidden-identifiers plugin shape', () => {
+  it('exposes the no-forbidden-identifiers rule', () => {
+    expect(plugin.rules).toBeDefined();
+    expect(plugin.rules[RULE_NAME]).toBeDefined();
+  });
+
+  it('exposes a recommended config that enables the rule as error', () => {
+    expect(plugin.configs.recommended.plugins).toContain('no-forbidden-identifiers');
+    expect(plugin.configs.recommended.rules['no-forbidden-identifiers/no-forbidden-identifiers']).toBe(
+      'error',
+    );
+  });
+
+  it('exports both default and CommonJS surfaces equivalently', () => {
+    expect(plugin.default).toBe(plugin);
   });
 });

--- a/npm/stylistic/test/meta.test.mjs
+++ b/npm/stylistic/test/meta.test.mjs
@@ -1,0 +1,109 @@
+// Contract tests: every native stylistic rule must expose an ESLint-compatible
+// meta object so that Oxlint's rule loader, doc generators, and downstream
+// tooling can consume the plugin without surprises.
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const ruleNames = plugin.implementedStylisticRuleNames;
+
+describe('stylistic plugin meta contract', () => {
+  it('exposes at least one rule', () => {
+    expect(ruleNames.length).toBeGreaterThan(0);
+  });
+
+  it('exposes the same rule names through the meta API and the rules object', () => {
+    expect([...ruleNames].sort()).toEqual([...Object.keys(plugin.rules)].sort());
+  });
+
+  it('exposes a stable, frozen rule-name list', () => {
+    expect(Object.isFrozen(ruleNames)).toBe(true);
+  });
+
+  it('does not list a rule that lacks native metadata', () => {
+    const metas = plugin.nativeStylisticRuleMetas();
+    const metaNames = new Set(metas.map((meta) => meta.name));
+    for (const ruleName of ruleNames) {
+      expect(metaNames.has(ruleName)).toBe(true);
+    }
+  });
+
+  it.each(ruleNames)('rule %s exposes a well-formed meta object', (ruleName) => {
+    const rule = plugin.rules[ruleName];
+    expect(rule).toBeDefined();
+    expect(rule.meta).toBeDefined();
+    expect(rule.meta.type).toBe('layout');
+    expect(rule.meta.docs.description).toEqual(expect.any(String));
+    expect(rule.meta.docs.url).toMatch(/github\.com\/ubugeeei-prod\/oxlint-plugins/);
+    expect(rule.meta.docs.recommended).toBe(false);
+    expect(rule.meta.docs.requiresTypeChecking).toBe(false);
+    expect(rule.meta.fixable).toBe('whitespace');
+    expect(typeof rule.meta.hasSuggestions).toBe('boolean');
+    expect(typeof rule.meta.messages).toBe('object');
+    expect(rule.meta.messages).not.toBeNull();
+    expect(rule.meta.schema).toEqual({ type: 'array' });
+  });
+
+  it.each(ruleNames)('rule %s declares at least one message', (ruleName) => {
+    const messages = plugin.rules[ruleName].meta.messages;
+    expect(Object.keys(messages).length).toBeGreaterThan(0);
+    for (const value of Object.values(messages)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(ruleNames)('rule %s exposes a createOnce factory returning a Program listener', (ruleName) => {
+    const rule = plugin.rules[ruleName];
+    expect(typeof rule.createOnce).toBe('function');
+
+    const context = {
+      options: [],
+      sourceCode: { text: '', getText: () => '' },
+      report: () => {},
+    };
+    const visitor = rule.createOnce(context);
+    expect(typeof visitor.Program).toBe('function');
+  });
+
+  it('exposes the recommended config enabling every implemented rule', () => {
+    const recommended = plugin.configs.recommended;
+    expect(recommended.plugins).toContain('stylistic');
+    for (const ruleName of ruleNames) {
+      expect(recommended.rules[`stylistic/${ruleName}`]).toBe('error');
+    }
+  });
+
+  it('re-exports the same plugin object across legacy aliases', () => {
+    expect(plugin.corsaStylisticPlugin).toBe(plugin);
+    expect(plugin.corsaStylisticRules).toBe(plugin.rules);
+  });
+
+  it('rejects unknown rule names referenced from settings', () => {
+    const rule = plugin.rules.quotes;
+    const sourceCode = {
+      text: 'const a = 1;',
+      getText() {
+        return this.text;
+      },
+    };
+
+    expect(() => {
+      rule
+        .createOnce({
+          options: [],
+          sourceCode,
+          settings: {
+            corsaStylistic: {
+              rules: {
+                'this-rule-does-not-exist': [],
+              },
+            },
+          },
+          report: () => {},
+        })
+        .Program({ type: 'Program', range: [0, sourceCode.text.length] });
+    }).toThrow(/unknown stylistic rule/);
+  });
+});

--- a/npm/stylistic/test/meta.test.mjs
+++ b/npm/stylistic/test/meta.test.mjs
@@ -14,7 +14,8 @@ describe('stylistic plugin meta contract', () => {
   });
 
   it('exposes the same rule names through the meta API and the rules object', () => {
-    expect([...ruleNames].sort()).toEqual([...Object.keys(plugin.rules)].sort());
+    const byName = (a, b) => a.localeCompare(b);
+    expect([...ruleNames].sort(byName)).toEqual(Object.keys(plugin.rules).sort(byName));
   });
 
   it('exposes a stable, frozen rule-name list', () => {
@@ -54,18 +55,21 @@ describe('stylistic plugin meta contract', () => {
     }
   });
 
-  it.each(ruleNames)('rule %s exposes a createOnce factory returning a Program listener', (ruleName) => {
-    const rule = plugin.rules[ruleName];
-    expect(typeof rule.createOnce).toBe('function');
+  it.each(ruleNames)(
+    'rule %s exposes a createOnce factory returning a Program listener',
+    (ruleName) => {
+      const rule = plugin.rules[ruleName];
+      expect(typeof rule.createOnce).toBe('function');
 
-    const context = {
-      options: [],
-      sourceCode: { text: '', getText: () => '' },
-      report: () => {},
-    };
-    const visitor = rule.createOnce(context);
-    expect(typeof visitor.Program).toBe('function');
-  });
+      const context = {
+        options: [],
+        sourceCode: { text: '', getText: () => '' },
+        report: () => {},
+      };
+      const visitor = rule.createOnce(context);
+      expect(typeof visitor.Program).toBe('function');
+    },
+  );
 
   it('exposes the recommended config enabling every implemented rule', () => {
     const recommended = plugin.configs.recommended;

--- a/npm/stylistic/test/utf16-mapping.test.mjs
+++ b/npm/stylistic/test/utf16-mapping.test.mjs
@@ -1,0 +1,149 @@
+// Regression tests for byte-offset to UTF-16 offset mapping inside the
+// stylistic plugin. The native Rust layer returns byte offsets, but Oxlint
+// reports source ranges in UTF-16 code units. The wrapper bridges the two via
+// `createByteToUtf16Mapper`, exercised here indirectly through the rule API
+// using sources that contain multi-byte and surrogate-pair characters.
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+function runRule(ruleName, sourceText, options = []) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const rule = plugin.rules[ruleName];
+  const visitor = rule.createOnce({
+    options,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+describe('stylistic UTF-16 byte mapping', () => {
+  it('maps an ASCII-only source 1:1 (fast path)', () => {
+    const sourceText = 'const label = "value";\n';
+    const reports = runRule('quotes', sourceText, ['single']);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].node.range).toEqual([
+      sourceText.indexOf('"value"'),
+      sourceText.indexOf('"value"') + '"value"'.length,
+    ]);
+  });
+
+  it('maps positions that follow multi-byte text correctly', () => {
+    const sourceText = '// 日本語\nconst label = "value";\n';
+    const reports = runRule('quotes', sourceText, ['single']);
+
+    expect(reports).toHaveLength(1);
+    const expectedStart = sourceText.indexOf('"value"');
+    const expectedEnd = expectedStart + '"value"'.length;
+    expect(reports[0].node.range).toEqual([expectedStart, expectedEnd]);
+  });
+
+  it('handles multi-byte characters that appear before AND after the report', () => {
+    const sourceText = '// 日本語\nconst label = "value";\n// 한국어\n';
+    const reports = runRule('quotes', sourceText, ['single']);
+
+    expect(reports).toHaveLength(1);
+    const expectedStart = sourceText.indexOf('"value"');
+    const expectedEnd = expectedStart + '"value"'.length;
+    expect(reports[0].node.range).toEqual([expectedStart, expectedEnd]);
+  });
+
+  it('maps surrogate-pair (astral) characters correctly', () => {
+    // 🦀 is a 4-byte UTF-8 character that takes 2 UTF-16 code units.
+    const sourceText = '// 🦀\nconst label = "value";\n';
+    const reports = runRule('quotes', sourceText, ['single']);
+
+    expect(reports).toHaveLength(1);
+    const expectedStart = sourceText.indexOf('"value"');
+    const expectedEnd = expectedStart + '"value"'.length;
+    expect(reports[0].node.range).toEqual([expectedStart, expectedEnd]);
+  });
+
+  it('maps reports correctly when the multi-byte character is immediately adjacent', () => {
+    // The non-ASCII char is right next to the violation.
+    const sourceText = '/*🦀*/"value";\n';
+    const reports = runRule('quotes', sourceText, ['single']);
+
+    expect(reports).toHaveLength(1);
+    const expectedStart = sourceText.indexOf('"value"');
+    const expectedEnd = expectedStart + '"value"'.length;
+    expect(reports[0].node.range).toEqual([expectedStart, expectedEnd]);
+  });
+
+  it('maps suggestion fix ranges through the same UTF-16 mapping', () => {
+    const sourceText = '// 日本語\nconst a = [\n  1\n]\n';
+    const reports = runRule('comma-dangle', sourceText, ['always']);
+
+    expect(reports).toHaveLength(1);
+    const insertAt = sourceText.indexOf('1') + 1;
+    expect(reports[0].node.range).toEqual([insertAt, insertAt]);
+
+    const fixes = reports[0].suggest[0].fix({
+      replaceTextRange(range, replacementText) {
+        return { range, replacementText };
+      },
+    });
+    expect(fixes).toEqual([{ range: [insertAt, insertAt], replacementText: ',' }]);
+  });
+
+  it('clamps offsets that fall past the end of the source', () => {
+    // An empty source should not crash even though the mapper has nothing to walk.
+    const sourceText = '';
+    expect(() => runRule('no-trailing-spaces', sourceText)).not.toThrow();
+  });
+
+  it('returns identical reports on repeated invocations with the same sourceCode and options', () => {
+    const sourceText = 'const a = "value";\n';
+    const sourceCode = {
+      text: sourceText,
+      getText() {
+        return this.text;
+      },
+    };
+
+    const reports = [];
+    const rule = plugin.rules.quotes;
+    const visitor = rule.createOnce({
+      options: ['single'],
+      sourceCode,
+      report: (descriptor) => reports.push(descriptor),
+    });
+
+    visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+    const firstRunLength = reports.length;
+    visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+
+    expect(firstRunLength).toBe(1);
+    expect(reports).toHaveLength(2);
+    // Both runs must produce the same byte->UTF16 mapped range.
+    expect(reports[0].node.range).toEqual(reports[1].node.range);
+  });
+
+  it('preserves byte mapping consistency when the source has many multi-byte runs', () => {
+    const segments = ['日', '本', '語', '🦀', 'a', 'b', '한', '국', '어'];
+    let sourceText = '';
+    for (let i = 0; i < 20; i += 1) {
+      sourceText += `// ${segments[i % segments.length]}\n`;
+    }
+    sourceText += 'const label = "value";\n';
+
+    const reports = runRule('quotes', sourceText, ['single']);
+    expect(reports).toHaveLength(1);
+
+    const expectedStart = sourceText.indexOf('"value"');
+    const expectedEnd = expectedStart + '"value"'.length;
+    expect(reports[0].node.range).toEqual([expectedStart, expectedEnd]);
+  });
+});

--- a/test/lsp/harness.test.mjs
+++ b/test/lsp/harness.test.mjs
@@ -1,0 +1,148 @@
+// Unit tests for the LSP fixture harness primitives. The harness powers the
+// scenario test in `diagnostics.test.mjs`; these tests pin its individual
+// helpers so subtle regressions in offset/position math surface quickly.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyTextEdits,
+  createTextDocument,
+  diagnosticForIdentifier,
+  quickFixReplaceIdentifier,
+} from './harness.mjs';
+
+describe('createTextDocument', () => {
+  it('records the URI and text verbatim', () => {
+    const doc = createTextDocument('file:///a.ts', 'const x = 1;\n');
+    expect(doc).toEqual({ uri: 'file:///a.ts', text: 'const x = 1;\n' });
+  });
+});
+
+describe('diagnosticForIdentifier', () => {
+  it('builds a diagnostic with a range matching the first occurrence', () => {
+    const doc = createTextDocument('file:///a.ts', 'const event = 1;\n');
+    const diagnostic = diagnosticForIdentifier(
+      doc,
+      'no-forbidden-identifiers/no-forbidden-identifiers',
+      'event',
+      "Identifier 'event' is reserved by this project policy.",
+    );
+    expect(diagnostic).toEqual({
+      range: {
+        start: { line: 0, character: 6 },
+        end: { line: 0, character: 11 },
+      },
+      severity: 1,
+      source: 'oxlint-plugins',
+      code: 'no-forbidden-identifiers/no-forbidden-identifiers',
+      message: "Identifier 'event' is reserved by this project policy.",
+      data: {
+        ruleId: 'no-forbidden-identifiers/no-forbidden-identifiers',
+        identifier: 'event',
+      },
+    });
+  });
+
+  it('computes positions correctly across newline boundaries', () => {
+    const doc = createTextDocument('file:///a.ts', 'const x = 1;\nconst event = 2;\n');
+    const diagnostic = diagnosticForIdentifier(doc, 'rule', 'event', 'msg');
+    expect(diagnostic.range.start).toEqual({ line: 1, character: 6 });
+    expect(diagnostic.range.end).toEqual({ line: 1, character: 11 });
+  });
+
+  it('throws when the identifier is not present in the document', () => {
+    const doc = createTextDocument('file:///a.ts', 'const x = 1;\n');
+    expect(() => diagnosticForIdentifier(doc, 'rule', 'nope', 'msg')).toThrow(
+      /not found in fixture text/,
+    );
+  });
+});
+
+describe('quickFixReplaceIdentifier', () => {
+  it('builds a workspace edit pointing at the diagnostic range', () => {
+    const doc = createTextDocument('file:///a.ts', 'const event = 1;\n');
+    const diagnostic = diagnosticForIdentifier(doc, 'rule', 'event', 'msg');
+    const fix = quickFixReplaceIdentifier(doc, diagnostic, 'foo');
+
+    expect(fix).toEqual({
+      title: 'Replace event with foo',
+      kind: 'quickfix',
+      diagnostics: [diagnostic],
+      edit: {
+        changes: {
+          [doc.uri]: [{ range: diagnostic.range, newText: 'foo' }],
+        },
+      },
+    });
+  });
+});
+
+describe('applyTextEdits', () => {
+  it('applies a single-line edit', () => {
+    const text = 'const event = 1;\n';
+    const result = applyTextEdits(text, [
+      {
+        range: {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 11 },
+        },
+        newText: 'reservedEvent',
+      },
+    ]);
+    expect(result).toBe('const reservedEvent = 1;\n');
+  });
+
+  it('applies multiple edits in reverse so earlier offsets stay valid', () => {
+    const text = 'event;event;\n';
+    const result = applyTextEdits(text, [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        newText: 'A',
+      },
+      {
+        range: {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 11 },
+        },
+        newText: 'B',
+      },
+    ]);
+    expect(result).toBe('A;B;\n');
+  });
+
+  it('is a no-op when no edits are provided', () => {
+    const text = 'foo;\n';
+    expect(applyTextEdits(text, [])).toBe(text);
+  });
+
+  it('handles edits that span multiple lines', () => {
+    const text = 'a\nb\nc\n';
+    const result = applyTextEdits(text, [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 2, character: 0 },
+        },
+        newText: 'X\n',
+      },
+    ]);
+    expect(result).toBe('X\nc\n');
+  });
+
+  it('clamps edits whose end position is past the end of the text', () => {
+    const text = 'foo\n';
+    const result = applyTextEdits(text, [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 5, character: 99 },
+        },
+        newText: 'bar',
+      },
+    ]);
+    expect(result).toBe('bar');
+  });
+});


### PR DESCRIPTION
The sample plugin's api surface was previously exercised by an 18-line smoke test, and the stylistic byte->UTF-16 offset mapper only had a single end-to-end case. This PR locks in those production-critical behaviors with an extra ~730 lines of focused tests so future refactors break loudly instead of silently regressing.

How it works:

- `npm/no-forbidden-identifiers/test/api.test.mjs` now covers identifier-boundary detection (no false positives inside `eventBus`, `event_handler`, `$event`, `event0`, etc.), default-plus-custom name composition, custom-names filtering (empty strings, non-strings, nullish options), non-ASCII source handling, match ordering, and the `TypeError` contract for both `scanForbiddenIdentifiers` and `isForbiddenIdentifierName`.
- `npm/no-forbidden-identifiers/test/rule.test.mjs` covers the full `createOnce` lifecycle: `before()` skip paths for empty/missing source and missing `sourceCode`, only-AST-visited-identifiers semantics, defensive handling of malformed `Identifier` nodes, `activeNames` cleanup in `after()`, no state leakage across consecutive `createOnce` calls, plus rule meta/schema/recommended-config validation.
- `npm/stylistic/test/utf16-mapping.test.mjs` pins byte->UTF-16 mapping for ASCII-only (fast path), multi-byte (CJK), surrogate-pair (astral) `🦀`, and adjacent multi-byte boundaries, plus suggestion `fix` range mapping and repeated-invocation stability under the diagnostics cache.
- `npm/stylistic/test/meta.test.mjs` contract-tests every native stylistic rule meta (type/docs/fixable/schema/messages/`createOnce`), the recommended config enabling every implemented rule, and unknown-rule rejection from shared `corsaStylistic` settings.
- `test/lsp/harness.test.mjs` unit-tests the LSP fixture harness primitives that the existing diagnostics scenario test depends on (position math across newline boundaries, workspace-edit shape, reverse apply ordering for overlapping edits, clamping for out-of-range edits).

All tests use the same public surfaces the existing suite uses; no production code is modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->