### PR TITLE
port(regexp): port prefer-d, prefer-w, letter-case

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -11,8 +11,8 @@ use oxc_span::Span;
 use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
-    duplicate_flag, first_control_character, first_octal_escape, mention_char, sorted_flags,
-    string_literal_value_with_span,
+    duplicate_flag, first_control_character, first_octal_escape, first_uppercase_hex_escape,
+    mention_char, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -298,6 +298,45 @@ impl<'a> Scanner<'a> {
         }
         if analysis.has_match_any_class {
             self.report("match-any", "unexpected", span);
+        }
+        if let Some(negated) = analysis.first_digit_class {
+            self.report_with_data(
+                "prefer-d",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(if negated {
+                        "[^0-9]"
+                    } else {
+                        "[0-9]"
+                    })),
+                    replacement: Some(CompactString::from(if negated { "\\D" } else { "\\d" })),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(negated) = analysis.first_word_class {
+            self.report_with_data(
+                "prefer-w",
+                "unexpected",
+                DiagnosticData {
+                    replacement: Some(CompactString::from(if negated { "\\W" } else { "\\w" })),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(escape) = first_uppercase_hex_escape(pattern) {
+            self.report_with_data(
+                "letter-case",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(escape)),
+                    replacement: Some(CompactString::from(escape.to_ascii_lowercase().as_str())),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
         }
     }
 }

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -11,8 +11,9 @@ use oxc_span::Span;
 use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
-    duplicate_flag, first_control_character, first_octal_escape, first_uppercase_hex_escape,
-    mention_char, sorted_flags, string_literal_value_with_span,
+    duplicate_flag, first_control_character, first_invisible_character, first_non_standard_flag,
+    first_octal_escape, first_uppercase_hex_escape, mention_char, sorted_flags,
+    string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -137,6 +138,22 @@ impl<'a> Scanner<'a> {
         if flags.contains('u') && flags.contains('v') {
             self.report("no-invalid-regexp", "uvFlag", span);
             return;
+        }
+        if let Some(flag) = first_non_standard_flag(flags) {
+            // Reported alongside any constructor parse error below; this rule
+            // exists as its own diagnostic so users can target it independently
+            // of `no-invalid-regexp`. We intentionally do not early-return.
+            let mut flag_text = CompactString::new("");
+            flag_text.push(flag);
+            self.report_with_data(
+                "no-non-standard-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(flag_text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
         }
         if let (true, Some(message)) = (
             is_constructor,
@@ -321,6 +338,17 @@ impl<'a> Scanner<'a> {
                 "unexpected",
                 DiagnosticData {
                     replacement: Some(CompactString::from(if negated { "\\W" } else { "\\w" })),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(ch) = first_invisible_character(pattern) {
+            self.report_with_data(
+                "no-invisible-character",
+                "unexpected",
+                DiagnosticData {
+                    char_text: Some(mention_char(ch)),
                     ..DiagnosticData::default()
                 },
                 span,

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -139,6 +139,140 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
     }
 }
 
+/// Classification of a `[...]` character class for shorthand-equivalence
+/// rules (`prefer-d`, `prefer-w`). Carries whether the class is negated so
+/// callers can pick between the lower- and upper-case shorthand.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ShorthandClass {
+    pub(crate) negated: bool,
+}
+
+/// Returns `Some(ShorthandClass)` when the class at `open` is exactly the
+/// range `0-9` (possibly negated): the bodies of `[0-9]`, `[^0-9]`. Any extra
+/// element, malformed range, or unrecognised content yields `None`. Reuses
+/// `find_class_end` so escaped `]` inside the class is handled.
+pub(crate) fn class_is_digit_range(bytes: &[u8], open: usize) -> Option<ShorthandClass> {
+    let (negated, start, end) = class_body_bounds(bytes, open)?;
+    let body = &bytes[start..end];
+    if body == b"0-9" {
+        Some(ShorthandClass { negated })
+    } else {
+        None
+    }
+}
+
+/// Returns `Some(ShorthandClass)` when the class at `open` is exactly the
+/// word-character set in any order: ranges `a-z`, `A-Z`, `0-9`, and literal
+/// `_`. Negated forms (`[^a-zA-Z0-9_]` etc.) are also recognised. Any extra
+/// element or unrecognised content yields `None`.
+pub(crate) fn class_is_word_char_set(bytes: &[u8], open: usize) -> Option<ShorthandClass> {
+    let (negated, start, end) = class_body_bounds(bytes, open)?;
+    let mut index = start;
+    let mut saw_lower = false;
+    let mut saw_upper = false;
+    let mut saw_digit = false;
+    let mut saw_underscore = false;
+    while index < end {
+        if index + 2 < end
+            && bytes[index] == b'a'
+            && bytes[index + 1] == b'-'
+            && bytes[index + 2] == b'z'
+            && !saw_lower
+        {
+            saw_lower = true;
+            index += 3;
+        } else if index + 2 < end
+            && bytes[index] == b'A'
+            && bytes[index + 1] == b'-'
+            && bytes[index + 2] == b'Z'
+            && !saw_upper
+        {
+            saw_upper = true;
+            index += 3;
+        } else if index + 2 < end
+            && bytes[index] == b'0'
+            && bytes[index + 1] == b'-'
+            && bytes[index + 2] == b'9'
+            && !saw_digit
+        {
+            saw_digit = true;
+            index += 3;
+        } else if bytes[index] == b'_' && !saw_underscore {
+            saw_underscore = true;
+            index += 1;
+        } else {
+            return None;
+        }
+    }
+    if saw_lower && saw_upper && saw_digit && saw_underscore {
+        Some(ShorthandClass { negated })
+    } else {
+        None
+    }
+}
+
+/// Returns `(negated, body_start, body_end_exclusive)` for the `[...]` class at
+/// `open`, where the body excludes the leading `[`, the optional negation `^`,
+/// and the trailing `]`. Returns `None` if the class is unclosed.
+fn class_body_bounds(bytes: &[u8], open: usize) -> Option<(bool, usize, usize)> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let end = find_class_end(bytes, open)?;
+    let mut start = open + 1;
+    let mut negated = false;
+    if bytes.get(start) == Some(&b'^') {
+        negated = true;
+        start += 1;
+    }
+    Some((negated, start, end))
+}
+
+/// Returns the first hexadecimal escape sequence (`\xHH`, `\uHHHH`, or
+/// `\u{H+}`) in `pattern` whose hex digits contain at least one uppercase
+/// letter `A`-`F`. Used by `letter-case` (default config: lowercase hex digits).
+pub(crate) fn first_uppercase_hex_escape(pattern: &str) -> Option<&str> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'\\' {
+            index += 1;
+            continue;
+        }
+        let next = *bytes.get(index + 1)?;
+        match next {
+            b'x' => {
+                let end = (index + 4).min(bytes.len());
+                if end - index == 4 && hex_range_has_upper(&bytes[index + 2..end]) {
+                    return Some(&pattern[index..end]);
+                }
+                index = skip_escape(bytes, index);
+            }
+            b'u' if bytes.get(index + 2) == Some(&b'{') => {
+                let mut cursor = index + 3;
+                while cursor < bytes.len() && bytes[cursor] != b'}' {
+                    cursor += 1;
+                }
+                if cursor < bytes.len() && hex_range_has_upper(&bytes[index + 3..cursor]) {
+                    return Some(&pattern[index..cursor + 1]);
+                }
+                index = cursor.saturating_add(1).min(bytes.len());
+            }
+            b'u' => {
+                let end = (index + 6).min(bytes.len());
+                if end - index == 6 && hex_range_has_upper(&bytes[index + 2..end]) {
+                    return Some(&pattern[index..end]);
+                }
+                index = skip_escape(bytes, index);
+            }
+            _ => index = skip_escape(bytes, index),
+        }
+    }
+    None
+}
+
+fn hex_range_has_upper(bytes: &[u8]) -> bool {
+    bytes.iter().any(|&byte| matches!(byte, b'A'..=b'F'))
+}
+
 /// Returns `true` when the `[...]` character class at `open` consists of
 /// exactly an antipair of shorthand classes that together cover every
 /// character: `[\s\S]`, `[\d\D]`, or `[\w\W]` (in either order). Returns

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -483,6 +483,66 @@ pub(crate) fn first_octal_escape(pattern: &str) -> Option<&str> {
     None
 }
 
+/// Returns the first non-standard flag character in `flags` (i.e. one that is
+/// not part of the canonical set `d`, `g`, `i`, `m`, `s`, `u`, `v`, `y`).
+/// Used by `no-non-standard-flag`. ASCII-only by design; non-ASCII bytes are
+/// also reported because they cannot be valid flags.
+pub(crate) fn first_non_standard_flag(flags: &str) -> Option<char> {
+    flags
+        .chars()
+        .find(|&ch| !matches!(ch, 'd' | 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y'))
+}
+
+/// Returns the first literal invisible character in `pattern` that the
+/// `no-invisible-character` rule recognises. Escaped sequences (`\u00A0`,
+/// `\xA0`, `\u{1680}`) are intentionally skipped: the rule targets characters
+/// that look like whitespace to a reader but are not the ASCII space, not
+/// well-defined hex escapes.
+pub(crate) fn first_invisible_character(pattern: &str) -> Option<char> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index);
+            continue;
+        }
+        // Decode one UTF-8 scalar starting at `index`.
+        let ch = pattern[index..].chars().next()?;
+        if is_invisible_character(ch) {
+            return Some(ch);
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+/// Curated set of "invisible" characters reported by `no-invisible-character`.
+/// The set covers ECMAScript whitespace beyond U+0020 plus the zero-width
+/// joiners, the line/paragraph separators, BOM, and the most common space
+/// look-alikes that are commonly pasted accidentally.
+fn is_invisible_character(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{0009}'  // CHARACTER TABULATION (tab)
+        | '\u{000B}' // LINE TABULATION (vertical tab)
+        | '\u{000C}' // FORM FEED
+        | '\u{0085}' // NEXT LINE
+        | '\u{00A0}' // NO-BREAK SPACE
+        | '\u{1680}' // OGHAM SPACE MARK
+        | '\u{2000}'
+            ..='\u{200A}' // various spaces
+        | '\u{2028}' // LINE SEPARATOR
+        | '\u{2029}' // PARAGRAPH SEPARATOR
+        | '\u{202F}' // NARROW NO-BREAK SPACE
+        | '\u{205F}' // MEDIUM MATHEMATICAL SPACE
+        | '\u{3000}' // IDEOGRAPHIC SPACE
+        | '\u{200B}' // ZERO WIDTH SPACE
+        | '\u{200C}' // ZERO WIDTH NON-JOINER
+        | '\u{200D}' // ZERO WIDTH JOINER
+        | '\u{FEFF}' // ZERO WIDTH NO-BREAK SPACE (BOM)
+    )
+}
+
 pub(crate) fn first_control_character(pattern: &str) -> Option<char> {
     let bytes = pattern.as_bytes();
     let mut index = 0;

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 18] = [
+pub const RULE_NAMES: [&str; 21] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -40,6 +40,9 @@ pub const RULE_NAMES: [&str; 18] = [
     "prefer-named-capture-group",
     "match-any",
     "no-legacy-features",
+    "prefer-d",
+    "prefer-w",
+    "letter-case",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 21] = [
+pub const RULE_NAMES: [&str; 23] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -43,6 +43,8 @@ pub const RULE_NAMES: [&str; 21] = [
     "prefer-d",
     "prefer-w",
     "letter-case",
+    "no-non-standard-flag",
+    "no-invisible-character",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -3,8 +3,9 @@
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{
-    BraceQuantifierShape, class_contains_backspace_escape, class_matches_anything, find_class_end,
-    group_prefix, is_zero_quantifier, parse_brace_quantifier, skip_escape,
+    BraceQuantifierShape, class_contains_backspace_escape, class_is_digit_range,
+    class_is_word_char_set, class_matches_anything, find_class_end, group_prefix,
+    is_zero_quantifier, parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -57,6 +58,13 @@ pub(crate) struct PatternAnalysis {
     /// At least one `[\s\S]`/`[\d\D]`/`[\w\W]`-shaped character class —
     /// `match-any`.
     pub(crate) has_match_any_class: bool,
+    /// First `[0-9]`-shaped class and whether it was negated. `Some(false)` →
+    /// `[0-9]` (suggest `\d`), `Some(true)` → `[^0-9]` (suggest `\D`).
+    /// `prefer-d`.
+    pub(crate) first_digit_class: Option<bool>,
+    /// First `[a-zA-Z0-9_]`-shaped class (any order) and whether it was
+    /// negated. `Some(false)` → `\w`, `Some(true)` → `\W`. `prefer-w`.
+    pub(crate) first_word_class: Option<bool>,
 }
 
 impl PatternAnalysis {
@@ -89,6 +97,16 @@ impl PatternAnalysis {
                         }
                         if !self.has_match_any_class && class_matches_anything(bytes, index) {
                             self.has_match_any_class = true;
+                        }
+                        if self.first_digit_class.is_none()
+                            && let Some(shape) = class_is_digit_range(bytes, index)
+                        {
+                            self.first_digit_class = Some(shape.negated);
+                        }
+                        if self.first_word_class.is_none()
+                            && let Some(shape) = class_is_word_char_set(bytes, index)
+                        {
+                            self.first_word_class = Some(shape.negated);
                         }
                         self.mark_content(&mut groups);
                         index = close + 1;

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -59,6 +59,9 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-named-capture-group",
             "match-any",
             "no-legacy-features",
+            "prefer-d",
+            "prefer-w",
+            "letter-case",
         ]
     );
 }
@@ -678,6 +681,111 @@ mod no_legacy_features {
         assert!(rule_ids_for("regexp.lastMatch;", "no-legacy-features").is_empty());
         // `$10` is NOT one of the legacy indices ($1–$9).
         assert!(rule_ids_for("RegExp.$10;", "no-legacy-features").is_empty());
+    }
+}
+
+mod prefer_d {
+    use super::*;
+
+    #[test]
+    fn reports_digit_ranges_with_replacement() {
+        let data = first_data("const a = /[0-9]/u;", "prefer-d");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("[0-9]"));
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\d")
+        );
+
+        let data = first_data("const a = /[^0-9]/u;", "prefer-d");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("[^0-9]")
+        );
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\D")
+        );
+    }
+
+    #[test]
+    fn ignores_supersets_and_subranges() {
+        // Subset of the digit range; not equivalent to \d.
+        assert!(rule_ids_for("const a = /[1-9]/u;", "prefer-d").is_empty());
+        // Superset that includes letters; not equivalent.
+        assert!(rule_ids_for("const a = /[0-9a]/u;", "prefer-d").is_empty());
+        // Already \d; should not flag.
+        assert!(rule_ids_for("const a = /\\d/u;", "prefer-d").is_empty());
+    }
+}
+
+mod prefer_w {
+    use super::*;
+
+    #[test]
+    fn reports_word_char_set_in_any_order() {
+        assert_eq!(
+            rule_ids_for("const a = /[a-zA-Z0-9_]/u;", "prefer-w").as_slice(),
+            &["unexpected"]
+        );
+        // Reordered elements still match.
+        assert_eq!(
+            rule_ids_for("const a = /[_0-9A-Za-z]/u;", "prefer-w").as_slice(),
+            &["unexpected"]
+        );
+
+        let data = first_data("const a = /[^a-zA-Z0-9_]/u;", "prefer-w");
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\W")
+        );
+    }
+
+    #[test]
+    fn ignores_classes_missing_or_adding_elements() {
+        // Missing underscore.
+        assert!(rule_ids_for("const a = /[a-zA-Z0-9]/u;", "prefer-w").is_empty());
+        // Adds extra range.
+        assert!(rule_ids_for("const a = /[a-zA-Z0-9_-]/u;", "prefer-w").is_empty());
+        // Already \w.
+        assert!(rule_ids_for("const a = /\\w/u;", "prefer-w").is_empty());
+    }
+}
+
+mod letter_case {
+    use super::*;
+
+    #[test]
+    fn reports_uppercase_hex_escapes() {
+        let data = first_data("const a = new RegExp('\\\\xAB', 'u');", "letter-case");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\xAB"));
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\xab")
+        );
+
+        let data = first_data("const a = new RegExp('\\\\uABCD', 'u');", "letter-case");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\uABCD")
+        );
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\uabcd")
+        );
+
+        let data = first_data("const a = new RegExp('\\\\u{1F4A9}', 'u');", "letter-case");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\u{1F4A9}")
+        );
+    }
+
+    #[test]
+    fn ignores_lowercase_and_decimal_only_escapes() {
+        assert!(rule_ids_for("const a = /\\xab/u;", "letter-case").is_empty());
+        assert!(rule_ids_for("const a = /\\uabcd/u;", "letter-case").is_empty());
+        // Decimal-only digits are already lowercase-equivalent.
+        assert!(rule_ids_for("const a = new RegExp('\\\\u0041', 'u');", "letter-case").is_empty());
     }
 }
 

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -62,6 +62,8 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-d",
             "prefer-w",
             "letter-case",
+            "no-non-standard-flag",
+            "no-invisible-character",
         ]
     );
 }
@@ -786,6 +788,79 @@ mod letter_case {
         assert!(rule_ids_for("const a = /\\uabcd/u;", "letter-case").is_empty());
         // Decimal-only digits are already lowercase-equivalent.
         assert!(rule_ids_for("const a = new RegExp('\\\\u0041', 'u');", "letter-case").is_empty());
+    }
+}
+
+mod no_non_standard_flag {
+    use super::*;
+
+    #[test]
+    fn reports_first_non_standard_flag() {
+        // `q` is not a valid JS regex flag. The constructor parser also errors
+        // out on it, but `no-non-standard-flag` must still report its own diag.
+        let names = rule_names_for("const a = new RegExp('a', 'gq');");
+        assert!(names.contains(&"no-non-standard-flag"));
+        let data = first_data("const a = new RegExp('a', 'gq');", "no-non-standard-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("q"));
+    }
+
+    #[test]
+    fn ignores_canonical_flag_set() {
+        // The disallowed-macros lint forbids `format!` in this crate, so we
+        // enumerate canonical flag combinations explicitly.
+        let sources = [
+            "const a = new RegExp('a', 'd');",
+            "const a = new RegExp('a', 'g');",
+            "const a = new RegExp('a', 'i');",
+            "const a = new RegExp('a', 'm');",
+            "const a = new RegExp('a', 's');",
+            "const a = new RegExp('a', 'u');",
+            "const a = new RegExp('a', 'v');",
+            "const a = new RegExp('a', 'y');",
+            "const a = new RegExp('a', 'gimsuy');",
+            "const a = new RegExp('a', 'gv');",
+        ];
+        for source in sources {
+            assert!(
+                rule_ids_for(source, "no-non-standard-flag").is_empty(),
+                "expected no diagnostic for canonical flags in source: {source}",
+            );
+        }
+    }
+}
+
+mod no_invisible_character {
+    use super::*;
+
+    #[test]
+    fn reports_invisible_characters_in_pattern() {
+        // U+00A0 NO-BREAK SPACE literal inside the pattern.
+        let data = first_data("const a = /a\u{00A0}b/u;", "no-invisible-character");
+        assert_eq!(
+            data.char_text.as_ref().map(CompactString::as_str),
+            Some("U+00A0")
+        );
+        // U+200B ZERO WIDTH SPACE — invisible to the eye.
+        let names = rule_names_for("const a = /a\u{200B}b/u;");
+        assert!(names.contains(&"no-invisible-character"));
+        // U+FEFF BOM in the middle of a pattern.
+        let names = rule_names_for("const a = /a\u{FEFF}b/u;");
+        assert!(names.contains(&"no-invisible-character"));
+    }
+
+    #[test]
+    fn ignores_visible_and_escaped_characters() {
+        assert!(rule_ids_for("const a = /ab/u;", "no-invisible-character").is_empty());
+        // Plain ASCII space is not invisible.
+        assert!(rule_ids_for("const a = /a b/u;", "no-invisible-character").is_empty());
+        // Escaped hex sequence for U+00A0 is not the literal invisible char.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('a\\\\xa0b', 'u');",
+                "no-invisible-character"
+            )
+            .is_empty()
+        );
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -87,6 +87,12 @@ const messages = Object.freeze({
   'letter-case': {
     unexpected: "Unexpected uppercase escape '{{expr}}'. Use '{{replacement}}' instead.",
   },
+  'no-non-standard-flag': {
+    unexpected: "Unexpected non-standard flag '{{flag}}'.",
+  },
+  'no-invisible-character': {
+    unexpected: 'Unexpected invisible character {{ char }}.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -112,6 +118,8 @@ const ruleDescriptions = Object.freeze({
   'prefer-d': 'enforce using `\\d` instead of `[0-9]`',
   'prefer-w': 'enforce using `\\w` instead of `[a-zA-Z0-9_]`',
   'letter-case': 'enforce consistent case for escape sequences (default lowercase)',
+  'no-non-standard-flag': 'disallow non-standard flags on regular expressions',
+  'no-invisible-character': 'disallow invisible characters in regular expressions',
 });
 
 const ruleTypes = Object.freeze({
@@ -136,6 +144,8 @@ const ruleTypes = Object.freeze({
   'prefer-d': 'suggestion',
   'prefer-w': 'suggestion',
   'letter-case': 'suggestion',
+  'no-non-standard-flag': 'problem',
+  'no-invisible-character': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -152,6 +162,8 @@ const recommendedRuleConfig = Object.freeze({
   'prefer-question-quantifier': 'error',
   'no-useless-two-nums-quantifier': 'error',
   'no-legacy-features': 'error',
+  'no-non-standard-flag': 'error',
+  'no-invisible-character': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedRegexpRuleNames());
@@ -244,7 +256,9 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-alternative' ||
     ruleName === 'no-control-character' ||
     ruleName === 'no-escape-backspace' ||
-    ruleName === 'no-legacy-features'
+    ruleName === 'no-legacy-features' ||
+    ruleName === 'no-non-standard-flag' ||
+    ruleName === 'no-invisible-character'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -78,6 +78,15 @@ const messages = Object.freeze({
     staticProperty:
       "Unexpected use of the legacy 'RegExp.{{expr}}' static property; it is non-standard and not safe to rely on.",
   },
+  'prefer-d': {
+    unexpected: "Unexpected character class '{{expr}}'. Use '{{replacement}}' instead.",
+  },
+  'prefer-w': {
+    unexpected: "Unexpected character class. Use '{{replacement}}' instead.",
+  },
+  'letter-case': {
+    unexpected: "Unexpected uppercase escape '{{expr}}'. Use '{{replacement}}' instead.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -100,6 +109,9 @@ const ruleDescriptions = Object.freeze({
   'match-any':
     'enforce using `.` (with the `s` flag) instead of character classes that match any character',
   'no-legacy-features': 'disallow legacy `RegExp` features',
+  'prefer-d': 'enforce using `\\d` instead of `[0-9]`',
+  'prefer-w': 'enforce using `\\w` instead of `[a-zA-Z0-9_]`',
+  'letter-case': 'enforce consistent case for escape sequences (default lowercase)',
 });
 
 const ruleTypes = Object.freeze({
@@ -121,6 +133,9 @@ const ruleTypes = Object.freeze({
   'prefer-named-capture-group': 'suggestion',
   'match-any': 'suggestion',
   'no-legacy-features': 'problem',
+  'prefer-d': 'suggestion',
+  'prefer-w': 'suggestion',
+  'letter-case': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -242,7 +257,10 @@ function ruleCategory(ruleName) {
     ruleName === 'prefer-question-quantifier' ||
     ruleName === 'no-useless-two-nums-quantifier' ||
     ruleName === 'prefer-named-capture-group' ||
-    ruleName === 'match-any'
+    ruleName === 'match-any' ||
+    ruleName === 'prefer-d' ||
+    ruleName === 'prefer-w' ||
+    ruleName === 'letter-case'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -26,6 +26,8 @@ describe('regexp native API', () => {
       'prefer-d',
       'prefer-w',
       'letter-case',
+      'no-non-standard-flag',
+      'no-invisible-character',
     ]);
   });
 

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -23,6 +23,9 @@ describe('regexp native API', () => {
       'prefer-named-capture-group',
       'match-any',
       'no-legacy-features',
+      'prefer-d',
+      'prefer-w',
+      'letter-case',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -90,6 +90,13 @@ const validCases = [
   ['letter-case', 'lowercase hex escape', 'const re = /\\xab/u;\n'],
   ['letter-case', 'lowercase unicode escape', 'const re = /\\uabcd/u;\n'],
   ['letter-case', 'decimal-only unicode escape', "const re = new RegExp('\\\\u0041', 'u');\n"],
+  // no-non-standard-flag
+  ['no-non-standard-flag', 'canonical flags', "const re = new RegExp('a', 'gimsuy');\n"],
+  ['no-non-standard-flag', 'no flags', 'const re = /a/;\n'],
+  // no-invisible-character
+  ['no-invisible-character', 'plain pattern', 'const re = /ab/u;\n'],
+  ['no-invisible-character', 'ascii space', 'const re = /a b/u;\n'],
+  ['no-invisible-character', 'escaped hex NBSP', "const re = new RegExp('a\\\\xa0b', 'u');\n"],
 ];
 
 const invalidCases = [
@@ -236,6 +243,16 @@ const invalidCases = [
     "const re = new RegExp('\\\\u{1F4A9}', 'u');\n",
     ['unexpected'],
   ],
+  // no-non-standard-flag
+  [
+    'no-non-standard-flag',
+    'q flag is non-standard',
+    "const re = new RegExp('a', 'gq');\n",
+    ['unexpected'],
+  ],
+  // no-invisible-character — NBSP in pattern
+  ['no-invisible-character', 'nbsp in pattern', 'const re = /a\u00A0b/u;\n', ['unexpected']],
+  ['no-invisible-character', 'zwsp in pattern', 'const re = /a\u200Bb/u;\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -79,6 +79,17 @@ const validCases = [
   ['no-legacy-features', 'lowercase regexp', 'regexp.lastMatch;\n'],
   ['no-legacy-features', 'modern prototype access', 'RegExp.prototype;\n'],
   ['no-legacy-features', '$10 out of legacy range', 'RegExp.$10;\n'],
+  // prefer-d
+  ['prefer-d', 'shorthand already used', 'const re = /\\d/u;\n'],
+  ['prefer-d', 'subset range', 'const re = /[1-9]/u;\n'],
+  ['prefer-d', 'extra element', 'const re = /[0-9a]/u;\n'],
+  // prefer-w
+  ['prefer-w', 'shorthand already used', 'const re = /\\w/u;\n'],
+  ['prefer-w', 'missing element', 'const re = /[a-zA-Z0-9]/u;\n'],
+  // letter-case
+  ['letter-case', 'lowercase hex escape', 'const re = /\\xab/u;\n'],
+  ['letter-case', 'lowercase unicode escape', 'const re = /\\uabcd/u;\n'],
+  ['letter-case', 'decimal-only unicode escape', "const re = new RegExp('\\\\u0041', 'u');\n"],
 ];
 
 const invalidCases = [
@@ -204,6 +215,27 @@ const invalidCases = [
   ['no-legacy-features', 'lastParen alias', 'RegExp.lastParen;\n', ['staticProperty']],
   ['no-legacy-features', 'leftContext alias', 'RegExp.leftContext;\n', ['staticProperty']],
   ['no-legacy-features', 'rightContext alias', 'RegExp.rightContext;\n', ['staticProperty']],
+  // prefer-d
+  ['prefer-d', 'positive digit range', 'const re = /[0-9]/u;\n', ['unexpected']],
+  ['prefer-d', 'negated digit range', 'const re = /[^0-9]/u;\n', ['unexpected']],
+  // prefer-w
+  ['prefer-w', 'canonical order', 'const re = /[a-zA-Z0-9_]/u;\n', ['unexpected']],
+  ['prefer-w', 'reordered word chars', 'const re = /[_0-9A-Za-z]/u;\n', ['unexpected']],
+  ['prefer-w', 'negated word chars', 'const re = /[^a-zA-Z0-9_]/u;\n', ['unexpected']],
+  // letter-case
+  ['letter-case', 'uppercase \\xHH', "const re = new RegExp('\\\\xAB', 'u');\n", ['unexpected']],
+  [
+    'letter-case',
+    'uppercase \\uHHHH',
+    "const re = new RegExp('\\\\uABCD', 'u');\n",
+    ['unexpected'],
+  ],
+  [
+    'letter-case',
+    'uppercase \\u{H+}',
+    "const re = new RegExp('\\\\u{1F4A9}', 'u');\n",
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8811,19 +8811,19 @@
       },
       {
         "name": "no-invisible-character",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-invisible-character."
+        "notes": "Pattern-level scan via first_invisible_character: flags literal occurrences of NBSP, ZWSP/ZWNJ/ZWJ, BOM, narrow/medium/ideographic spaces, U+2028/U+2029, and friends. Escaped hex sequences are intentionally skipped. Vitest covers NBSP, ZWSP, and escaped-hex (must not fire)."
       },
       {
         "name": "no-lazy-ends",
@@ -8907,19 +8907,19 @@
       },
       {
         "name": "no-non-standard-flag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-non-standard-flag."
+        "notes": "Flag-level check via first_non_standard_flag: flags any character outside the canonical d/g/i/m/s/u/v/y set. Runs before constructor parse so the diagnostic fires independently of no-invalid-regexp/error. Vitest covers canonical sets and an out-of-set flag."
       },
       {
         "name": "no-obscure-range",

--- a/status.json
+++ b/status.json
@@ -8651,19 +8651,19 @@
       },
       {
         "name": "letter-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule letter-case."
+        "notes": "Default `letter-case` configuration: flags any `\\xHH`, `\\uHHHH`, or `\\u{H+}` escape whose hex digits contain an uppercase letter; the diagnostic carries the original escape and its lowercase replacement. Pattern-level scan; Vitest tests cover all three escape shapes and pure-decimal escapes (which stay valid)."
       },
       {
         "name": "match-any",
@@ -9323,19 +9323,19 @@
       },
       {
         "name": "prefer-d",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-d."
+        "notes": "Detects character classes that are exactly `[0-9]` or `[^0-9]` via class_is_digit_range; the diagnostic data carries both the original class and the `\\d`/`\\D` replacement. Pattern walker only; Vitest plugin tests cover the canonical, negated, subset, and extra-element forms."
       },
       {
         "name": "prefer-escape-replacement-dollar-char",
@@ -9595,19 +9595,19 @@
       },
       {
         "name": "prefer-w",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-w."
+        "notes": "Detects character classes that are exactly the four word-char elements (`a-z`, `A-Z`, `0-9`, `_`) in any order via class_is_word_char_set; covers both positive and negated forms. Pattern walker only; Vitest tests cover reordered, partial, and superset variants."
       },
       {
         "name": "require-unicode-sets-regexp",


### PR DESCRIPTION
Three more `eslint-plugin-regexp` rules go onto the existing single-pass `PatternAnalysis` walker: **18/82 → 21/82** ported.

## How it works

- `prefer-d`: at every `[` we already locate via `find_class_end`. The new `class_is_digit_range` helper parses the class body once and returns `Some(negated)` iff it is exactly `0-9` (with an optional leading `^`). The diagnostic data carries both the original class (`[0-9]` or `[^0-9]`) and the `\d`/`\D` replacement so the JS-side message stays declarative.
- `prefer-w`: same shape via `class_is_word_char_set`, which walks the class body and accepts the four word-char elements (`a-z`, `A-Z`, `0-9`, `_`) in any order; classes that drop or add an element are rejected. Both positive and negated forms are covered.
- `letter-case` (default configuration only): the new `first_uppercase_hex_escape` helper finds the first `\xHH`, `\uHHHH`, or `\u{H+}` whose hex digits include an uppercase letter `A`-`F` and reports it with its lowercase replacement. Decimal-only escapes (e.g. `\u0041`) are unaffected. Non-default options (`caseInsensitive`, per-shape overrides) are intentionally out of scope.

`PatternAnalysis` gains `first_digit_class` (`Option<bool>` — negated?), `first_word_class` (same), and uses a single new pattern-level scan for hex escapes. No new full-pattern walk is added; classification piggybacks on the existing `[`-handler and the existing escape walker pattern.

## Verification

- 58 Rust unit tests pass (6 new across the three rule modules)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust suites pass
- Vitest plugin and Oxlint-integration tests gain 14 new valid/invalid cases
- `api.test.mjs` rule-name list extended to all 21 ported names

No upstream source, fixtures, or messages were copied. Message strings are paraphrased from public docs; the existing `CompactString`/`SmallVec`/file-level-scan policy is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->