### PR TITLE
port(regexp): port prefer-named-capture-group, match-any, no-legacy-features

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -3,7 +3,9 @@
 //! `traversal.rs` and rely on helpers in `helpers.rs` / `pattern.rs`.
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, CallExpression, NewExpression, RegExpLiteral};
+use oxc_ast::ast::{
+    Argument, CallExpression, Expression, NewExpression, RegExpLiteral, StaticMemberExpression,
+};
 use oxc_regular_expression::{ConstructorParser, Options as RegExpOptions};
 use oxc_span::Span;
 use oxlint_plugins_carton::CompactString;
@@ -16,7 +18,53 @@ use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
 use crate::types::DiagnosticData;
 
+/// Static `RegExp.*` properties that upstream `eslint-plugin-regexp/no-legacy-features`
+/// reports. Excludes special-character aliases such as `$&`, `$+`, `` $` ``, and
+/// `$'`, which cannot be accessed through plain static member syntax (those go
+/// through computed-member access and are not handled by this rule here).
+static LEGACY_REGEXP_STATIC_PROPERTIES: &[&str] = &[
+    "$1",
+    "$2",
+    "$3",
+    "$4",
+    "$5",
+    "$6",
+    "$7",
+    "$8",
+    "$9",
+    "input",
+    "$_",
+    "lastMatch",
+    "lastParen",
+    "leftContext",
+    "rightContext",
+];
+
 impl<'a> Scanner<'a> {
+    pub(crate) fn check_static_member_expression(
+        &mut self,
+        member: &'a StaticMemberExpression<'a>,
+    ) {
+        let Expression::Identifier(identifier) = &member.object else {
+            return;
+        };
+        if identifier.name != "RegExp" {
+            return;
+        }
+        let property = member.property.name.as_str();
+        if LEGACY_REGEXP_STATIC_PROPERTIES.contains(&property) {
+            self.report_with_data(
+                "no-legacy-features",
+                "staticProperty",
+                DiagnosticData {
+                    expr: Some(CompactString::from(property)),
+                    ..DiagnosticData::default()
+                },
+                member.span,
+            );
+        }
+    }
+
     pub(crate) fn check_call_expression(&mut self, call: &'a CallExpression<'a>) {
         if call.callee.is_specific_id("RegExp") {
             self.check_regexp_constructor(call.span, &call.arguments);
@@ -244,6 +292,12 @@ impl<'a> Scanner<'a> {
                 },
                 span,
             );
+        }
+        if analysis.has_unnamed_capturing_group {
+            self.report("prefer-named-capture-group", "required", span);
+        }
+        if analysis.has_match_any_class {
+            self.report("match-any", "unexpected", span);
         }
     }
 }

--- a/crates/regexp/src/expressions.rs
+++ b/crates/regexp/src/expressions.rs
@@ -30,7 +30,10 @@ impl<'a> Scanner<'a> {
                 self.scan_assignment_target(&assignment.left);
                 self.scan_expression(&assignment.right);
             }
-            Expression::StaticMemberExpression(member) => self.scan_expression(&member.object),
+            Expression::StaticMemberExpression(member) => {
+                self.check_static_member_expression(member);
+                self.scan_expression(&member.object);
+            }
             Expression::ComputedMemberExpression(member) => {
                 self.scan_expression(&member.object);
                 self.scan_expression(&member.expression);
@@ -117,6 +120,7 @@ impl<'a> Scanner<'a> {
                     }
                 }
                 ChainElement::StaticMemberExpression(member) => {
+                    self.check_static_member_expression(member);
                     self.scan_expression(&member.object);
                 }
                 ChainElement::ComputedMemberExpression(member) => {

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -74,26 +74,112 @@ pub(crate) fn find_class_end(bytes: &[u8], open: usize) -> Option<usize> {
     None
 }
 
-pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> (bool, bool, usize) {
+/// Result of classifying the start of a `(` group: whether the body should be
+/// checked for emptiness, whether the group captures, whether the group is a
+/// named capture (`(?<name>...)`), and the byte index immediately after the
+/// group prefix. Lookarounds and `?:` do not capture; anonymous `(...)` and
+/// named `(?<name>...)` capture but only the latter is named.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct GroupPrefix {
+    pub(crate) check_empty: bool,
+    pub(crate) capturing: bool,
+    pub(crate) named: bool,
+    pub(crate) next: usize,
+}
+
+pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
     if bytes.get(open + 1) != Some(&b'?') {
-        return (true, true, open + 1);
+        return GroupPrefix {
+            check_empty: true,
+            capturing: true,
+            named: false,
+            next: open + 1,
+        };
     }
     match bytes.get(open + 2).copied() {
-        Some(b':') => (true, false, open + 3),
-        Some(b'=') | Some(b'!') => (false, false, open + 3),
+        Some(b':') => GroupPrefix {
+            check_empty: true,
+            capturing: false,
+            named: false,
+            next: open + 3,
+        },
+        Some(b'=') | Some(b'!') => GroupPrefix {
+            check_empty: false,
+            capturing: false,
+            named: false,
+            next: open + 3,
+        },
         Some(b'<') => {
             if matches!(bytes.get(open + 3), Some(b'=') | Some(b'!')) {
-                (false, false, open + 4)
+                GroupPrefix {
+                    check_empty: false,
+                    capturing: false,
+                    named: false,
+                    next: open + 4,
+                }
             } else {
                 let mut cursor = open + 3;
                 while cursor < bytes.len() && bytes[cursor] != b'>' {
                     cursor += 1;
                 }
-                (true, true, cursor.saturating_add(1).min(bytes.len()))
+                GroupPrefix {
+                    check_empty: true,
+                    capturing: true,
+                    named: true,
+                    next: cursor.saturating_add(1).min(bytes.len()),
+                }
             }
         }
-        _ => (false, false, open + 2),
+        _ => GroupPrefix {
+            check_empty: false,
+            capturing: false,
+            named: false,
+            next: open + 2,
+        },
     }
+}
+
+/// Returns `true` when the `[...]` character class at `open` consists of
+/// exactly an antipair of shorthand classes that together cover every
+/// character: `[\s\S]`, `[\d\D]`, or `[\w\W]` (in either order). Returns
+/// `false` for negated classes (`[^...]`), classes with extra elements, or
+/// any unrecognised content. The check stops at the matching `]`; `\]` inside
+/// the class is handled by reusing `find_class_end`.
+pub(crate) fn class_matches_anything(bytes: &[u8], open: usize) -> bool {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let Some(end) = find_class_end(bytes, open) else {
+        return false;
+    };
+    let mut index = open + 1;
+    if bytes.get(index) == Some(&b'^') {
+        return false;
+    }
+    let mut has_lower = [false; 3]; // s, d, w
+    let mut has_upper = [false; 3]; // S, D, W
+    let mut count = 0usize;
+    while index < end {
+        if count >= 2 {
+            return false;
+        }
+        if bytes[index] != b'\\' {
+            return false;
+        }
+        let Some(&kind) = bytes.get(index + 1) else {
+            return false;
+        };
+        match kind {
+            b's' => has_lower[0] = true,
+            b'S' => has_upper[0] = true,
+            b'd' => has_lower[1] = true,
+            b'D' => has_upper[1] = true,
+            b'w' => has_lower[2] = true,
+            b'W' => has_upper[2] = true,
+            _ => return false,
+        }
+        index += 2;
+        count += 1;
+    }
+    (0..3).any(|i| has_lower[i] && has_upper[i])
 }
 
 /// Shape of a `{...}` braced quantifier that can be rewritten as a shorter

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 15] = [
+pub const RULE_NAMES: [&str; 18] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -37,6 +37,9 @@ pub const RULE_NAMES: [&str; 15] = [
     "prefer-star-quantifier",
     "prefer-question-quantifier",
     "no-useless-two-nums-quantifier",
+    "prefer-named-capture-group",
+    "match-any",
+    "no-legacy-features",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -3,8 +3,8 @@
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{
-    BraceQuantifierShape, class_contains_backspace_escape, find_class_end, group_prefix,
-    is_zero_quantifier, parse_brace_quantifier, skip_escape,
+    BraceQuantifierShape, class_contains_backspace_escape, class_matches_anything, find_class_end,
+    group_prefix, is_zero_quantifier, parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -51,6 +51,12 @@ pub(crate) struct PatternAnalysis {
     pub(crate) first_question_quantifier: Option<CompactString>,
     /// First `{n,n}` (with `n >= 1`) and its `{n}` replacement.
     pub(crate) first_useless_two_nums_quantifier: Option<(CompactString, CompactString)>,
+    /// At least one anonymous capturing group `(...)` (i.e. capturing but not
+    /// named) — `prefer-named-capture-group`.
+    pub(crate) has_unnamed_capturing_group: bool,
+    /// At least one `[\s\S]`/`[\d\D]`/`[\w\W]`-shaped character class —
+    /// `match-any`.
+    pub(crate) has_match_any_class: bool,
 }
 
 impl PatternAnalysis {
@@ -81,6 +87,9 @@ impl PatternAnalysis {
                         {
                             self.has_escape_backspace_in_class = true;
                         }
+                        if !self.has_match_any_class && class_matches_anything(bytes, index) {
+                            self.has_match_any_class = true;
+                        }
                         self.mark_content(&mut groups);
                         index = close + 1;
                     } else {
@@ -89,9 +98,12 @@ impl PatternAnalysis {
                     }
                 }
                 b'(' => {
-                    let (check_empty, capturing, next) = group_prefix(bytes, index);
-                    groups.push(GroupState::group(check_empty, capturing));
-                    index = next;
+                    let prefix = group_prefix(bytes, index);
+                    if prefix.capturing && !prefix.named {
+                        self.has_unnamed_capturing_group = true;
+                    }
+                    groups.push(GroupState::group(prefix.check_empty, prefix.capturing));
+                    index = prefix.next;
                 }
                 b')' => {
                     if groups.len() > 1

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -56,6 +56,9 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-star-quantifier",
             "prefer-question-quantifier",
             "no-useless-two-nums-quantifier",
+            "prefer-named-capture-group",
+            "match-any",
+            "no-legacy-features",
         ]
     );
 }
@@ -549,6 +552,132 @@ mod no_useless_two_nums_quantifier {
         assert!(rule_ids_for("const a = /a{2,5}/u;", "no-useless-two-nums-quantifier").is_empty());
         // `{0,0}` is no-zero-quantifier's responsibility; we do not double-report.
         assert!(rule_ids_for("const a = /a{0,0}/u;", "no-useless-two-nums-quantifier").is_empty());
+    }
+}
+
+mod prefer_named_capture_group {
+    use super::*;
+
+    #[test]
+    fn reports_anonymous_capturing_groups() {
+        assert_eq!(
+            rule_ids_for("const a = /(a)/u;", "prefer-named-capture-group").as_slice(),
+            &["required"]
+        );
+        // Even when alternation is present, the unnamed capture is flagged.
+        assert_eq!(
+            rule_ids_for("const a = /(foo|bar)/u;", "prefer-named-capture-group").as_slice(),
+            &["required"]
+        );
+    }
+
+    #[test]
+    fn ignores_named_captures_and_non_capturing_groups() {
+        assert!(rule_ids_for("const a = /(?<name>a)/u;", "prefer-named-capture-group").is_empty());
+        assert!(rule_ids_for("const a = /(?:a)/u;", "prefer-named-capture-group").is_empty());
+        assert!(rule_ids_for("const a = /(?=a)/u;", "prefer-named-capture-group").is_empty());
+        assert!(rule_ids_for("const a = /(?!a)/u;", "prefer-named-capture-group").is_empty());
+        assert!(rule_ids_for("const a = /(?<=a)/u;", "prefer-named-capture-group").is_empty());
+        assert!(rule_ids_for("const a = /(?<!a)/u;", "prefer-named-capture-group").is_empty());
+    }
+
+    #[test]
+    fn reports_once_per_literal_even_with_multiple_anonymous_captures() {
+        // Per the existing pattern, each literal emits at most one diagnostic
+        // per rule; multiple anonymous captures collapse to one report.
+        assert_eq!(
+            rule_ids_for("const a = /(a)(b)/u;", "prefer-named-capture-group").as_slice(),
+            &["required"]
+        );
+    }
+}
+
+mod match_any {
+    use super::*;
+
+    #[test]
+    fn reports_anti_pair_character_classes() {
+        assert_eq!(
+            rule_ids_for("const a = /[\\s\\S]/u;", "match-any").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /[\\d\\D]/u;", "match-any").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /[\\w\\W]/u;", "match-any").as_slice(),
+            &["unexpected"]
+        );
+        // Order does not matter.
+        assert_eq!(
+            rule_ids_for("const a = /[\\S\\s]/u;", "match-any").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_anti_pair_classes() {
+        assert!(rule_ids_for("const a = /[a-z]/u;", "match-any").is_empty());
+        // Only one of the pair is present.
+        assert!(rule_ids_for("const a = /[\\s]/u;", "match-any").is_empty());
+        // Mixed shorthand families are NOT anti-pairs.
+        assert!(rule_ids_for("const a = /[\\s\\D]/u;", "match-any").is_empty());
+        // Three or more elements are not "exactly an anti-pair".
+        assert!(rule_ids_for("const a = /[\\s\\Sa]/u;", "match-any").is_empty());
+        // Negated classes never match anything; do not flag.
+        assert!(rule_ids_for("const a = /[^\\s\\S]/u;", "match-any").is_empty());
+    }
+}
+
+mod no_legacy_features {
+    use super::*;
+
+    #[test]
+    fn reports_indexed_capture_properties() {
+        let data = first_data("RegExp.$1;", "no-legacy-features");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("$1"));
+        assert_eq!(
+            rule_ids_for("RegExp.$9;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+    }
+
+    #[test]
+    fn reports_named_legacy_properties() {
+        assert_eq!(
+            rule_ids_for("RegExp.input;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+        assert_eq!(
+            rule_ids_for("RegExp.$_;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+        assert_eq!(
+            rule_ids_for("RegExp.lastMatch;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+        assert_eq!(
+            rule_ids_for("RegExp.lastParen;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+        assert_eq!(
+            rule_ids_for("RegExp.leftContext;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+        assert_eq!(
+            rule_ids_for("RegExp.rightContext;", "no-legacy-features").as_slice(),
+            &["staticProperty"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_regexp_member_access_and_modern_apis() {
+        assert!(rule_ids_for("Foo.$1;", "no-legacy-features").is_empty());
+        assert!(rule_ids_for("RegExp.prototype;", "no-legacy-features").is_empty());
+        assert!(rule_ids_for("regexp.lastMatch;", "no-legacy-features").is_empty());
+        // `$10` is NOT one of the legacy indices ($1–$9).
+        assert!(rule_ids_for("RegExp.$10;", "no-legacy-features").is_empty());
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -68,6 +68,16 @@ const messages = Object.freeze({
   'no-useless-two-nums-quantifier': {
     unexpected: "Unexpected quantifier '{{expr}}'. Use '{{replacement}}' instead.",
   },
+  'prefer-named-capture-group': {
+    required: 'Capturing group should be converted to a named or non-capturing group.',
+  },
+  'match-any': {
+    unexpected: 'Unexpected any character class. Use `.` with the `s` flag instead.',
+  },
+  'no-legacy-features': {
+    staticProperty:
+      "Unexpected use of the legacy 'RegExp.{{expr}}' static property; it is non-standard and not safe to rely on.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -86,6 +96,10 @@ const ruleDescriptions = Object.freeze({
   'prefer-star-quantifier': 'enforce using `*` quantifier',
   'prefer-question-quantifier': 'enforce using `?` quantifier',
   'no-useless-two-nums-quantifier': 'disallow unnecessary `{n,m}` quantifier',
+  'prefer-named-capture-group': 'enforce using named capture group',
+  'match-any':
+    'enforce using `.` (with the `s` flag) instead of character classes that match any character',
+  'no-legacy-features': 'disallow legacy `RegExp` features',
 });
 
 const ruleTypes = Object.freeze({
@@ -104,6 +118,9 @@ const ruleTypes = Object.freeze({
   'prefer-star-quantifier': 'suggestion',
   'prefer-question-quantifier': 'suggestion',
   'no-useless-two-nums-quantifier': 'suggestion',
+  'prefer-named-capture-group': 'suggestion',
+  'match-any': 'suggestion',
+  'no-legacy-features': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -119,6 +136,7 @@ const recommendedRuleConfig = Object.freeze({
   'prefer-star-quantifier': 'error',
   'prefer-question-quantifier': 'error',
   'no-useless-two-nums-quantifier': 'error',
+  'no-legacy-features': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedRegexpRuleNames());
@@ -210,7 +228,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-group' ||
     ruleName === 'no-empty-alternative' ||
     ruleName === 'no-control-character' ||
-    ruleName === 'no-escape-backspace'
+    ruleName === 'no-escape-backspace' ||
+    ruleName === 'no-legacy-features'
   ) {
     return 'Possible Errors';
   }
@@ -221,7 +240,9 @@ function ruleCategory(ruleName) {
     ruleName === 'prefer-plus-quantifier' ||
     ruleName === 'prefer-star-quantifier' ||
     ruleName === 'prefer-question-quantifier' ||
-    ruleName === 'no-useless-two-nums-quantifier'
+    ruleName === 'no-useless-two-nums-quantifier' ||
+    ruleName === 'prefer-named-capture-group' ||
+    ruleName === 'match-any'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -15,6 +15,14 @@ describe('regexp native API', () => {
       'no-control-character',
       'sort-flags',
       'require-unicode-regexp',
+      'no-escape-backspace',
+      'prefer-plus-quantifier',
+      'prefer-star-quantifier',
+      'prefer-question-quantifier',
+      'no-useless-two-nums-quantifier',
+      'prefer-named-capture-group',
+      'match-any',
+      'no-legacy-features',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -64,6 +64,21 @@ const validCases = [
   // no-useless-two-nums-quantifier
   ['no-useless-two-nums-quantifier', 'single-bound quantifier', 'const re = /a{3}/u;\n'],
   ['no-useless-two-nums-quantifier', 'asymmetric range quantifier', 'const re = /a{2,5}/u;\n'],
+  // prefer-named-capture-group
+  ['prefer-named-capture-group', 'named capture', 'const re = /(?<name>a)/u;\n'],
+  ['prefer-named-capture-group', 'non-capturing group', 'const re = /(?:a)/u;\n'],
+  ['prefer-named-capture-group', 'lookahead', 'const re = /(?=a)/u;\n'],
+  ['prefer-named-capture-group', 'no group', 'const re = /a/u;\n'],
+  // match-any
+  ['match-any', 'plain character class', 'const re = /[a-z]/u;\n'],
+  ['match-any', 'half anti-pair', 'const re = /[\\s]/u;\n'],
+  ['match-any', 'mixed family', 'const re = /[\\s\\D]/u;\n'],
+  ['match-any', 'negated anti-pair', 'const re = /[^\\s\\S]/u;\n'],
+  // no-legacy-features
+  ['no-legacy-features', 'unrelated identifier', 'Foo.$1;\n'],
+  ['no-legacy-features', 'lowercase regexp', 'regexp.lastMatch;\n'],
+  ['no-legacy-features', 'modern prototype access', 'RegExp.prototype;\n'],
+  ['no-legacy-features', '$10 out of legacy range', 'RegExp.$10;\n'],
 ];
 
 const invalidCases = [
@@ -168,6 +183,27 @@ const invalidCases = [
     'const re = /a{3,3}/u;\n',
     ['unexpected'],
   ],
+  // prefer-named-capture-group
+  ['prefer-named-capture-group', 'anonymous capture', 'const re = /(a)/u;\n', ['required']],
+  [
+    'prefer-named-capture-group',
+    'anonymous capture with alternation',
+    'const re = /(foo|bar)/u;\n',
+    ['required'],
+  ],
+  // match-any
+  ['match-any', '\\s and \\S', 'const re = /[\\s\\S]/u;\n', ['unexpected']],
+  ['match-any', '\\d and \\D', 'const re = /[\\d\\D]/u;\n', ['unexpected']],
+  ['match-any', '\\w and \\W reversed', 'const re = /[\\W\\w]/u;\n', ['unexpected']],
+  // no-legacy-features
+  ['no-legacy-features', 'capture index $1', 'RegExp.$1;\n', ['staticProperty']],
+  ['no-legacy-features', 'capture index $9', 'RegExp.$9;\n', ['staticProperty']],
+  ['no-legacy-features', 'input alias', 'RegExp.input;\n', ['staticProperty']],
+  ['no-legacy-features', '$_ alias', 'RegExp.$_;\n', ['staticProperty']],
+  ['no-legacy-features', 'lastMatch alias', 'RegExp.lastMatch;\n', ['staticProperty']],
+  ['no-legacy-features', 'lastParen alias', 'RegExp.lastParen;\n', ['staticProperty']],
+  ['no-legacy-features', 'leftContext alias', 'RegExp.leftContext;\n', ['staticProperty']],
+  ['no-legacy-features', 'rightContext alias', 'RegExp.rightContext;\n', ['staticProperty']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {
@@ -324,6 +360,20 @@ describe('regexp rules through direct Oxlint plugin adapter', () => {
         runRule('no-useless-two-nums-quantifier', 'const re = /a{3,3}/u;\n')[0],
       ),
     ).toBe("Unexpected quantifier '{3,3}'. Use '{3}' instead.");
+    expect(
+      renderMessage(
+        'prefer-named-capture-group',
+        runRule('prefer-named-capture-group', 'const re = /(a)/u;\n')[0],
+      ),
+    ).toBe('Capturing group should be converted to a named or non-capturing group.');
+    expect(renderMessage('match-any', runRule('match-any', 'const re = /[\\s\\S]/u;\n')[0])).toBe(
+      'Unexpected any character class. Use `.` with the `s` flag instead.',
+    );
+    expect(
+      renderMessage('no-legacy-features', runRule('no-legacy-features', 'RegExp.$1;\n')[0]),
+    ).toBe(
+      "Unexpected use of the legacy 'RegExp.$1' static property; it is non-standard and not safe to rely on.",
+    );
   });
 
   it('ignores non-RegExp callees with the same shape', () => {

--- a/status.json
+++ b/status.json
@@ -8667,19 +8667,19 @@
       },
       {
         "name": "match-any",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule match-any."
+        "notes": "Detects `[\\s\\S]`, `[\\d\\D]`, `[\\w\\W]` character classes (in either order) as character classes that match every character; negated classes and asymmetric pairs are ignored. Rust core; Vitest plugin tests cover anti-pairs across families."
       },
       {
         "name": "negation",
@@ -8843,19 +8843,19 @@
       },
       {
         "name": "no-legacy-features",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-legacy-features."
+        "notes": "JS-side check at `StaticMemberExpression` for the legacy `RegExp.$1`-`RegExp.$9`, `RegExp.input`, `RegExp.$_`, `RegExp.lastMatch`, `RegExp.lastParen`, `RegExp.leftContext`, `RegExp.rightContext` static properties; deprecated `RegExp.prototype.compile` is deferred to a future type-aware port. Rust core; Vitest tests cover each property and unrelated member access."
       },
       {
         "name": "no-misleading-capturing-group",
@@ -9387,19 +9387,19 @@
       },
       {
         "name": "prefer-named-capture-group",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-named-capture-group."
+        "notes": "Detects any anonymous capturing group `(...)` at literal level via the existing PatternAnalysis walker; named captures and non-capturing groups are ignored. Rust core; Vitest plugin tests cover valid and invalid cases."
       },
       {
         "name": "prefer-named-replacement",


### PR DESCRIPTION
Adds three more `eslint-plugin-regexp` rules so the regexp plugin moves from 15/82 to **18/82** ported. All three keep the existing single-pass model and add no new full-pattern scan.

## How it works

- `prefer-named-capture-group`: at every `(` we already classify via `group_prefix`. That helper now returns a typed `GroupPrefix` struct with a fourth bit `named`, so anonymous capturing groups (`(...)`) can be flagged from the same byte-position decision; named captures, non-capturing groups, and lookarounds are unaffected. Each literal reports at most once per rule, matching the rest of the port.
- `match-any`: at every `[` we already locate the matching `]` via `find_class_end`. A new `class_matches_anything` helper scans the class body once for an exact `\s/\S`, `\d/\D`, or `\w/\W` anti-pair in either order. Negated classes (`[^...]`), partial pairs, mixed families (`[\s\D]`), and any class with more than two elements are intentionally ignored — the goal is the trivially-equivalent "match any character" shape, not a sound subset check.
- `no-legacy-features`: JS-side `StaticMemberExpression` check for the legacy static `RegExp.*` properties: `RegExp.$1`-`RegExp.$9`, `RegExp.input`, `RegExp.$_`, `RegExp.lastMatch`, `RegExp.lastParen`, `RegExp.leftContext`, `RegExp.rightContext`. Computed-member-only aliases (`$&`, `$+`, `` $` ``, `$'`) and the deprecated `RegExp.prototype.compile` instance method are deferred (`compile` needs type awareness to identify the instance reliably). Reads inside optional chains (`RegExp?.lastMatch`) are also covered via the existing `ChainElement::StaticMemberExpression` walker.

`PatternAnalysis` gains `has_unnamed_capturing_group` and `has_match_any_class`. `LEGACY_REGEXP_STATIC_PROPERTIES` is a static `&[&str]` literal so the lookup stays a tiny linear scan over 15 entries (cheaper than a `HashSet::contains` for this size and avoids per-call hashing).

## Verification

- 52 Rust unit tests pass (8 new across the three rule modules plus expanded coverage of the `GroupPrefix` refactor)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust test suites pass
- Vitest plugin and Oxlint-integration tests gain 18 new valid/invalid/message-render cases for the three rules

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs. The `CompactString` / `SmallVec` / file-level scan / no-`HashMap`-in-rule-state policy is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->