### PR TITLE
port(regexp): port no-trivially-nested-assertion and no-extra-lookaround-assertions

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -555,6 +555,12 @@ impl<'a> Scanner<'a> {
         if analysis.has_unsorted_class_elements {
             self.report("sort-character-class-elements", "unexpected", span);
         }
+        if analysis.has_trivially_nested_assertion {
+            self.report("no-trivially-nested-assertion", "unexpected", span);
+        }
+        if analysis.has_extra_lookaround_assertion {
+            self.report("no-extra-lookaround-assertions", "unexpected", span);
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 53] = [
+pub const RULE_NAMES: [&str; 55] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -75,6 +75,8 @@ pub const RULE_NAMES: [&str; 53] = [
     "prefer-quantifier",
     "no-useless-string-literal",
     "sort-character-class-elements",
+    "no-trivially-nested-assertion",
+    "no-extra-lookaround-assertions",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -22,6 +22,16 @@ pub(crate) struct GroupState {
     pub(crate) body_start: usize,
     pub(crate) seen_pipe: bool,
     pub(crate) current_has_content: bool,
+    /// Number of top-level atoms in the current alternative. Each literal
+    /// character, escape, character class, or completed nested group counts
+    /// as one atom. Reset by `|`. Used to detect "body is exactly one
+    /// nested group" cases (`no-trivially-nested-assertion` and
+    /// `no-extra-lookaround-assertions`).
+    pub(crate) current_alt_atom_count: u32,
+    /// `true` if the most recently completed atom in the current alternative
+    /// was a lookaround group closing. Pairs with `current_alt_atom_count`
+    /// to identify single-assertion bodies.
+    pub(crate) last_atom_was_lookaround: bool,
 }
 
 impl GroupState {
@@ -34,6 +44,8 @@ impl GroupState {
             body_start: 0,
             seen_pipe: false,
             current_has_content: false,
+            current_alt_atom_count: 0,
+            last_atom_was_lookaround: false,
         }
     }
 
@@ -52,6 +64,8 @@ impl GroupState {
             body_start,
             seen_pipe: false,
             current_has_content: false,
+            current_alt_atom_count: 0,
+            last_atom_was_lookaround: false,
         }
     }
 }
@@ -138,6 +152,12 @@ pub(crate) struct PatternAnalysis {
     /// At least one `[...]` class whose body is all-alphanumeric-literal but
     /// out of sorted order. `sort-character-class-elements`.
     pub(crate) has_unsorted_class_elements: bool,
+    /// `(?:(?=...))` — a non-capturing group whose entire body is exactly
+    /// one nested lookaround. `no-trivially-nested-assertion`.
+    pub(crate) has_trivially_nested_assertion: bool,
+    /// `(?=(?=...))` — a lookaround whose entire body is exactly one nested
+    /// lookaround. `no-extra-lookaround-assertions`.
+    pub(crate) has_extra_lookaround_assertion: bool,
 }
 
 impl PatternAnalysis {
@@ -287,7 +307,29 @@ impl PatternAnalysis {
                                 }
                             }
                         }
-                        self.mark_content(&mut groups);
+                        // Bodies that consist of exactly one nested lookaround
+                        // atom (and nothing else) are reported as trivially
+                        // nested. `no-trivially-nested-assertion` targets the
+                        // `(?:` outer wrapper, `no-extra-lookaround-assertions`
+                        // targets the `(?=` / `(?!` / `(?<=` / `(?<!` outer
+                        // wrapper. Both require: no `|` seen, atom_count == 1,
+                        // and the single atom was itself a lookaround.
+                        if !group.seen_pipe
+                            && group.current_alt_atom_count == 1
+                            && group.last_atom_was_lookaround
+                        {
+                            if group.is_non_capturing {
+                                self.has_trivially_nested_assertion = true;
+                            }
+                            if group.is_lookaround {
+                                self.has_extra_lookaround_assertion = true;
+                            }
+                        }
+                        if group.is_lookaround {
+                            self.mark_atom_from_lookaround(&mut groups);
+                        } else {
+                            self.mark_content(&mut groups);
+                        }
                     }
                     index += 1;
                 }
@@ -298,6 +340,8 @@ impl PatternAnalysis {
                         }
                         group.seen_pipe = true;
                         group.current_has_content = false;
+                        group.current_alt_atom_count = 0;
+                        group.last_atom_was_lookaround = false;
                     }
                     index += 1;
                 }
@@ -397,6 +441,16 @@ impl PatternAnalysis {
     fn mark_content(&self, groups: &mut SmallVec<[GroupState; 8]>) {
         if let Some(group) = groups.last_mut() {
             group.current_has_content = true;
+            group.current_alt_atom_count = group.current_alt_atom_count.saturating_add(1);
+            group.last_atom_was_lookaround = false;
+        }
+    }
+
+    fn mark_atom_from_lookaround(&self, groups: &mut SmallVec<[GroupState; 8]>) {
+        if let Some(group) = groups.last_mut() {
+            group.current_has_content = true;
+            group.current_alt_atom_count = group.current_alt_atom_count.saturating_add(1);
+            group.last_atom_was_lookaround = true;
         }
     }
 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -94,8 +94,74 @@ fn exposes_initial_regexp_rule_names() {
             "prefer-quantifier",
             "no-useless-string-literal",
             "sort-character-class-elements",
+            "no-trivially-nested-assertion",
+            "no-extra-lookaround-assertions",
         ]
     );
+}
+
+mod no_trivially_nested_assertion {
+    use super::*;
+
+    #[test]
+    fn reports_non_cap_wrapping_only_lookaround() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:(?=a))/u;", "no-trivially-nested-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:(?!b))/u;", "no-trivially-nested-assertion").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:(?<=c))/u;", "no-trivially-nested-assertion").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_cap_with_other_content_or_unrelated_groups() {
+        // Lookaround + extra content — wrapper carries that content.
+        assert!(
+            rule_ids_for("const a = /(?:(?=a)b)/u;", "no-trivially-nested-assertion").is_empty()
+        );
+        // Plain literal body — handled by other rules, not this one.
+        assert!(rule_ids_for("const a = /(?:a)/u;", "no-trivially-nested-assertion").is_empty());
+        // Capturing group — not in scope.
+        assert!(rule_ids_for("const a = /((?=a))/u;", "no-trivially-nested-assertion").is_empty());
+        // Lookaround alone at top level — not nested.
+        assert!(rule_ids_for("const a = /(?=a)/u;", "no-trivially-nested-assertion").is_empty());
+    }
+}
+
+mod no_extra_lookaround_assertions {
+    use super::*;
+
+    #[test]
+    fn reports_lookaround_wrapping_only_another_lookaround() {
+        assert_eq!(
+            rule_ids_for("const a = /(?=(?=a))/u;", "no-extra-lookaround-assertions").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?<!(?!b))/u;", "no-extra-lookaround-assertions").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_shapes() {
+        // Lookaround with literal body — fine.
+        assert!(rule_ids_for("const a = /(?=ab)/u;", "no-extra-lookaround-assertions").is_empty());
+        // Non-cap wrapping a lookaround is the other rule's job.
+        assert!(
+            rule_ids_for("const a = /(?:(?=a))/u;", "no-extra-lookaround-assertions").is_empty()
+        );
+        // Lookaround followed by more content.
+        assert!(
+            rule_ids_for("const a = /(?=(?=a)b)/u;", "no-extra-lookaround-assertions").is_empty()
+        );
+    }
 }
 
 mod no_useless_string_literal {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -202,6 +202,14 @@ const messages = Object.freeze({
   'sort-character-class-elements': {
     unexpected: 'Character class elements are not sorted; reorder them lexicographically.',
   },
+  'no-trivially-nested-assertion': {
+    unexpected:
+      'Non-capturing group whose body is exactly one lookaround assertion; drop the `(?:` ... `)` wrapper.',
+  },
+  'no-extra-lookaround-assertions': {
+    unexpected:
+      'Lookaround assertion whose body is exactly one nested lookaround; drop the outer assertion.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -281,6 +289,10 @@ const ruleDescriptions = Object.freeze({
     'disallow string literals in v-mode classes when a bare character would do',
   'sort-character-class-elements':
     'enforce sorted character class elements when the body is all literal alphanumerics',
+  'no-trivially-nested-assertion':
+    'disallow non-capturing groups whose entire body is a single lookaround assertion',
+  'no-extra-lookaround-assertions':
+    'disallow lookaround assertions whose entire body is a single nested lookaround',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -336,6 +348,8 @@ const ruleTypes = Object.freeze({
   'prefer-quantifier': 'suggestion',
   'no-useless-string-literal': 'suggestion',
   'sort-character-class-elements': 'suggestion',
+  'no-trivially-nested-assertion': 'suggestion',
+  'no-extra-lookaround-assertions': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -492,7 +506,9 @@ function ruleCategory(ruleName) {
     ruleName === 'no-useless-non-capturing-group' ||
     ruleName === 'prefer-quantifier' ||
     ruleName === 'no-useless-string-literal' ||
-    ruleName === 'sort-character-class-elements'
+    ruleName === 'sort-character-class-elements' ||
+    ruleName === 'no-trivially-nested-assertion' ||
+    ruleName === 'no-extra-lookaround-assertions'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -58,6 +58,8 @@ describe('regexp native API', () => {
       'prefer-quantifier',
       'no-useless-string-literal',
       'sort-character-class-elements',
+      'no-trivially-nested-assertion',
+      'no-extra-lookaround-assertions',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -104,6 +104,12 @@ const validCases = [
   ['sort-character-class-elements', 'sorted class', 'const re = /[ab]/u;\n'],
   ['sort-character-class-elements', 'class with escape', 'const re = /[a\\d]/u;\n'],
   ['sort-character-class-elements', 'class with range', 'const re = /[a-z]/u;\n'],
+  // no-trivially-nested-assertion
+  ['no-trivially-nested-assertion', 'non-cap with literal body', 'const re = /(?:a)/u;\n'],
+  ['no-trivially-nested-assertion', 'lookaround at top level', 'const re = /(?=a)/u;\n'],
+  // no-extra-lookaround-assertions
+  ['no-extra-lookaround-assertions', 'lookaround with literal body', 'const re = /(?=a)/u;\n'],
+  ['no-extra-lookaround-assertions', 'non-cap wrapping lookaround', 'const re = /(?:(?=a))/u;\n'],
 ];
 
 const invalidCases = [
@@ -300,6 +306,32 @@ const invalidCases = [
     'sort-character-class-elements',
     'mixed digits and letters',
     'const re = /[b1a]/u;\n',
+    ['unexpected'],
+  ],
+  // no-trivially-nested-assertion
+  [
+    'no-trivially-nested-assertion',
+    'non-cap wrapping lookahead',
+    'const re = /(?:(?=a))/u;\n',
+    ['unexpected'],
+  ],
+  [
+    'no-trivially-nested-assertion',
+    'non-cap wrapping lookbehind',
+    'const re = /(?:(?<=a))/u;\n',
+    ['unexpected'],
+  ],
+  // no-extra-lookaround-assertions
+  [
+    'no-extra-lookaround-assertions',
+    'nested positive lookahead',
+    'const re = /(?=(?=a))/u;\n',
+    ['unexpected'],
+  ],
+  [
+    'no-extra-lookaround-assertions',
+    'nested negative lookbehind',
+    'const re = /(?<!(?!b))/u;\n',
     ['unexpected'],
   ],
 ];

--- a/status.json
+++ b/status.json
@@ -8795,19 +8795,19 @@
       },
       {
         "name": "no-extra-lookaround-assertions",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-extra-lookaround-assertions."
+        "notes": "Same atom-count tracker as no-trivially-nested-assertion, but targets lookaround wrappers: at close of a `(?=` / `(?!` / `(?<=` / `(?<!` group whose body is exactly one nested lookaround atom, the outer assertion is reported as redundant."
       },
       {
         "name": "no-invisible-character",
@@ -9019,19 +9019,19 @@
       },
       {
         "name": "no-trivially-nested-assertion",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-trivially-nested-assertion."
+        "notes": "GroupState gains per-alternative atom_count and last_atom_was_lookaround. At close `)`, when a non-capturing group has not seen `|`, its body is exactly one atom, AND that atom was a lookaround close, the wrapper is reported as trivially nested."
       },
       {
         "name": "no-trivially-nested-quantifier",


### PR DESCRIPTION
Two more `eslint-plugin-regexp` rules on top of #94. Regexp port advances **54 → 56 / 82**.

## How it works

`GroupState` gains two per-alternative fields: `current_alt_atom_count` and `last_atom_was_lookaround`. The `mark_content` path increments `atom_count` and sets `last_atom_was_lookaround = false`; closing a lookaround increments the parent's `atom_count` and sets `last_atom_was_lookaround = true`. The `|` handler resets both fields for the new alternative.

At close `)`, when `atom_count == 1`, `last_atom_was_lookaround`, and the group has not seen `|`:
- non-capturing wrapper (`(?:`) fires `no-trivially-nested-assertion` (e.g. `(?:(?=a))`)
- lookaround wrapper (`(?=` / `(?!` / `(?<=` / `(?<!`) fires `no-extra-lookaround-assertions` (e.g. `(?=(?=a))`)

This is the first time we track atom granularity rather than byte content. The atom counter ignores anchors `^`/`$` (they were not `mark_content` emitters before) and counts character classes, escapes, and completed nested groups as single atoms each.

## Verification

- 127 Rust unit tests pass (8 new across the two rule modules)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 8 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 55 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->