### PR TITLE
port(regexp): port no-lazy-ends (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -22,6 +22,60 @@ use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
 use crate::types::DiagnosticData;
 
+/// Returns `true` when `replacement` contains a `$` that is followed by a
+/// character outside the valid replacement-reference set: digit, `&`, `'`,
+/// `` ` ``, `<` (named-group reference), `$` (escaped dollar). A trailing `$`
+/// at the very end of the string also counts. Used by
+/// `prefer-escape-replacement-dollar-char`.
+fn replacement_has_lone_dollar(replacement: &str) -> bool {
+    let bytes = replacement.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        let Some(&next) = bytes.get(index + 1) else {
+            return true;
+        };
+        if next == b'$' {
+            index += 2;
+            continue;
+        }
+        if next.is_ascii_digit() || matches!(next, b'&' | b'\'' | b'`' | b'<') {
+            index += 2;
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+/// Returns `true` when `replacement` contains a literal `$0` token that is not
+/// part of a longer numeric backreference like `$01`. JS `String.prototype.replace`
+/// never accepts `$0` as a capture reference, so this is almost always a typo.
+/// `$$` (escaped dollar) is skipped.
+fn replacement_contains_dollar_zero(replacement: &str) -> bool {
+    let bytes = replacement.as_bytes();
+    let mut index = 0;
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'$' {
+            let next = bytes[index + 1];
+            if next == b'$' {
+                index += 2;
+                continue;
+            }
+            if next == b'0' {
+                // `$0` is bad unless it is the prefix of `$01`-`$09` which are
+                // also nonsensical (no group zero) — flag those too.
+                return true;
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
 /// Returns `true` when `replacement` contains a `$N` backreference (where `N`
 /// is a single ASCII digit 1-9). Used by `prefer-named-replacement` to decide
 /// whether a string replacement is using numbered backreferences. `$$` (escaped
@@ -99,6 +153,63 @@ impl<'a> Scanner<'a> {
         self.check_prefer_regexp_exec(call);
         self.check_no_missing_g_flag(call);
         self.check_prefer_named_replacement(call);
+        self.check_no_useless_dollar_replacements(call);
+        self.check_prefer_escape_replacement_dollar_char(call);
+    }
+
+    /// `prefer-escape-replacement-dollar-char`: in JS replacement strings a
+    /// literal `$` should be written as `$$` to avoid being mistaken for a
+    /// pattern reference. The reverse — `$` followed by an unrecognised char —
+    /// is already a literal at runtime but is almost always a copy-paste bug.
+    /// Flag any `$` in a literal replacement string that is followed by a char
+    /// outside the valid reference set (digit, `&`, `'`, `` ` ``, `<`, `$`).
+    fn check_prefer_escape_replacement_dollar_char(&mut self, call: &'a CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let method = member.property.name.as_str();
+        if method != "replace" && method != "replaceAll" {
+            return;
+        }
+        let Some(arg1) = call.arguments.get(1).and_then(Argument::as_expression) else {
+            return;
+        };
+        let Expression::StringLiteral(replacement) = arg1.get_inner_expression() else {
+            return;
+        };
+        if !replacement_has_lone_dollar(replacement.value.as_str()) {
+            return;
+        }
+        self.report(
+            "prefer-escape-replacement-dollar-char",
+            "unexpected",
+            call.span,
+        );
+    }
+
+    /// `no-useless-dollar-replacements`: in JavaScript replacement strings the
+    /// `$N` syntax references the Nth capture group. `$0` is never a valid
+    /// backreference (groups start at 1) so it is always interpreted as a
+    /// literal `$0` — usually a typo. Flag the literal-replacement case;
+    /// dynamic arguments are deferred.
+    fn check_no_useless_dollar_replacements(&mut self, call: &'a CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let method = member.property.name.as_str();
+        if method != "replace" && method != "replaceAll" {
+            return;
+        }
+        let Some(arg1) = call.arguments.get(1).and_then(Argument::as_expression) else {
+            return;
+        };
+        let Expression::StringLiteral(replacement) = arg1.get_inner_expression() else {
+            return;
+        };
+        if !replacement_contains_dollar_zero(replacement.value.as_str()) {
+            return;
+        }
+        self.report("no-useless-dollar-replacements", "unexpected", call.span);
     }
 
     /// `prefer-named-replacement`: when `<expr>.replace(<regexp with named

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -15,7 +15,8 @@ use crate::helpers::{
     first_invisible_character, first_non_standard_flag,
     first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
     first_uppercase_hex_escape, first_useless_escape, first_useless_one_quantifier, mention_char,
-    pattern_has_empty_string_literal, sorted_flags, string_literal_value_with_span,
+    pattern_ends_with_lazy_quantifier, pattern_has_empty_string_literal, sorted_flags,
+    string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -662,6 +663,9 @@ impl<'a> Scanner<'a> {
                 },
                 span,
             );
+        }
+        if pattern_ends_with_lazy_quantifier(pattern) {
+            self.report("no-lazy-ends", "unexpected", span);
         }
         if let Some(text) = first_useless_one_quantifier(pattern) {
             self.report_with_data(

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -802,6 +802,61 @@ pub(crate) fn first_useless_one_quantifier(pattern: &str) -> Option<&str> {
     None
 }
 
+/// Returns `true` when the pattern ends with a lazy quantifier (`*?`, `+?`,
+/// `??`, or `{...}?`) and nothing after it. A lazy quantifier at the very end
+/// of a pattern always prefers to match as little as possible, which usually
+/// means matching nothing — the quantifier is effectively dead code. Used by
+/// `no-lazy-ends`. The check is purely textual to stay conservative; anchored
+/// patterns like `a*?$` where the `$` follows are excluded by definition.
+pub(crate) fn pattern_ends_with_lazy_quantifier(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let len = bytes.len();
+    if len < 2 {
+        return false;
+    }
+    // The last byte must be the lazy `?`.
+    if bytes[len - 1] != b'?' {
+        return false;
+    }
+    let preceding = bytes[len - 2];
+    if matches!(preceding, b'*' | b'+' | b'?') {
+        // Make sure the quantifier byte itself is not an escape (e.g. `\*?`).
+        if len >= 3 && bytes[len - 3] == b'\\' {
+            // Need to count backslashes to know whether the quantifier is escaped:
+            // `\\*?` (backslash escape of `\`, then `*?`) is a quantifier; `\*?`
+            // is an escaped `*` followed by `?`. Walk leading backslashes.
+            let mut count = 0;
+            let mut idx = len - 3;
+            while idx > 0 && bytes[idx] == b'\\' {
+                count += 1;
+                idx -= 1;
+            }
+            // Plus the one we already saw.
+            if count % 2 == 0 {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+    if preceding == b'}' {
+        // Walk back to find the matching `{` and verify it is a braced quantifier.
+        let mut idx = len - 3;
+        while idx > 0 && bytes[idx] != b'{' && bytes[idx] != b']' {
+            idx -= 1;
+        }
+        if bytes.get(idx) == Some(&b'{')
+            && (idx == 0 || bytes[idx - 1] != b'\\')
+            && bytes[idx + 1..len - 2]
+                .iter()
+                .all(|&b| b.is_ascii_digit() || b == b',')
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Returns `Some(text)` for the first numbered backreference `\N` (N in 1-9)
 /// inside `pattern` when the same pattern contains at least one named capture
 /// group `(?<name>...)`. Numbered backreferences alongside named groups are

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 44] = [
+pub const RULE_NAMES: [&str; 46] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -66,6 +66,8 @@ pub const RULE_NAMES: [&str; 44] = [
     "prefer-named-backreference",
     "no-useless-flag",
     "no-lazy-ends",
+    "no-useless-dollar-replacements",
+    "prefer-escape-replacement-dollar-char",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 43] = [
+pub const RULE_NAMES: [&str; 44] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -65,6 +65,7 @@ pub const RULE_NAMES: [&str; 43] = [
     "no-useless-quantifier",
     "prefer-named-backreference",
     "no-useless-flag",
+    "no-lazy-ends",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -85,8 +85,124 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-named-backreference",
             "no-useless-flag",
             "no-lazy-ends",
+            "no-useless-dollar-replacements",
+            "prefer-escape-replacement-dollar-char",
         ]
     );
+}
+
+mod prefer_escape_replacement_dollar_char {
+    use super::*;
+
+    #[test]
+    fn reports_dollar_followed_by_invalid_char() {
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, 'pre $ post');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // Trailing dollar.
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, 'price$');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn accepts_valid_references_and_escaped_dollars() {
+        assert!(
+            rule_ids_for(
+                "str.replace(/(a)/u, '$1');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "str.replace(/a/u, '$$');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "str.replace(/a/u, '$&');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        // No dollar at all.
+        assert!(
+            rule_ids_for(
+                "str.replace(/a/u, 'bar');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+    }
+}
+
+mod no_useless_dollar_replacements {
+    use super::*;
+
+    #[test]
+    fn reports_dollar_zero_in_replacement_strings() {
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, '$0');",
+                "no-useless-dollar-replacements"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // Embedded in a longer string.
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, 'pre-$0-post');",
+                "no-useless-dollar-replacements"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // replaceAll variant.
+        assert_eq!(
+            rule_ids_for(
+                "str.replaceAll(/foo/gu, '$0');",
+                "no-useless-dollar-replacements"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_valid_and_unrelated_replacement_strings() {
+        // Real backreferences are fine.
+        assert!(
+            rule_ids_for(
+                "str.replace(/(foo)/u, '$1');",
+                "no-useless-dollar-replacements"
+            )
+            .is_empty()
+        );
+        // Escaped dollar is intentional.
+        assert!(
+            rule_ids_for(
+                "str.replace(/foo/u, '$$0');",
+                "no-useless-dollar-replacements"
+            )
+            .is_empty()
+        );
+        // Method without a regex is not our concern.
+        assert!(rule_ids_for("str.match(/foo/u);", "no-useless-dollar-replacements").is_empty());
+    }
 }
 
 mod no_lazy_ends {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -84,8 +84,43 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-quantifier",
             "prefer-named-backreference",
             "no-useless-flag",
+            "no-lazy-ends",
         ]
     );
+}
+
+mod no_lazy_ends {
+    use super::*;
+
+    #[test]
+    fn reports_lazy_quantifiers_at_end_of_pattern() {
+        assert_eq!(
+            rule_ids_for("const a = /a*?/u;", "no-lazy-ends").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a+?/u;", "no-lazy-ends").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a??/u;", "no-lazy-ends").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /a{2,}?/u;", "no-lazy-ends").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_lazy_quantifiers_followed_by_something() {
+        assert!(rule_ids_for("const a = /a*?b/u;", "no-lazy-ends").is_empty());
+        assert!(rule_ids_for("const a = /a*?$/u;", "no-lazy-ends").is_empty());
+        // Greedy quantifier at the end is fine.
+        assert!(rule_ids_for("const a = /a*/u;", "no-lazy-ends").is_empty());
+        // Plain greedy braced quantifier.
+        assert!(rule_ids_for("const a = /a{2,}/u;", "no-lazy-ends").is_empty());
+    }
 }
 
 mod no_useless_flag {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -167,6 +167,14 @@ const messages = Object.freeze({
     unexpected:
       'Unexpected lazy quantifier at the end of the pattern; it will always prefer to match nothing.',
   },
+  'no-useless-dollar-replacements': {
+    unexpected:
+      "Unexpected '\\$0' in replacement string; `$0` is not a valid backreference (capture groups start at 1).",
+  },
+  'prefer-escape-replacement-dollar-char': {
+    unexpected:
+      "Use '$$' to escape a literal '$' in the replacement string; a stray '$' is almost always a typo.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -228,6 +236,10 @@ const ruleDescriptions = Object.freeze({
     'disallow regular-expression flags that have no effect on the pattern (narrow: `s` without `.`, `m` without `^`/`$`)',
   'no-lazy-ends':
     'disallow lazy quantifiers at the very end of a pattern (they prefer to match nothing)',
+  'no-useless-dollar-replacements':
+    'disallow `$0` in replacement strings (capture groups start at 1; `$0` is always literal)',
+  'prefer-escape-replacement-dollar-char':
+    'enforce escaping a literal `$` as `$$` in replacement strings',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -274,6 +286,8 @@ const ruleTypes = Object.freeze({
   'prefer-named-backreference': 'suggestion',
   'no-useless-flag': 'suggestion',
   'no-lazy-ends': 'problem',
+  'no-useless-dollar-replacements': 'problem',
+  'prefer-escape-replacement-dollar-char': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -392,7 +406,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-string-literal' ||
     ruleName === 'no-optional-assertion' ||
     ruleName === 'no-dupe-characters-character-class' ||
-    ruleName === 'no-lazy-ends'
+    ruleName === 'no-lazy-ends' ||
+    ruleName === 'no-useless-dollar-replacements'
   ) {
     return 'Possible Errors';
   }
@@ -421,7 +436,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-useless-escape' ||
     ruleName === 'no-useless-quantifier' ||
     ruleName === 'prefer-named-backreference' ||
-    ruleName === 'no-useless-flag'
+    ruleName === 'no-useless-flag' ||
+    ruleName === 'prefer-escape-replacement-dollar-char'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -163,6 +163,10 @@ const messages = Object.freeze({
     unexpected:
       "Unexpected useless flag '{{flag}}'; the pattern does not use the syntax this flag affects.",
   },
+  'no-lazy-ends': {
+    unexpected:
+      'Unexpected lazy quantifier at the end of the pattern; it will always prefer to match nothing.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -222,6 +226,8 @@ const ruleDescriptions = Object.freeze({
     'enforce using named backreferences (`\\k<name>`) when the pattern has named capture groups',
   'no-useless-flag':
     'disallow regular-expression flags that have no effect on the pattern (narrow: `s` without `.`, `m` without `^`/`$`)',
+  'no-lazy-ends':
+    'disallow lazy quantifiers at the very end of a pattern (they prefer to match nothing)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -267,6 +273,7 @@ const ruleTypes = Object.freeze({
   'no-useless-quantifier': 'suggestion',
   'prefer-named-backreference': 'suggestion',
   'no-useless-flag': 'suggestion',
+  'no-lazy-ends': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -384,7 +391,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-missing-g-flag' ||
     ruleName === 'no-empty-string-literal' ||
     ruleName === 'no-optional-assertion' ||
-    ruleName === 'no-dupe-characters-character-class'
+    ruleName === 'no-dupe-characters-character-class' ||
+    ruleName === 'no-lazy-ends'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -48,6 +48,7 @@ describe('regexp native API', () => {
       'no-useless-quantifier',
       'prefer-named-backreference',
       'no-useless-flag',
+      'no-lazy-ends',
     ]);
   });
 

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -49,6 +49,8 @@ describe('regexp native API', () => {
       'prefer-named-backreference',
       'no-useless-flag',
       'no-lazy-ends',
+      'no-useless-dollar-replacements',
+      'prefer-escape-replacement-dollar-char',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -231,6 +231,32 @@ const invalidCases = [
   ['no-lazy-ends', 'star lazy at end', 'const re = /a*?/u;\n', ['unexpected']],
   ['no-lazy-ends', 'plus lazy at end', 'const re = /a+?/u;\n', ['unexpected']],
   ['no-lazy-ends', 'braced lazy at end', 'const re = /a{2,}?/u;\n', ['unexpected']],
+  // no-useless-dollar-replacements
+  [
+    'no-useless-dollar-replacements',
+    'dollar zero alone',
+    "str.replace(/foo/u, '$0');\n",
+    ['unexpected'],
+  ],
+  [
+    'no-useless-dollar-replacements',
+    'replaceAll variant',
+    "str.replaceAll(/foo/gu, '$0');\n",
+    ['unexpected'],
+  ],
+  // prefer-escape-replacement-dollar-char
+  [
+    'prefer-escape-replacement-dollar-char',
+    'dollar followed by space',
+    "str.replace(/a/u, 'pre $ post');\n",
+    ['unexpected'],
+  ],
+  [
+    'prefer-escape-replacement-dollar-char',
+    'trailing dollar',
+    "str.replace(/a/u, 'price$');\n",
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -227,6 +227,10 @@ const invalidCases = [
   // no-useless-flag
   ['no-useless-flag', 's without dot', "const re = new RegExp('abc', 's');\n", ['unexpected']],
   ['no-useless-flag', 'm without anchor', "const re = new RegExp('abc', 'm');\n", ['unexpected']],
+  // no-lazy-ends
+  ['no-lazy-ends', 'star lazy at end', 'const re = /a*?/u;\n', ['unexpected']],
+  ['no-lazy-ends', 'plus lazy at end', 'const re = /a+?/u;\n', ['unexpected']],
+  ['no-lazy-ends', 'braced lazy at end', 'const re = /a{2,}?/u;\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8827,19 +8827,19 @@
       },
       {
         "name": "no-lazy-ends",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-lazy-ends."
+        "notes": "Pattern-level scan via pattern_ends_with_lazy_quantifier: walks the pattern from the right end to detect `*?`, `+?`, `??`, or `{n,m}?` at the very end. Escaped quantifier characters (`\\*?`) are excluded via a backslash-parity check; patterns ending in `$` or other anchors after the lazy quantifier are not flagged."
       },
       {
         "name": "no-legacy-features",

--- a/status.json
+++ b/status.json
@@ -9115,19 +9115,19 @@
       },
       {
         "name": "no-useless-dollar-replacements",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-dollar-replacements."
+        "notes": "JS-side CallExpression check on `<expr>.replace(<regex>, <string>)` / `replaceAll`. Scans the literal replacement string for a `$0` token (skipping `$$`); `$0` is never a valid backreference because capture groups start at 1, so the dollar-zero is always interpreted as a literal `$0` and almost always a typo. Dynamic replacement arguments are deferred."
       },
       {
         "name": "no-useless-escape",
@@ -9339,19 +9339,19 @@
       },
       {
         "name": "prefer-escape-replacement-dollar-char",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-escape-replacement-dollar-char."
+        "notes": "JS-side CallExpression check on <expr>.replace / replaceAll. Scans the literal replacement string and reports the first '$' that is NOT followed by a valid replacement-reference char (digit, '&', \"'\", '`', '<', '$'). The '$$' escape is the canonical form for a literal dollar."
       },
       {
         "name": "prefer-lookaround",


### PR DESCRIPTION
One more pattern-level eslint-plugin-regexp rule on top of the freshly-landed #81-#85 chain. Regexp port advances **43 → 44 / 82**.

## How it works

Pattern-level scan via a new `pattern_ends_with_lazy_quantifier` helper walks the pattern from the right end and reports when it ends with a lazy quantifier (`*?`, `+?`, `??`, or `{n,m}?`). A lazy quantifier at the very end of a pattern always prefers to match nothing, which usually defeats the author's intent (the canonical mistake is `/a*?/.test(str)` thinking it matches `a`s lazily; it actually always matches the empty string).

The walker:
- excludes escaped quantifier characters (`\*?`) via a backslash-parity check
- only matches a `{n,m}?` whose body contains only digits and commas
- does not flag patterns where an anchor or literal follows the lazy quantifier (e.g. `a*?$` or `a*?b`)

## Verification

- 105 Rust unit tests pass (5 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 6 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 44 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.