### PR TITLE
port(regexp): port no-useless-quantifier and prefer-named-backreference

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -12,8 +12,9 @@ use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
     duplicate_flag, first_control_character, first_fixed_unicode_escape, first_hex_x_escape,
-    first_invisible_character, first_non_standard_flag, first_octal_escape,
-    first_surrogate_pair_escape, first_uppercase_hex_escape, first_useless_escape, mention_char,
+    first_invisible_character, first_non_standard_flag,
+    first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
+    first_uppercase_hex_escape, first_useless_escape, first_useless_one_quantifier, mention_char,
     pattern_has_empty_string_literal, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
@@ -625,6 +626,28 @@ impl<'a> Scanner<'a> {
                 DiagnosticData {
                     expr: Some(original),
                     replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(text) = first_useless_one_quantifier(pattern) {
+            self.report_with_data(
+                "no-useless-quantifier",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(text)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(text) = first_numbered_backreference_with_named_group(pattern) {
+            self.report_with_data(
+                "prefer-named-backreference",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(text)),
                     ..DiagnosticData::default()
                 },
                 span,

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -312,7 +312,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.check_flag_style(flags, span);
-        self.check_pattern_rules(pattern, span);
+        self.check_pattern_rules(pattern, flags, span);
     }
 
     #[allow(
@@ -364,9 +364,41 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn check_pattern_rules(&mut self, pattern: &str, span: Span) {
+    fn check_pattern_rules(&mut self, pattern: &str, flags: &str, span: Span) {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern);
+
+        // `no-useless-flag` (narrow form): the `s` flag only affects the
+        // matching of `.`; the `m` flag only affects `^` and `$`. If neither
+        // syntax appears in the pattern, the flag is provably inert. Other
+        // useless-flag shapes (e.g. `i` on a pattern with no letters) are
+        // intentionally deferred — they need a richer case-class analysis.
+        if flags.contains('s') && !analysis.has_unescaped_dot {
+            let mut text = CompactString::new("");
+            text.push('s');
+            self.report_with_data(
+                "no-useless-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if flags.contains('m') && !analysis.has_unescaped_anchor {
+            let mut text = CompactString::new("");
+            text.push('m');
+            self.report_with_data(
+                "no-useless-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -766,6 +766,76 @@ fn append_lower_hex(target: &mut CompactString, mut value: u32) {
     }
 }
 
+/// Returns `Some(original)` when the pattern contains a literal `{1}` or
+/// `{1,1}` quantifier at the top level. Such quantifiers are no-ops; the
+/// referenced atom matches itself exactly once anyway. Class context is
+/// skipped because `{` and `1` are literal characters inside `[...]`. Used by
+/// `no-useless-quantifier`.
+pub(crate) fn first_useless_one_quantifier(pattern: &str) -> Option<&str> {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'[' {
+            if let Some(close) = find_class_end(bytes, index) {
+                index = close + 1;
+                continue;
+            }
+            return None;
+        }
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
+        }
+        if bytes[index] == b'{' && bytes.get(index + 1) == Some(&b'1') {
+            if bytes.get(index + 2) == Some(&b'}') {
+                return Some(&pattern[index..index + 3]);
+            }
+            if bytes.get(index + 2) == Some(&b',')
+                && bytes.get(index + 3) == Some(&b'1')
+                && bytes.get(index + 4) == Some(&b'}')
+            {
+                return Some(&pattern[index..index + 5]);
+            }
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Returns `Some(text)` for the first numbered backreference `\N` (N in 1-9)
+/// inside `pattern` when the same pattern contains at least one named capture
+/// group `(?<name>...)`. Numbered backreferences alongside named groups are
+/// the canonical case for `prefer-named-backreference`. Backreferences inside
+/// classes are skipped because they are literal characters there.
+pub(crate) fn first_numbered_backreference_with_named_group(pattern: &str) -> Option<&str> {
+    let bytes = pattern.as_bytes();
+    if !pattern.contains("(?<") {
+        return None;
+    }
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'[' {
+            if let Some(close) = find_class_end(bytes, index) {
+                index = close + 1;
+                continue;
+            }
+            return None;
+        }
+        if bytes[index] == b'\\'
+            && let Some(&next) = bytes.get(index + 1)
+            && matches!(next, b'1'..=b'9')
+        {
+            return Some(&pattern[index..index + 2]);
+        }
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
+        }
+        index += 1;
+    }
+    None
+}
+
 /// Returns `Some(byte)` for the first escape `\X` in `pattern` where `X` is
 /// a character that is never special in a regular expression (not in a
 /// character class either), so the `\` is useless. Stays narrow on purpose:

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 42] = [
+pub const RULE_NAMES: [&str; 43] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -64,6 +64,7 @@ pub const RULE_NAMES: [&str; 42] = [
     "no-useless-escape",
     "no-useless-quantifier",
     "prefer-named-backreference",
+    "no-useless-flag",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 40] = [
+pub const RULE_NAMES: [&str; 42] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -62,6 +62,8 @@ pub const RULE_NAMES: [&str; 40] = [
     "no-dupe-characters-character-class",
     "prefer-range",
     "no-useless-escape",
+    "no-useless-quantifier",
+    "prefer-named-backreference",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -97,6 +97,14 @@ pub(crate) struct PatternAnalysis {
     /// First run of three or more consecutive ASCII letters/digits inside the
     /// same `[...]` class. `prefer-range`.
     pub(crate) first_collapsible_run: Option<(char, char)>,
+    /// The pattern contains at least one unescaped `.` outside a character
+    /// class. Used by `no-useless-flag` to decide whether the `s` flag has
+    /// any effect.
+    pub(crate) has_unescaped_dot: bool,
+    /// The pattern contains at least one unescaped `^` or `$` outside a
+    /// character class. Used by `no-useless-flag` to decide whether the `m`
+    /// flag has any effect.
+    pub(crate) has_unescaped_anchor: bool,
 }
 
 impl PatternAnalysis {
@@ -258,7 +266,16 @@ impl PatternAnalysis {
                     }
                     index += 1;
                 }
-                b'+' | b'}' | b'^' | b'$' => {
+                b'^' | b'$' => {
+                    self.has_unescaped_anchor = true;
+                    index += 1;
+                }
+                b'+' | b'}' => {
+                    index += 1;
+                }
+                b'.' => {
+                    self.has_unescaped_dot = true;
+                    self.mark_content(&mut groups);
                     index += 1;
                 }
                 _ => {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -81,6 +81,8 @@ fn exposes_initial_regexp_rule_names() {
             "no-dupe-characters-character-class",
             "prefer-range",
             "no-useless-escape",
+            "no-useless-quantifier",
+            "prefer-named-backreference",
         ]
     );
 }
@@ -1446,6 +1448,51 @@ mod no_useless_escape {
         assert!(rule_ids_for("const a = /\\./u;", "no-useless-escape").is_empty());
         // Inside a character class — deferred to keep the check sound.
         assert!(rule_ids_for("const a = /[\\:]/u;", "no-useless-escape").is_empty());
+    }
+}
+
+mod no_useless_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_one_braced_quantifiers() {
+        let data = first_data("const a = /a{1}/u;", "no-useless-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{1}"));
+        let data = first_data("const a = /a{1,1}/u;", "no-useless-quantifier");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("{1,1}"));
+    }
+
+    #[test]
+    fn ignores_other_quantifiers_and_class_contexts() {
+        assert!(rule_ids_for("const a = /a{2}/u;", "no-useless-quantifier").is_empty());
+        assert!(rule_ids_for("const a = /a{1,3}/u;", "no-useless-quantifier").is_empty());
+        // `{1}` inside a class is literal characters, not a quantifier.
+        assert!(rule_ids_for("const a = /[{1}]/u;", "no-useless-quantifier").is_empty());
+    }
+}
+
+mod prefer_named_backreference {
+    use super::*;
+
+    #[test]
+    fn reports_numbered_backreference_alongside_named_capture() {
+        let data = first_data(
+            "const a = /(?<year>\\d{4})-\\1/u;",
+            "prefer-named-backreference",
+        );
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\1"));
+    }
+
+    #[test]
+    fn ignores_numbered_backref_without_named_group_and_class_contents() {
+        // No named capture in the pattern — \1 is the only way to refer back.
+        assert!(
+            rule_ids_for("const a = /(\\d{4})-\\1/u;", "prefer-named-backreference").is_empty()
+        );
+        // \1 inside a character class is literal, not a backreference.
+        assert!(
+            rule_ids_for("const a = /(?<n>a)[\\1b]/u;", "prefer-named-backreference").is_empty()
+        );
     }
 }
 

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -83,8 +83,35 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-escape",
             "no-useless-quantifier",
             "prefer-named-backreference",
+            "no-useless-flag",
         ]
     );
+}
+
+mod no_useless_flag {
+    use super::*;
+
+    #[test]
+    fn reports_s_flag_on_dotless_patterns() {
+        let data = first_data("const a = new RegExp('abc', 's');", "no-useless-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("s"));
+    }
+
+    #[test]
+    fn reports_m_flag_on_anchorless_patterns() {
+        let data = first_data("const a = new RegExp('abc', 'm');", "no-useless-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("m"));
+    }
+
+    #[test]
+    fn accepts_flag_when_pattern_uses_the_corresponding_syntax() {
+        // `.` makes the `s` flag meaningful.
+        assert!(rule_ids_for("const a = new RegExp('a.b', 's');", "no-useless-flag").is_empty());
+        // `^` makes the `m` flag meaningful.
+        assert!(rule_ids_for("const a = new RegExp('^abc', 'm');", "no-useless-flag").is_empty());
+        // `$` at end activates the `m` flag.
+        assert!(rule_ids_for("const a = new RegExp('abc$', 'm');", "no-useless-flag").is_empty());
+    }
 }
 
 mod no_optional_assertion {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -152,6 +152,13 @@ const messages = Object.freeze({
     unexpected:
       "Unnecessary escape '{{expr}}'. Use '{{replacement}}' instead — the character has no special meaning here.",
   },
+  'no-useless-quantifier': {
+    unexpected: "Unexpected quantifier '{{expr}}' that matches exactly once and can be removed.",
+  },
+  'prefer-named-backreference': {
+    unexpected:
+      "Numbered backreference '{{expr}}' is used alongside a named capture group; prefer a named backreference `\\k<name>`.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -205,6 +212,10 @@ const ruleDescriptions = Object.freeze({
     'disallow duplicate literal characters in a character class',
   'prefer-range': 'enforce using a range (`a-c`) instead of three or more consecutive characters',
   'no-useless-escape': 'disallow escape sequences that have no effect on the matched character',
+  'no-useless-quantifier':
+    'disallow `{1}` and `{1,1}` quantifiers (they match exactly once and can be removed)',
+  'prefer-named-backreference':
+    'enforce using named backreferences (`\\k<name>`) when the pattern has named capture groups',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -247,6 +258,8 @@ const ruleTypes = Object.freeze({
   'no-dupe-characters-character-class': 'problem',
   'prefer-range': 'suggestion',
   'no-useless-escape': 'suggestion',
+  'no-useless-quantifier': 'suggestion',
+  'prefer-named-backreference': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -390,7 +403,9 @@ function ruleCategory(ruleName) {
     ruleName === 'no-obscure-range' ||
     ruleName === 'prefer-unicode-codepoint-escapes' ||
     ruleName === 'prefer-range' ||
-    ruleName === 'no-useless-escape'
+    ruleName === 'no-useless-escape' ||
+    ruleName === 'no-useless-quantifier' ||
+    ruleName === 'prefer-named-backreference'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -159,6 +159,10 @@ const messages = Object.freeze({
     unexpected:
       "Numbered backreference '{{expr}}' is used alongside a named capture group; prefer a named backreference `\\k<name>`.",
   },
+  'no-useless-flag': {
+    unexpected:
+      "Unexpected useless flag '{{flag}}'; the pattern does not use the syntax this flag affects.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -216,6 +220,8 @@ const ruleDescriptions = Object.freeze({
     'disallow `{1}` and `{1,1}` quantifiers (they match exactly once and can be removed)',
   'prefer-named-backreference':
     'enforce using named backreferences (`\\k<name>`) when the pattern has named capture groups',
+  'no-useless-flag':
+    'disallow regular-expression flags that have no effect on the pattern (narrow: `s` without `.`, `m` without `^`/`$`)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -260,6 +266,7 @@ const ruleTypes = Object.freeze({
   'no-useless-escape': 'suggestion',
   'no-useless-quantifier': 'suggestion',
   'prefer-named-backreference': 'suggestion',
+  'no-useless-flag': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -405,7 +412,8 @@ function ruleCategory(ruleName) {
     ruleName === 'prefer-range' ||
     ruleName === 'no-useless-escape' ||
     ruleName === 'no-useless-quantifier' ||
-    ruleName === 'prefer-named-backreference'
+    ruleName === 'prefer-named-backreference' ||
+    ruleName === 'no-useless-flag'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -45,6 +45,8 @@ describe('regexp native API', () => {
       'no-dupe-characters-character-class',
       'prefer-range',
       'no-useless-escape',
+      'no-useless-quantifier',
+      'prefer-named-backreference',
     ]);
   });
 

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -47,6 +47,7 @@ describe('regexp native API', () => {
       'no-useless-escape',
       'no-useless-quantifier',
       'prefer-named-backreference',
+      'no-useless-flag',
     ]);
   });
 
@@ -61,10 +62,12 @@ describe('regexp native API', () => {
     );
 
     expect(diagnostics.map((diagnostic) => [diagnostic.ruleName, diagnostic.messageId])).toEqual([
-      // /[]/mi — flag style + pattern checks all fire.
+      // /[]/mi — flag style + pattern checks all fire. The `m` flag is also
+      // useless because the pattern has no unescaped `^` or `$`.
       ['sort-flags', 'sortFlags'],
       ['require-unicode-regexp', 'require'],
       ['require-unicode-sets-regexp', 'require'],
+      ['no-useless-flag', 'unexpected'],
       ['no-empty-character-class', 'empty'],
       // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
@@ -79,7 +82,7 @@ describe('regexp native API', () => {
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[6].data.charText).toBe('U+0001');
+    expect(diagnostics[7].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {
@@ -99,10 +102,11 @@ describe('regexp native API', () => {
 
   it('returns no diagnostics for clean sources', () => {
     // Sources that use the `v` flag stay quiet because `require-unicode-sets-regexp`
-    // is the only flag-style rule that targets that flag specifically; everything
-    // else needs an unrelated pattern issue.
+    // is the only flag-style rule that targets that flag specifically; the other
+    // flags must also avoid `no-useless-flag` — `s` needs an unescaped `.`, `m`
+    // needs `^` or `$`, so we keep the flag set narrow.
     expect(scanRegexp('const re = /a+/v;\n', 'fixture.js')).toEqual([]);
-    expect(scanRegexp("const re = new RegExp('a', 'gimsv');\n", 'fixture.js')).toEqual([]);
+    expect(scanRegexp("const re = new RegExp('a', 'giv');\n", 'fixture.js')).toEqual([]);
   });
 
   it('returns no diagnostics when the source fails to parse', () => {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -214,6 +214,16 @@ const invalidCases = [
   // no-useless-escape
   ['no-useless-escape', 'escaped colon', 'const re = /\\:/u;\n', ['unexpected']],
   ['no-useless-escape', 'escaped at sign', 'const re = /a\\@b/u;\n', ['unexpected']],
+  // no-useless-quantifier
+  ['no-useless-quantifier', 'a{1}', 'const re = /a{1}/u;\n', ['unexpected']],
+  ['no-useless-quantifier', 'a{1,1}', 'const re = /a{1,1}/u;\n', ['unexpected']],
+  // prefer-named-backreference
+  [
+    'prefer-named-backreference',
+    'mixed numbered backref',
+    'const re = /(?<year>\\d{4})-\\1/u;\n',
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -224,6 +224,9 @@ const invalidCases = [
     'const re = /(?<year>\\d{4})-\\1/u;\n',
     ['unexpected'],
   ],
+  // no-useless-flag
+  ['no-useless-flag', 's without dot', "const re = new RegExp('abc', 's');\n", ['unexpected']],
+  ['no-useless-flag', 'm without anchor', "const re = new RegExp('abc', 'm');\n", ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9147,19 +9147,19 @@
       },
       {
         "name": "no-useless-flag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-flag."
+        "notes": "PatternAnalysis gains has_unescaped_dot and has_unescaped_anchor (set by the existing walker on `.` / `^` / `$` outside character classes). After scanning, the rule consults the flags string: `s` without `.` is inert, and `m` without `^`/`$` is inert. Other flags (`i`, etc.) are deferred — they need richer letter/case analysis."
       },
       {
         "name": "no-useless-lazy",

--- a/status.json
+++ b/status.json
@@ -9195,19 +9195,19 @@
       },
       {
         "name": "no-useless-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-quantifier."
+        "notes": "Pattern-level scan via first_useless_one_quantifier: walks the pattern bytes, skips classes via find_class_end, and reports the first literal `{1}` or `{1,1}` at top level. Other quantifiers with min=max=1 forms beyond these two are deferred."
       },
       {
         "name": "no-useless-range",
@@ -9371,19 +9371,19 @@
       },
       {
         "name": "prefer-named-backreference",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-named-backreference."
+        "notes": "Pattern-level scan via first_numbered_backreference_with_named_group: gates on the presence of `(?<` (named capture) anywhere in the pattern, then walks for `\\N` (N in 1-9) outside classes. Classes are skipped because `\\1` is literal there."
       },
       {
         "name": "prefer-named-capture-group",


### PR DESCRIPTION
Stacked on top of #83. Regexp port **40 → 42 / 82** once the chain lands.

## How it works

- `no-useless-quantifier`: a new `first_useless_one_quantifier` helper walks the pattern bytes, skips any `[...]` class via `find_class_end`, and reports the first literal `{1}` or `{1,1}` quantifier at the top level. Other useless-quantifier shapes (e.g. a quantifier on a body that always matches the empty string) are deferred — they need group-content tracking we have not implemented.
- `prefer-named-backreference`: a new `first_numbered_backreference_with_named_group` helper short-circuits on patterns without a named-capture marker `(?<`, then walks for `\N` (N in 1-9) outside classes. Classes are skipped because `\1` is a literal there. Reports the first numbered backreference when at least one named capture is present.

Both helpers reuse the existing `find_class_end` / `skip_escape` primitives so no new full-pattern walk is added; per literal the additional cost is two narrow byte scans gated on cheap precondition checks.

## Verification

- 100 Rust unit tests pass (4 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 7 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 42 ported names

## Stacked dependency

Targets `port/regexp-prefer-character-class` (PR #83). Once #80 → #81 → #82 → #83 land, this PR rebases cleanly onto main.

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->