### PR TITLE
port(regexp): port no-useless-dollar-replacements (narrow: $0)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -22,6 +22,35 @@ use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
 use crate::types::DiagnosticData;
 
+/// Returns `true` when `replacement` contains a `$` that is followed by a
+/// character outside the valid replacement-reference set: digit, `&`, `'`,
+/// `` ` ``, `<` (named-group reference), `$` (escaped dollar). A trailing `$`
+/// at the very end of the string also counts. Used by
+/// `prefer-escape-replacement-dollar-char`.
+fn replacement_has_lone_dollar(replacement: &str) -> bool {
+    let bytes = replacement.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        let Some(&next) = bytes.get(index + 1) else {
+            return true;
+        };
+        if next == b'$' {
+            index += 2;
+            continue;
+        }
+        if next.is_ascii_digit() || matches!(next, b'&' | b'\'' | b'`' | b'<') {
+            index += 2;
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
 /// Returns `true` when `replacement` contains a literal `$0` token that is not
 /// part of a longer numeric backreference like `$01`. JS `String.prototype.replace`
 /// never accepts `$0` as a capture reference, so this is almost always a typo.
@@ -125,6 +154,37 @@ impl<'a> Scanner<'a> {
         self.check_no_missing_g_flag(call);
         self.check_prefer_named_replacement(call);
         self.check_no_useless_dollar_replacements(call);
+        self.check_prefer_escape_replacement_dollar_char(call);
+    }
+
+    /// `prefer-escape-replacement-dollar-char`: in JS replacement strings a
+    /// literal `$` should be written as `$$` to avoid being mistaken for a
+    /// pattern reference. The reverse — `$` followed by an unrecognised char —
+    /// is already a literal at runtime but is almost always a copy-paste bug.
+    /// Flag any `$` in a literal replacement string that is followed by a char
+    /// outside the valid reference set (digit, `&`, `'`, `` ` ``, `<`, `$`).
+    fn check_prefer_escape_replacement_dollar_char(&mut self, call: &'a CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let method = member.property.name.as_str();
+        if method != "replace" && method != "replaceAll" {
+            return;
+        }
+        let Some(arg1) = call.arguments.get(1).and_then(Argument::as_expression) else {
+            return;
+        };
+        let Expression::StringLiteral(replacement) = arg1.get_inner_expression() else {
+            return;
+        };
+        if !replacement_has_lone_dollar(replacement.value.as_str()) {
+            return;
+        }
+        self.report(
+            "prefer-escape-replacement-dollar-char",
+            "unexpected",
+            call.span,
+        );
     }
 
     /// `no-useless-dollar-replacements`: in JavaScript replacement strings the

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -22,6 +22,31 @@ use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
 use crate::types::DiagnosticData;
 
+/// Returns `true` when `replacement` contains a literal `$0` token that is not
+/// part of a longer numeric backreference like `$01`. JS `String.prototype.replace`
+/// never accepts `$0` as a capture reference, so this is almost always a typo.
+/// `$$` (escaped dollar) is skipped.
+fn replacement_contains_dollar_zero(replacement: &str) -> bool {
+    let bytes = replacement.as_bytes();
+    let mut index = 0;
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'$' {
+            let next = bytes[index + 1];
+            if next == b'$' {
+                index += 2;
+                continue;
+            }
+            if next == b'0' {
+                // `$0` is bad unless it is the prefix of `$01`-`$09` which are
+                // also nonsensical (no group zero) — flag those too.
+                return true;
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
 /// Returns `true` when `replacement` contains a `$N` backreference (where `N`
 /// is a single ASCII digit 1-9). Used by `prefer-named-replacement` to decide
 /// whether a string replacement is using numbered backreferences. `$$` (escaped
@@ -99,6 +124,32 @@ impl<'a> Scanner<'a> {
         self.check_prefer_regexp_exec(call);
         self.check_no_missing_g_flag(call);
         self.check_prefer_named_replacement(call);
+        self.check_no_useless_dollar_replacements(call);
+    }
+
+    /// `no-useless-dollar-replacements`: in JavaScript replacement strings the
+    /// `$N` syntax references the Nth capture group. `$0` is never a valid
+    /// backreference (groups start at 1) so it is always interpreted as a
+    /// literal `$0` — usually a typo. Flag the literal-replacement case;
+    /// dynamic arguments are deferred.
+    fn check_no_useless_dollar_replacements(&mut self, call: &'a CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+        let method = member.property.name.as_str();
+        if method != "replace" && method != "replaceAll" {
+            return;
+        }
+        let Some(arg1) = call.arguments.get(1).and_then(Argument::as_expression) else {
+            return;
+        };
+        let Expression::StringLiteral(replacement) = arg1.get_inner_expression() else {
+            return;
+        };
+        if !replacement_contains_dollar_zero(replacement.value.as_str()) {
+            return;
+        }
+        self.report("no-useless-dollar-replacements", "unexpected", call.span);
     }
 
     /// `prefer-named-replacement`: when `<expr>.replace(<regexp with named

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 44] = [
+pub const RULE_NAMES: [&str; 45] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -66,6 +66,7 @@ pub const RULE_NAMES: [&str; 44] = [
     "prefer-named-backreference",
     "no-useless-flag",
     "no-lazy-ends",
+    "no-useless-dollar-replacements",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 45] = [
+pub const RULE_NAMES: [&str; 46] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -67,6 +67,7 @@ pub const RULE_NAMES: [&str; 45] = [
     "no-useless-flag",
     "no-lazy-ends",
     "no-useless-dollar-replacements",
+    "prefer-escape-replacement-dollar-char",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -86,8 +86,67 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-flag",
             "no-lazy-ends",
             "no-useless-dollar-replacements",
+            "prefer-escape-replacement-dollar-char",
         ]
     );
+}
+
+mod prefer_escape_replacement_dollar_char {
+    use super::*;
+
+    #[test]
+    fn reports_dollar_followed_by_invalid_char() {
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, 'pre $ post');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // Trailing dollar.
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, 'price$');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn accepts_valid_references_and_escaped_dollars() {
+        assert!(
+            rule_ids_for(
+                "str.replace(/(a)/u, '$1');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "str.replace(/a/u, '$$');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "str.replace(/a/u, '$&');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        // No dollar at all.
+        assert!(
+            rule_ids_for(
+                "str.replace(/a/u, 'bar');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+    }
 }
 
 mod no_useless_dollar_replacements {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -85,8 +85,65 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-named-backreference",
             "no-useless-flag",
             "no-lazy-ends",
+            "no-useless-dollar-replacements",
         ]
     );
+}
+
+mod no_useless_dollar_replacements {
+    use super::*;
+
+    #[test]
+    fn reports_dollar_zero_in_replacement_strings() {
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, '$0');",
+                "no-useless-dollar-replacements"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // Embedded in a longer string.
+        assert_eq!(
+            rule_ids_for(
+                "str.replace(/foo/u, 'pre-$0-post');",
+                "no-useless-dollar-replacements"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // replaceAll variant.
+        assert_eq!(
+            rule_ids_for(
+                "str.replaceAll(/foo/gu, '$0');",
+                "no-useless-dollar-replacements"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_valid_and_unrelated_replacement_strings() {
+        // Real backreferences are fine.
+        assert!(
+            rule_ids_for(
+                "str.replace(/(foo)/u, '$1');",
+                "no-useless-dollar-replacements"
+            )
+            .is_empty()
+        );
+        // Escaped dollar is intentional.
+        assert!(
+            rule_ids_for(
+                "str.replace(/foo/u, '$$0');",
+                "no-useless-dollar-replacements"
+            )
+            .is_empty()
+        );
+        // Method without a regex is not our concern.
+        assert!(rule_ids_for("str.match(/foo/u);", "no-useless-dollar-replacements").is_empty());
+    }
 }
 
 mod no_lazy_ends {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -171,6 +171,10 @@ const messages = Object.freeze({
     unexpected:
       "Unexpected '\\$0' in replacement string; `$0` is not a valid backreference (capture groups start at 1).",
   },
+  'prefer-escape-replacement-dollar-char': {
+    unexpected:
+      "Use '$$' to escape a literal '$' in the replacement string; a stray '$' is almost always a typo.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -234,6 +238,8 @@ const ruleDescriptions = Object.freeze({
     'disallow lazy quantifiers at the very end of a pattern (they prefer to match nothing)',
   'no-useless-dollar-replacements':
     'disallow `$0` in replacement strings (capture groups start at 1; `$0` is always literal)',
+  'prefer-escape-replacement-dollar-char':
+    'enforce escaping a literal `$` as `$$` in replacement strings',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -281,6 +287,7 @@ const ruleTypes = Object.freeze({
   'no-useless-flag': 'suggestion',
   'no-lazy-ends': 'problem',
   'no-useless-dollar-replacements': 'problem',
+  'prefer-escape-replacement-dollar-char': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -429,7 +436,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-useless-escape' ||
     ruleName === 'no-useless-quantifier' ||
     ruleName === 'prefer-named-backreference' ||
-    ruleName === 'no-useless-flag'
+    ruleName === 'no-useless-flag' ||
+    ruleName === 'prefer-escape-replacement-dollar-char'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -167,6 +167,10 @@ const messages = Object.freeze({
     unexpected:
       'Unexpected lazy quantifier at the end of the pattern; it will always prefer to match nothing.',
   },
+  'no-useless-dollar-replacements': {
+    unexpected:
+      "Unexpected '\\$0' in replacement string; `$0` is not a valid backreference (capture groups start at 1).",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -228,6 +232,8 @@ const ruleDescriptions = Object.freeze({
     'disallow regular-expression flags that have no effect on the pattern (narrow: `s` without `.`, `m` without `^`/`$`)',
   'no-lazy-ends':
     'disallow lazy quantifiers at the very end of a pattern (they prefer to match nothing)',
+  'no-useless-dollar-replacements':
+    'disallow `$0` in replacement strings (capture groups start at 1; `$0` is always literal)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -274,6 +280,7 @@ const ruleTypes = Object.freeze({
   'prefer-named-backreference': 'suggestion',
   'no-useless-flag': 'suggestion',
   'no-lazy-ends': 'problem',
+  'no-useless-dollar-replacements': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -392,7 +399,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-empty-string-literal' ||
     ruleName === 'no-optional-assertion' ||
     ruleName === 'no-dupe-characters-character-class' ||
-    ruleName === 'no-lazy-ends'
+    ruleName === 'no-lazy-ends' ||
+    ruleName === 'no-useless-dollar-replacements'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -50,6 +50,7 @@ describe('regexp native API', () => {
       'no-useless-flag',
       'no-lazy-ends',
       'no-useless-dollar-replacements',
+      'prefer-escape-replacement-dollar-char',
     ]);
   });
 

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -49,6 +49,7 @@ describe('regexp native API', () => {
       'prefer-named-backreference',
       'no-useless-flag',
       'no-lazy-ends',
+      'no-useless-dollar-replacements',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -231,6 +231,19 @@ const invalidCases = [
   ['no-lazy-ends', 'star lazy at end', 'const re = /a*?/u;\n', ['unexpected']],
   ['no-lazy-ends', 'plus lazy at end', 'const re = /a+?/u;\n', ['unexpected']],
   ['no-lazy-ends', 'braced lazy at end', 'const re = /a{2,}?/u;\n', ['unexpected']],
+  // no-useless-dollar-replacements
+  [
+    'no-useless-dollar-replacements',
+    'dollar zero alone',
+    "str.replace(/foo/u, '$0');\n",
+    ['unexpected'],
+  ],
+  [
+    'no-useless-dollar-replacements',
+    'replaceAll variant',
+    "str.replaceAll(/foo/gu, '$0');\n",
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -244,6 +244,19 @@ const invalidCases = [
     "str.replaceAll(/foo/gu, '$0');\n",
     ['unexpected'],
   ],
+  // prefer-escape-replacement-dollar-char
+  [
+    'prefer-escape-replacement-dollar-char',
+    'dollar followed by space',
+    "str.replace(/a/u, 'pre $ post');\n",
+    ['unexpected'],
+  ],
+  [
+    'prefer-escape-replacement-dollar-char',
+    'trailing dollar',
+    "str.replace(/a/u, 'price$');\n",
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9339,19 +9339,19 @@
       },
       {
         "name": "prefer-escape-replacement-dollar-char",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-escape-replacement-dollar-char."
+        "notes": "JS-side CallExpression check on <expr>.replace / replaceAll. Scans the literal replacement string and reports the first '$' that is NOT followed by a valid replacement-reference char (digit, '&', \"'\", '`', '<', '$'). The '$$' escape is the canonical form for a literal dollar."
       },
       {
         "name": "prefer-lookaround",

--- a/status.json
+++ b/status.json
@@ -9115,19 +9115,19 @@
       },
       {
         "name": "no-useless-dollar-replacements",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-dollar-replacements."
+        "notes": "JS-side CallExpression check on `<expr>.replace(<regex>, <string>)` / `replaceAll`. Scans the literal replacement string for a `$0` token (skipping `$$`); `$0` is never a valid backreference because capture groups start at 1, so the dollar-zero is always interpreted as a literal `$0` and almost always a typo. Dynamic replacement arguments are deferred."
       },
       {
         "name": "no-useless-escape",


### PR DESCRIPTION
Stacked on top of #86. Regexp port **44 → 45 / 82** once the chain lands.

## How it works

JS-side `CallExpression` check on `<expr>.replace(<regex>, <string>)` and `replaceAll`. The new `check_no_useless_dollar_replacements` gates on a `StaticMemberExpression` callee whose property is `replace` or `replaceAll`, requires the second argument to be a `StringLiteral`, and scans its value for a `$0` token via `replacement_contains_dollar_zero`. `$$` is treated as an escaped dollar and skipped.

`$0` is never a valid backreference in `String.prototype.replace`: capture groups are 1-indexed, so the engine always interprets `$0` as the literal two-character sequence `$0`. The rule catches this almost-always-a-typo statically.

Dynamic replacement arguments (template literals with substitutions, identifier references, etc.) are deferred — those need type-aware information beyond what this plugin sees.

## Verification

- 107 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 5 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 45 ported names

## Stacked dependency

Targets `port/regexp-no-lazy-ends` (PR #86). Once #86 lands, this PR rebases cleanly onto main.

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.