### PR TITLE
port(regexp): port no-obscure-range and prefer-unicode-codepoint-escapes

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -12,8 +12,9 @@ use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
     duplicate_flag, first_control_character, first_fixed_unicode_escape, first_hex_x_escape,
-    first_invisible_character, first_non_standard_flag, first_octal_escape,
-    first_surrogate_pair_escape, first_uppercase_hex_escape, mention_char,
+    first_invisible_character, first_non_standard_flag,
+    first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
+    first_uppercase_hex_escape, first_useless_escape, first_useless_one_quantifier, mention_char,
     pattern_has_empty_string_literal, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
@@ -311,7 +312,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.check_flag_style(flags, span);
-        self.check_pattern_rules(pattern, span);
+        self.check_pattern_rules(pattern, flags, span);
     }
 
     #[allow(
@@ -363,9 +364,41 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn check_pattern_rules(&mut self, pattern: &str, span: Span) {
+    fn check_pattern_rules(&mut self, pattern: &str, flags: &str, span: Span) {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern);
+
+        // `no-useless-flag` (narrow form): the `s` flag only affects the
+        // matching of `.`; the `m` flag only affects `^` and `$`. If neither
+        // syntax appears in the pattern, the flag is provably inert. Other
+        // useless-flag shapes (e.g. `i` on a pattern with no letters) are
+        // intentionally deferred — they need a richer case-class analysis.
+        if flags.contains('s') && !analysis.has_unescaped_dot {
+            let mut text = CompactString::new("");
+            text.push('s');
+            self.report_with_data(
+                "no-useless-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if flags.contains('m') && !analysis.has_unescaped_anchor {
+            let mut text = CompactString::new("");
+            text.push('m');
+            self.report_with_data(
+                "no-useless-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);
@@ -589,6 +622,80 @@ impl<'a> Scanner<'a> {
                 "unexpected",
                 DiagnosticData {
                     expr: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(ch) = analysis.first_dupe_class_literal {
+            let mut text = CompactString::new("");
+            text.push(ch);
+            self.report_with_data(
+                "no-dupe-characters-character-class",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some((start, end)) = analysis.first_collapsible_run {
+            let mut original = CompactString::new("");
+            // Push the inclusive run as the original text for the diagnostic.
+            let mut cursor = start as u8;
+            while cursor <= end as u8 {
+                original.push(cursor as char);
+                cursor += 1;
+            }
+            let mut replacement = CompactString::new("");
+            replacement.push(start);
+            replacement.push('-');
+            replacement.push(end);
+            self.report_with_data(
+                "prefer-range",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(original),
+                    replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(text) = first_useless_one_quantifier(pattern) {
+            self.report_with_data(
+                "no-useless-quantifier",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(text)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(text) = first_numbered_backreference_with_named_group(pattern) {
+            self.report_with_data(
+                "prefer-named-backreference",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(text)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(byte) = first_useless_escape(pattern) {
+            let mut text = CompactString::new("\\");
+            text.push(byte as char);
+            let mut replacement = CompactString::new("");
+            replacement.push(byte as char);
+            self.report_with_data(
+                "no-useless-escape",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(text),
+                    replacement: Some(replacement),
                     ..DiagnosticData::default()
                 },
                 span,

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -13,8 +13,8 @@ use oxlint_plugins_carton::CompactString;
 use crate::helpers::{
     duplicate_flag, first_control_character, first_fixed_unicode_escape, first_hex_x_escape,
     first_invisible_character, first_non_standard_flag, first_octal_escape,
-    first_uppercase_hex_escape, mention_char, pattern_has_empty_string_literal, sorted_flags,
-    string_literal_value_with_span,
+    first_surrogate_pair_escape, first_uppercase_hex_escape, mention_char,
+    pattern_has_empty_string_literal, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -578,6 +578,33 @@ impl<'a> Scanner<'a> {
         }
         if analysis.has_confusing_quantifier {
             self.report("confusing-quantifier", "unexpected", span);
+        }
+        if let Some((start, end)) = analysis.first_obscure_range {
+            let mut text = CompactString::new("");
+            text.push(start);
+            text.push('-');
+            text.push(end);
+            self.report_with_data(
+                "no-obscure-range",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some((escape, replacement)) = first_surrogate_pair_escape(pattern) {
+            self.report_with_data(
+                "prefer-unicode-codepoint-escapes",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(escape)),
+                    replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
         }
     }
 }

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -611,6 +611,161 @@ pub(crate) fn first_fixed_unicode_escape(pattern: &str) -> Option<(&str, Compact
     None
 }
 
+/// Returns `Some((start, end))` when the `[...]` class at `open` contains at
+/// least one `X-Y` range whose endpoints cross ASCII character categories
+/// (digit/uppercase letter/lowercase letter/other). Such ranges almost always
+/// sweep up unexpected characters in the gaps between categories (the
+/// canonical example is `[A-z]`, which includes `[\]^_` and `` ` ``). Used by
+/// `no-obscure-range`. Escaped or compound endpoints are intentionally
+/// ignored so the check stays sound (no false positives).
+pub(crate) fn class_first_obscure_range(bytes: &[u8], open: usize) -> Option<(char, char)> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let end = find_class_end(bytes, open)?;
+    let mut index = open + 1;
+    if bytes.get(index) == Some(&b'^') {
+        index += 1;
+    }
+    while index + 2 < end {
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).min(end);
+            continue;
+        }
+        if bytes[index + 1] != b'-' {
+            index += 1;
+            continue;
+        }
+        if bytes[index + 2] == b'\\' || bytes[index + 2] == b']' {
+            // Skip escaped or end-of-class endpoints; equivalence is hard to
+            // judge without decoding the escape.
+            index += 1;
+            continue;
+        }
+        let start_byte = bytes[index];
+        let end_byte = bytes[index + 2];
+        if start_byte.is_ascii() && end_byte.is_ascii() && is_obscure_range(start_byte, end_byte) {
+            return Some((start_byte as char, end_byte as char));
+        }
+        index += 3;
+    }
+    None
+}
+
+fn is_obscure_range(start: u8, end: u8) -> bool {
+    if start > end {
+        return false;
+    }
+    let start_category = ascii_category(start);
+    let end_category = ascii_category(end);
+    // A range stays within one of the canonical categories (digits or
+    // lowercase letters or uppercase letters) — that is fine. Anything else
+    // crosses a boundary and is flagged.
+    !matches!(
+        (start_category, end_category),
+        (AsciiCategory::Digit, AsciiCategory::Digit)
+            | (AsciiCategory::Lowercase, AsciiCategory::Lowercase)
+            | (AsciiCategory::Uppercase, AsciiCategory::Uppercase)
+    ) && (start_category != AsciiCategory::Other || end_category != AsciiCategory::Other)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AsciiCategory {
+    Digit,
+    Lowercase,
+    Uppercase,
+    Other,
+}
+
+fn ascii_category(byte: u8) -> AsciiCategory {
+    match byte {
+        b'0'..=b'9' => AsciiCategory::Digit,
+        b'a'..=b'z' => AsciiCategory::Lowercase,
+        b'A'..=b'Z' => AsciiCategory::Uppercase,
+        _ => AsciiCategory::Other,
+    }
+}
+
+/// Returns the first surrogate-pair escape sequence `\uHHHH\uHHHH` in
+/// `pattern` together with its `\u{CODEPOINT}` replacement (hex digits in
+/// lower case). Used by `prefer-unicode-codepoint-escapes`. Unrelated
+/// adjacent `\uHHHH` escapes (where the pair is not a valid surrogate pair)
+/// are skipped.
+pub(crate) fn first_surrogate_pair_escape(pattern: &str) -> Option<(&str, CompactString)> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index + 12 <= bytes.len() {
+        if bytes[index] != b'\\' || bytes[index + 1] != b'u' {
+            index += 1;
+            continue;
+        }
+        let Some(high) = read_fixed_hex4(&bytes[index + 2..index + 6]) else {
+            index = skip_escape(bytes, index);
+            continue;
+        };
+        if !(0xD800..=0xDBFF).contains(&high) {
+            index = skip_escape(bytes, index);
+            continue;
+        }
+        if bytes[index + 6] != b'\\' || bytes[index + 7] != b'u' {
+            index = skip_escape(bytes, index);
+            continue;
+        }
+        let Some(low) = read_fixed_hex4(&bytes[index + 8..index + 12]) else {
+            index = skip_escape(bytes, index);
+            continue;
+        };
+        if !(0xDC00..=0xDFFF).contains(&low) {
+            index = skip_escape(bytes, index);
+            continue;
+        }
+        let original = &pattern[index..index + 12];
+        let codepoint = ((high - 0xD800) << 10) + (low - 0xDC00) + 0x10000;
+        let mut replacement = CompactString::new("\\u{");
+        append_lower_hex(&mut replacement, codepoint);
+        replacement.push('}');
+        return Some((original, replacement));
+    }
+    None
+}
+
+fn read_fixed_hex4(bytes: &[u8]) -> Option<u32> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    let mut value: u32 = 0;
+    for byte in bytes.iter().take(4) {
+        let digit = match byte {
+            b'0'..=b'9' => byte - b'0',
+            b'a'..=b'f' => byte - b'a' + 10,
+            b'A'..=b'F' => byte - b'A' + 10,
+            _ => return None,
+        };
+        value = value * 16 + u32::from(digit);
+    }
+    Some(value)
+}
+
+fn append_lower_hex(target: &mut CompactString, mut value: u32) {
+    if value == 0 {
+        target.push('0');
+        return;
+    }
+    let mut buf = [0u8; 8];
+    let mut cursor = buf.len();
+    while value > 0 {
+        cursor -= 1;
+        let digit = (value & 0xf) as u8;
+        buf[cursor] = if digit < 10 {
+            b'0' + digit
+        } else {
+            b'a' + digit - 10
+        };
+        value >>= 4;
+    }
+    if let Ok(text) = std::str::from_utf8(&buf[cursor..]) {
+        target.push_str(text);
+    }
+}
+
 /// Returns `Some(ch)` when the `[...]` class at `open` is exactly `[X]` for a
 /// regular ASCII literal `X`. Negated classes, escaped contents, ranges,
 /// nested classes, and bodies of length other than one are intentionally

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -766,6 +766,220 @@ fn append_lower_hex(target: &mut CompactString, mut value: u32) {
     }
 }
 
+/// Returns `Some(original)` when the pattern contains a literal `{1}` or
+/// `{1,1}` quantifier at the top level. Such quantifiers are no-ops; the
+/// referenced atom matches itself exactly once anyway. Class context is
+/// skipped because `{` and `1` are literal characters inside `[...]`. Used by
+/// `no-useless-quantifier`.
+pub(crate) fn first_useless_one_quantifier(pattern: &str) -> Option<&str> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'[' {
+            if let Some(close) = find_class_end(bytes, index) {
+                index = close + 1;
+                continue;
+            }
+            return None;
+        }
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
+        }
+        if bytes[index] == b'{' && bytes.get(index + 1) == Some(&b'1') {
+            if bytes.get(index + 2) == Some(&b'}') {
+                return Some(&pattern[index..index + 3]);
+            }
+            if bytes.get(index + 2) == Some(&b',')
+                && bytes.get(index + 3) == Some(&b'1')
+                && bytes.get(index + 4) == Some(&b'}')
+            {
+                return Some(&pattern[index..index + 5]);
+            }
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Returns `Some(text)` for the first numbered backreference `\N` (N in 1-9)
+/// inside `pattern` when the same pattern contains at least one named capture
+/// group `(?<name>...)`. Numbered backreferences alongside named groups are
+/// the canonical case for `prefer-named-backreference`. Backreferences inside
+/// classes are skipped because they are literal characters there.
+pub(crate) fn first_numbered_backreference_with_named_group(pattern: &str) -> Option<&str> {
+    let bytes = pattern.as_bytes();
+    if !pattern.contains("(?<") {
+        return None;
+    }
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'[' {
+            if let Some(close) = find_class_end(bytes, index) {
+                index = close + 1;
+                continue;
+            }
+            return None;
+        }
+        if bytes[index] == b'\\'
+            && let Some(&next) = bytes.get(index + 1)
+            && matches!(next, b'1'..=b'9')
+        {
+            return Some(&pattern[index..index + 2]);
+        }
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Returns `Some(byte)` for the first escape `\X` in `pattern` where `X` is
+/// a character that is never special in a regular expression (not in a
+/// character class either), so the `\` is useless. Stays narrow on purpose:
+/// only flags a curated list of punctuation that has no escape semantics
+/// (`:`, `;`, `,`, `=`, `!`, `#`, `@`, `<`, `>`, `&`, `_`, `%`, `~`, `'`,
+/// `"`, `/`). Walks the pattern with the existing class-skipping logic so
+/// escapes inside `[...]` (where `]` and `-` carry extra meaning) are not
+/// considered. Used by `no-useless-escape`.
+pub(crate) fn first_useless_escape(pattern: &str) -> Option<u8> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'[' {
+            // Skip the entire character class — the rules for "useless" inside
+            // a class differ, and we conservatively defer them.
+            if let Some(close) = find_class_end(bytes, index) {
+                index = close + 1;
+                continue;
+            }
+            return None;
+        }
+        if bytes[index] != b'\\' {
+            index += 1;
+            continue;
+        }
+        if let Some(&next) = bytes.get(index + 1)
+            && is_pointlessly_escaped(next)
+        {
+            return Some(next);
+        }
+        index = skip_escape(bytes, index).max(index + 1);
+    }
+    None
+}
+
+fn is_pointlessly_escaped(byte: u8) -> bool {
+    matches!(
+        byte,
+        b':' | b';'
+            | b','
+            | b'='
+            | b'!'
+            | b'#'
+            | b'@'
+            | b'<'
+            | b'>'
+            | b'&'
+            | b'_'
+            | b'%'
+            | b'~'
+            | b'\''
+            | b'"'
+            | b'/'
+    )
+}
+
+/// Returns `Some(byte)` for the first ASCII literal byte that appears more
+/// than once in the `[...]` class at `open`. Escapes, ranges, and nested
+/// classes are intentionally skipped — comparing them for equivalence needs
+/// decoding we have not implemented yet. Used by
+/// `no-dupe-characters-character-class`. Keeps a small fixed-size bitmap on
+/// the stack so the check has no allocation.
+pub(crate) fn class_first_duplicate_literal(bytes: &[u8], open: usize) -> Option<u8> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let end = find_class_end(bytes, open)?;
+    let mut index = open + 1;
+    if bytes.get(index) == Some(&b'^') {
+        index += 1;
+    }
+    // 16 bytes covers all 128 ASCII bit slots.
+    let mut seen = [0u8; 16];
+    while index < end {
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).min(end);
+            continue;
+        }
+        if index + 2 < end && bytes[index + 1] == b'-' {
+            // Skip the entire range — `a-c` does not mean three repeats of
+            // any character, and the helper deliberately ignores ranges.
+            index += 3;
+            continue;
+        }
+        let byte = bytes[index];
+        if byte.is_ascii() {
+            let bit = byte as usize;
+            let slot = bit / 8;
+            let mask = 1u8 << (bit % 8);
+            if seen[slot] & mask != 0 {
+                return Some(byte);
+            }
+            seen[slot] |= mask;
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Returns `Some((start, end))` when the `[...]` class at `open` contains
+/// three or more consecutive ASCII characters (digits, lower-case, or
+/// upper-case letters) at the top level — these collapse into the equivalent
+/// range `start-end`. Used by `prefer-range`. Escapes and existing ranges
+/// are intentionally skipped to keep the check conservative.
+pub(crate) fn class_first_collapsible_run(bytes: &[u8], open: usize) -> Option<(char, char)> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let end = find_class_end(bytes, open)?;
+    let mut index = open + 1;
+    if bytes.get(index) == Some(&b'^') {
+        index += 1;
+    }
+    while index < end {
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).min(end);
+            continue;
+        }
+        if index + 2 < end && bytes[index + 1] == b'-' {
+            index += 3;
+            continue;
+        }
+        if is_collapsible_run_byte(bytes[index]) {
+            let start = bytes[index];
+            let mut run_end = start;
+            let mut cursor = index + 1;
+            while cursor < end
+                && bytes[cursor] == run_end + 1
+                && is_collapsible_run_byte(bytes[cursor])
+            {
+                run_end = bytes[cursor];
+                cursor += 1;
+            }
+            if run_end >= start + 2 {
+                return Some((start as char, run_end as char));
+            }
+            index = cursor.max(index + 1);
+            continue;
+        }
+        index += 1;
+    }
+    None
+}
+
+fn is_collapsible_run_byte(byte: u8) -> bool {
+    matches!(byte, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z')
+}
+
 /// Returns `Some(ch)` when the `[...]` class at `open` is exactly `[X]` for a
 /// regular ASCII literal `X`. Negated classes, escaped contents, ranges,
 /// nested classes, and bodies of length other than one are intentionally

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 37] = [
+pub const RULE_NAMES: [&str; 43] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -59,6 +59,12 @@ pub const RULE_NAMES: [&str; 37] = [
     "prefer-named-replacement",
     "no-obscure-range",
     "prefer-unicode-codepoint-escapes",
+    "no-dupe-characters-character-class",
+    "prefer-range",
+    "no-useless-escape",
+    "no-useless-quantifier",
+    "prefer-named-backreference",
+    "no-useless-flag",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 35] = [
+pub const RULE_NAMES: [&str; 37] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -57,6 +57,8 @@ pub const RULE_NAMES: [&str; 35] = [
     "require-unicode-sets-regexp",
     "confusing-quantifier",
     "prefer-named-replacement",
+    "no-obscure-range",
+    "prefer-unicode-codepoint-escapes",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -3,10 +3,10 @@
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{
-    BraceQuantifierShape, class_contains_backspace_escape, class_has_useless_range,
-    class_is_digit_range, class_is_useless_single_literal, class_is_word_char_set,
-    class_matches_anything, find_class_end, group_prefix, is_zero_quantifier,
-    parse_brace_quantifier, skip_escape,
+    BraceQuantifierShape, class_contains_backspace_escape, class_first_obscure_range,
+    class_has_useless_range, class_is_digit_range, class_is_useless_single_literal,
+    class_is_word_char_set, class_matches_anything, find_class_end, group_prefix,
+    is_zero_quantifier, parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -86,6 +86,10 @@ pub(crate) struct PatternAnalysis {
     /// `{0,N}?`, `{0,}?`). Such quantifiers always prefer the empty match and
     /// rarely express the author's intent. `confusing-quantifier`.
     pub(crate) has_confusing_quantifier: bool,
+    /// First `X-Y` range whose endpoints cross ASCII character categories
+    /// (e.g. `A-z`). The captured chars are the original endpoints.
+    /// `no-obscure-range`.
+    pub(crate) first_obscure_range: Option<(char, char)>,
 }
 
 impl PatternAnalysis {
@@ -138,6 +142,11 @@ impl PatternAnalysis {
                             && let Some(ch) = class_is_useless_single_literal(bytes, index)
                         {
                             self.first_useless_single_literal_class = Some(ch);
+                        }
+                        if self.first_obscure_range.is_none()
+                            && let Some(range) = class_first_obscure_range(bytes, index)
+                        {
+                            self.first_obscure_range = Some(range);
                         }
                         self.mark_content(&mut groups);
                         index = close + 1;

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -3,10 +3,11 @@
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{
-    BraceQuantifierShape, class_contains_backspace_escape, class_first_obscure_range,
-    class_has_useless_range, class_is_digit_range, class_is_useless_single_literal,
-    class_is_word_char_set, class_matches_anything, find_class_end, group_prefix,
-    is_zero_quantifier, parse_brace_quantifier, skip_escape,
+    BraceQuantifierShape, class_contains_backspace_escape, class_first_collapsible_run,
+    class_first_duplicate_literal, class_first_obscure_range, class_has_useless_range,
+    class_is_digit_range, class_is_useless_single_literal, class_is_word_char_set,
+    class_matches_anything, find_class_end, group_prefix, is_zero_quantifier,
+    parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -90,6 +91,20 @@ pub(crate) struct PatternAnalysis {
     /// (e.g. `A-z`). The captured chars are the original endpoints.
     /// `no-obscure-range`.
     pub(crate) first_obscure_range: Option<(char, char)>,
+    /// First ASCII literal that appears more than once inside the same
+    /// `[...]` class. `no-dupe-characters-character-class`.
+    pub(crate) first_dupe_class_literal: Option<char>,
+    /// First run of three or more consecutive ASCII letters/digits inside the
+    /// same `[...]` class. `prefer-range`.
+    pub(crate) first_collapsible_run: Option<(char, char)>,
+    /// The pattern contains at least one unescaped `.` outside a character
+    /// class. Used by `no-useless-flag` to decide whether the `s` flag has
+    /// any effect.
+    pub(crate) has_unescaped_dot: bool,
+    /// The pattern contains at least one unescaped `^` or `$` outside a
+    /// character class. Used by `no-useless-flag` to decide whether the `m`
+    /// flag has any effect.
+    pub(crate) has_unescaped_anchor: bool,
 }
 
 impl PatternAnalysis {
@@ -147,6 +162,16 @@ impl PatternAnalysis {
                             && let Some(range) = class_first_obscure_range(bytes, index)
                         {
                             self.first_obscure_range = Some(range);
+                        }
+                        if self.first_dupe_class_literal.is_none()
+                            && let Some(byte) = class_first_duplicate_literal(bytes, index)
+                        {
+                            self.first_dupe_class_literal = Some(byte as char);
+                        }
+                        if self.first_collapsible_run.is_none()
+                            && let Some(run) = class_first_collapsible_run(bytes, index)
+                        {
+                            self.first_collapsible_run = Some(run);
                         }
                         self.mark_content(&mut groups);
                         index = close + 1;
@@ -241,7 +266,16 @@ impl PatternAnalysis {
                     }
                     index += 1;
                 }
-                b'+' | b'}' | b'^' | b'$' => {
+                b'^' | b'$' => {
+                    self.has_unescaped_anchor = true;
+                    index += 1;
+                }
+                b'+' | b'}' => {
+                    index += 1;
+                }
+                b'.' => {
+                    self.has_unescaped_dot = true;
+                    self.mark_content(&mut groups);
                     index += 1;
                 }
                 _ => {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -76,6 +76,8 @@ fn exposes_initial_regexp_rule_names() {
             "require-unicode-sets-regexp",
             "confusing-quantifier",
             "prefer-named-replacement",
+            "no-obscure-range",
+            "prefer-unicode-codepoint-escapes",
         ]
     );
 }
@@ -1282,6 +1284,69 @@ mod prefer_named_replacement {
         // Unrelated method.
         assert!(
             rule_ids_for("str.match(/(?<year>\\d{4})/u);", "prefer-named-replacement").is_empty()
+        );
+    }
+}
+
+mod no_obscure_range {
+    use super::*;
+
+    #[test]
+    fn reports_boundary_crossing_ranges() {
+        let data = first_data("const a = /[A-z]/u;", "no-obscure-range");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("A-z"));
+        assert_eq!(
+            rule_ids_for("const a = /[0-A]/u;", "no-obscure-range").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_canonical_within_category_ranges() {
+        assert!(rule_ids_for("const a = /[a-z]/u;", "no-obscure-range").is_empty());
+        assert!(rule_ids_for("const a = /[A-Z]/u;", "no-obscure-range").is_empty());
+        assert!(rule_ids_for("const a = /[0-9]/u;", "no-obscure-range").is_empty());
+        // Escaped endpoints are skipped — we cannot easily reason about them.
+        assert!(rule_ids_for("const a = /[\\x41-z]/u;", "no-obscure-range").is_empty());
+    }
+}
+
+mod prefer_unicode_codepoint_escapes {
+    use super::*;
+
+    #[test]
+    fn reports_surrogate_pairs() {
+        let data = first_data(
+            "const a = new RegExp('\\\\uD83D\\\\uDE00', 'u');",
+            "prefer-unicode-codepoint-escapes",
+        );
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\uD83D\\uDE00")
+        );
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\u{1f600}")
+        );
+    }
+
+    #[test]
+    fn ignores_non_surrogate_pairs_and_codepoint_escapes() {
+        // Two BMP unicode escapes are unrelated.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\u0041\\\\u0042', 'u');",
+                "prefer-unicode-codepoint-escapes"
+            )
+            .is_empty()
+        );
+        // Already the codepoint form.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\u{1F600}', 'u');",
+                "prefer-unicode-codepoint-escapes"
+            )
+            .is_empty()
         );
     }
 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -78,8 +78,40 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-named-replacement",
             "no-obscure-range",
             "prefer-unicode-codepoint-escapes",
+            "no-dupe-characters-character-class",
+            "prefer-range",
+            "no-useless-escape",
+            "no-useless-quantifier",
+            "prefer-named-backreference",
+            "no-useless-flag",
         ]
     );
+}
+
+mod no_useless_flag {
+    use super::*;
+
+    #[test]
+    fn reports_s_flag_on_dotless_patterns() {
+        let data = first_data("const a = new RegExp('abc', 's');", "no-useless-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("s"));
+    }
+
+    #[test]
+    fn reports_m_flag_on_anchorless_patterns() {
+        let data = first_data("const a = new RegExp('abc', 'm');", "no-useless-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("m"));
+    }
+
+    #[test]
+    fn accepts_flag_when_pattern_uses_the_corresponding_syntax() {
+        // `.` makes the `s` flag meaningful.
+        assert!(rule_ids_for("const a = new RegExp('a.b', 's');", "no-useless-flag").is_empty());
+        // `^` makes the `m` flag meaningful.
+        assert!(rule_ids_for("const a = new RegExp('^abc', 'm');", "no-useless-flag").is_empty());
+        // `$` at end activates the `m` flag.
+        assert!(rule_ids_for("const a = new RegExp('abc$', 'm');", "no-useless-flag").is_empty());
+    }
 }
 
 mod no_optional_assertion {
@@ -1347,6 +1379,146 @@ mod prefer_unicode_codepoint_escapes {
                 "prefer-unicode-codepoint-escapes"
             )
             .is_empty()
+        );
+    }
+}
+
+mod no_dupe_characters_character_class {
+    use super::*;
+
+    #[test]
+    fn reports_duplicate_literal_characters() {
+        let data = first_data("const a = /[aab]/u;", "no-dupe-characters-character-class");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("a"));
+        // Reordered or with surrounding chars still reports.
+        assert_eq!(
+            rule_ids_for("const a = /[xaya]/u;", "no-dupe-characters-character-class").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_unique_literals_ranges_and_escapes() {
+        assert!(
+            rule_ids_for("const a = /[abc]/u;", "no-dupe-characters-character-class").is_empty()
+        );
+        // Range `a-c` is not a duplicate of `a`.
+        assert!(
+            rule_ids_for("const a = /[a-c]/u;", "no-dupe-characters-character-class").is_empty()
+        );
+        // Escapes are skipped; `\\d\\d` is not flagged.
+        assert!(
+            rule_ids_for(
+                "const a = /[\\d\\d]/u;",
+                "no-dupe-characters-character-class"
+            )
+            .is_empty()
+        );
+    }
+}
+
+mod prefer_range {
+    use super::*;
+
+    #[test]
+    fn reports_three_or_more_consecutive_literals() {
+        let data = first_data("const a = /[abc]/u;", "prefer-range");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("abc"));
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("a-c")
+        );
+        // Digits collapse just like letters.
+        assert_eq!(
+            rule_ids_for("const a = /[12345]/u;", "prefer-range").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_short_runs_and_existing_ranges() {
+        assert!(rule_ids_for("const a = /[ab]/u;", "prefer-range").is_empty());
+        // A range already covers the chars; no further reduction needed.
+        assert!(rule_ids_for("const a = /[a-c]/u;", "prefer-range").is_empty());
+        // Non-consecutive bytes break the run.
+        assert!(rule_ids_for("const a = /[acd]/u;", "prefer-range").is_empty());
+    }
+}
+
+mod no_useless_escape {
+    use super::*;
+
+    #[test]
+    fn reports_pointless_escapes_outside_classes() {
+        let data = first_data("const a = /\\:/u;", "no-useless-escape");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\:"));
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some(":")
+        );
+        // Other punctuation variants.
+        assert_eq!(
+            rule_ids_for("const a = /a\\@b/u;", "no-useless-escape").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /\\#/u;", "no-useless-escape").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_known_escape_sequences_and_class_contents() {
+        // Real escapes are untouched.
+        assert!(rule_ids_for("const a = /\\d/u;", "no-useless-escape").is_empty());
+        assert!(rule_ids_for("const a = /\\b/u;", "no-useless-escape").is_empty());
+        assert!(rule_ids_for("const a = /\\./u;", "no-useless-escape").is_empty());
+        // Inside a character class — deferred to keep the check sound.
+        assert!(rule_ids_for("const a = /[\\:]/u;", "no-useless-escape").is_empty());
+    }
+}
+
+mod no_useless_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_one_braced_quantifiers() {
+        let data = first_data("const a = /a{1}/u;", "no-useless-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{1}"));
+        let data = first_data("const a = /a{1,1}/u;", "no-useless-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{1,1}"));
+    }
+
+    #[test]
+    fn ignores_other_quantifiers_and_class_contexts() {
+        assert!(rule_ids_for("const a = /a{2}/u;", "no-useless-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{1,3}/u;", "no-useless-quantifier").is_empty());
+        // `{1}` inside a class is literal characters, not a quantifier.
+        assert!(rule_ids_for("const a = /[{1}]/u;", "no-useless-quantifier").is_empty());
+    }
+}
+
+mod prefer_named_backreference {
+    use super::*;
+
+    #[test]
+    fn reports_numbered_backreference_alongside_named_capture() {
+        let data = first_data(
+            "const a = /(?<year>\\d{4})-\\1/u;",
+            "prefer-named-backreference",
+        );
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\1"));
+    }
+
+    #[test]
+    fn ignores_numbered_backref_without_named_group_and_class_contents() {
+        // No named capture in the pattern — \1 is the only way to refer back.
+        assert!(
+            rule_ids_for("const a = /(\\d{4})-\\1/u;", "prefer-named-backreference").is_empty()
+        );
+        // \1 inside a character class is literal, not a backreference.
+        assert!(
+            rule_ids_for("const a = /(?<n>a)[\\1b]/u;", "prefer-named-backreference").is_empty()
         );
     }
 }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -142,6 +142,27 @@ const messages = Object.freeze({
     unexpected:
       "Unexpected surrogate-pair escape '{{expr}}'. Use the unicode code-point escape '{{replacement}}' instead.",
   },
+  'no-dupe-characters-character-class': {
+    unexpected: "Duplicate character '{{expr}}' in a character class.",
+  },
+  'prefer-range': {
+    unexpected: "Unexpected consecutive characters '{{expr}}'. Use '{{replacement}}' instead.",
+  },
+  'no-useless-escape': {
+    unexpected:
+      "Unnecessary escape '{{expr}}'. Use '{{replacement}}' instead — the character has no special meaning here.",
+  },
+  'no-useless-quantifier': {
+    unexpected: "Unexpected quantifier '{{expr}}' that matches exactly once and can be removed.",
+  },
+  'prefer-named-backreference': {
+    unexpected:
+      "Numbered backreference '{{expr}}' is used alongside a named capture group; prefer a named backreference `\\k<name>`.",
+  },
+  'no-useless-flag': {
+    unexpected:
+      "Unexpected useless flag '{{flag}}'; the pattern does not use the syntax this flag affects.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -191,6 +212,16 @@ const ruleDescriptions = Object.freeze({
     'disallow character class ranges that cross ASCII category boundaries (digits/uppercase/lowercase)',
   'prefer-unicode-codepoint-escapes':
     'enforce using `\\u{H+}` over surrogate-pair `\\uHHHH\\uHHHH` escapes',
+  'no-dupe-characters-character-class':
+    'disallow duplicate literal characters in a character class',
+  'prefer-range': 'enforce using a range (`a-c`) instead of three or more consecutive characters',
+  'no-useless-escape': 'disallow escape sequences that have no effect on the matched character',
+  'no-useless-quantifier':
+    'disallow `{1}` and `{1,1}` quantifiers (they match exactly once and can be removed)',
+  'prefer-named-backreference':
+    'enforce using named backreferences (`\\k<name>`) when the pattern has named capture groups',
+  'no-useless-flag':
+    'disallow regular-expression flags that have no effect on the pattern (narrow: `s` without `.`, `m` without `^`/`$`)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -230,6 +261,12 @@ const ruleTypes = Object.freeze({
   'prefer-named-replacement': 'suggestion',
   'no-obscure-range': 'suggestion',
   'prefer-unicode-codepoint-escapes': 'suggestion',
+  'no-dupe-characters-character-class': 'problem',
+  'prefer-range': 'suggestion',
+  'no-useless-escape': 'suggestion',
+  'no-useless-quantifier': 'suggestion',
+  'prefer-named-backreference': 'suggestion',
+  'no-useless-flag': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -346,7 +383,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-lookarounds-assertion' ||
     ruleName === 'no-missing-g-flag' ||
     ruleName === 'no-empty-string-literal' ||
-    ruleName === 'no-optional-assertion'
+    ruleName === 'no-optional-assertion' ||
+    ruleName === 'no-dupe-characters-character-class'
   ) {
     return 'Possible Errors';
   }
@@ -370,7 +408,12 @@ function ruleCategory(ruleName) {
     ruleName === 'confusing-quantifier' ||
     ruleName === 'prefer-named-replacement' ||
     ruleName === 'no-obscure-range' ||
-    ruleName === 'prefer-unicode-codepoint-escapes'
+    ruleName === 'prefer-unicode-codepoint-escapes' ||
+    ruleName === 'prefer-range' ||
+    ruleName === 'no-useless-escape' ||
+    ruleName === 'no-useless-quantifier' ||
+    ruleName === 'prefer-named-backreference' ||
+    ruleName === 'no-useless-flag'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -134,6 +134,14 @@ const messages = Object.freeze({
     unexpected:
       'Use a named-group replacement (`$<name>`) instead of a numbered backreference when the regular expression has named capture groups.',
   },
+  'no-obscure-range': {
+    unexpected:
+      "Unexpected character class range '{{expr}}' crosses character category boundaries.",
+  },
+  'prefer-unicode-codepoint-escapes': {
+    unexpected:
+      "Unexpected surrogate-pair escape '{{expr}}'. Use the unicode code-point escape '{{replacement}}' instead.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -179,6 +187,10 @@ const ruleDescriptions = Object.freeze({
     'disallow lazy quantifiers (`*?`, `??`, `{0,}?`, `{0,1}?`) whose minimum is zero',
   'prefer-named-replacement':
     'enforce using named-group replacements (`$<name>`) when the regular expression has named captures',
+  'no-obscure-range':
+    'disallow character class ranges that cross ASCII category boundaries (digits/uppercase/lowercase)',
+  'prefer-unicode-codepoint-escapes':
+    'enforce using `\\u{H+}` over surrogate-pair `\\uHHHH\\uHHHH` escapes',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -216,6 +228,8 @@ const ruleTypes = Object.freeze({
   'require-unicode-sets-regexp': 'suggestion',
   'confusing-quantifier': 'suggestion',
   'prefer-named-replacement': 'suggestion',
+  'no-obscure-range': 'suggestion',
+  'prefer-unicode-codepoint-escapes': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -354,7 +368,9 @@ function ruleCategory(ruleName) {
     ruleName === 'no-useless-range' ||
     ruleName === 'no-useless-character-class' ||
     ruleName === 'confusing-quantifier' ||
-    ruleName === 'prefer-named-replacement'
+    ruleName === 'prefer-named-replacement' ||
+    ruleName === 'no-obscure-range' ||
+    ruleName === 'prefer-unicode-codepoint-escapes'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -42,6 +42,12 @@ describe('regexp native API', () => {
       'prefer-named-replacement',
       'no-obscure-range',
       'prefer-unicode-codepoint-escapes',
+      'no-dupe-characters-character-class',
+      'prefer-range',
+      'no-useless-escape',
+      'no-useless-quantifier',
+      'prefer-named-backreference',
+      'no-useless-flag',
     ]);
   });
 
@@ -56,10 +62,12 @@ describe('regexp native API', () => {
     );
 
     expect(diagnostics.map((diagnostic) => [diagnostic.ruleName, diagnostic.messageId])).toEqual([
-      // /[]/mi — flag style + pattern checks all fire.
+      // /[]/mi — flag style + pattern checks all fire. The `m` flag is also
+      // useless because the pattern has no unescaped `^` or `$`.
       ['sort-flags', 'sortFlags'],
       ['require-unicode-regexp', 'require'],
       ['require-unicode-sets-regexp', 'require'],
+      ['no-useless-flag', 'unexpected'],
       ['no-empty-character-class', 'empty'],
       // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
@@ -74,7 +82,7 @@ describe('regexp native API', () => {
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[6].data.charText).toBe('U+0001');
+    expect(diagnostics[7].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {
@@ -94,10 +102,11 @@ describe('regexp native API', () => {
 
   it('returns no diagnostics for clean sources', () => {
     // Sources that use the `v` flag stay quiet because `require-unicode-sets-regexp`
-    // is the only flag-style rule that targets that flag specifically; everything
-    // else needs an unrelated pattern issue.
+    // is the only flag-style rule that targets that flag specifically; the other
+    // flags must also avoid `no-useless-flag` — `s` needs an unescaped `.`, `m`
+    // needs `^` or `$`, so we keep the flag set narrow.
     expect(scanRegexp('const re = /a+/v;\n', 'fixture.js')).toEqual([]);
-    expect(scanRegexp("const re = new RegExp('a', 'gimsv');\n", 'fixture.js')).toEqual([]);
+    expect(scanRegexp("const re = new RegExp('a', 'giv');\n", 'fixture.js')).toEqual([]);
   });
 
   it('returns no diagnostics when the source fails to parse', () => {

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -40,6 +40,8 @@ describe('regexp native API', () => {
       'require-unicode-sets-regexp',
       'confusing-quantifier',
       'prefer-named-replacement',
+      'no-obscure-range',
+      'prefer-unicode-codepoint-escapes',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -191,6 +191,16 @@ const invalidCases = [
     "str.replaceAll(/(?<year>\\d{4})/gu, 'year: $1');\n",
     ['unexpected'],
   ],
+  // no-obscure-range
+  ['no-obscure-range', 'A-z range', 'const re = /[A-z]/u;\n', ['unexpected']],
+  ['no-obscure-range', '0-A range', 'const re = /[0-A]/u;\n', ['unexpected']],
+  // prefer-unicode-codepoint-escapes
+  [
+    'prefer-unicode-codepoint-escapes',
+    'surrogate pair',
+    "const re = new RegExp('\\\\uD83D\\\\uDE00', 'u');\n",
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -201,6 +201,32 @@ const invalidCases = [
     "const re = new RegExp('\\\\uD83D\\\\uDE00', 'u');\n",
     ['unexpected'],
   ],
+  // no-dupe-characters-character-class
+  [
+    'no-dupe-characters-character-class',
+    'literal duplicate',
+    'const re = /[aab]/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-range
+  ['prefer-range', 'three consecutive letters', 'const re = /[abc]/u;\n', ['unexpected']],
+  ['prefer-range', 'five consecutive digits', 'const re = /[12345]/u;\n', ['unexpected']],
+  // no-useless-escape
+  ['no-useless-escape', 'escaped colon', 'const re = /\\:/u;\n', ['unexpected']],
+  ['no-useless-escape', 'escaped at sign', 'const re = /a\\@b/u;\n', ['unexpected']],
+  // no-useless-quantifier
+  ['no-useless-quantifier', 'a{1}', 'const re = /a{1}/u;\n', ['unexpected']],
+  ['no-useless-quantifier', 'a{1,1}', 'const re = /a{1,1}/u;\n', ['unexpected']],
+  // prefer-named-backreference
+  [
+    'prefer-named-backreference',
+    'mixed numbered backref',
+    'const re = /(?<year>\\d{4})-\\1/u;\n',
+    ['unexpected'],
+  ],
+  // no-useless-flag
+  ['no-useless-flag', 's without dot', "const re = new RegExp('abc', 's');\n", ['unexpected']],
+  ['no-useless-flag', 'm without anchor', "const re = new RegExp('abc', 'm');\n", ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8715,19 +8715,19 @@
       },
       {
         "name": "no-dupe-characters-character-class",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-dupe-characters-character-class."
+        "notes": "Class-level scan via class_first_duplicate_literal: walks the class body with a 128-bit on-stack bitmap; skips escapes and ranges so it never false-positives on `\\\\d\\\\d` or `a-c`. Reports the first ASCII literal that appears twice."
       },
       {
         "name": "no-dupe-disjunctions",
@@ -9131,35 +9131,35 @@
       },
       {
         "name": "no-useless-escape",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-escape."
+        "notes": "Pattern-level scan via first_useless_escape: walks the pattern bytes, skips any [...] class via find_class_end, and reports the first \\X where X is in a curated list of punctuation chars that have no special meaning at top level (colon/semicolon/comma/equals/bang/hash/at/lt/gt/ampersand/underscore/percent/tilde/quote/dquote/slash). Known escape sequences and escapes inside classes are deferred."
       },
       {
         "name": "no-useless-flag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-flag."
+        "notes": "PatternAnalysis gains has_unescaped_dot and has_unescaped_anchor (set by the existing walker on `.` / `^` / `$` outside character classes). After scanning, the rule consults the flags string: `s` without `.` is inert, and `m` without `^`/`$` is inert. Other flags (`i`, etc.) are deferred — they need richer letter/case analysis."
       },
       {
         "name": "no-useless-lazy",
@@ -9195,19 +9195,19 @@
       },
       {
         "name": "no-useless-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-quantifier."
+        "notes": "Pattern-level scan via first_useless_one_quantifier: walks the pattern bytes, skips classes via find_class_end, and reports the first literal `{1}` or `{1,1}` at top level. Other quantifiers with min=max=1 forms beyond these two are deferred."
       },
       {
         "name": "no-useless-range",
@@ -9371,19 +9371,19 @@
       },
       {
         "name": "prefer-named-backreference",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-named-backreference."
+        "notes": "Pattern-level scan via first_numbered_backreference_with_named_group: gates on the presence of `(?<` (named capture) anywhere in the pattern, then walks for `\\N` (N in 1-9) outside classes. Classes are skipped because `\\1` is literal there."
       },
       {
         "name": "prefer-named-capture-group",
@@ -9483,19 +9483,19 @@
       },
       {
         "name": "prefer-range",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-range."
+        "notes": "Class-level scan via class_first_collapsible_run finds three or more consecutive ASCII letters/digits at the top level of a class and reports them with the equivalent `a-c`-style replacement. Escapes and existing ranges are skipped to keep the check conservative."
       },
       {
         "name": "prefer-regexp-exec",

--- a/status.json
+++ b/status.json
@@ -8923,19 +8923,19 @@
       },
       {
         "name": "no-obscure-range",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-obscure-range."
+        "notes": "Class-level scan via class_first_obscure_range flags `X-Y` ranges whose endpoints cross ASCII category boundaries (digit / uppercase / lowercase / other). Escaped endpoints are skipped because their equivalence is hard to judge without decoding. The check stays sound (no false positives on within-category ranges)."
       },
       {
         "name": "no-optional-assertion",
@@ -9579,19 +9579,19 @@
       },
       {
         "name": "prefer-unicode-codepoint-escapes",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-unicode-codepoint-escapes."
+        "notes": "Pattern-level scan via first_surrogate_pair_escape detects `\\uHHHH\\uHHHH` pairs where the first hex is a high surrogate (D800-DBFF) and the second a low surrogate (DC00-DFFF). The diagnostic carries the original pair and the `\\u{H+}` codepoint replacement."
       },
       {
         "name": "prefer-w",


### PR DESCRIPTION
Stacked on top of #80. Regexp port **35 → 37 / 82** once the chain lands.

## How it works

- `no-obscure-range`: a new `class_first_obscure_range` helper walks each `[...]` once and reports the first `X-Y` range whose endpoints cross ASCII category boundaries (digit / uppercase / lowercase / other). The canonical case is `[A-z]`, which silently sweeps up `[\]^_` between `Z` and `a`. Escaped or `]`-terminated endpoints are skipped because their equivalence is hard to judge without decoding the escape; this keeps the check sound (no false positives).
- `prefer-unicode-codepoint-escapes`: a new `first_surrogate_pair_escape` helper scans the pattern source via the existing `skip_escape` walker and detects `\uHHHH\uHHHH` pairs where the first hex is a high surrogate (`D800-DBFF`) and the second a low surrogate (`DC00-DFFF`). The diagnostic carries the original pair and the `\u{H+}` codepoint replacement (hex digits in lower case to match `letter-case`'s default).

`PatternAnalysis` gains `first_obscure_range`. Both checks reuse existing primitives, so no new full-pattern walk is added.

## Verification

- 90 Rust unit tests pass (4 new across the two rule modules)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- 79 workspace Rust suites pass
- Vitest plugin tests gain 9 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 37 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs. The existing `CompactString`/`SmallVec`/file-level-scan policy is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->