### PR TITLE
port(regexp): port no-useless-flag (narrow form for s and m)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -312,7 +312,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.check_flag_style(flags, span);
-        self.check_pattern_rules(pattern, span);
+        self.check_pattern_rules(pattern, flags, span);
     }
 
     #[allow(
@@ -364,9 +364,41 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn check_pattern_rules(&mut self, pattern: &str, span: Span) {
+    fn check_pattern_rules(&mut self, pattern: &str, flags: &str, span: Span) {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern);
+
+        // `no-useless-flag` (narrow form): the `s` flag only affects the
+        // matching of `.`; the `m` flag only affects `^` and `$`. If neither
+        // syntax appears in the pattern, the flag is provably inert. Other
+        // useless-flag shapes (e.g. `i` on a pattern with no letters) are
+        // intentionally deferred — they need a richer case-class analysis.
+        if flags.contains('s') && !analysis.has_unescaped_dot {
+            let mut text = CompactString::new("");
+            text.push('s');
+            self.report_with_data(
+                "no-useless-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if flags.contains('m') && !analysis.has_unescaped_anchor {
+            let mut text = CompactString::new("");
+            text.push('m');
+            self.report_with_data(
+                "no-useless-flag",
+                "unexpected",
+                DiagnosticData {
+                    flag: Some(text),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 42] = [
+pub const RULE_NAMES: [&str; 43] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -64,6 +64,7 @@ pub const RULE_NAMES: [&str; 42] = [
     "no-useless-escape",
     "no-useless-quantifier",
     "prefer-named-backreference",
+    "no-useless-flag",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -97,6 +97,14 @@ pub(crate) struct PatternAnalysis {
     /// First run of three or more consecutive ASCII letters/digits inside the
     /// same `[...]` class. `prefer-range`.
     pub(crate) first_collapsible_run: Option<(char, char)>,
+    /// The pattern contains at least one unescaped `.` outside a character
+    /// class. Used by `no-useless-flag` to decide whether the `s` flag has
+    /// any effect.
+    pub(crate) has_unescaped_dot: bool,
+    /// The pattern contains at least one unescaped `^` or `$` outside a
+    /// character class. Used by `no-useless-flag` to decide whether the `m`
+    /// flag has any effect.
+    pub(crate) has_unescaped_anchor: bool,
 }
 
 impl PatternAnalysis {
@@ -258,7 +266,16 @@ impl PatternAnalysis {
                     }
                     index += 1;
                 }
-                b'+' | b'}' | b'^' | b'$' => {
+                b'^' | b'$' => {
+                    self.has_unescaped_anchor = true;
+                    index += 1;
+                }
+                b'+' | b'}' => {
+                    index += 1;
+                }
+                b'.' => {
+                    self.has_unescaped_dot = true;
+                    self.mark_content(&mut groups);
                     index += 1;
                 }
                 _ => {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -83,8 +83,35 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-escape",
             "no-useless-quantifier",
             "prefer-named-backreference",
+            "no-useless-flag",
         ]
     );
+}
+
+mod no_useless_flag {
+    use super::*;
+
+    #[test]
+    fn reports_s_flag_on_dotless_patterns() {
+        let data = first_data("const a = new RegExp('abc', 's');", "no-useless-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("s"));
+    }
+
+    #[test]
+    fn reports_m_flag_on_anchorless_patterns() {
+        let data = first_data("const a = new RegExp('abc', 'm');", "no-useless-flag");
+        assert_eq!(data.flag.as_ref().map(CompactString::as_str), Some("m"));
+    }
+
+    #[test]
+    fn accepts_flag_when_pattern_uses_the_corresponding_syntax() {
+        // `.` makes the `s` flag meaningful.
+        assert!(rule_ids_for("const a = new RegExp('a.b', 's');", "no-useless-flag").is_empty());
+        // `^` makes the `m` flag meaningful.
+        assert!(rule_ids_for("const a = new RegExp('^abc', 'm');", "no-useless-flag").is_empty());
+        // `$` at end activates the `m` flag.
+        assert!(rule_ids_for("const a = new RegExp('abc$', 'm');", "no-useless-flag").is_empty());
+    }
 }
 
 mod no_optional_assertion {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -159,6 +159,10 @@ const messages = Object.freeze({
     unexpected:
       "Numbered backreference '{{expr}}' is used alongside a named capture group; prefer a named backreference `\\k<name>`.",
   },
+  'no-useless-flag': {
+    unexpected:
+      "Unexpected useless flag '{{flag}}'; the pattern does not use the syntax this flag affects.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -216,6 +220,8 @@ const ruleDescriptions = Object.freeze({
     'disallow `{1}` and `{1,1}` quantifiers (they match exactly once and can be removed)',
   'prefer-named-backreference':
     'enforce using named backreferences (`\\k<name>`) when the pattern has named capture groups',
+  'no-useless-flag':
+    'disallow regular-expression flags that have no effect on the pattern (narrow: `s` without `.`, `m` without `^`/`$`)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -260,6 +266,7 @@ const ruleTypes = Object.freeze({
   'no-useless-escape': 'suggestion',
   'no-useless-quantifier': 'suggestion',
   'prefer-named-backreference': 'suggestion',
+  'no-useless-flag': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -405,7 +412,8 @@ function ruleCategory(ruleName) {
     ruleName === 'prefer-range' ||
     ruleName === 'no-useless-escape' ||
     ruleName === 'no-useless-quantifier' ||
-    ruleName === 'prefer-named-backreference'
+    ruleName === 'prefer-named-backreference' ||
+    ruleName === 'no-useless-flag'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -62,10 +62,12 @@ describe('regexp native API', () => {
     );
 
     expect(diagnostics.map((diagnostic) => [diagnostic.ruleName, diagnostic.messageId])).toEqual([
-      // /[]/mi — flag style + pattern checks all fire.
+      // /[]/mi — flag style + pattern checks all fire. The `m` flag is also
+      // useless because the pattern has no unescaped `^` or `$`.
       ['sort-flags', 'sortFlags'],
       ['require-unicode-regexp', 'require'],
       ['require-unicode-sets-regexp', 'require'],
+      ['no-useless-flag', 'unexpected'],
       ['no-empty-character-class', 'empty'],
       // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
@@ -80,7 +82,7 @@ describe('regexp native API', () => {
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[6].data.charText).toBe('U+0001');
+    expect(diagnostics[7].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {
@@ -100,10 +102,11 @@ describe('regexp native API', () => {
 
   it('returns no diagnostics for clean sources', () => {
     // Sources that use the `v` flag stay quiet because `require-unicode-sets-regexp`
-    // is the only flag-style rule that targets that flag specifically; everything
-    // else needs an unrelated pattern issue.
+    // is the only flag-style rule that targets that flag specifically; the other
+    // flags must also avoid `no-useless-flag` — `s` needs an unescaped `.`, `m`
+    // needs `^` or `$`, so we keep the flag set narrow.
     expect(scanRegexp('const re = /a+/v;\n', 'fixture.js')).toEqual([]);
-    expect(scanRegexp("const re = new RegExp('a', 'gimsv');\n", 'fixture.js')).toEqual([]);
+    expect(scanRegexp("const re = new RegExp('a', 'giv');\n", 'fixture.js')).toEqual([]);
   });
 
   it('returns no diagnostics when the source fails to parse', () => {

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -47,6 +47,7 @@ describe('regexp native API', () => {
       'no-useless-escape',
       'no-useless-quantifier',
       'prefer-named-backreference',
+      'no-useless-flag',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -224,6 +224,9 @@ const invalidCases = [
     'const re = /(?<year>\\d{4})-\\1/u;\n',
     ['unexpected'],
   ],
+  // no-useless-flag
+  ['no-useless-flag', 's without dot', "const re = new RegExp('abc', 's');\n", ['unexpected']],
+  ['no-useless-flag', 'm without anchor', "const re = new RegExp('abc', 'm');\n", ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9147,19 +9147,19 @@
       },
       {
         "name": "no-useless-flag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-flag."
+        "notes": "PatternAnalysis gains has_unescaped_dot and has_unescaped_anchor (set by the existing walker on `.` / `^` / `$` outside character classes). After scanning, the rule consults the flags string: `s` without `.` is inert, and `m` without `^`/`$` is inert. Other flags (`i`, etc.) are deferred — they need richer letter/case analysis."
       },
       {
         "name": "no-useless-lazy",


### PR DESCRIPTION
Stacked on top of #84. Regexp port **42 → 43 / 82** once the chain lands.

## How it works

`PatternAnalysis` gains `has_unescaped_dot` and `has_unescaped_anchor`; the walker sets them on `.` and on `^` / `$` outside character classes. After scanning, `check_pattern_rules` consults the flags string and reports `no-useless-flag` when:

- the `s` flag is present but the pattern has no unescaped `.`
- the `m` flag is present but the pattern has no unescaped `^` or `$`

Other flags (`i`, `g`, etc.) are intentionally deferred. `i` needs a letter-class analysis that we have not implemented; `g` is context-sensitive at the call site rather than the pattern itself (already partially covered by `no-missing-g-flag`). The narrow port catches the canonical mistakes (turning on a flag whose syntax never appears) without risking false positives on the harder cases.

`check_pattern_rules` now takes `flags` so the new check can read both the pattern walk results and the flag set in one place.

## Verification

- 103 Rust unit tests pass (3 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 4 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 43 ported names

## Stacked dependency

Targets `port/regexp-prefer-character-class-batch` (PR #84).

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs. The existing `CompactString`/`SmallVec`/file-level-scan policy is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->