### PR TITLE
port(regexp): port no-empty-lookarounds-assertion and prefer-regexp-exec

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -70,6 +70,39 @@ impl<'a> Scanner<'a> {
         if call.callee.is_specific_id("RegExp") {
             self.check_regexp_constructor(call.span, &call.arguments);
         }
+        self.check_prefer_regexp_exec(call);
+    }
+
+    /// `prefer-regexp-exec`: flag `<expr>.match(<regexp literal without 'g'>)`
+    /// and recommend `<regexp literal>.exec(<expr>)`. We can only act on
+    /// RegExp literals (constructor calls need type information to identify
+    /// the receiver as a string). Patterns without a `g` flag are the
+    /// canonical case the rule targets.
+    fn check_prefer_regexp_exec(&mut self, call: &'a CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        if member.property.name != "match" {
+            return;
+        }
+        if call.arguments.len() != 1 {
+            return;
+        }
+        let Some(argument) = call.arguments.first().and_then(Argument::as_expression) else {
+            return;
+        };
+        let Expression::RegExpLiteral(literal) = argument.get_inner_expression() else {
+            return;
+        };
+        let flags = literal
+            .raw
+            .as_ref()
+            .and_then(|raw| raw.as_str().rsplit_once('/').map(|(_, flags)| flags))
+            .unwrap_or("");
+        if flags.contains('g') {
+            return;
+        }
+        self.report("prefer-regexp-exec", "unexpected", call.span);
     }
 
     pub(crate) fn check_new_expression(&mut self, new_expression: &'a NewExpression<'a>) {
@@ -389,6 +422,9 @@ impl<'a> Scanner<'a> {
                 },
                 span,
             );
+        }
+        if analysis.has_empty_lookaround {
+            self.report("no-empty-lookarounds-assertion", "unexpected", span);
         }
         if let Some(ch) = analysis.first_useless_range {
             let mut text = CompactString::new("");

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -84,6 +84,7 @@ pub(crate) struct GroupPrefix {
     pub(crate) check_empty: bool,
     pub(crate) capturing: bool,
     pub(crate) named: bool,
+    pub(crate) is_lookaround: bool,
     pub(crate) next: usize,
 }
 
@@ -93,6 +94,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             check_empty: true,
             capturing: true,
             named: false,
+            is_lookaround: false,
             next: open + 1,
         };
     }
@@ -101,12 +103,14 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             check_empty: true,
             capturing: false,
             named: false,
+            is_lookaround: false,
             next: open + 3,
         },
         Some(b'=') | Some(b'!') => GroupPrefix {
             check_empty: false,
             capturing: false,
             named: false,
+            is_lookaround: true,
             next: open + 3,
         },
         Some(b'<') => {
@@ -115,6 +119,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
                     check_empty: false,
                     capturing: false,
                     named: false,
+                    is_lookaround: true,
                     next: open + 4,
                 }
             } else {
@@ -126,6 +131,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
                     check_empty: true,
                     capturing: true,
                     named: true,
+                    is_lookaround: false,
                     next: cursor.saturating_add(1).min(bytes.len()),
                 }
             }
@@ -134,6 +140,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             check_empty: false,
             capturing: false,
             named: false,
+            is_lookaround: false,
             next: open + 2,
         },
     }

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 26] = [
+pub const RULE_NAMES: [&str; 28] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -48,6 +48,8 @@ pub const RULE_NAMES: [&str; 26] = [
     "hexadecimal-escape",
     "unicode-escape",
     "no-useless-range",
+    "no-empty-lookarounds-assertion",
+    "prefer-regexp-exec",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -12,6 +12,7 @@ use crate::helpers::{
 pub(crate) struct GroupState {
     pub(crate) check_empty: bool,
     pub(crate) capturing: bool,
+    pub(crate) is_lookaround: bool,
     pub(crate) seen_pipe: bool,
     pub(crate) current_has_content: bool,
 }
@@ -21,15 +22,17 @@ impl GroupState {
         Self {
             check_empty: false,
             capturing: false,
+            is_lookaround: false,
             seen_pipe: false,
             current_has_content: false,
         }
     }
 
-    fn group(check_empty: bool, capturing: bool) -> Self {
+    fn group(check_empty: bool, capturing: bool, is_lookaround: bool) -> Self {
         Self {
             check_empty,
             capturing,
+            is_lookaround,
             seen_pipe: false,
             current_has_content: false,
         }
@@ -68,6 +71,9 @@ pub(crate) struct PatternAnalysis {
     /// First useless single-character range like `[a-a]`. The captured `char`
     /// is the repeated endpoint. `no-useless-range`.
     pub(crate) first_useless_range: Option<char>,
+    /// At least one lookaround assertion (`(?=)`, `(?!)`, `(?<=)`, `(?<!)`)
+    /// with an empty body. `no-empty-lookarounds-assertion`.
+    pub(crate) has_empty_lookaround: bool,
 }
 
 impl PatternAnalysis {
@@ -128,7 +134,11 @@ impl PatternAnalysis {
                     if prefix.capturing && !prefix.named {
                         self.has_unnamed_capturing_group = true;
                     }
-                    groups.push(GroupState::group(prefix.check_empty, prefix.capturing));
+                    groups.push(GroupState::group(
+                        prefix.check_empty,
+                        prefix.capturing,
+                        prefix.is_lookaround,
+                    ));
                     index = prefix.next;
                 }
                 b')' => {
@@ -143,6 +153,9 @@ impl PatternAnalysis {
                             if group.capturing {
                                 self.has_empty_capturing_group = true;
                             }
+                        }
+                        if group.is_lookaround && !group.seen_pipe && !group.current_has_content {
+                            self.has_empty_lookaround = true;
                         }
                         self.mark_content(&mut groups);
                     }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -67,6 +67,8 @@ fn exposes_initial_regexp_rule_names() {
             "hexadecimal-escape",
             "unicode-escape",
             "no-useless-range",
+            "no-empty-lookarounds-assertion",
+            "prefer-regexp-exec",
         ]
     );
 }
@@ -963,6 +965,64 @@ mod no_useless_range {
         assert!(rule_ids_for("const a = /[0-9]/u;", "no-useless-range").is_empty());
         // Bare repeated characters without a `-` in between are not ranges.
         assert!(rule_ids_for("const a = /[aa]/u;", "no-useless-range").is_empty());
+    }
+}
+
+mod no_empty_lookarounds_assertion {
+    use super::*;
+
+    #[test]
+    fn reports_each_empty_lookaround_shape() {
+        assert_eq!(
+            rule_ids_for("const a = /(?=)/u;", "no-empty-lookarounds-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?!)/u;", "no-empty-lookarounds-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<=)/u;", "no-empty-lookarounds-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<!)/u;", "no-empty-lookarounds-assertion").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_filled_lookarounds_and_empty_non_lookaround_groups() {
+        assert!(rule_ids_for("const a = /(?=a)/u;", "no-empty-lookarounds-assertion").is_empty());
+        // Empty non-capturing group is `no-empty-group`'s responsibility.
+        assert!(rule_ids_for("const a = /(?:)/u;", "no-empty-lookarounds-assertion").is_empty());
+    }
+}
+
+mod prefer_regexp_exec {
+    use super::*;
+
+    #[test]
+    fn reports_string_match_with_non_global_regexp() {
+        assert_eq!(
+            rule_ids_for("str.match(/foo/u);", "prefer-regexp-exec").as_slice(),
+            &["unexpected"]
+        );
+        // Other call shapes still match if the property is `match`.
+        assert_eq!(
+            rule_ids_for("obj.prop.match(/foo/);", "prefer-regexp-exec").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_global_regexps_and_unrelated_calls() {
+        assert!(rule_ids_for("str.match(/foo/gu);", "prefer-regexp-exec").is_empty());
+        assert!(rule_ids_for("str.match(/foo/g);", "prefer-regexp-exec").is_empty());
+        // Non-literal argument — we cannot be sure of the flags.
+        assert!(rule_ids_for("str.match(pattern);", "prefer-regexp-exec").is_empty());
+        // Different method name.
+        assert!(rule_ids_for("str.replace(/foo/u, 'bar');", "prefer-regexp-exec").is_empty());
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -102,6 +102,14 @@ const messages = Object.freeze({
   'no-useless-range': {
     unexpected: "Unexpected useless range '{{expr}}'. Use '{{replacement}}' instead.",
   },
+  'no-empty-lookarounds-assertion': {
+    unexpected:
+      'Unexpected empty lookaround assertion; this assertion can never fail or succeed meaningfully.',
+  },
+  'prefer-regexp-exec': {
+    unexpected:
+      'Use `RegExp.prototype.exec` instead of `String.prototype.match` for non-global regular expressions.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -132,6 +140,9 @@ const ruleDescriptions = Object.freeze({
   'hexadecimal-escape': 'disallow `\\xHH` escape sequences (default `never`)',
   'unicode-escape': 'enforce using `\\u{HHHH}` over `\\uHHHH` (default `unicodeCodePointEscape`)',
   'no-useless-range': 'disallow character class ranges whose start equals their end',
+  'no-empty-lookarounds-assertion': 'disallow lookaround assertions with an empty body',
+  'prefer-regexp-exec':
+    'enforce `RegExp.prototype.exec` over `String.prototype.match` for non-global regexes',
 });
 
 const ruleTypes = Object.freeze({
@@ -161,6 +172,8 @@ const ruleTypes = Object.freeze({
   'hexadecimal-escape': 'suggestion',
   'unicode-escape': 'suggestion',
   'no-useless-range': 'suggestion',
+  'no-empty-lookarounds-assertion': 'problem',
+  'prefer-regexp-exec': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -273,7 +286,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-escape-backspace' ||
     ruleName === 'no-legacy-features' ||
     ruleName === 'no-non-standard-flag' ||
-    ruleName === 'no-invisible-character'
+    ruleName === 'no-invisible-character' ||
+    ruleName === 'no-empty-lookarounds-assertion'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -31,6 +31,8 @@ describe('regexp native API', () => {
       'hexadecimal-escape',
       'unicode-escape',
       'no-useless-range',
+      'no-empty-lookarounds-assertion',
+      'prefer-regexp-exec',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -134,6 +134,22 @@ const invalidCases = [
   // no-useless-range
   ['no-useless-range', 'literal a-a range', 'const re = /[a-a]/u;\n', ['unexpected']],
   ['no-useless-range', 'literal 0-0 range', 'const re = /[0-0]/u;\n', ['unexpected']],
+  // no-empty-lookarounds-assertion
+  [
+    'no-empty-lookarounds-assertion',
+    'empty positive lookahead',
+    'const re = /(?=)/u;\n',
+    ['unexpected'],
+  ],
+  [
+    'no-empty-lookarounds-assertion',
+    'empty negative lookbehind',
+    'const re = /(?<!)/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-regexp-exec
+  ['prefer-regexp-exec', 'match with non-global literal', 'str.match(/foo/u);\n', ['unexpected']],
+  ['prefer-regexp-exec', 'member-chained receiver', 'obj.prop.match(/bar/);\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8747,19 +8747,19 @@
       },
       {
         "name": "no-empty-lookarounds-assertion",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-empty-lookarounds-assertion."
+        "notes": "GroupPrefix gains is_lookaround so the existing pattern walker can flag any of `(?=)` / `(?!)` / `(?<=)` / `(?<!)` whose body is empty; non-capturing empty groups stay with no-empty-group."
       },
       {
         "name": "no-empty-string-literal",
@@ -9499,19 +9499,19 @@
       },
       {
         "name": "prefer-regexp-exec",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-regexp-exec."
+        "notes": "JS-side CallExpression check on `<expr>.match(<regexp literal>)` where the literal has no `g` flag. RegExp constructor calls are deferred because deciding whether the receiver is a string needs type information."
       },
       {
         "name": "prefer-regexp-test",


### PR DESCRIPTION
Stacked on top of #75. Regexp port advances **26 → 28 / 82** once the chain lands.

## How it works

- `no-empty-lookarounds-assertion`: `GroupPrefix` gains an `is_lookaround` flag so the existing pattern walker can recognise `(?=)`, `(?!)`, `(?<=)`, and `(?<!)` at open time and check the body for emptiness at close time. Empty non-capturing groups remain `no-empty-group`'s responsibility — the two rules do not double-report.
- `prefer-regexp-exec`: JS-side `CallExpression` check that fires on `<expr>.match(<regexp literal>)` when the regexp literal has no `g` flag, recommending `RegExp.prototype.exec` instead. `RegExp` constructor arguments are intentionally deferred because deciding whether the receiver is actually a `String` needs type information beyond what this plugin sees; that case can land alongside the type-aware port.

## Verification

- 72 Rust unit tests pass (4 new across the two rule modules)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust suites pass
- Vitest plugin tests gain 9 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 28 ported names

## Stacked dependency

Targets `port/regexp-hex-unicode-useless-range` (PR #75). Once #75 lands, this PR rebases cleanly onto main.

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs. The existing `CompactString`/`SmallVec`/file-level-scan policy is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->