### PR TITLE
port(regexp): port prefer-quantifier (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -517,6 +517,9 @@ impl<'a> Scanner<'a> {
         if analysis.has_useless_non_capturing_group {
             self.report("no-useless-non-capturing-group", "unexpected", span);
         }
+        if analysis.has_preferable_quantifier_group {
+            self.report("prefer-quantifier", "unexpected", span);
+        }
         if let Some(ch) = analysis.first_useless_string_literal {
             let mut original = CompactString::new("\\q{");
             original.push(ch);

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 50] = [
+pub const RULE_NAMES: [&str; 51] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -72,6 +72,7 @@ pub const RULE_NAMES: [&str; 50] = [
     "control-character-escape",
     "grapheme-string-literal",
     "no-useless-non-capturing-group",
+    "prefer-quantifier",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -129,6 +129,11 @@ pub(crate) struct PatternAnalysis {
     /// regular ASCII alphanumeric character and is not followed by a
     /// quantifier — the wrapper is useless. `no-useless-non-capturing-group`.
     pub(crate) has_useless_non_capturing_group: bool,
+    /// At least one `(?:X){n}` non-capturing group whose body is a single
+    /// regular ASCII alphanumeric character AND is followed by a quantifier —
+    /// the wrapper is unnecessary because the quantifier could apply to the
+    /// bare atom. `prefer-quantifier`.
+    pub(crate) has_preferable_quantifier_group: bool,
 }
 
 impl PatternAnalysis {
@@ -249,12 +254,14 @@ impl PatternAnalysis {
                         if group.is_lookaround && bytes.get(index + 1) == Some(&b'?') {
                             self.has_optional_assertion = true;
                         }
-                        // `(?:X)` with a single ASCII-alphanumeric body and no
-                        // following quantifier — the wrapper carries no meaning.
-                        // We only consider non-capturing groups with no `|` and
-                        // exactly one literal byte between `:` and `)`. Other
-                        // body shapes (escapes, classes, groups) are deferred
-                        // so the check stays sound.
+                        // `(?:X)` with a single ASCII-alphanumeric body. The
+                        // wrapper carries no meaning regardless of what follows
+                        // because the quantifier (if any) could apply directly
+                        // to the bare atom. Two complementary rules cover this:
+                        // `no-useless-non-capturing-group` when no quantifier
+                        // follows, `prefer-quantifier` when one does. We only
+                        // consider non-capturing groups with no `|` and exactly
+                        // one literal byte between `:` and `)`.
                         if group.is_non_capturing
                             && !group.seen_pipe
                             && index == group.body_start + 1
@@ -263,8 +270,12 @@ impl PatternAnalysis {
                             let next = bytes.get(index + 1).copied();
                             let followed_by_quantifier =
                                 matches!(next, Some(b'*' | b'+' | b'?' | b'{'));
-                            if byte.is_ascii_alphanumeric() && !followed_by_quantifier {
-                                self.has_useless_non_capturing_group = true;
+                            if byte.is_ascii_alphanumeric() {
+                                if followed_by_quantifier {
+                                    self.has_preferable_quantifier_group = true;
+                                } else {
+                                    self.has_useless_non_capturing_group = true;
+                                }
                             }
                         }
                         self.mark_content(&mut groups);

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -91,8 +91,45 @@ fn exposes_initial_regexp_rule_names() {
             "control-character-escape",
             "grapheme-string-literal",
             "no-useless-non-capturing-group",
+            "prefer-quantifier",
         ]
     );
+}
+
+mod prefer_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_single_body_groups_followed_by_quantifier() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:a){3}/u;", "prefer-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:a)+/u;", "prefer-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:a)*/u;", "prefer-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:a)?/u;", "prefer-quantifier").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_group_shapes() {
+        // No quantifier follows — no-useless-non-capturing-group's job.
+        assert!(rule_ids_for("const a = /(?:a)/u;", "prefer-quantifier").is_empty());
+        // Multi-byte body — `ab{3}` would change semantics, so the wrapper is needed.
+        assert!(rule_ids_for("const a = /(?:ab){3}/u;", "prefer-quantifier").is_empty());
+        // Capturing group is intentional and outside this rule.
+        assert!(rule_ids_for("const a = /(a){3}/u;", "prefer-quantifier").is_empty());
+        // Alternation body.
+        assert!(rule_ids_for("const a = /(?:a|b){3}/u;", "prefer-quantifier").is_empty());
+    }
 }
 
 mod no_useless_non_capturing_group {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -191,6 +191,10 @@ const messages = Object.freeze({
     unexpected:
       'Unexpected non-capturing group with a single literal body; remove the `(?:` ... `)` wrapper.',
   },
+  'prefer-quantifier': {
+    unexpected:
+      'Apply the quantifier directly to the single-character body instead of wrapping it in a non-capturing group.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -264,6 +268,8 @@ const ruleDescriptions = Object.freeze({
     'disallow single-character `\\q{X}` string literals in v-mode character classes',
   'no-useless-non-capturing-group':
     'disallow non-capturing groups that wrap a single literal character without a quantifier',
+  'prefer-quantifier':
+    'apply quantifiers directly to single-character atoms instead of wrapping them in a non-capturing group',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -316,6 +322,7 @@ const ruleTypes = Object.freeze({
   'control-character-escape': 'problem',
   'grapheme-string-literal': 'suggestion',
   'no-useless-non-capturing-group': 'suggestion',
+  'prefer-quantifier': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -469,7 +476,8 @@ function ruleCategory(ruleName) {
     ruleName === 'prefer-escape-replacement-dollar-char' ||
     ruleName === 'use-ignore-case' ||
     ruleName === 'grapheme-string-literal' ||
-    ruleName === 'no-useless-non-capturing-group'
+    ruleName === 'no-useless-non-capturing-group' ||
+    ruleName === 'prefer-quantifier'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -55,6 +55,7 @@ describe('regexp native API', () => {
       'control-character-escape',
       'grapheme-string-literal',
       'no-useless-non-capturing-group',
+      'prefer-quantifier',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -282,6 +282,9 @@ const invalidCases = [
     'const re = /pre(?:b)post/u;\n',
     ['unexpected'],
   ],
+  // prefer-quantifier
+  ['prefer-quantifier', 'braced quantifier', 'const re = /(?:a){3}/u;\n', ['unexpected']],
+  ['prefer-quantifier', 'plus quantifier', 'const re = /(?:a)+/u;\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9451,19 +9451,19 @@
       },
       {
         "name": "prefer-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-quantifier."
+        "notes": "Built on the GroupState body-byte tracker introduced for no-useless-non-capturing-group. At close `)`, when the group is non-capturing, has not seen `|`, the body is exactly one ASCII alphanumeric byte, AND the byte after `)` is a quantifier (`*`, `+`, `?`, or `{`), the wrapper is reported. The quantifier could apply directly to the bare atom. Multi-atom bodies and escape/class/group bodies are deferred."
       },
       {
         "name": "prefer-question-quantifier",


### PR DESCRIPTION
Complementary to `no-useless-non-capturing-group` (PR #92, just landed). Regexp port advances **51 → 52 / 82**.

## How it works

Built on the `GroupState.body_start` tracker introduced for `no-useless-non-capturing-group`. At close `)`, when the group is non-capturing, has not seen `|`, the body is exactly one ASCII alphanumeric byte, AND the byte after `)` is a quantifier (`*`, `+`, `?`, or `{`), the wrapper is reported as preferable to bare quantifier application. Multi-atom bodies and escape/class/group bodies are deferred.

The two single-byte-body rules are now complementary:
- `no-useless-non-capturing-group` fires when no quantifier follows
- `prefer-quantifier` fires when one does

Together they cover the entire `(?:X)` narrow case.

## Verification

- 119 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 5 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 51 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->