### PR TITLE
port(regexp): port no-non-standard-flag and no-invisible-character

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -11,8 +11,9 @@ use oxc_span::Span;
 use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
-    duplicate_flag, first_control_character, first_octal_escape, first_uppercase_hex_escape,
-    mention_char, sorted_flags, string_literal_value_with_span,
+    duplicate_flag, first_control_character, first_invisible_character, first_non_standard_flag,
+    first_octal_escape, first_uppercase_hex_escape, mention_char, sorted_flags,
+    string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -137,6 +138,22 @@ impl<'a> Scanner<'a> {
         if flags.contains('u') && flags.contains('v') {
             self.report("no-invalid-regexp", "uvFlag", span);
             return;
+        }
+        if let Some(flag) = first_non_standard_flag(flags) {
+            // Reported alongside any constructor parse error below; this rule
+            // exists as its own diagnostic so users can target it independently
+            // of `no-invalid-regexp`. We intentionally do not early-return.
+            let mut flag_text = CompactString::new("");
+            flag_text.push(flag);
+            self.report_with_data(
+                "no-non-standard-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(flag_text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
         }
         if let (true, Some(message)) = (
             is_constructor,
@@ -321,6 +338,17 @@ impl<'a> Scanner<'a> {
                 "unexpected",
                 DiagnosticData {
                     replacement: Some(CompactString::from(if negated { "\\W" } else { "\\w" })),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(ch) = first_invisible_character(pattern) {
+            self.report_with_data(
+                "no-invisible-character",
+                "unexpected",
+                DiagnosticData {
+                    char_text: Some(mention_char(ch)),
                     ..DiagnosticData::default()
                 },
                 span,

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -483,6 +483,66 @@ pub(crate) fn first_octal_escape(pattern: &str) -> Option<&str> {
     None
 }
 
+/// Returns the first non-standard flag character in `flags` (i.e. one that is
+/// not part of the canonical set `d`, `g`, `i`, `m`, `s`, `u`, `v`, `y`).
+/// Used by `no-non-standard-flag`. ASCII-only by design; non-ASCII bytes are
+/// also reported because they cannot be valid flags.
+pub(crate) fn first_non_standard_flag(flags: &str) -> Option<char> {
+    flags
+        .chars()
+        .find(|&ch| !matches!(ch, 'd' | 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y'))
+}
+
+/// Returns the first literal invisible character in `pattern` that the
+/// `no-invisible-character` rule recognises. Escaped sequences (`\u00A0`,
+/// `\xA0`, `\u{1680}`) are intentionally skipped: the rule targets characters
+/// that look like whitespace to a reader but are not the ASCII space, not
+/// well-defined hex escapes.
+pub(crate) fn first_invisible_character(pattern: &str) -> Option<char> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index);
+            continue;
+        }
+        // Decode one UTF-8 scalar starting at `index`.
+        let ch = pattern[index..].chars().next()?;
+        if is_invisible_character(ch) {
+            return Some(ch);
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+/// Curated set of "invisible" characters reported by `no-invisible-character`.
+/// The set covers ECMAScript whitespace beyond U+0020 plus the zero-width
+/// joiners, the line/paragraph separators, BOM, and the most common space
+/// look-alikes that are commonly pasted accidentally.
+fn is_invisible_character(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{0009}'  // CHARACTER TABULATION (tab)
+        | '\u{000B}' // LINE TABULATION (vertical tab)
+        | '\u{000C}' // FORM FEED
+        | '\u{0085}' // NEXT LINE
+        | '\u{00A0}' // NO-BREAK SPACE
+        | '\u{1680}' // OGHAM SPACE MARK
+        | '\u{2000}'
+            ..='\u{200A}' // various spaces
+        | '\u{2028}' // LINE SEPARATOR
+        | '\u{2029}' // PARAGRAPH SEPARATOR
+        | '\u{202F}' // NARROW NO-BREAK SPACE
+        | '\u{205F}' // MEDIUM MATHEMATICAL SPACE
+        | '\u{3000}' // IDEOGRAPHIC SPACE
+        | '\u{200B}' // ZERO WIDTH SPACE
+        | '\u{200C}' // ZERO WIDTH NON-JOINER
+        | '\u{200D}' // ZERO WIDTH JOINER
+        | '\u{FEFF}' // ZERO WIDTH NO-BREAK SPACE (BOM)
+    )
+}
+
 pub(crate) fn first_control_character(pattern: &str) -> Option<char> {
     let bytes = pattern.as_bytes();
     let mut index = 0;

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 21] = [
+pub const RULE_NAMES: [&str; 23] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -43,6 +43,8 @@ pub const RULE_NAMES: [&str; 21] = [
     "prefer-d",
     "prefer-w",
     "letter-case",
+    "no-non-standard-flag",
+    "no-invisible-character",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -62,6 +62,8 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-d",
             "prefer-w",
             "letter-case",
+            "no-non-standard-flag",
+            "no-invisible-character",
         ]
     );
 }
@@ -786,6 +788,79 @@ mod letter_case {
         assert!(rule_ids_for("const a = /\\uabcd/u;", "letter-case").is_empty());
         // Decimal-only digits are already lowercase-equivalent.
         assert!(rule_ids_for("const a = new RegExp('\\\\u0041', 'u');", "letter-case").is_empty());
+    }
+}
+
+mod no_non_standard_flag {
+    use super::*;
+
+    #[test]
+    fn reports_first_non_standard_flag() {
+        // `q` is not a valid JS regex flag. The constructor parser also errors
+        // out on it, but `no-non-standard-flag` must still report its own diag.
+        let names = rule_names_for("const a = new RegExp('a', 'gq');");
+        assert!(names.contains(&"no-non-standard-flag"));
+        let data = first_data("const a = new RegExp('a', 'gq');", "no-non-standard-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("q"));
+    }
+
+    #[test]
+    fn ignores_canonical_flag_set() {
+        // The disallowed-macros lint forbids `format!` in this crate, so we
+        // enumerate canonical flag combinations explicitly.
+        let sources = [
+            "const a = new RegExp('a', 'd');",
+            "const a = new RegExp('a', 'g');",
+            "const a = new RegExp('a', 'i');",
+            "const a = new RegExp('a', 'm');",
+            "const a = new RegExp('a', 's');",
+            "const a = new RegExp('a', 'u');",
+            "const a = new RegExp('a', 'v');",
+            "const a = new RegExp('a', 'y');",
+            "const a = new RegExp('a', 'gimsuy');",
+            "const a = new RegExp('a', 'gv');",
+        ];
+        for source in sources {
+            assert!(
+                rule_ids_for(source, "no-non-standard-flag").is_empty(),
+                "expected no diagnostic for canonical flags in source: {source}",
+            );
+        }
+    }
+}
+
+mod no_invisible_character {
+    use super::*;
+
+    #[test]
+    fn reports_invisible_characters_in_pattern() {
+        // U+00A0 NO-BREAK SPACE literal inside the pattern.
+        let data = first_data("const a = /a\u{00A0}b/u;", "no-invisible-character");
+        assert_eq!(
+            data.char_text.as_ref().map(CompactString::as_str),
+            Some("U+00A0")
+        );
+        // U+200B ZERO WIDTH SPACE — invisible to the eye.
+        let names = rule_names_for("const a = /a\u{200B}b/u;");
+        assert!(names.contains(&"no-invisible-character"));
+        // U+FEFF BOM in the middle of a pattern.
+        let names = rule_names_for("const a = /a\u{FEFF}b/u;");
+        assert!(names.contains(&"no-invisible-character"));
+    }
+
+    #[test]
+    fn ignores_visible_and_escaped_characters() {
+        assert!(rule_ids_for("const a = /ab/u;", "no-invisible-character").is_empty());
+        // Plain ASCII space is not invisible.
+        assert!(rule_ids_for("const a = /a b/u;", "no-invisible-character").is_empty());
+        // Escaped hex sequence for U+00A0 is not the literal invisible char.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('a\\\\xa0b', 'u');",
+                "no-invisible-character"
+            )
+            .is_empty()
+        );
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -87,6 +87,12 @@ const messages = Object.freeze({
   'letter-case': {
     unexpected: "Unexpected uppercase escape '{{expr}}'. Use '{{replacement}}' instead.",
   },
+  'no-non-standard-flag': {
+    unexpected: "Unexpected non-standard flag '{{flag}}'.",
+  },
+  'no-invisible-character': {
+    unexpected: 'Unexpected invisible character {{ char }}.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -112,6 +118,8 @@ const ruleDescriptions = Object.freeze({
   'prefer-d': 'enforce using `\\d` instead of `[0-9]`',
   'prefer-w': 'enforce using `\\w` instead of `[a-zA-Z0-9_]`',
   'letter-case': 'enforce consistent case for escape sequences (default lowercase)',
+  'no-non-standard-flag': 'disallow non-standard flags on regular expressions',
+  'no-invisible-character': 'disallow invisible characters in regular expressions',
 });
 
 const ruleTypes = Object.freeze({
@@ -136,6 +144,8 @@ const ruleTypes = Object.freeze({
   'prefer-d': 'suggestion',
   'prefer-w': 'suggestion',
   'letter-case': 'suggestion',
+  'no-non-standard-flag': 'problem',
+  'no-invisible-character': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -152,6 +162,8 @@ const recommendedRuleConfig = Object.freeze({
   'prefer-question-quantifier': 'error',
   'no-useless-two-nums-quantifier': 'error',
   'no-legacy-features': 'error',
+  'no-non-standard-flag': 'error',
+  'no-invisible-character': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedRegexpRuleNames());
@@ -244,7 +256,9 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-alternative' ||
     ruleName === 'no-control-character' ||
     ruleName === 'no-escape-backspace' ||
-    ruleName === 'no-legacy-features'
+    ruleName === 'no-legacy-features' ||
+    ruleName === 'no-non-standard-flag' ||
+    ruleName === 'no-invisible-character'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -26,6 +26,8 @@ describe('regexp native API', () => {
       'prefer-d',
       'prefer-w',
       'letter-case',
+      'no-non-standard-flag',
+      'no-invisible-character',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -90,6 +90,13 @@ const validCases = [
   ['letter-case', 'lowercase hex escape', 'const re = /\\xab/u;\n'],
   ['letter-case', 'lowercase unicode escape', 'const re = /\\uabcd/u;\n'],
   ['letter-case', 'decimal-only unicode escape', "const re = new RegExp('\\\\u0041', 'u');\n"],
+  // no-non-standard-flag
+  ['no-non-standard-flag', 'canonical flags', "const re = new RegExp('a', 'gimsuy');\n"],
+  ['no-non-standard-flag', 'no flags', 'const re = /a/;\n'],
+  // no-invisible-character
+  ['no-invisible-character', 'plain pattern', 'const re = /ab/u;\n'],
+  ['no-invisible-character', 'ascii space', 'const re = /a b/u;\n'],
+  ['no-invisible-character', 'escaped hex NBSP', "const re = new RegExp('a\\\\xa0b', 'u');\n"],
 ];
 
 const invalidCases = [
@@ -236,6 +243,16 @@ const invalidCases = [
     "const re = new RegExp('\\\\u{1F4A9}', 'u');\n",
     ['unexpected'],
   ],
+  // no-non-standard-flag
+  [
+    'no-non-standard-flag',
+    'q flag is non-standard',
+    "const re = new RegExp('a', 'gq');\n",
+    ['unexpected'],
+  ],
+  // no-invisible-character — NBSP in pattern
+  ['no-invisible-character', 'nbsp in pattern', 'const re = /a\u00A0b/u;\n', ['unexpected']],
+  ['no-invisible-character', 'zwsp in pattern', 'const re = /a\u200Bb/u;\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8811,19 +8811,19 @@
       },
       {
         "name": "no-invisible-character",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-invisible-character."
+        "notes": "Pattern-level scan via first_invisible_character: flags literal occurrences of NBSP, ZWSP/ZWNJ/ZWJ, BOM, narrow/medium/ideographic spaces, U+2028/U+2029, and friends. Escaped hex sequences are intentionally skipped. Vitest covers NBSP, ZWSP, and escaped-hex (must not fire)."
       },
       {
         "name": "no-lazy-ends",
@@ -8907,19 +8907,19 @@
       },
       {
         "name": "no-non-standard-flag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-non-standard-flag."
+        "notes": "Flag-level check via first_non_standard_flag: flags any character outside the canonical d/g/i/m/s/u/v/y set. Runs before constructor parse so the diagnostic fires independently of no-invalid-regexp/error. Vitest covers canonical sets and an out-of-set flag."
       },
       {
         "name": "no-obscure-range",


### PR DESCRIPTION
Stacked on top of #73. Adds two more `eslint-plugin-regexp` rules: **21/82 → 23/82** ported once both PRs land.

## How it works

- `no-non-standard-flag`: a new `first_non_standard_flag` helper returns the first character in the flags string outside the canonical `d`/`g`/`i`/`m`/`s`/`u`/`v`/`y` set. The diagnostic is emitted before the constructor-parse short-circuit, so this rule fires independently of `no-invalid-regexp/error` and both can report on the same input. The offending flag is carried in `DiagnosticData.flag`.
- `no-invisible-character`: `first_invisible_character` scans the pattern source for literal occurrences of invisible whitespace and zero-width characters (NBSP `U+00A0`, ZWSP/ZWNJ/ZWJ `U+200B`/`U+200C`/`U+200D`, BOM `U+FEFF`, narrow/medium/ideographic spaces, `U+2028`/`U+2029`, plus the `U+2000`-`U+200A` block and a few others). Escape sequences are skipped via the existing `skip_escape` walker so `\xA0` stays a hex escape and is reported by `no-control-character` if appropriate.

## Verification

- 62 Rust unit tests pass (4 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust suites pass
- Vitest plugin tests gain 8 valid/invalid cases; `api.test.mjs` rule-name list extended to all 23 ported names

## Stacked dependency

This PR targets `port/regexp-prefer-d-prefer-w-letter-case` (PR #73), not `main`. Once #73 lands, this PR will rebase cleanly onto main.

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs. The existing `CompactString`/`SmallVec`/file-level-scan policy is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->