### PR TITLE
port(regexp): port control-character-escape

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -12,7 +12,7 @@ use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
     duplicate_flag, first_control_character, first_fixed_unicode_escape, first_hex_x_escape,
-    first_invisible_character, first_non_standard_flag,
+    first_invisible_character, first_literal_control_character, first_non_standard_flag,
     first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
     first_uppercase_hex_escape, first_useless_escape, first_useless_one_quantifier, mention_char,
     pattern_ends_with_lazy_quantifier, pattern_has_empty_string_literal, sorted_flags,
@@ -544,6 +544,17 @@ impl<'a> Scanner<'a> {
         if let Some(ch) = first_control_character(pattern) {
             self.report_with_data(
                 "no-control-character",
+                "unexpected",
+                DiagnosticData {
+                    char_text: Some(mention_char(ch)),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
+        if let Some(ch) = first_literal_control_character(pattern) {
+            self.report_with_data(
+                "control-character-escape",
                 "unexpected",
                 DiagnosticData {
                     char_text: Some(mention_char(ch)),

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -1167,6 +1167,22 @@ pub(crate) fn class_has_useless_range(bytes: &[u8], open: usize) -> Option<char>
     None
 }
 
+/// Returns the first raw control character (`U+0000`-`U+001F` or `U+007F`)
+/// that appears literally in `pattern`. Unlike `first_control_character` this
+/// helper does NOT decode escape sequences — `\x01` as a four-character escape
+/// is returned `None` because the control character is not present in the
+/// pattern bytes themselves. Used by `control-character-escape`, which targets
+/// only the literal occurrences and asks the author to use an escape form.
+pub(crate) fn first_literal_control_character(pattern: &str) -> Option<char> {
+    for ch in pattern.chars() {
+        let code = ch as u32;
+        if code < 0x20 || code == 0x7f {
+            return Some(ch);
+        }
+    }
+    None
+}
+
 pub(crate) fn first_control_character(pattern: &str) -> Option<char> {
     let bytes = pattern.as_bytes();
     let mut index = 0;

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 47] = [
+pub const RULE_NAMES: [&str; 48] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -69,6 +69,7 @@ pub const RULE_NAMES: [&str; 47] = [
     "no-useless-dollar-replacements",
     "prefer-escape-replacement-dollar-char",
     "use-ignore-case",
+    "control-character-escape",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -88,8 +88,42 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-dollar-replacements",
             "prefer-escape-replacement-dollar-char",
             "use-ignore-case",
+            "control-character-escape",
         ]
     );
+}
+
+mod control_character_escape {
+    use super::*;
+
+    #[test]
+    fn reports_literal_control_characters() {
+        // U+0001 SOH as a literal character inside the regex pattern.
+        assert_eq!(
+            rule_ids_for(
+                "const a = new RegExp('\\x01', 'u');",
+                "control-character-escape"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_escaped_control_character_references() {
+        // `\\x01` in the JS source decodes to the four-character regex escape;
+        // there is no literal control byte in the pattern, so this rule does
+        // not fire (no-control-character still does).
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\x01', 'u');",
+                "control-character-escape"
+            )
+            .is_empty()
+        );
+        // Plain ASCII pattern.
+        assert!(rule_ids_for("const a = /abc/u;", "control-character-escape").is_empty());
+    }
 }
 
 mod use_ignore_case {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -179,6 +179,10 @@ const messages = Object.freeze({
     unexpected:
       "Character class mixes lower- and upper-case forms of the same letter; add the 'i' flag instead.",
   },
+  'control-character-escape': {
+    unexpected:
+      'Unexpected literal control character {{ char }} in the pattern; use a `\\xHH` or `\\uHHHH` escape sequence instead.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -246,6 +250,8 @@ const ruleDescriptions = Object.freeze({
     'enforce escaping a literal `$` as `$$` in replacement strings',
   'use-ignore-case':
     'enforce the `i` flag when a character class mixes lower- and upper-case letters',
+  'control-character-escape':
+    'enforce escaping literal control characters in regular-expression patterns',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -295,6 +301,7 @@ const ruleTypes = Object.freeze({
   'no-useless-dollar-replacements': 'problem',
   'prefer-escape-replacement-dollar-char': 'suggestion',
   'use-ignore-case': 'suggestion',
+  'control-character-escape': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -414,7 +421,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-optional-assertion' ||
     ruleName === 'no-dupe-characters-character-class' ||
     ruleName === 'no-lazy-ends' ||
-    ruleName === 'no-useless-dollar-replacements'
+    ruleName === 'no-useless-dollar-replacements' ||
+    ruleName === 'control-character-escape'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -52,6 +52,7 @@ describe('regexp native API', () => {
       'no-useless-dollar-replacements',
       'prefer-escape-replacement-dollar-char',
       'use-ignore-case',
+      'control-character-escape',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -260,6 +260,13 @@ const invalidCases = [
   // use-ignore-case
   ['use-ignore-case', 'lower and upper of a', 'const re = /[aA]/u;\n', ['unexpected']],
   ['use-ignore-case', 'multi case pair', 'const re = /[aAbB]/u;\n', ['unexpected']],
+  // control-character-escape
+  [
+    'control-character-escape',
+    'literal SOH',
+    "const re = new RegExp('\\x01', 'u');\n",
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8603,19 +8603,19 @@
       },
       {
         "name": "control-character-escape",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule control-character-escape."
+        "notes": "Pattern-level scan via first_literal_control_character: walks the pattern chars and reports the first raw character with code point < 0x20 or 0x7F (i.e. an actual control byte). Unlike no-control-character, this helper does NOT decode escape sequences — `\\xHH` reaching the regex engine as four characters is not flagged, only literal control bytes that landed in the pattern via a host-language escape like `\\u0001` in a JS string literal."
       },
       {
         "name": "grapheme-string-literal",


### PR DESCRIPTION
One more pattern-level eslint-plugin-regexp rule on top of #89. Regexp port advances **48 → 49 / 82**.

## How it works

Pattern-level scan via a new `first_literal_control_character` helper: walks the pattern characters and reports the first one with code point `< 0x20` or `0x7F`. Unlike `first_control_character` (which `no-control-character` uses), this helper does NOT decode escape sequences — `\xHH` reaching the regex engine as four characters is not flagged, only literal control bytes that landed in the pattern via a host-language escape like `\u0001` in a JS string literal.

The two rules are intentional parallel emissions: `no-control-character` flags both literal control characters and `\xHH`/`\uHHHH` escape forms that reference them, while `control-character-escape` targets only the literal form and recommends adding an escape. Users can enable them independently.

## Verification

- 113 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 3 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 48 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->