### PR TITLE
port(regexp): port no-optional-assertion and require-unicode-sets-regexp

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -297,6 +297,9 @@ impl<'a> Scanner<'a> {
         if !flags.contains('u') && !flags.contains('v') {
             self.report("require-unicode-regexp", "require", span);
         }
+        if !flags.contains('v') {
+            self.report("require-unicode-sets-regexp", "require", span);
+        }
     }
 
     fn check_pattern_rules(&mut self, pattern: &str, span: Span) {
@@ -508,6 +511,9 @@ impl<'a> Scanner<'a> {
                 },
                 span,
             );
+        }
+        if analysis.has_optional_assertion {
+            self.report("no-optional-assertion", "unexpected", span);
         }
     }
 }

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 31] = [
+pub const RULE_NAMES: [&str; 33] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -53,6 +53,8 @@ pub const RULE_NAMES: [&str; 31] = [
     "no-missing-g-flag",
     "no-useless-character-class",
     "no-empty-string-literal",
+    "no-optional-assertion",
+    "require-unicode-sets-regexp",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -78,6 +78,10 @@ pub(crate) struct PatternAnalysis {
     /// First single-literal class `[X]` and the bare character it could be
     /// replaced with. `no-useless-character-class`.
     pub(crate) first_useless_single_literal_class: Option<char>,
+    /// At least one lookaround assertion followed by an optional `?` quantifier
+    /// (`(?=a)?`). The `?` is always meaningless because the assertion either
+    /// succeeds or fails without consuming input. `no-optional-assertion`.
+    pub(crate) has_optional_assertion: bool,
 }
 
 impl PatternAnalysis {
@@ -165,6 +169,13 @@ impl PatternAnalysis {
                         }
                         if group.is_lookaround && !group.seen_pipe && !group.current_has_content {
                             self.has_empty_lookaround = true;
+                        }
+                        // `(?=...)?` and friends: a `?` immediately after the
+                        // closing paren of a lookaround makes the assertion
+                        // optional, which is always meaningless because the
+                        // assertion does not consume input.
+                        if group.is_lookaround && bytes.get(index + 1) == Some(&b'?') {
+                            self.has_optional_assertion = true;
                         }
                         self.mark_content(&mut groups);
                     }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -72,8 +72,79 @@ fn exposes_initial_regexp_rule_names() {
             "no-missing-g-flag",
             "no-useless-character-class",
             "no-empty-string-literal",
+            "no-optional-assertion",
+            "require-unicode-sets-regexp",
         ]
     );
+}
+
+mod no_optional_assertion {
+    use super::*;
+
+    #[test]
+    fn reports_question_after_each_lookaround_shape() {
+        assert_eq!(
+            rule_ids_for("const a = /(?=a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?!a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<=a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<!a)?/u;", "no-optional-assertion").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_assertions_without_quantifier_and_non_assertion_optionals() {
+        assert!(rule_ids_for("const a = /(?=a)/u;", "no-optional-assertion").is_empty());
+        // `?` after a non-lookaround group must not fire this rule.
+        assert!(rule_ids_for("const a = /(?:a)?/u;", "no-optional-assertion").is_empty());
+        assert!(rule_ids_for("const a = /(a)?/u;", "no-optional-assertion").is_empty());
+    }
+}
+
+mod require_unicode_sets_regexp {
+    use super::*;
+
+    #[test]
+    fn reports_missing_v_flag() {
+        assert_eq!(
+            rule_ids_for("const a = /a/u;", "require-unicode-sets-regexp").as_slice(),
+            &["require"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a/;", "require-unicode-sets-regexp").as_slice(),
+            &["require"]
+        );
+        assert_eq!(
+            rule_ids_for(
+                "const a = new RegExp('a', 'gimsu');",
+                "require-unicode-sets-regexp"
+            )
+            .as_slice(),
+            &["require"]
+        );
+    }
+
+    #[test]
+    fn accepts_patterns_with_v_flag() {
+        assert!(rule_ids_for("const a = /a/v;", "require-unicode-sets-regexp").is_empty());
+        assert!(rule_ids_for("const a = /a/gv;", "require-unicode-sets-regexp").is_empty());
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('a', 'v');",
+                "require-unicode-sets-regexp"
+            )
+            .is_empty()
+        );
+    }
 }
 
 #[test]
@@ -89,10 +160,11 @@ fn ignores_dynamic_constructor_arguments() {
     assert!(ids("const a = new RegExp(pattern, 'u');").is_empty());
     assert!(ids("const a = RegExp();").is_empty());
     // When the flags argument is non-literal we still scan the pattern and
-    // assume no `u`/`v` flag, which surfaces `require-unicode-regexp` only.
+    // assume no `u`/`v` flag, which surfaces both `require-unicode-regexp`
+    // (needs `u` or `v`) and `require-unicode-sets-regexp` (needs `v`).
     assert_eq!(
         rule_names_for("const a = new RegExp('a', flags);").as_slice(),
-        &["require-unicode-regexp"]
+        &["require-unicode-regexp", "require-unicode-sets-regexp"]
     );
 }
 
@@ -1142,8 +1214,15 @@ fn reports_multiple_rules_for_a_single_regex() {
 
 #[test]
 fn reports_each_literal_independently() {
+    // The `u`-only flags trigger `require-unicode-sets-regexp` once per literal
+    // alongside the pattern-specific diagnostics.
     assert_eq!(
         rule_names_for("const a = /[]/u; const b = /a|/u;").as_slice(),
-        &["no-empty-character-class", "no-empty-alternative"]
+        &[
+            "require-unicode-sets-regexp",
+            "no-empty-character-class",
+            "require-unicode-sets-regexp",
+            "no-empty-alternative",
+        ]
     );
 }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -119,6 +119,13 @@ const messages = Object.freeze({
   'no-empty-string-literal': {
     unexpected: 'Unexpected empty string literal inside a character class.',
   },
+  'no-optional-assertion': {
+    unexpected:
+      'Unexpected optional lookaround assertion; an assertion does not consume input, so the `?` is meaningless.',
+  },
+  'require-unicode-sets-regexp': {
+    require: "Use the 'v' flag.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -157,8 +164,10 @@ const ruleDescriptions = Object.freeze({
   'no-useless-character-class':
     'disallow character classes that contain only a single literal character',
   'no-empty-string-literal': 'disallow empty string literals (`\\q{}`) inside character classes',
+  'no-optional-assertion':
+    'disallow optional quantifiers (`?`) immediately after a lookaround assertion',
+  'require-unicode-sets-regexp': 'enforce the use of the `v` flag (unicode sets mode)',
 });
-
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
   'no-empty-character-class': 'suggestion',
@@ -191,6 +200,8 @@ const ruleTypes = Object.freeze({
   'no-missing-g-flag': 'problem',
   'no-useless-character-class': 'suggestion',
   'no-empty-string-literal': 'problem',
+  'no-optional-assertion': 'problem',
+  'require-unicode-sets-regexp': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -306,7 +317,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-invisible-character' ||
     ruleName === 'no-empty-lookarounds-assertion' ||
     ruleName === 'no-missing-g-flag' ||
-    ruleName === 'no-empty-string-literal'
+    ruleName === 'no-empty-string-literal' ||
+    ruleName === 'no-optional-assertion'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -36,6 +36,8 @@ describe('regexp native API', () => {
       'no-missing-g-flag',
       'no-useless-character-class',
       'no-empty-string-literal',
+      'no-optional-assertion',
+      'require-unicode-sets-regexp',
     ]);
   });
 
@@ -50,17 +52,22 @@ describe('regexp native API', () => {
     );
 
     expect(diagnostics.map((diagnostic) => [diagnostic.ruleName, diagnostic.messageId])).toEqual([
+      // /[]/mi — flag style + pattern checks all fire.
       ['sort-flags', 'sortFlags'],
       ['require-unicode-regexp', 'require'],
+      ['require-unicode-sets-regexp', 'require'],
       ['no-empty-character-class', 'empty'],
+      // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
+      // new RegExp('\\x01', 'u') — u is present so only require-unicode-sets-regexp fires alongside the control-character diagnostic.
+      ['require-unicode-sets-regexp', 'require'],
       ['no-control-character', 'unexpected'],
     ]);
     expect(diagnostics[0].data).toMatchObject({
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[4].data.charText).toBe('U+0001');
+    expect(diagnostics[6].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {
@@ -79,8 +86,11 @@ describe('regexp native API', () => {
   });
 
   it('returns no diagnostics for clean sources', () => {
-    expect(scanRegexp('const re = /a+/u;\n', 'fixture.js')).toEqual([]);
-    expect(scanRegexp("const re = new RegExp('a', 'gimsu');\n", 'fixture.js')).toEqual([]);
+    // Sources that use the `v` flag stay quiet because `require-unicode-sets-regexp`
+    // is the only flag-style rule that targets that flag specifically; everything
+    // else needs an unrelated pattern issue.
+    expect(scanRegexp('const re = /a+/v;\n', 'fixture.js')).toEqual([]);
+    expect(scanRegexp("const re = new RegExp('a', 'gimsv');\n", 'fixture.js')).toEqual([]);
   });
 
   it('returns no diagnostics when the source fails to parse', () => {
@@ -90,13 +100,17 @@ describe('regexp native API', () => {
 
   it('reports each literal separately', () => {
     const diagnostics = scanRegexp('const a = /[]/u; const b = /a|/u;\n', 'fixture.js');
+    // Each `u`-only literal fires require-unicode-sets-regexp once on top of
+    // the pattern-specific diagnostic.
     expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'require-unicode-sets-regexp',
       'no-empty-character-class',
+      'require-unicode-sets-regexp',
       'no-empty-alternative',
     ]);
     expect(diagnostics[0].loc.startLine).toBe(1);
-    expect(diagnostics[1].loc.startLine).toBe(1);
-    expect(diagnostics[1].loc.startColumn).toBeGreaterThan(diagnostics[0].loc.startColumn);
+    expect(diagnostics[3].loc.startLine).toBe(1);
+    expect(diagnostics[3].loc.startColumn).toBeGreaterThan(diagnostics[1].loc.startColumn);
   });
 
   it('ignores callers that are not RegExp', () => {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -163,6 +163,17 @@ const invalidCases = [
   ['no-useless-character-class', 'single digit class', 'const re = /[5]/u;\n', ['unexpected']],
   // no-empty-string-literal
   ['no-empty-string-literal', 'empty v literal', 'const re = /[\\q{}]/v;\n', ['unexpected']],
+  // no-optional-assertion
+  [
+    'no-optional-assertion',
+    'optional positive lookahead',
+    'const re = /(?=a)?/u;\n',
+    ['unexpected'],
+  ],
+  ['no-optional-assertion', 'optional lookbehind', 'const re = /(?<=a)?/u;\n', ['unexpected']],
+  // require-unicode-sets-regexp
+  ['require-unicode-sets-regexp', 'u flag only', 'const re = /a/u;\n', ['require']],
+  ['require-unicode-sets-regexp', 'no flags', 'const re = /a/;\n', ['require']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8939,19 +8939,19 @@
       },
       {
         "name": "no-optional-assertion",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-optional-assertion."
+        "notes": "GroupPrefix gains is_lookaround so the closing paren handler can peek the next byte: if a lookaround is followed by `?`, it is reported. Other quantifiers on assertions are syntax errors in the regexp parser anyway, so we only target the `?` case explicitly."
       },
       {
         "name": "no-potentially-useless-backreference",
@@ -9611,19 +9611,19 @@
       },
       {
         "name": "require-unicode-sets-regexp",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-unicode-sets-regexp."
+        "notes": "Flag-level check that mirrors require-unicode-regexp but specifically requires the `v` (unicode sets) flag rather than `u` or `v`. Patterns that only carry `u` still fire this rule when it is enabled."
       },
       {
         "name": "simplify-set-operations",


### PR DESCRIPTION
Stacked on top of #77 (which already absorbed #78). Regexp port **31 → 33 / 82** once the chain lands.

## How it works

- `no-optional-assertion`: the existing `GroupPrefix.is_lookaround` flag is consulted at close-paren time. When the next byte is `?`, the assertion is wrapped in a meaningless optional quantifier (an assertion does not consume input, so `?` on it is a no-op). Other quantifiers on assertions (`*`, `+`, `{n,m}`) are syntax errors in the regexp parser, so we only target `?` explicitly.
- `require-unicode-sets-regexp`: flag-level check that mirrors `require-unicode-regexp` but specifically requires the `v` (unicode sets) flag. Patterns that only carry `u` still fire this rule when enabled.

`PatternAnalysis` gains `has_optional_assertion`. No new full-pattern scan is added — both rules ride on existing primitives.

## Cross-rule test churn

Because `require-unicode-sets-regexp` fires on every pattern that lacks `v`, two assertions that capture the full diagnostic stream for `u`-only sources are updated, and two `api.test.mjs` "clean source" fixtures move from `u` to `v`. Tests that filter to a specific rule name are unaffected.

## Verification

- 82 Rust unit tests pass (8 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust suites pass
- Vitest plugin tests gain 8 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 33 ported names

No upstream source, fixtures, or messages were copied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->