### PR TITLE
port(regexp): port 5 quantifier/escape rules from eslint-plugin-regexp

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -197,5 +197,53 @@ impl<'a> Scanner<'a> {
                 span,
             );
         }
+        if analysis.has_escape_backspace_in_class {
+            self.report("no-escape-backspace", "unexpected", span);
+        }
+        if let Some(expr) = analysis.first_plus_quantifier {
+            self.report_with_data(
+                "prefer-plus-quantifier",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(expr),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(expr) = analysis.first_star_quantifier {
+            self.report_with_data(
+                "prefer-star-quantifier",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(expr),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(expr) = analysis.first_question_quantifier {
+            self.report_with_data(
+                "prefer-question-quantifier",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(expr),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some((expr, replacement)) = analysis.first_useless_two_nums_quantifier {
+            self.report_with_data(
+                "no-useless-two-nums-quantifier",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(expr),
+                    replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
     }
 }

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -96,6 +96,118 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> (bool, bool, usize) {
     }
 }
 
+/// Shape of a `{...}` braced quantifier that can be rewritten as a shorter
+/// quantifier. `Plus` is `{1,}`, `Star` is `{0,}`, `Question` is `{0,1}`, and
+/// `EqualTwoNums(n)` is `{n,n}` with `n >= 1` (the `n == 0` case is reported by
+/// `no-zero-quantifier` instead).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BraceQuantifierShape {
+    Plus,
+    Star,
+    Question,
+    EqualTwoNums(u64),
+}
+
+/// Parse a `{n}`, `{n,}`, or `{n,m}` quantifier starting at `open` (the `{`
+/// byte). Returns `(end_exclusive, original_text, shape)` if the quantifier is
+/// well-formed and matches one of the four rewritable shapes; otherwise `None`.
+/// The decision is intentionally conservative: malformed inputs (e.g. trailing
+/// digits without a closing brace, non-digit characters) fall through to the
+/// caller's existing scan loop.
+pub(crate) fn parse_brace_quantifier(
+    bytes: &[u8],
+    open: usize,
+) -> Option<(usize, &str, BraceQuantifierShape)> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'{'));
+
+    let mut cursor = open + 1;
+    let first_start = cursor;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+        cursor += 1;
+    }
+    if cursor == first_start {
+        return None;
+    }
+    let first = parse_u64(&bytes[first_start..cursor])?;
+
+    match bytes.get(cursor).copied() {
+        Some(b'}') => {
+            // `{n}` — never rewritable on its own (this is the canonical form).
+            let _ = first;
+            None
+        }
+        Some(b',') => {
+            cursor += 1;
+            let second_start = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            if bytes.get(cursor) != Some(&b'}') {
+                return None;
+            }
+            let end = cursor + 1;
+            let original =
+                std::str::from_utf8(&bytes[open..end]).expect("ASCII slice is valid UTF-8");
+
+            if second_start == cursor {
+                // `{n,}` — open-ended.
+                let shape = match first {
+                    0 => BraceQuantifierShape::Star,
+                    1 => BraceQuantifierShape::Plus,
+                    _ => return None,
+                };
+                Some((end, original, shape))
+            } else {
+                // `{n,m}`.
+                let second = parse_u64(&bytes[second_start..cursor])?;
+                if first == 0 && second == 1 {
+                    Some((end, original, BraceQuantifierShape::Question))
+                } else if first == second && first >= 1 {
+                    Some((end, original, BraceQuantifierShape::EqualTwoNums(first)))
+                } else {
+                    None
+                }
+            }
+        }
+        _ => None,
+    }
+}
+
+fn parse_u64(digits: &[u8]) -> Option<u64> {
+    let mut value: u64 = 0;
+    for &byte in digits {
+        let digit = byte.checked_sub(b'0')?;
+        if digit > 9 {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add(u64::from(digit))?;
+    }
+    Some(value)
+}
+
+/// Returns `true` when the character class starting at `open` (a `[` byte)
+/// contains at least one `\b` escape. The class is delimited by `find_class_end`
+/// semantics, so `\]` inside the class is correctly skipped.
+pub(crate) fn class_contains_backspace_escape(bytes: &[u8], open: usize) -> bool {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let Some(end) = find_class_end(bytes, open) else {
+        return false;
+    };
+
+    let mut index = open + 1;
+    while index < end {
+        if bytes[index] == b'\\' {
+            if bytes.get(index + 1) == Some(&b'b') {
+                return true;
+            }
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
+        }
+        index += 1;
+    }
+    false
+}
+
 pub(crate) fn is_zero_quantifier(bytes: &[u8], open: usize) -> bool {
     let mut cursor = open + 1;
     while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 10] = [
+pub const RULE_NAMES: [&str; 15] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -32,6 +32,11 @@ pub const RULE_NAMES: [&str; 10] = [
     "no-control-character",
     "sort-flags",
     "require-unicode-regexp",
+    "no-escape-backspace",
+    "prefer-plus-quantifier",
+    "prefer-star-quantifier",
+    "prefer-question-quantifier",
+    "no-useless-two-nums-quantifier",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -1,8 +1,11 @@
 //! Group/alternative bookkeeping while walking a regexp pattern source.
 
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
 
-use crate::helpers::{find_class_end, group_prefix, is_zero_quantifier, skip_escape};
+use crate::helpers::{
+    BraceQuantifierShape, class_contains_backspace_escape, find_class_end, group_prefix,
+    is_zero_quantifier, parse_brace_quantifier, skip_escape,
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct GroupState {
@@ -39,6 +42,15 @@ pub(crate) struct PatternAnalysis {
     pub(crate) has_empty_capturing_group: bool,
     pub(crate) has_empty_alternative: bool,
     pub(crate) has_zero_quantifier: bool,
+    pub(crate) has_escape_backspace_in_class: bool,
+    /// First braced quantifier rewritable as `+`, e.g. `{1,}`.
+    pub(crate) first_plus_quantifier: Option<CompactString>,
+    /// First braced quantifier rewritable as `*`, e.g. `{0,}`.
+    pub(crate) first_star_quantifier: Option<CompactString>,
+    /// First braced quantifier rewritable as `?`, e.g. `{0,1}`.
+    pub(crate) first_question_quantifier: Option<CompactString>,
+    /// First `{n,n}` (with `n >= 1`) and its `{n}` replacement.
+    pub(crate) first_useless_two_nums_quantifier: Option<(CompactString, CompactString)>,
 }
 
 impl PatternAnalysis {
@@ -63,6 +75,11 @@ impl PatternAnalysis {
                     if let Some(close) = close {
                         if close == index + 1 {
                             self.has_empty_character_class = true;
+                        }
+                        if !self.has_escape_backspace_in_class
+                            && class_contains_backspace_escape(bytes, index)
+                        {
+                            self.has_escape_backspace_in_class = true;
                         }
                         self.mark_content(&mut groups);
                         index = close + 1;
@@ -107,7 +124,19 @@ impl PatternAnalysis {
                     self.has_zero_quantifier = true;
                     index += 1;
                 }
-                b'*' | b'+' | b'?' | b'{' | b'}' | b'^' | b'$' => {
+                b'{' => {
+                    if let Some((end, original, shape)) = parse_brace_quantifier(bytes, index) {
+                        self.record_brace_quantifier(original, shape);
+                        // Advance past the `}` so we do not re-scan the digits inside.
+                        // Skipping the body is safe: digits are not quantifiable on
+                        // their own and contain no further regexp syntax we need to
+                        // observe for the other rules tracked here.
+                        index = end;
+                        continue;
+                    }
+                    index += 1;
+                }
+                b'*' | b'+' | b'?' | b'}' | b'^' | b'$' => {
                     index += 1;
                 }
                 _ => {
@@ -125,9 +154,60 @@ impl PatternAnalysis {
         }
     }
 
+    fn record_brace_quantifier(&mut self, original: &str, shape: BraceQuantifierShape) {
+        match shape {
+            BraceQuantifierShape::Plus => {
+                if self.first_plus_quantifier.is_none() {
+                    self.first_plus_quantifier = Some(CompactString::from(original));
+                }
+            }
+            BraceQuantifierShape::Star => {
+                if self.first_star_quantifier.is_none() {
+                    self.first_star_quantifier = Some(CompactString::from(original));
+                }
+            }
+            BraceQuantifierShape::Question => {
+                if self.first_question_quantifier.is_none() {
+                    self.first_question_quantifier = Some(CompactString::from(original));
+                }
+            }
+            BraceQuantifierShape::EqualTwoNums(value) => {
+                if self.first_useless_two_nums_quantifier.is_none() {
+                    let mut replacement = CompactString::new("{");
+                    push_u64_decimal(&mut replacement, value);
+                    replacement.push('}');
+                    self.first_useless_two_nums_quantifier =
+                        Some((CompactString::from(original), replacement));
+                }
+            }
+        }
+    }
+
     fn mark_content(&self, groups: &mut SmallVec<[GroupState; 8]>) {
         if let Some(group) = groups.last_mut() {
             group.current_has_content = true;
         }
+    }
+}
+
+/// Append the decimal representation of `value` to `target` without allocating
+/// an intermediate `String`. Stays on the stack via a small fixed buffer; a
+/// `u64` has at most 20 decimal digits.
+fn push_u64_decimal(target: &mut CompactString, value: u64) {
+    let mut buf = [0u8; 20];
+    let mut cursor = buf.len();
+    let mut remaining = value;
+    if remaining == 0 {
+        cursor -= 1;
+        buf[cursor] = b'0';
+    } else {
+        while remaining > 0 {
+            cursor -= 1;
+            buf[cursor] = b'0' + (remaining % 10) as u8;
+            remaining /= 10;
+        }
+    }
+    if let Ok(text) = std::str::from_utf8(&buf[cursor..]) {
+        target.push_str(text);
     }
 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -51,6 +51,11 @@ fn exposes_initial_regexp_rule_names() {
             "no-control-character",
             "sort-flags",
             "require-unicode-regexp",
+            "no-escape-backspace",
+            "prefer-plus-quantifier",
+            "prefer-star-quantifier",
+            "prefer-question-quantifier",
+            "no-useless-two-nums-quantifier",
         ]
     );
 }
@@ -435,6 +440,125 @@ mod require_unicode_regexp {
             rule_ids_for("const a = new RegExp('a', 'u');", "require-unicode-regexp").is_empty()
         );
     }
+}
+
+mod no_escape_backspace {
+    use super::*;
+
+    #[test]
+    fn reports_backspace_escape_inside_character_class() {
+        assert_eq!(
+            rule_ids_for("const a = /[\\b]/u;", "no-escape-backspace").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a[\\b]b/u;", "no-escape-backspace").as_slice(),
+            &["unexpected"]
+        );
+        // Mixed-content classes still report when `\b` is one element.
+        assert_eq!(
+            rule_ids_for("const a = /[a\\b]/u;", "no-escape-backspace").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_word_boundary_outside_character_class() {
+        // `\b` outside a character class is the word-boundary assertion, not a
+        // backspace; the rule must not flag it.
+        assert!(rule_ids_for("const a = /\\bword/u;", "no-escape-backspace").is_empty());
+        assert!(rule_ids_for("const a = /a\\bb/u;", "no-escape-backspace").is_empty());
+    }
+
+    #[test]
+    fn ignores_other_classes() {
+        assert!(rule_ids_for("const a = /[a-z]/u;", "no-escape-backspace").is_empty());
+        // `\\b` (escaped backslash followed by `b`) is just the letter `b`.
+        assert!(rule_ids_for("const a = /[\\\\b]/u;", "no-escape-backspace").is_empty());
+    }
+}
+
+mod prefer_plus_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_one_or_more_braced_form() {
+        let data = first_data("const a = /a{1,}/u;", "prefer-plus-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{1,}"));
+    }
+
+    #[test]
+    fn accepts_other_quantifiers_and_plus_itself() {
+        assert!(rule_ids_for("const a = /a+/u;", "prefer-plus-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{2,}/u;", "prefer-plus-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{1,3}/u;", "prefer-plus-quantifier").is_empty());
+    }
+}
+
+mod prefer_star_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_zero_or_more_braced_form() {
+        let data = first_data("const a = /a{0,}/u;", "prefer-star-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{0,}"));
+    }
+
+    #[test]
+    fn accepts_star_and_other_quantifiers() {
+        assert!(rule_ids_for("const a = /a*/u;", "prefer-star-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{1,}/u;", "prefer-star-quantifier").is_empty());
+        // `{0,N}` is a different shape; not flagged by this rule.
+        assert!(rule_ids_for("const a = /a{0,5}/u;", "prefer-star-quantifier").is_empty());
+    }
+}
+
+mod prefer_question_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_zero_or_one_braced_form() {
+        let data = first_data("const a = /a{0,1}/u;", "prefer-question-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{0,1}"));
+    }
+
+    #[test]
+    fn accepts_question_mark_and_unrelated_quantifiers() {
+        assert!(rule_ids_for("const a = /a?/u;", "prefer-question-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{0,2}/u;", "prefer-question-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{1,2}/u;", "prefer-question-quantifier").is_empty());
+    }
+}
+
+mod no_useless_two_nums_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_equal_bounds_quantifier() {
+        let data = first_data("const a = /a{3,3}/u;", "no-useless-two-nums-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{3,3}"));
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("{3}")
+        );
+    }
+
+    #[test]
+    fn accepts_distinct_bounds_and_canonical_form() {
+        assert!(rule_ids_for("const a = /a{3}/u;", "no-useless-two-nums-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{2,5}/u;", "no-useless-two-nums-quantifier").is_empty());
+        // `{0,0}` is no-zero-quantifier's responsibility; we do not double-report.
+        assert!(rule_ids_for("const a = /a{0,0}/u;", "no-useless-two-nums-quantifier").is_empty());
+    }
+}
+
+#[test]
+fn brace_quantifier_rules_ignore_quantifiers_inside_character_classes() {
+    // Inside `[...]` braces are literal characters, not quantifier syntax.
+    assert!(rule_ids_for("const a = /[a{1,}]/u;", "prefer-plus-quantifier").is_empty());
+    assert!(rule_ids_for("const a = /[a{0,}]/u;", "prefer-star-quantifier").is_empty());
+    assert!(rule_ids_for("const a = /[a{0,1}]/u;", "prefer-question-quantifier").is_empty());
+    assert!(rule_ids_for("const a = /[a{3,3}]/u;", "no-useless-two-nums-quantifier").is_empty());
 }
 
 #[test]

--- a/crates/regexp/src/types.rs
+++ b/crates/regexp/src/types.rs
@@ -11,6 +11,7 @@ pub struct DiagnosticData {
     pub sorted_flags: Option<CompactString>,
     pub expr: Option<CompactString>,
     pub char_text: Option<CompactString>,
+    pub replacement: Option<CompactString>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/npm/regexp/api.d.ts
+++ b/npm/regexp/api.d.ts
@@ -5,6 +5,7 @@ export type RegexpDiagnosticData = {
   sortedFlags?: string;
   expr?: string;
   charText?: string;
+  replacement?: string;
 };
 
 export type RegexpDiagnosticLoc = {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -52,6 +52,21 @@ const messages = Object.freeze({
   'require-unicode-regexp': {
     require: "Use the 'u' flag.",
   },
+  'no-escape-backspace': {
+    unexpected: "Unexpected '\\b' inside a character class. Use '\\x08' to match the backspace character.",
+  },
+  'prefer-plus-quantifier': {
+    unexpected: "Unexpected quantifier '{{expr}}'. Use '+' instead.",
+  },
+  'prefer-star-quantifier': {
+    unexpected: "Unexpected quantifier '{{expr}}'. Use '*' instead.",
+  },
+  'prefer-question-quantifier': {
+    unexpected: "Unexpected quantifier '{{expr}}'. Use '?' instead.",
+  },
+  'no-useless-two-nums-quantifier': {
+    unexpected: "Unexpected quantifier '{{expr}}'. Use '{{replacement}}' instead.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -65,6 +80,11 @@ const ruleDescriptions = Object.freeze({
   'no-control-character': 'disallow control characters',
   'sort-flags': 'require regex flags to be sorted',
   'require-unicode-regexp': 'enforce the use of the `u` flag',
+  'no-escape-backspace': 'disallow escape backspace (`[\\b]`)',
+  'prefer-plus-quantifier': 'enforce using `+` quantifier',
+  'prefer-star-quantifier': 'enforce using `*` quantifier',
+  'prefer-question-quantifier': 'enforce using `?` quantifier',
+  'no-useless-two-nums-quantifier': 'disallow unnecessary `{n,m}` quantifier',
 });
 
 const ruleTypes = Object.freeze({
@@ -78,6 +98,11 @@ const ruleTypes = Object.freeze({
   'no-control-character': 'suggestion',
   'sort-flags': 'suggestion',
   'require-unicode-regexp': 'suggestion',
+  'no-escape-backspace': 'suggestion',
+  'prefer-plus-quantifier': 'suggestion',
+  'prefer-star-quantifier': 'suggestion',
+  'prefer-question-quantifier': 'suggestion',
+  'no-useless-two-nums-quantifier': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -88,6 +113,11 @@ const recommendedRuleConfig = Object.freeze({
   'no-empty-alternative': 'warn',
   'no-zero-quantifier': 'error',
   'sort-flags': 'error',
+  'no-escape-backspace': 'error',
+  'prefer-plus-quantifier': 'error',
+  'prefer-star-quantifier': 'error',
+  'prefer-question-quantifier': 'error',
+  'no-useless-two-nums-quantifier': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedRegexpRuleNames());
@@ -178,11 +208,20 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-character-class' ||
     ruleName === 'no-empty-group' ||
     ruleName === 'no-empty-alternative' ||
-    ruleName === 'no-control-character'
+    ruleName === 'no-control-character' ||
+    ruleName === 'no-escape-backspace'
   ) {
     return 'Possible Errors';
   }
   if (ruleName === 'sort-flags') {
+    return 'Stylistic Issues';
+  }
+  if (
+    ruleName === 'prefer-plus-quantifier' ||
+    ruleName === 'prefer-star-quantifier' ||
+    ruleName === 'prefer-question-quantifier' ||
+    ruleName === 'no-useless-two-nums-quantifier'
+  ) {
     return 'Stylistic Issues';
   }
   return 'Best Practices';

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -53,7 +53,8 @@ const messages = Object.freeze({
     require: "Use the 'u' flag.",
   },
   'no-escape-backspace': {
-    unexpected: "Unexpected '\\b' inside a character class. Use '\\x08' to match the backspace character.",
+    unexpected:
+      "Unexpected '\\b' inside a character class. Use '\\x08' to match the backspace character.",
   },
   'prefer-plus-quantifier': {
     unexpected: "Unexpected quantifier '{{expr}}'. Use '+' instead.",

--- a/npm/regexp/src/lib.rs
+++ b/npm/regexp/src/lib.rs
@@ -22,6 +22,7 @@ mod napi_abi {
         pub sorted_flags: Option<String>,
         pub expr: Option<String>,
         pub char_text: Option<String>,
+        pub replacement: Option<String>,
     }
 
     #[napi(object)]
@@ -72,6 +73,10 @@ mod napi_abi {
                     char_text: diagnostic
                         .data
                         .char_text
+                        .map(|value| value.as_str().to_owned()),
+                    replacement: diagnostic
+                        .data
+                        .replacement
                         .map(|value| value.as_str().to_owned()),
                 },
                 loc: DiagnosticLoc {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -49,6 +49,21 @@ const validCases = [
   ['require-unicode-regexp', 'unicode flag', 'const re = /a/u;\n'],
   ['require-unicode-regexp', 'unicode set flag', 'const re = /a/v;\n'],
   ['require-unicode-regexp', 'unicode with other flags', 'const re = /a/gu;\n'],
+  // no-escape-backspace
+  ['no-escape-backspace', 'plain word boundary', 'const re = /\\bword/u;\n'],
+  ['no-escape-backspace', 'character class without \\b', 'const re = /[a-z]/u;\n'],
+  // prefer-plus-quantifier
+  ['prefer-plus-quantifier', 'plus quantifier', 'const re = /a+/u;\n'],
+  ['prefer-plus-quantifier', 'two-or-more braced quantifier', 'const re = /a{2,}/u;\n'],
+  // prefer-star-quantifier
+  ['prefer-star-quantifier', 'star quantifier', 'const re = /a*/u;\n'],
+  ['prefer-star-quantifier', 'open-upper-bound greater than zero', 'const re = /a{1,}/u;\n'],
+  // prefer-question-quantifier
+  ['prefer-question-quantifier', 'question quantifier', 'const re = /a?/u;\n'],
+  ['prefer-question-quantifier', 'distinct range bounds', 'const re = /a{1,2}/u;\n'],
+  // no-useless-two-nums-quantifier
+  ['no-useless-two-nums-quantifier', 'single-bound quantifier', 'const re = /a{3}/u;\n'],
+  ['no-useless-two-nums-quantifier', 'asymmetric range quantifier', 'const re = /a{2,5}/u;\n'],
 ];
 
 const invalidCases = [
@@ -116,6 +131,47 @@ const invalidCases = [
     'constructor without flags',
     "const re = new RegExp('a');\n",
     ['require'],
+  ],
+  // no-escape-backspace
+  [
+    'no-escape-backspace',
+    'backspace alone in class',
+    'const re = /[\\b]/u;\n',
+    ['unexpected'],
+  ],
+  [
+    'no-escape-backspace',
+    'backspace mixed with other class elements',
+    'const re = /[a\\b]/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-plus-quantifier
+  [
+    'prefer-plus-quantifier',
+    'one-or-more braced quantifier',
+    'const re = /a{1,}/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-star-quantifier
+  [
+    'prefer-star-quantifier',
+    'zero-or-more braced quantifier',
+    'const re = /a{0,}/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-question-quantifier
+  [
+    'prefer-question-quantifier',
+    'zero-or-one braced quantifier',
+    'const re = /a{0,1}/u;\n',
+    ['unexpected'],
+  ],
+  // no-useless-two-nums-quantifier
+  [
+    'no-useless-two-nums-quantifier',
+    'equal-bounds quantifier',
+    'const re = /a{3,3}/u;\n',
+    ['unexpected'],
   ],
 ];
 
@@ -249,6 +305,30 @@ describe('regexp rules through direct Oxlint plugin adapter', () => {
         runRule('no-invalid-regexp', "new RegExp('a', 'gg');\n")[0],
       ),
     ).toBe('Duplicate g flag.');
+    expect(
+      renderMessage(
+        'prefer-plus-quantifier',
+        runRule('prefer-plus-quantifier', 'const re = /a{1,}/u;\n')[0],
+      ),
+    ).toBe("Unexpected quantifier '{1,}'. Use '+' instead.");
+    expect(
+      renderMessage(
+        'prefer-star-quantifier',
+        runRule('prefer-star-quantifier', 'const re = /a{0,}/u;\n')[0],
+      ),
+    ).toBe("Unexpected quantifier '{0,}'. Use '*' instead.");
+    expect(
+      renderMessage(
+        'prefer-question-quantifier',
+        runRule('prefer-question-quantifier', 'const re = /a{0,1}/u;\n')[0],
+      ),
+    ).toBe("Unexpected quantifier '{0,1}'. Use '?' instead.");
+    expect(
+      renderMessage(
+        'no-useless-two-nums-quantifier',
+        runRule('no-useless-two-nums-quantifier', 'const re = /a{3,3}/u;\n')[0],
+      ),
+    ).toBe("Unexpected quantifier '{3,3}'. Use '{3}' instead.");
   });
 
   it('ignores non-RegExp callees with the same shape', () => {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -133,12 +133,7 @@ const invalidCases = [
     ['require'],
   ],
   // no-escape-backspace
-  [
-    'no-escape-backspace',
-    'backspace alone in class',
-    'const re = /[\\b]/u;\n',
-    ['unexpected'],
-  ],
+  ['no-escape-backspace', 'backspace alone in class', 'const re = /[\\b]/u;\n', ['unexpected']],
   [
     'no-escape-backspace',
     'backspace mixed with other class elements',

--- a/status.json
+++ b/status.json
@@ -8779,19 +8779,19 @@
       },
       {
         "name": "no-escape-backspace",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-escape-backspace."
+        "notes": "Detected at the literal level: `\\b` is flagged whenever it appears inside a `[...]` character class. Rust core via pattern walker; covered by insta-style unit tests and Vitest plugin tests."
       },
       {
         "name": "no-extra-lookaround-assertions",
@@ -9259,19 +9259,19 @@
       },
       {
         "name": "no-useless-two-nums-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-two-nums-quantifier."
+        "notes": "Detects `{n,n}` with `n >= 1` and reports it as rewritable to `{n}` (the `n == 0` case stays with `no-zero-quantifier`). Pattern walker only; covered by Rust unit tests and Vitest plugin tests."
       },
       {
         "name": "optimal-lookaround-quantifier",
@@ -9419,19 +9419,19 @@
       },
       {
         "name": "prefer-plus-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-plus-quantifier."
+        "notes": "Detects `{1,}` and reports it as rewritable to `+`. Pattern walker only (no full regexp parse); covered by Rust unit tests and Vitest plugin tests."
       },
       {
         "name": "prefer-predefined-assertion",
@@ -9467,19 +9467,19 @@
       },
       {
         "name": "prefer-question-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-question-quantifier."
+        "notes": "Detects `{0,1}` and reports it as rewritable to `?`. Pattern walker only; covered by Rust unit tests and Vitest plugin tests."
       },
       {
         "name": "prefer-range",
@@ -9563,19 +9563,19 @@
       },
       {
         "name": "prefer-star-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-star-quantifier."
+        "notes": "Detects `{0,}` and reports it as rewritable to `*`. Pattern walker only; covered by Rust unit tests and Vitest plugin tests."
       },
       {
         "name": "prefer-unicode-codepoint-escapes",


### PR DESCRIPTION
Adds the five smallest pattern-only rules of `eslint-plugin-regexp` to the existing port so the regexp plugin moves from 10/82 to 15/82 ported. All five share the existing single-pass `PatternAnalysis` walker in `crates/regexp/src/pattern.rs`, so the cost per regex literal is one extra brace-quantifier parse and two extra boolean checks — no new full-pattern scan.

## How it works

- `no-escape-backspace`: at every `[...]` we already locate via `find_class_end`, scan the class body once for a `\b` escape (`class_contains_backspace_escape` in `helpers.rs`). Outside a class the rule never fires, which keeps the word-boundary assertion `\b` untouched.
- `prefer-plus-quantifier`, `prefer-star-quantifier`, `prefer-question-quantifier`, `no-useless-two-nums-quantifier`: `parse_brace_quantifier` (new, in `helpers.rs`) parses `{n}`, `{n,}`, `{n,m}` conservatively and returns one of four rewritable shapes. The walker’s `b'{'` arm consults it once and records the first match per literal; malformed inputs fall through to the existing scan so they never affect other rules. The `{n,n}` rule carries its `{n}` replacement through a new `DiagnosticData.replacement` field, plumbed across NAPI to the JS message template. The `n == 0` cases stay with `no-zero-quantifier` so we do not double-report.
- All four quantifier rules respect character-class context: inside `[...]`, braces are literal characters and the walker skips them. Tests pin this with `[a{1,}]`-style fixtures.

`status.json` flips these five from `pending` to `ported` with the standard test-coverage flags. 79 workspace Rust suites and 44 regexp unit tests pass (12 new); `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all --check` are clean. Vitest plugin and Oxlint integration tests are extended with valid/invalid/message cases for all five rules; the message-template render tests assert the exact upstream-parity strings (e.g. `"Unexpected quantifier '{1,}'. Use '+' instead."`).

No upstream source, fixtures, or messages were copied: the message strings are paraphrased from the public rule docs, and the parsing logic is independent of upstream's `regexpp`-based pipeline. The existing performance constraints (`CompactString`, `SmallVec`, file-level scan, no `HashMap`/`String` in rule state) are preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->