### PR TITLE
port(regexp): port grapheme-string-literal (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -514,6 +514,23 @@ impl<'a> Scanner<'a> {
         if analysis.has_case_pair_class && !flags.contains('i') {
             self.report("use-ignore-case", "unexpected", span);
         }
+        if let Some(ch) = analysis.first_useless_string_literal {
+            let mut original = CompactString::new("\\q{");
+            original.push(ch);
+            original.push('}');
+            let mut replacement = CompactString::new("");
+            replacement.push(ch);
+            self.report_with_data(
+                "grapheme-string-literal",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(original),
+                    replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -984,6 +984,39 @@ pub(crate) fn class_has_case_pair(bytes: &[u8], open: usize) -> bool {
     (0..26).any(|i| has_lower[i] && has_upper[i])
 }
 
+/// Returns `Some(byte)` when the `[...]` class at `open` contains a `\q{X}`
+/// string literal whose body is exactly one ASCII char. Such literals are
+/// equivalent to the bare character in v-mode, so the `\q{}` wrapper is
+/// useless. Used by `grapheme-string-literal`. Multi-character string
+/// literals (`\q{ab}`, `\q{}`) and non-ASCII bodies are deferred — the bare
+/// equivalent depends on grapheme analysis we have not implemented.
+pub(crate) fn class_has_useless_string_literal(bytes: &[u8], open: usize) -> Option<u8> {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let end = find_class_end(bytes, open)?;
+    let mut index = open + 1;
+    while index + 4 < end {
+        if bytes[index] == b'\\' && bytes[index + 1] == b'q' && bytes[index + 2] == b'{' {
+            let mut cursor = index + 3;
+            while cursor < end && bytes[cursor] != b'}' {
+                cursor += 1;
+            }
+            if cursor < end {
+                let inner = &bytes[index + 3..cursor];
+                if inner.len() == 1 {
+                    let ch = inner[0];
+                    if ch.is_ascii_alphanumeric() {
+                        return Some(ch);
+                    }
+                }
+                index = cursor + 1;
+                continue;
+            }
+        }
+        index += 1;
+    }
+    None
+}
+
 /// Returns `Some(byte)` for the first ASCII literal byte that appears more
 /// than once in the `[...]` class at `open`. Escapes, ranges, and nested
 /// classes are intentionally skipped — comparing them for equivalence needs

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 48] = [
+pub const RULE_NAMES: [&str; 49] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -70,6 +70,7 @@ pub const RULE_NAMES: [&str; 48] = [
     "prefer-escape-replacement-dollar-char",
     "use-ignore-case",
     "control-character-escape",
+    "grapheme-string-literal",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -5,9 +5,9 @@ use oxlint_plugins_carton::{CompactString, SmallVec};
 use crate::helpers::{
     BraceQuantifierShape, class_contains_backspace_escape, class_first_collapsible_run,
     class_first_duplicate_literal, class_first_obscure_range, class_has_case_pair,
-    class_has_useless_range, class_is_digit_range, class_is_useless_single_literal,
-    class_is_word_char_set, class_matches_anything, find_class_end, group_prefix,
-    is_zero_quantifier, parse_brace_quantifier, skip_escape,
+    class_has_useless_range, class_has_useless_string_literal, class_is_digit_range,
+    class_is_useless_single_literal, class_is_word_char_set, class_matches_anything,
+    find_class_end, group_prefix, is_zero_quantifier, parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -108,6 +108,9 @@ pub(crate) struct PatternAnalysis {
     /// At least one character class contains both the lower- and upper-case
     /// form of an ASCII letter (e.g. `[aA]`). `use-ignore-case`.
     pub(crate) has_case_pair_class: bool,
+    /// First single-character `\q{X}` string literal inside a class, holding
+    /// the bare character it could be simplified to. `grapheme-string-literal`.
+    pub(crate) first_useless_string_literal: Option<char>,
 }
 
 impl PatternAnalysis {
@@ -168,6 +171,11 @@ impl PatternAnalysis {
                         }
                         if !self.has_case_pair_class && class_has_case_pair(bytes, index) {
                             self.has_case_pair_class = true;
+                        }
+                        if self.first_useless_string_literal.is_none()
+                            && let Some(byte) = class_has_useless_string_literal(bytes, index)
+                        {
+                            self.first_useless_string_literal = Some(byte as char);
                         }
                         if self.first_dupe_class_literal.is_none()
                             && let Some(byte) = class_first_duplicate_literal(bytes, index)

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -89,8 +89,41 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-escape-replacement-dollar-char",
             "use-ignore-case",
             "control-character-escape",
+            "grapheme-string-literal",
         ]
     );
+}
+
+mod grapheme_string_literal {
+    use super::*;
+
+    #[test]
+    fn reports_single_character_string_literals_in_v_classes() {
+        let data = first_data("const a = /[\\q{a}]/v;", "grapheme-string-literal");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\q{a}")
+        );
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("a")
+        );
+        // Digits collapse the same way.
+        assert_eq!(
+            rule_ids_for("const a = /[\\q{5}]/v;", "grapheme-string-literal").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_empty_and_multi_character_string_literals() {
+        // Empty string literal is no-empty-string-literal's job.
+        assert!(rule_ids_for("const a = /[\\q{}]/v;", "grapheme-string-literal").is_empty());
+        // Two-character grapheme — needs grapheme analysis we don't do here.
+        assert!(rule_ids_for("const a = /[\\q{ab}]/v;", "grapheme-string-literal").is_empty());
+        // Plain character class.
+        assert!(rule_ids_for("const a = /[ab]/v;", "grapheme-string-literal").is_empty());
+    }
 }
 
 mod control_character_escape {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -183,6 +183,10 @@ const messages = Object.freeze({
     unexpected:
       'Unexpected literal control character {{ char }} in the pattern; use a `\\xHH` or `\\uHHHH` escape sequence instead.',
   },
+  'grapheme-string-literal': {
+    unexpected:
+      "Unexpected single-character string literal '{{expr}}'. Use '{{replacement}}' instead.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -252,6 +256,8 @@ const ruleDescriptions = Object.freeze({
     'enforce the `i` flag when a character class mixes lower- and upper-case letters',
   'control-character-escape':
     'enforce escaping literal control characters in regular-expression patterns',
+  'grapheme-string-literal':
+    'disallow single-character `\\q{X}` string literals in v-mode character classes',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -302,6 +308,7 @@ const ruleTypes = Object.freeze({
   'prefer-escape-replacement-dollar-char': 'suggestion',
   'use-ignore-case': 'suggestion',
   'control-character-escape': 'problem',
+  'grapheme-string-literal': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -453,7 +460,8 @@ function ruleCategory(ruleName) {
     ruleName === 'prefer-named-backreference' ||
     ruleName === 'no-useless-flag' ||
     ruleName === 'prefer-escape-replacement-dollar-char' ||
-    ruleName === 'use-ignore-case'
+    ruleName === 'use-ignore-case' ||
+    ruleName === 'grapheme-string-literal'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -53,6 +53,7 @@ describe('regexp native API', () => {
       'prefer-escape-replacement-dollar-char',
       'use-ignore-case',
       'control-character-escape',
+      'grapheme-string-literal',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -267,6 +267,13 @@ const invalidCases = [
     "const re = new RegExp('\\x01', 'u');\n",
     ['unexpected'],
   ],
+  // grapheme-string-literal
+  [
+    'grapheme-string-literal',
+    'single-char string literal',
+    'const re = /[\\q{a}]/v;\n',
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8619,19 +8619,19 @@
       },
       {
         "name": "grapheme-string-literal",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule grapheme-string-literal."
+        "notes": "Class-level scan via class_has_useless_string_literal: walks the v-mode `[...]` body for `\\q{X}` literals whose body is exactly one ASCII alphanumeric character; that wraps a single bare char to no effect. Empty literals (`\\q{}`) stay with no-empty-string-literal; multi-character literals are deferred (they need grapheme analysis)."
       },
       {
         "name": "hexadecimal-escape",


### PR DESCRIPTION
One more class-level eslint-plugin-regexp rule on top of #90. Regexp port advances **49 → 50 / 82**.

## How it works

Class-level scan via a new `class_has_useless_string_literal` helper: walks the v-mode `[...]` body for `\q{X}` literals whose body is exactly one ASCII alphanumeric character. That wraps a single bare char to no effect (`[\q{a}]` is the same as `[a]` in v-mode), so the rule recommends stripping the `\q{}` wrapper.

Empty literals (`\q{}`) stay with `no-empty-string-literal`; multi-character literals are intentionally deferred — they need grapheme cluster analysis we have not implemented.

`PatternAnalysis` gains `first_useless_string_literal`. The check reuses the existing `find_class_end` primitive and adds no new full-pattern walk.

## Verification

- 115 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 4 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 49 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.