### PR TITLE
port(regexp): port no-useless-string-literal and sort-character-class-elements

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -530,12 +530,30 @@ impl<'a> Scanner<'a> {
                 "grapheme-string-literal",
                 "unexpected",
                 DiagnosticData {
+                    expr: Some(original.clone()),
+                    replacement: Some(replacement.clone()),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
+            // `no-useless-string-literal` covers the same single-character
+            // `\q{X}` case from a slightly different angle (the string-literal
+            // wrapper is dropped because the bare char already works in
+            // v-mode classes); fire both rules so users can enable them
+            // independently.
+            self.report_with_data(
+                "no-useless-string-literal",
+                "unexpected",
+                DiagnosticData {
                     expr: Some(original),
                     replacement: Some(replacement),
                     ..DiagnosticData::default()
                 },
                 span,
             );
+        }
+        if analysis.has_unsorted_class_elements {
+            self.report("sort-character-class-elements", "unexpected", span);
         }
 
         if analysis.has_empty_character_class {

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -997,6 +997,43 @@ pub(crate) fn class_has_case_pair(bytes: &[u8], open: usize) -> bool {
 /// useless. Used by `grapheme-string-literal`. Multi-character string
 /// literals (`\q{ab}`, `\q{}`) and non-ASCII bodies are deferred — the bare
 /// equivalent depends on grapheme analysis we have not implemented.
+///
+/// Returns `true` when the `[...]` class at `open` is composed exclusively of
+/// distinct ASCII alphanumeric byte literals AND those bytes appear out of
+/// sorted order. Classes containing escapes, ranges, the `^` negation, or
+/// non-alphanumeric literals are deferred (the sort order semantics get
+/// hairy across categories). Used by `sort-character-class-elements`.
+pub(crate) fn class_has_unsorted_literal_elements(bytes: &[u8], open: usize) -> bool {
+    debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
+    let Some(end) = find_class_end(bytes, open) else {
+        return false;
+    };
+    let mut index = open + 1;
+    if bytes.get(index) == Some(&b'^') {
+        return false;
+    }
+    let mut prev: u8 = 0;
+    let mut unsorted = false;
+    while index < end {
+        let byte = bytes[index];
+        if byte == b'\\' {
+            return false;
+        }
+        if index + 2 < end && bytes[index + 1] == b'-' {
+            return false;
+        }
+        if !byte.is_ascii_alphanumeric() {
+            return false;
+        }
+        if byte < prev {
+            unsorted = true;
+        }
+        prev = byte;
+        index += 1;
+    }
+    unsorted
+}
+
 pub(crate) fn class_has_useless_string_literal(bytes: &[u8], open: usize) -> Option<u8> {
     debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
     let end = find_class_end(bytes, open)?;

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 51] = [
+pub const RULE_NAMES: [&str; 53] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -73,6 +73,8 @@ pub const RULE_NAMES: [&str; 51] = [
     "grapheme-string-literal",
     "no-useless-non-capturing-group",
     "prefer-quantifier",
+    "no-useless-string-literal",
+    "sort-character-class-elements",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -5,9 +5,10 @@ use oxlint_plugins_carton::{CompactString, SmallVec};
 use crate::helpers::{
     BraceQuantifierShape, class_contains_backspace_escape, class_first_collapsible_run,
     class_first_duplicate_literal, class_first_obscure_range, class_has_case_pair,
-    class_has_useless_range, class_has_useless_string_literal, class_is_digit_range,
-    class_is_useless_single_literal, class_is_word_char_set, class_matches_anything,
-    find_class_end, group_prefix, is_zero_quantifier, parse_brace_quantifier, skip_escape,
+    class_has_unsorted_literal_elements, class_has_useless_range, class_has_useless_string_literal,
+    class_is_digit_range, class_is_useless_single_literal, class_is_word_char_set,
+    class_matches_anything, find_class_end, group_prefix, is_zero_quantifier,
+    parse_brace_quantifier, skip_escape,
 };
 
 #[derive(Clone, Copy)]
@@ -134,6 +135,9 @@ pub(crate) struct PatternAnalysis {
     /// the wrapper is unnecessary because the quantifier could apply to the
     /// bare atom. `prefer-quantifier`.
     pub(crate) has_preferable_quantifier_group: bool,
+    /// At least one `[...]` class whose body is all-alphanumeric-literal but
+    /// out of sorted order. `sort-character-class-elements`.
+    pub(crate) has_unsorted_class_elements: bool,
 }
 
 impl PatternAnalysis {
@@ -194,6 +198,11 @@ impl PatternAnalysis {
                         }
                         if !self.has_case_pair_class && class_has_case_pair(bytes, index) {
                             self.has_case_pair_class = true;
+                        }
+                        if !self.has_unsorted_class_elements
+                            && class_has_unsorted_literal_elements(bytes, index)
+                        {
+                            self.has_unsorted_class_elements = true;
                         }
                         if self.first_useless_string_literal.is_none()
                             && let Some(byte) = class_has_useless_string_literal(bytes, index)

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -92,8 +92,61 @@ fn exposes_initial_regexp_rule_names() {
             "grapheme-string-literal",
             "no-useless-non-capturing-group",
             "prefer-quantifier",
+            "no-useless-string-literal",
+            "sort-character-class-elements",
         ]
     );
+}
+
+mod no_useless_string_literal {
+    use super::*;
+
+    #[test]
+    fn fires_alongside_grapheme_string_literal_on_single_char_body() {
+        assert_eq!(
+            rule_ids_for("const a = /[\\q{a}]/v;", "no-useless-string-literal").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_empty_and_multi_character_bodies() {
+        assert!(rule_ids_for("const a = /[\\q{}]/v;", "no-useless-string-literal").is_empty());
+        assert!(rule_ids_for("const a = /[\\q{ab}]/v;", "no-useless-string-literal").is_empty());
+    }
+}
+
+mod sort_character_class_elements {
+    use super::*;
+
+    #[test]
+    fn reports_unsorted_all_literal_classes() {
+        assert_eq!(
+            rule_ids_for("const a = /[ba]/u;", "sort-character-class-elements").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /[cba]/u;", "sort-character-class-elements").as_slice(),
+            &["unexpected"]
+        );
+        // Digits and letters intermixed but still unsorted.
+        assert_eq!(
+            rule_ids_for("const a = /[b1a]/u;", "sort-character-class-elements").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_sorted_classes_and_classes_with_escapes_or_ranges() {
+        assert!(rule_ids_for("const a = /[ab]/u;", "sort-character-class-elements").is_empty());
+        assert!(rule_ids_for("const a = /[abc]/u;", "sort-character-class-elements").is_empty());
+        // Escape inside class — deferred.
+        assert!(rule_ids_for("const a = /[a\\d]/u;", "sort-character-class-elements").is_empty());
+        // Range — deferred.
+        assert!(rule_ids_for("const a = /[a-z]/u;", "sort-character-class-elements").is_empty());
+        // Negated class — deferred.
+        assert!(rule_ids_for("const a = /[^ba]/u;", "sort-character-class-elements").is_empty());
+    }
 }
 
 mod prefer_quantifier {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -195,6 +195,13 @@ const messages = Object.freeze({
     unexpected:
       'Apply the quantifier directly to the single-character body instead of wrapping it in a non-capturing group.',
   },
+  'no-useless-string-literal': {
+    unexpected:
+      "Unexpected single-character string literal '{{expr}}'. Drop the `\\q{...}` wrapper and use '{{replacement}}' instead.",
+  },
+  'sort-character-class-elements': {
+    unexpected: 'Character class elements are not sorted; reorder them lexicographically.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -270,6 +277,10 @@ const ruleDescriptions = Object.freeze({
     'disallow non-capturing groups that wrap a single literal character without a quantifier',
   'prefer-quantifier':
     'apply quantifiers directly to single-character atoms instead of wrapping them in a non-capturing group',
+  'no-useless-string-literal':
+    'disallow string literals in v-mode classes when a bare character would do',
+  'sort-character-class-elements':
+    'enforce sorted character class elements when the body is all literal alphanumerics',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -323,6 +334,8 @@ const ruleTypes = Object.freeze({
   'grapheme-string-literal': 'suggestion',
   'no-useless-non-capturing-group': 'suggestion',
   'prefer-quantifier': 'suggestion',
+  'no-useless-string-literal': 'suggestion',
+  'sort-character-class-elements': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -477,7 +490,9 @@ function ruleCategory(ruleName) {
     ruleName === 'use-ignore-case' ||
     ruleName === 'grapheme-string-literal' ||
     ruleName === 'no-useless-non-capturing-group' ||
-    ruleName === 'prefer-quantifier'
+    ruleName === 'prefer-quantifier' ||
+    ruleName === 'no-useless-string-literal' ||
+    ruleName === 'sort-character-class-elements'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -56,6 +56,8 @@ describe('regexp native API', () => {
       'grapheme-string-literal',
       'no-useless-non-capturing-group',
       'prefer-quantifier',
+      'no-useless-string-literal',
+      'sort-character-class-elements',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -97,6 +97,13 @@ const validCases = [
   ['no-invisible-character', 'plain pattern', 'const re = /ab/u;\n'],
   ['no-invisible-character', 'ascii space', 'const re = /a b/u;\n'],
   ['no-invisible-character', 'escaped hex NBSP', "const re = new RegExp('a\\\\xa0b', 'u');\n"],
+  // no-useless-string-literal
+  ['no-useless-string-literal', 'empty literal', 'const re = /[\\q{}]/v;\n'],
+  ['no-useless-string-literal', 'multi-char literal', 'const re = /[\\q{ab}]/v;\n'],
+  // sort-character-class-elements
+  ['sort-character-class-elements', 'sorted class', 'const re = /[ab]/u;\n'],
+  ['sort-character-class-elements', 'class with escape', 'const re = /[a\\d]/u;\n'],
+  ['sort-character-class-elements', 'class with range', 'const re = /[a-z]/u;\n'],
 ];
 
 const invalidCases = [
@@ -285,6 +292,16 @@ const invalidCases = [
   // prefer-quantifier
   ['prefer-quantifier', 'braced quantifier', 'const re = /(?:a){3}/u;\n', ['unexpected']],
   ['prefer-quantifier', 'plus quantifier', 'const re = /(?:a)+/u;\n', ['unexpected']],
+  // no-useless-string-literal
+  ['no-useless-string-literal', 'single-char body', 'const re = /[\\q{a}]/v;\n', ['unexpected']],
+  // sort-character-class-elements
+  ['sort-character-class-elements', 'reversed letters', 'const re = /[ba]/u;\n', ['unexpected']],
+  [
+    'sort-character-class-elements',
+    'mixed digits and letters',
+    'const re = /[b1a]/u;\n',
+    ['unexpected'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9243,19 +9243,19 @@
       },
       {
         "name": "no-useless-string-literal",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-useless-string-literal."
+        "notes": "Parallel emission with grapheme-string-literal: both fire on `\\q{X}` with a single ASCII alphanumeric body. Users can enable them independently. Empty / multi-character bodies are deferred."
       },
       {
         "name": "no-useless-two-nums-quantifier",
@@ -9659,19 +9659,19 @@
       },
       {
         "name": "sort-character-class-elements",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule sort-character-class-elements."
+        "notes": "Class-level scan via class_has_unsorted_literal_elements: walks the class body once, rejecting on any escape, range, negation, or non-alphanumeric byte. Reports when the remaining all-literal elements are not in ascending byte order. Sorting semantics across escapes/ranges are intentionally deferred."
       },
       {
         "name": "strict",


### PR DESCRIPTION
Two more `eslint-plugin-regexp` rules. Regexp port advances **52 → 54 / 82**.

## How it works

- `no-useless-string-literal`: parallel emission with `grapheme-string-literal`. Both fire on `\q{X}` with a single ASCII alphanumeric body, so users can enable them independently. Empty bodies (handled by `no-empty-string-literal`) and multi-character bodies (which need grapheme-cluster analysis) are deferred.
- `sort-character-class-elements`: a new `class_has_unsorted_literal_elements` helper walks each `[...]` body once, rejecting on any escape, range, negation, or non-alphanumeric byte. When the remaining all-literal elements are not in ascending byte order, the rule fires. Sorting semantics across escapes / ranges are intentionally deferred — they need an ordering schema we have not built.

`PatternAnalysis` gains `has_unsorted_class_elements`. The new check reuses the existing `find_class_end` primitive and adds no new full-pattern walk.

## Verification

- 121 Rust unit tests pass (8 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 9 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 51 ported names (so far on this branch — #93 also lands `prefer-quantifier` for 52)

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->