### PR TITLE
port(regexp): port no-missing-g-flag

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -13,7 +13,8 @@ use oxlint_plugins_carton::CompactString;
 use crate::helpers::{
     duplicate_flag, first_control_character, first_fixed_unicode_escape, first_hex_x_escape,
     first_invisible_character, first_non_standard_flag, first_octal_escape,
-    first_uppercase_hex_escape, mention_char, sorted_flags, string_literal_value_with_span,
+    first_uppercase_hex_escape, mention_char, pattern_has_empty_string_literal, sorted_flags,
+    string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -71,6 +72,50 @@ impl<'a> Scanner<'a> {
             self.check_regexp_constructor(call.span, &call.arguments);
         }
         self.check_prefer_regexp_exec(call);
+        self.check_no_missing_g_flag(call);
+    }
+
+    /// `no-missing-g-flag`: `<expr>.matchAll(<regexp without 'g'>)` and
+    /// `<expr>.replaceAll(<regexp without 'g'>, ...)` throw at runtime (the
+    /// engine requires the global flag). Flag the literal-regexp case
+    /// statically; constructor calls are deferred for the same type-info
+    /// reason as `prefer-regexp-exec`.
+    fn check_no_missing_g_flag(&mut self, call: &'a CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let method = member.property.name.as_str();
+        if method != "matchAll" && method != "replaceAll" {
+            return;
+        }
+        if call.arguments.is_empty() {
+            return;
+        }
+        let Some(argument) = call.arguments.first().and_then(Argument::as_expression) else {
+            return;
+        };
+        let Expression::RegExpLiteral(literal) = argument.get_inner_expression() else {
+            return;
+        };
+        let flags = literal
+            .raw
+            .as_ref()
+            .and_then(|raw| raw.as_str().rsplit_once('/').map(|(_, flags)| flags))
+            .unwrap_or("");
+        if flags.contains('g') {
+            return;
+        }
+        let mut method_text = CompactString::new("");
+        method_text.push_str(method);
+        self.report_with_data(
+            "no-missing-g-flag",
+            "unexpected",
+            DiagnosticData {
+                expr: Some(method_text),
+                ..DiagnosticData::default()
+            },
+            call.span,
+        );
     }
 
     /// `prefer-regexp-exec`: flag `<expr>.match(<regexp literal without 'g'>)`
@@ -252,6 +297,9 @@ impl<'a> Scanner<'a> {
         if !flags.contains('u') && !flags.contains('v') {
             self.report("require-unicode-regexp", "require", span);
         }
+        if !flags.contains('v') {
+            self.report("require-unicode-sets-regexp", "require", span);
+        }
     }
 
     fn check_pattern_rules(&mut self, pattern: &str, span: Span) {
@@ -426,6 +474,26 @@ impl<'a> Scanner<'a> {
         if analysis.has_empty_lookaround {
             self.report("no-empty-lookarounds-assertion", "unexpected", span);
         }
+        if let Some(ch) = analysis.first_useless_single_literal_class {
+            let mut original = CompactString::new("[");
+            original.push(ch);
+            original.push(']');
+            let mut replacement = CompactString::new("");
+            replacement.push(ch);
+            self.report_with_data(
+                "no-useless-character-class",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(original),
+                    replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if pattern_has_empty_string_literal(pattern) {
+            self.report("no-empty-string-literal", "unexpected", span);
+        }
         if let Some(ch) = analysis.first_useless_range {
             let mut text = CompactString::new("");
             text.push(ch);
@@ -443,6 +511,9 @@ impl<'a> Scanner<'a> {
                 },
                 span,
             );
+        }
+        if analysis.has_optional_assertion {
+            self.report("no-optional-assertion", "unexpected", span);
         }
     }
 }

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -611,6 +611,71 @@ pub(crate) fn first_fixed_unicode_escape(pattern: &str) -> Option<(&str, Compact
     None
 }
 
+/// Returns `Some(ch)` when the `[...]` class at `open` is exactly `[X]` for a
+/// regular ASCII literal `X`. Negated classes, escaped contents, ranges,
+/// nested classes, and bodies of length other than one are intentionally
+/// ignored — they need more analysis to know the class is truly equivalent
+/// to the bare character. Used by `no-useless-character-class`.
+pub(crate) fn class_is_useless_single_literal(bytes: &[u8], open: usize) -> Option<char> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let end = find_class_end(bytes, open)?;
+    let start = open + 1;
+    if bytes.get(start) == Some(&b'^') {
+        return None;
+    }
+    if end - start != 1 {
+        return None;
+    }
+    let byte = bytes[start];
+    // Reject anything that would carry extra regex meaning by itself, anything
+    // non-ASCII (multi-byte chars are fine in principle but reading them as a
+    // single byte is incorrect), and anything that would change the surrounding
+    // pattern if extracted from the class context.
+    if !byte.is_ascii()
+        || matches!(
+            byte,
+            b'\\'
+                | b'-'
+                | b'['
+                | b']'
+                | b'^'
+                | b'$'
+                | b'.'
+                | b'|'
+                | b'('
+                | b')'
+                | b'*'
+                | b'+'
+                | b'?'
+                | b'{'
+                | b'}'
+        )
+    {
+        return None;
+    }
+    Some(byte as char)
+}
+
+/// Returns `true` when `pattern` contains the literal sequence `\q{}` — an
+/// empty string literal inside a class. The `\q{...}` syntax is only valid in
+/// `v`-flag patterns, so its presence implies `v`-mode without us needing to
+/// inspect the flags here. Used by `no-empty-string-literal`.
+pub(crate) fn pattern_has_empty_string_literal(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index + 3 < bytes.len() {
+        if bytes[index] == b'\\'
+            && bytes[index + 1] == b'q'
+            && bytes[index + 2] == b'{'
+            && bytes[index + 3] == b'}'
+        {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
 /// Returns `true` when the `[...]` class at `open` contains at least one
 /// `X-X` range whose start and end byte are literal ASCII characters that
 /// match exactly. Used by `no-useless-range`. Escaped or compound ranges

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 28] = [
+pub const RULE_NAMES: [&str; 33] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -50,6 +50,11 @@ pub const RULE_NAMES: [&str; 28] = [
     "no-useless-range",
     "no-empty-lookarounds-assertion",
     "prefer-regexp-exec",
+    "no-missing-g-flag",
+    "no-useless-character-class",
+    "no-empty-string-literal",
+    "no-optional-assertion",
+    "require-unicode-sets-regexp",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -4,8 +4,9 @@ use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{
     BraceQuantifierShape, class_contains_backspace_escape, class_has_useless_range,
-    class_is_digit_range, class_is_word_char_set, class_matches_anything, find_class_end,
-    group_prefix, is_zero_quantifier, parse_brace_quantifier, skip_escape,
+    class_is_digit_range, class_is_useless_single_literal, class_is_word_char_set,
+    class_matches_anything, find_class_end, group_prefix, is_zero_quantifier,
+    parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -74,6 +75,13 @@ pub(crate) struct PatternAnalysis {
     /// At least one lookaround assertion (`(?=)`, `(?!)`, `(?<=)`, `(?<!)`)
     /// with an empty body. `no-empty-lookarounds-assertion`.
     pub(crate) has_empty_lookaround: bool,
+    /// First single-literal class `[X]` and the bare character it could be
+    /// replaced with. `no-useless-character-class`.
+    pub(crate) first_useless_single_literal_class: Option<char>,
+    /// At least one lookaround assertion followed by an optional `?` quantifier
+    /// (`(?=a)?`). The `?` is always meaningless because the assertion either
+    /// succeeds or fails without consuming input. `no-optional-assertion`.
+    pub(crate) has_optional_assertion: bool,
 }
 
 impl PatternAnalysis {
@@ -122,6 +130,11 @@ impl PatternAnalysis {
                         {
                             self.first_useless_range = Some(ch);
                         }
+                        if self.first_useless_single_literal_class.is_none()
+                            && let Some(ch) = class_is_useless_single_literal(bytes, index)
+                        {
+                            self.first_useless_single_literal_class = Some(ch);
+                        }
                         self.mark_content(&mut groups);
                         index = close + 1;
                     } else {
@@ -156,6 +169,13 @@ impl PatternAnalysis {
                         }
                         if group.is_lookaround && !group.seen_pipe && !group.current_has_content {
                             self.has_empty_lookaround = true;
+                        }
+                        // `(?=...)?` and friends: a `?` immediately after the
+                        // closing paren of a lookaround makes the assertion
+                        // optional, which is always meaningless because the
+                        // assertion does not consume input.
+                        if group.is_lookaround && bytes.get(index + 1) == Some(&b'?') {
+                            self.has_optional_assertion = true;
                         }
                         self.mark_content(&mut groups);
                     }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -69,8 +69,82 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-range",
             "no-empty-lookarounds-assertion",
             "prefer-regexp-exec",
+            "no-missing-g-flag",
+            "no-useless-character-class",
+            "no-empty-string-literal",
+            "no-optional-assertion",
+            "require-unicode-sets-regexp",
         ]
     );
+}
+
+mod no_optional_assertion {
+    use super::*;
+
+    #[test]
+    fn reports_question_after_each_lookaround_shape() {
+        assert_eq!(
+            rule_ids_for("const a = /(?=a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?!a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<=a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<!a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_assertions_without_quantifier_and_non_assertion_optionals() {
+        assert!(rule_ids_for("const a = /(?=a)/u;", "no-optional-assertion").is_empty());
+        // `?` after a non-lookaround group must not fire this rule.
+        assert!(rule_ids_for("const a = /(?:a)?/u;", "no-optional-assertion").is_empty());
+        assert!(rule_ids_for("const a = /(a)?/u;", "no-optional-assertion").is_empty());
+    }
+}
+
+mod require_unicode_sets_regexp {
+    use super::*;
+
+    #[test]
+    fn reports_missing_v_flag() {
+        assert_eq!(
+            rule_ids_for("const a = /a/u;", "require-unicode-sets-regexp").as_slice(),
+            &["require"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a/;", "require-unicode-sets-regexp").as_slice(),
+            &["require"]
+        );
+        assert_eq!(
+            rule_ids_for(
+                "const a = new RegExp('a', 'gimsu');",
+                "require-unicode-sets-regexp"
+            )
+            .as_slice(),
+            &["require"]
+        );
+    }
+
+    #[test]
+    fn accepts_patterns_with_v_flag() {
+        assert!(rule_ids_for("const a = /a/v;", "require-unicode-sets-regexp").is_empty());
+        assert!(rule_ids_for("const a = /a/gv;", "require-unicode-sets-regexp").is_empty());
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('a', 'v');",
+                "require-unicode-sets-regexp"
+            )
+            .is_empty()
+        );
+    }
 }
 
 #[test]
@@ -86,10 +160,11 @@ fn ignores_dynamic_constructor_arguments() {
     assert!(ids("const a = new RegExp(pattern, 'u');").is_empty());
     assert!(ids("const a = RegExp();").is_empty());
     // When the flags argument is non-literal we still scan the pattern and
-    // assume no `u`/`v` flag, which surfaces `require-unicode-regexp` only.
+    // assume no `u`/`v` flag, which surfaces both `require-unicode-regexp`
+    // (needs `u` or `v`) and `require-unicode-sets-regexp` (needs `v`).
     assert_eq!(
         rule_names_for("const a = new RegExp('a', flags);").as_slice(),
-        &["require-unicode-regexp"]
+        &["require-unicode-regexp", "require-unicode-sets-regexp"]
     );
 }
 
@@ -1026,6 +1101,98 @@ mod prefer_regexp_exec {
     }
 }
 
+mod no_missing_g_flag {
+    use super::*;
+
+    #[test]
+    fn reports_match_all_and_replace_all_without_g() {
+        let data = first_data("str.matchAll(/foo/u);", "no-missing-g-flag");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("matchAll")
+        );
+        let data = first_data("str.replaceAll(/foo/, 'bar');", "no-missing-g-flag");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("replaceAll")
+        );
+    }
+
+    #[test]
+    fn ignores_global_regexps_and_unrelated_calls() {
+        assert!(rule_ids_for("str.matchAll(/foo/g);", "no-missing-g-flag").is_empty());
+        assert!(rule_ids_for("str.replaceAll(/foo/gu, 'bar');", "no-missing-g-flag").is_empty());
+        // Non-literal argument — flags cannot be determined statically.
+        assert!(rule_ids_for("str.matchAll(pattern);", "no-missing-g-flag").is_empty());
+        // Unrelated method.
+        assert!(rule_ids_for("str.match(/foo/u);", "no-missing-g-flag").is_empty());
+        // `replaceAll` accepts a string as its first argument; we must not
+        // false-positive when the call is not regex-based.
+        assert!(rule_ids_for("str.replaceAll('foo', 'bar');", "no-missing-g-flag").is_empty());
+    }
+}
+
+mod no_useless_character_class {
+    use super::*;
+
+    #[test]
+    fn reports_single_literal_classes() {
+        let data = first_data("const a = /[a]/u;", "no-useless-character-class");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("[a]"));
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("a")
+        );
+        assert_eq!(
+            rule_ids_for("const a = /[5]/u;", "no-useless-character-class").as_slice(),
+            &["unexpected"]
+        );
+        // Even followed by a quantifier the class is equivalent to the bare char.
+        assert_eq!(
+            rule_ids_for("const a = /[a]+/u;", "no-useless-character-class").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_negation_escape_and_multi_element_classes() {
+        assert!(rule_ids_for("const a = /[^a]/u;", "no-useless-character-class").is_empty());
+        assert!(rule_ids_for("const a = /[\\d]/u;", "no-useless-character-class").is_empty());
+        assert!(rule_ids_for("const a = /[ab]/u;", "no-useless-character-class").is_empty());
+        // `[-]` is technically one literal but `-` carries range meaning;
+        // we intentionally skip it.
+        assert!(rule_ids_for("const a = /[-]/u;", "no-useless-character-class").is_empty());
+    }
+}
+
+mod no_empty_string_literal {
+    use super::*;
+
+    #[test]
+    fn reports_empty_v_mode_string_literal() {
+        assert_eq!(
+            rule_ids_for("const a = /[\\q{}]/v;", "no-empty-string-literal").as_slice(),
+            &["unexpected"]
+        );
+        // Non-empty string literals are not flagged.
+        assert!(rule_ids_for("const a = /[\\q{ab}]/v;", "no-empty-string-literal").is_empty());
+    }
+
+    #[test]
+    fn ignores_unrelated_braced_constructs() {
+        // `\u{...}` is unrelated.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\u{41}', 'u');",
+                "no-empty-string-literal"
+            )
+            .is_empty()
+        );
+        // `{}` outside a `\q` context is not the empty string literal.
+        assert!(rule_ids_for("const a = /a{}/u;", "no-empty-string-literal").is_empty());
+    }
+}
+
 #[test]
 fn brace_quantifier_rules_ignore_quantifiers_inside_character_classes() {
     // Inside `[...]` braces are literal characters, not quantifier syntax.
@@ -1047,8 +1214,15 @@ fn reports_multiple_rules_for_a_single_regex() {
 
 #[test]
 fn reports_each_literal_independently() {
+    // The `u`-only flags trigger `require-unicode-sets-regexp` once per literal
+    // alongside the pattern-specific diagnostics.
     assert_eq!(
         rule_names_for("const a = /[]/u; const b = /a|/u;").as_slice(),
-        &["no-empty-character-class", "no-empty-alternative"]
+        &[
+            "require-unicode-sets-regexp",
+            "no-empty-character-class",
+            "require-unicode-sets-regexp",
+            "no-empty-alternative",
+        ]
     );
 }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -110,6 +110,22 @@ const messages = Object.freeze({
     unexpected:
       'Use `RegExp.prototype.exec` instead of `String.prototype.match` for non-global regular expressions.',
   },
+  'no-missing-g-flag': {
+    unexpected: "`String.prototype.{{expr}}` requires a regular expression with the 'g' flag.",
+  },
+  'no-useless-character-class': {
+    unexpected: "Unexpected single-character class '{{expr}}'. Use '{{replacement}}' instead.",
+  },
+  'no-empty-string-literal': {
+    unexpected: 'Unexpected empty string literal inside a character class.',
+  },
+  'no-optional-assertion': {
+    unexpected:
+      'Unexpected optional lookaround assertion; an assertion does not consume input, so the `?` is meaningless.',
+  },
+  'require-unicode-sets-regexp': {
+    require: "Use the 'v' flag.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -143,8 +159,15 @@ const ruleDescriptions = Object.freeze({
   'no-empty-lookarounds-assertion': 'disallow lookaround assertions with an empty body',
   'prefer-regexp-exec':
     'enforce `RegExp.prototype.exec` over `String.prototype.match` for non-global regexes',
+  'no-missing-g-flag':
+    'enforce that `String.prototype.matchAll` and `replaceAll` arguments use the `g` flag',
+  'no-useless-character-class':
+    'disallow character classes that contain only a single literal character',
+  'no-empty-string-literal': 'disallow empty string literals (`\\q{}`) inside character classes',
+  'no-optional-assertion':
+    'disallow optional quantifiers (`?`) immediately after a lookaround assertion',
+  'require-unicode-sets-regexp': 'enforce the use of the `v` flag (unicode sets mode)',
 });
-
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
   'no-empty-character-class': 'suggestion',
@@ -174,6 +197,11 @@ const ruleTypes = Object.freeze({
   'no-useless-range': 'suggestion',
   'no-empty-lookarounds-assertion': 'problem',
   'prefer-regexp-exec': 'suggestion',
+  'no-missing-g-flag': 'problem',
+  'no-useless-character-class': 'suggestion',
+  'no-empty-string-literal': 'problem',
+  'no-optional-assertion': 'problem',
+  'require-unicode-sets-regexp': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -287,7 +315,10 @@ function ruleCategory(ruleName) {
     ruleName === 'no-legacy-features' ||
     ruleName === 'no-non-standard-flag' ||
     ruleName === 'no-invisible-character' ||
-    ruleName === 'no-empty-lookarounds-assertion'
+    ruleName === 'no-empty-lookarounds-assertion' ||
+    ruleName === 'no-missing-g-flag' ||
+    ruleName === 'no-empty-string-literal' ||
+    ruleName === 'no-optional-assertion'
   ) {
     return 'Possible Errors';
   }
@@ -306,7 +337,8 @@ function ruleCategory(ruleName) {
     ruleName === 'letter-case' ||
     ruleName === 'hexadecimal-escape' ||
     ruleName === 'unicode-escape' ||
-    ruleName === 'no-useless-range'
+    ruleName === 'no-useless-range' ||
+    ruleName === 'no-useless-character-class'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -59,9 +59,12 @@ describe('regexp native API', () => {
       ['no-empty-character-class', 'empty'],
       // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
-      // new RegExp('\\x01', 'u') — u is present so only require-unicode-sets-regexp fires alongside the control-character diagnostic.
+      // new RegExp('\\x01', 'u') — u is present so require-unicode-sets-regexp fires
+      // alongside the control-character diagnostic and `hexadecimal-escape` (the
+      // `\xHH` escape is independently flagged regardless of the character value).
       ['require-unicode-sets-regexp', 'require'],
       ['no-control-character', 'unexpected'],
+      ['hexadecimal-escape', 'unexpected'],
     ]);
     expect(diagnostics[0].data).toMatchObject({
       flags: 'mi',

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -33,6 +33,11 @@ describe('regexp native API', () => {
       'no-useless-range',
       'no-empty-lookarounds-assertion',
       'prefer-regexp-exec',
+      'no-missing-g-flag',
+      'no-useless-character-class',
+      'no-empty-string-literal',
+      'no-optional-assertion',
+      'require-unicode-sets-regexp',
     ]);
   });
 
@@ -47,17 +52,22 @@ describe('regexp native API', () => {
     );
 
     expect(diagnostics.map((diagnostic) => [diagnostic.ruleName, diagnostic.messageId])).toEqual([
+      // /[]/mi — flag style + pattern checks all fire.
       ['sort-flags', 'sortFlags'],
       ['require-unicode-regexp', 'require'],
+      ['require-unicode-sets-regexp', 'require'],
       ['no-empty-character-class', 'empty'],
+      // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
+      // new RegExp('\\x01', 'u') — u is present so only require-unicode-sets-regexp fires alongside the control-character diagnostic.
+      ['require-unicode-sets-regexp', 'require'],
       ['no-control-character', 'unexpected'],
     ]);
     expect(diagnostics[0].data).toMatchObject({
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[4].data.charText).toBe('U+0001');
+    expect(diagnostics[6].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {
@@ -76,8 +86,11 @@ describe('regexp native API', () => {
   });
 
   it('returns no diagnostics for clean sources', () => {
-    expect(scanRegexp('const re = /a+/u;\n', 'fixture.js')).toEqual([]);
-    expect(scanRegexp("const re = new RegExp('a', 'gimsu');\n", 'fixture.js')).toEqual([]);
+    // Sources that use the `v` flag stay quiet because `require-unicode-sets-regexp`
+    // is the only flag-style rule that targets that flag specifically; everything
+    // else needs an unrelated pattern issue.
+    expect(scanRegexp('const re = /a+/v;\n', 'fixture.js')).toEqual([]);
+    expect(scanRegexp("const re = new RegExp('a', 'gimsv');\n", 'fixture.js')).toEqual([]);
   });
 
   it('returns no diagnostics when the source fails to parse', () => {
@@ -87,13 +100,17 @@ describe('regexp native API', () => {
 
   it('reports each literal separately', () => {
     const diagnostics = scanRegexp('const a = /[]/u; const b = /a|/u;\n', 'fixture.js');
+    // Each `u`-only literal fires require-unicode-sets-regexp once on top of
+    // the pattern-specific diagnostic.
     expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'require-unicode-sets-regexp',
       'no-empty-character-class',
+      'require-unicode-sets-regexp',
       'no-empty-alternative',
     ]);
     expect(diagnostics[0].loc.startLine).toBe(1);
-    expect(diagnostics[1].loc.startLine).toBe(1);
-    expect(diagnostics[1].loc.startColumn).toBeGreaterThan(diagnostics[0].loc.startColumn);
+    expect(diagnostics[3].loc.startLine).toBe(1);
+    expect(diagnostics[3].loc.startColumn).toBeGreaterThan(diagnostics[1].loc.startColumn);
   });
 
   it('ignores callers that are not RegExp', () => {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -150,6 +150,30 @@ const invalidCases = [
   // prefer-regexp-exec
   ['prefer-regexp-exec', 'match with non-global literal', 'str.match(/foo/u);\n', ['unexpected']],
   ['prefer-regexp-exec', 'member-chained receiver', 'obj.prop.match(/bar/);\n', ['unexpected']],
+  // no-missing-g-flag
+  ['no-missing-g-flag', 'matchAll without g', 'str.matchAll(/foo/u);\n', ['unexpected']],
+  [
+    'no-missing-g-flag',
+    'replaceAll regex without g',
+    "str.replaceAll(/foo/, 'bar');\n",
+    ['unexpected'],
+  ],
+  // no-useless-character-class
+  ['no-useless-character-class', 'single literal class', 'const re = /[a]/u;\n', ['unexpected']],
+  ['no-useless-character-class', 'single digit class', 'const re = /[5]/u;\n', ['unexpected']],
+  // no-empty-string-literal
+  ['no-empty-string-literal', 'empty v literal', 'const re = /[\\q{}]/v;\n', ['unexpected']],
+  // no-optional-assertion
+  [
+    'no-optional-assertion',
+    'optional positive lookahead',
+    'const re = /(?=a)?/u;\n',
+    ['unexpected'],
+  ],
+  ['no-optional-assertion', 'optional lookbehind', 'const re = /(?<=a)?/u;\n', ['unexpected']],
+  // require-unicode-sets-regexp
+  ['require-unicode-sets-regexp', 'u flag only', 'const re = /a/u;\n', ['require']],
+  ['require-unicode-sets-regexp', 'no flags', 'const re = /a/;\n', ['require']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8763,19 +8763,19 @@
       },
       {
         "name": "no-empty-string-literal",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-empty-string-literal."
+        "notes": "Substring scan via pattern_has_empty_string_literal: the `\\q{}` syntax is only legal in `v`-flag patterns, so seeing the literal sequence implies v-mode without needing a flag check."
       },
       {
         "name": "no-escape-backspace",
@@ -8891,19 +8891,19 @@
       },
       {
         "name": "no-missing-g-flag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-missing-g-flag."
+        "notes": "JS-side CallExpression check on `<expr>.matchAll(...)` and `<expr>.replaceAll(...)` where the first argument is a RegExp literal without the `g` flag. RegExp constructor calls are deferred (need type information)."
       },
       {
         "name": "no-non-standard-flag",
@@ -8939,19 +8939,19 @@
       },
       {
         "name": "no-optional-assertion",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-optional-assertion."
+        "notes": "GroupPrefix gains is_lookaround so the closing paren handler can peek the next byte: if a lookaround is followed by `?`, it is reported. Other quantifiers on assertions are syntax errors in the regexp parser anyway, so we only target the `?` case explicitly."
       },
       {
         "name": "no-potentially-useless-backreference",
@@ -9099,19 +9099,19 @@
       },
       {
         "name": "no-useless-character-class",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-character-class."
+        "notes": "Class-level scan via class_is_useless_single_literal flags `[X]` where the body is exactly one ASCII literal with no regex meaning of its own; negation, escapes, ranges, and multi-element classes are deferred to keep the check sound (no false positives)."
       },
       {
         "name": "no-useless-dollar-replacements",
@@ -9611,19 +9611,19 @@
       },
       {
         "name": "require-unicode-sets-regexp",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-unicode-sets-regexp."
+        "notes": "Flag-level check that mirrors require-unicode-regexp but specifically requires the `v` (unicode sets) flag rather than `u` or `v`. Patterns that only carry `u` still fire this rule when it is enabled."
       },
       {
         "name": "simplify-set-operations",


### PR DESCRIPTION
Stacked on top of #75 (which already absorbed #76). Mirror of `prefer-regexp-exec`: regexp port advances **28 → 29 / 82** once #75 lands.

## How it works

`<expr>.matchAll(<regexp>)` and `<expr>.replaceAll(<regexp>, ...)` throw a `TypeError` at runtime when the regexp argument does not carry the `g` flag — the spec requires the global flag for those methods. A new `check_no_missing_g_flag` walks every `CallExpression`, gates on a `StaticMemberExpression` callee whose property is `matchAll` or `replaceAll`, and reports when the first argument is a `RegExpLiteral` whose flags string does not contain `g`. The method name is carried through `DiagnosticData.expr` so the JS-side message can distinguish the two methods.

`RegExp` constructor calls are intentionally deferred for the same type-info reason as `prefer-regexp-exec`; the type-aware port can extend coverage later. `replaceAll` with a string first argument is also ignored — that signature does not need a regex at all, so flagging it would be a false positive.

## Verification

- 74 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust suites pass
- Vitest plugin tests gain 6 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 29 ported names

No upstream source, fixtures, or messages were copied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->