### PR TITLE
port(regexp): port no-useless-non-capturing-group (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -514,6 +514,9 @@ impl<'a> Scanner<'a> {
         if analysis.has_case_pair_class && !flags.contains('i') {
             self.report("use-ignore-case", "unexpected", span);
         }
+        if analysis.has_useless_non_capturing_group {
+            self.report("no-useless-non-capturing-group", "unexpected", span);
+        }
         if let Some(ch) = analysis.first_useless_string_literal {
             let mut original = CompactString::new("\\q{");
             original.push(ch);

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -85,6 +85,7 @@ pub(crate) struct GroupPrefix {
     pub(crate) capturing: bool,
     pub(crate) named: bool,
     pub(crate) is_lookaround: bool,
+    pub(crate) is_non_capturing: bool,
     pub(crate) next: usize,
 }
 
@@ -95,6 +96,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             capturing: true,
             named: false,
             is_lookaround: false,
+            is_non_capturing: false,
             next: open + 1,
         };
     }
@@ -104,6 +106,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             capturing: false,
             named: false,
             is_lookaround: false,
+            is_non_capturing: true,
             next: open + 3,
         },
         Some(b'=') | Some(b'!') => GroupPrefix {
@@ -111,6 +114,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             capturing: false,
             named: false,
             is_lookaround: true,
+            is_non_capturing: false,
             next: open + 3,
         },
         Some(b'<') => {
@@ -120,6 +124,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
                     capturing: false,
                     named: false,
                     is_lookaround: true,
+                    is_non_capturing: false,
                     next: open + 4,
                 }
             } else {
@@ -132,6 +137,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
                     capturing: true,
                     named: true,
                     is_lookaround: false,
+                    is_non_capturing: false,
                     next: cursor.saturating_add(1).min(bytes.len()),
                 }
             }
@@ -141,6 +147,7 @@ pub(crate) fn group_prefix(bytes: &[u8], open: usize) -> GroupPrefix {
             capturing: false,
             named: false,
             is_lookaround: false,
+            is_non_capturing: false,
             next: open + 2,
         },
     }

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 49] = [
+pub const RULE_NAMES: [&str; 50] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -71,6 +71,7 @@ pub const RULE_NAMES: [&str; 49] = [
     "use-ignore-case",
     "control-character-escape",
     "grapheme-string-literal",
+    "no-useless-non-capturing-group",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -15,6 +15,10 @@ pub(crate) struct GroupState {
     pub(crate) check_empty: bool,
     pub(crate) capturing: bool,
     pub(crate) is_lookaround: bool,
+    pub(crate) is_non_capturing: bool,
+    /// Byte offset of the body start (after the prefix). Used by
+    /// `no-useless-non-capturing-group` to read the body character.
+    pub(crate) body_start: usize,
     pub(crate) seen_pipe: bool,
     pub(crate) current_has_content: bool,
 }
@@ -25,16 +29,26 @@ impl GroupState {
             check_empty: false,
             capturing: false,
             is_lookaround: false,
+            is_non_capturing: false,
+            body_start: 0,
             seen_pipe: false,
             current_has_content: false,
         }
     }
 
-    fn group(check_empty: bool, capturing: bool, is_lookaround: bool) -> Self {
+    fn group(
+        check_empty: bool,
+        capturing: bool,
+        is_lookaround: bool,
+        is_non_capturing: bool,
+        body_start: usize,
+    ) -> Self {
         Self {
             check_empty,
             capturing,
             is_lookaround,
+            is_non_capturing,
+            body_start,
             seen_pipe: false,
             current_has_content: false,
         }
@@ -111,6 +125,10 @@ pub(crate) struct PatternAnalysis {
     /// First single-character `\q{X}` string literal inside a class, holding
     /// the bare character it could be simplified to. `grapheme-string-literal`.
     pub(crate) first_useless_string_literal: Option<char>,
+    /// At least one `(?:X)` non-capturing group whose body is a single
+    /// regular ASCII alphanumeric character and is not followed by a
+    /// quantifier — the wrapper is useless. `no-useless-non-capturing-group`.
+    pub(crate) has_useless_non_capturing_group: bool,
 }
 
 impl PatternAnalysis {
@@ -203,6 +221,8 @@ impl PatternAnalysis {
                         prefix.check_empty,
                         prefix.capturing,
                         prefix.is_lookaround,
+                        prefix.is_non_capturing,
+                        prefix.next,
                     ));
                     index = prefix.next;
                 }
@@ -228,6 +248,24 @@ impl PatternAnalysis {
                         // assertion does not consume input.
                         if group.is_lookaround && bytes.get(index + 1) == Some(&b'?') {
                             self.has_optional_assertion = true;
+                        }
+                        // `(?:X)` with a single ASCII-alphanumeric body and no
+                        // following quantifier — the wrapper carries no meaning.
+                        // We only consider non-capturing groups with no `|` and
+                        // exactly one literal byte between `:` and `)`. Other
+                        // body shapes (escapes, classes, groups) are deferred
+                        // so the check stays sound.
+                        if group.is_non_capturing
+                            && !group.seen_pipe
+                            && index == group.body_start + 1
+                        {
+                            let byte = bytes[group.body_start];
+                            let next = bytes.get(index + 1).copied();
+                            let followed_by_quantifier =
+                                matches!(next, Some(b'*' | b'+' | b'?' | b'{'));
+                            if byte.is_ascii_alphanumeric() && !followed_by_quantifier {
+                                self.has_useless_non_capturing_group = true;
+                            }
                         }
                         self.mark_content(&mut groups);
                     }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -90,8 +90,51 @@ fn exposes_initial_regexp_rule_names() {
             "use-ignore-case",
             "control-character-escape",
             "grapheme-string-literal",
+            "no-useless-non-capturing-group",
         ]
     );
+}
+
+mod no_useless_non_capturing_group {
+    use super::*;
+
+    #[test]
+    fn reports_single_literal_body_without_quantifier() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:a)/u;", "no-useless-non-capturing-group").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for(
+                "const a = /pre(?:b)post/u;",
+                "no-useless-non-capturing-group"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+        // Digits also collapse the same way.
+        assert_eq!(
+            rule_ids_for("const a = /(?:5)/u;", "no-useless-non-capturing-group").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_multi_atom_alternation_quantifier_and_capture_groups() {
+        // Multi-byte body — bare equivalence is not obvious without atom analysis.
+        assert!(rule_ids_for("const a = /(?:abc)/u;", "no-useless-non-capturing-group").is_empty());
+        // Followed by quantifier — the group is the quantified unit.
+        assert!(rule_ids_for("const a = /(?:a)+/u;", "no-useless-non-capturing-group").is_empty());
+        assert!(
+            rule_ids_for("const a = /(?:a){3}/u;", "no-useless-non-capturing-group").is_empty()
+        );
+        // Capturing group — not non-capturing.
+        assert!(rule_ids_for("const a = /(a)/u;", "no-useless-non-capturing-group").is_empty());
+        // Alternation present — not eligible for the narrow form.
+        assert!(rule_ids_for("const a = /(?:a|b)/u;", "no-useless-non-capturing-group").is_empty());
+        // Escape inside body — deferred.
+        assert!(rule_ids_for("const a = /(?:\\d)/u;", "no-useless-non-capturing-group").is_empty());
+    }
 }
 
 mod grapheme_string_literal {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -187,6 +187,10 @@ const messages = Object.freeze({
     unexpected:
       "Unexpected single-character string literal '{{expr}}'. Use '{{replacement}}' instead.",
   },
+  'no-useless-non-capturing-group': {
+    unexpected:
+      'Unexpected non-capturing group with a single literal body; remove the `(?:` ... `)` wrapper.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -258,6 +262,8 @@ const ruleDescriptions = Object.freeze({
     'enforce escaping literal control characters in regular-expression patterns',
   'grapheme-string-literal':
     'disallow single-character `\\q{X}` string literals in v-mode character classes',
+  'no-useless-non-capturing-group':
+    'disallow non-capturing groups that wrap a single literal character without a quantifier',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -309,6 +315,7 @@ const ruleTypes = Object.freeze({
   'use-ignore-case': 'suggestion',
   'control-character-escape': 'problem',
   'grapheme-string-literal': 'suggestion',
+  'no-useless-non-capturing-group': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -461,7 +468,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-useless-flag' ||
     ruleName === 'prefer-escape-replacement-dollar-char' ||
     ruleName === 'use-ignore-case' ||
-    ruleName === 'grapheme-string-literal'
+    ruleName === 'grapheme-string-literal' ||
+    ruleName === 'no-useless-non-capturing-group'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -54,6 +54,7 @@ describe('regexp native API', () => {
       'use-ignore-case',
       'control-character-escape',
       'grapheme-string-literal',
+      'no-useless-non-capturing-group',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -274,6 +274,14 @@ const invalidCases = [
     'const re = /[\\q{a}]/v;\n',
     ['unexpected'],
   ],
+  // no-useless-non-capturing-group
+  ['no-useless-non-capturing-group', 'single-char body', 'const re = /(?:a)/u;\n', ['unexpected']],
+  [
+    'no-useless-non-capturing-group',
+    'inline context',
+    'const re = /pre(?:b)post/u;\n',
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9179,19 +9179,19 @@
       },
       {
         "name": "no-useless-non-capturing-group",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-non-capturing-group."
+        "notes": "GroupPrefix gains is_non_capturing, GroupState tracks body_start. At close `)`, when the group is non-capturing, has no `|` seen, and contains exactly one ASCII alphanumeric byte (and the following byte is not a quantifier), the wrapper is reported as useless. Multi-byte bodies, escapes, classes, nested groups, and quantified groups are intentionally deferred."
       },
       {
         "name": "no-useless-quantifier",


### PR DESCRIPTION
One more group-aware eslint-plugin-regexp rule on top of #91. Regexp port advances **50 → 51 / 82**.

## How it works

`GroupPrefix` gains `is_non_capturing` (the `(?:` shape). `GroupState` tracks `body_start` (the byte offset immediately after the prefix). At close `)`, when the group is non-capturing, has not seen `|`, and the body span between `body_start` and the closing position is exactly one ASCII alphanumeric byte (and the byte after the `)` is not a quantifier `*`, `+`, `?`, or `{`), the wrapper is reported as useless.

Multi-byte bodies, escapes, classes, nested groups, and quantified groups are intentionally deferred — they need atom-level analysis we have not implemented.

This is the first rule that uses per-group body-byte tracking, which opens the door to porting `prefer-quantifier`, the `no-trivially-nested-*` family, and `prefer-character-class` in follow-up PRs once the tracker is generalized.

## Verification

- 117 Rust unit tests pass (4 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 7 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 50 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->