### PR TITLE
port(regexp): port no-trivially-nested-quantifier (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -561,6 +561,12 @@ impl<'a> Scanner<'a> {
         if analysis.has_extra_lookaround_assertion {
             self.report("no-extra-lookaround-assertions", "unexpected", span);
         }
+        if analysis.has_trivially_nested_quantifier {
+            self.report("no-trivially-nested-quantifier", "unexpected", span);
+        }
+        if analysis.has_preferable_character_class {
+            self.report("prefer-character-class", "unexpected", span);
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 55] = [
+pub const RULE_NAMES: [&str; 57] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -77,6 +77,8 @@ pub const RULE_NAMES: [&str; 55] = [
     "sort-character-class-elements",
     "no-trivially-nested-assertion",
     "no-extra-lookaround-assertions",
+    "no-trivially-nested-quantifier",
+    "prefer-character-class",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -32,6 +32,15 @@ pub(crate) struct GroupState {
     /// was a lookaround group closing. Pairs with `current_alt_atom_count`
     /// to identify single-assertion bodies.
     pub(crate) last_atom_was_lookaround: bool,
+    /// Byte offset where the current alternative began. For the first
+    /// alternative this equals `body_start`; for subsequent alts it is the
+    /// position immediately after the previous `|`. Used by
+    /// `prefer-character-class` to inspect each alternative's literal shape.
+    pub(crate) current_alt_start: usize,
+    /// `true` while every alternative observed so far in this group has
+    /// consisted of exactly one ASCII alphanumeric byte. Used by
+    /// `prefer-character-class`.
+    pub(crate) all_alts_single_literal: bool,
 }
 
 impl GroupState {
@@ -46,6 +55,8 @@ impl GroupState {
             current_has_content: false,
             current_alt_atom_count: 0,
             last_atom_was_lookaround: false,
+            current_alt_start: 0,
+            all_alts_single_literal: true,
         }
     }
 
@@ -66,6 +77,8 @@ impl GroupState {
             current_has_content: false,
             current_alt_atom_count: 0,
             last_atom_was_lookaround: false,
+            current_alt_start: body_start,
+            all_alts_single_literal: true,
         }
     }
 }
@@ -158,6 +171,14 @@ pub(crate) struct PatternAnalysis {
     /// `(?=(?=...))` — a lookaround whose entire body is exactly one nested
     /// lookaround. `no-extra-lookaround-assertions`.
     pub(crate) has_extra_lookaround_assertion: bool,
+    /// `(?:X+)+` etc. — a non-capturing group whose body is a single
+    /// quantified ASCII alphanumeric atom AND is itself followed by a
+    /// quantifier. `no-trivially-nested-quantifier`.
+    pub(crate) has_trivially_nested_quantifier: bool,
+    /// `(?:a|b|c)` — a non-capturing group whose alternation has at least
+    /// two alternatives and every alternative is exactly one ASCII
+    /// alphanumeric literal byte. `prefer-character-class`.
+    pub(crate) has_preferable_character_class: bool,
 }
 
 impl PatternAnalysis {
@@ -325,6 +346,44 @@ impl PatternAnalysis {
                                 self.has_extra_lookaround_assertion = true;
                             }
                         }
+                        // `(?:X+)+` and similar: non-capturing wrapper whose
+                        // body is a single ASCII alphanumeric atom followed
+                        // by `*`/`+`/`?`, and is itself followed by a
+                        // quantifier. Both quantifiers apply to the same bare
+                        // atom so the outer wrapper carries no meaning.
+                        // `(?:a|b|c)` with all-single-literal alternatives ->
+                        // `prefer-character-class`. We tracked per-alt
+                        // single-literal shape during scanning; combined with
+                        // the final-alt check here, an alternation with at
+                        // least one `|` and every alt being a bare
+                        // alphanumeric letter/digit is reported.
+                        if group.is_non_capturing && group.seen_pipe {
+                            let alt_len = index - group.current_alt_start;
+                            let final_alt_simple = alt_len == 1
+                                && bytes[group.current_alt_start].is_ascii_alphanumeric();
+                            if group.all_alts_single_literal && final_alt_simple {
+                                self.has_preferable_character_class = true;
+                            }
+                        }
+                        // Multi-byte bodies, escapes, classes, and braced
+                        // quantifiers are deferred to keep the check sound.
+                        if group.is_non_capturing
+                            && !group.seen_pipe
+                            && index == group.body_start + 2
+                        {
+                            let body0 = bytes[group.body_start];
+                            let body1 = bytes[group.body_start + 1];
+                            let outer_q = matches!(
+                                bytes.get(index + 1).copied(),
+                                Some(b'*' | b'+' | b'?' | b'{')
+                            );
+                            if body0.is_ascii_alphanumeric()
+                                && matches!(body1, b'*' | b'+' | b'?')
+                                && outer_q
+                            {
+                                self.has_trivially_nested_quantifier = true;
+                            }
+                        }
                         if group.is_lookaround {
                             self.mark_atom_from_lookaround(&mut groups);
                         } else {
@@ -338,10 +397,21 @@ impl PatternAnalysis {
                         if !group.current_has_content {
                             self.has_empty_alternative = true;
                         }
+                        // Check the closing alternative for `prefer-character-class`:
+                        // each alt must be exactly one ASCII alphanumeric byte.
+                        if group.all_alts_single_literal {
+                            let alt_len = index - group.current_alt_start;
+                            if alt_len != 1
+                                || !bytes[group.current_alt_start].is_ascii_alphanumeric()
+                            {
+                                group.all_alts_single_literal = false;
+                            }
+                        }
                         group.seen_pipe = true;
                         group.current_has_content = false;
                         group.current_alt_atom_count = 0;
                         group.last_atom_was_lookaround = false;
+                        group.current_alt_start = index + 1;
                     }
                     index += 1;
                 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -96,6 +96,8 @@ fn exposes_initial_regexp_rule_names() {
             "sort-character-class-elements",
             "no-trivially-nested-assertion",
             "no-extra-lookaround-assertions",
+            "no-trivially-nested-quantifier",
+            "prefer-character-class",
         ]
     );
 }
@@ -160,6 +162,84 @@ mod no_extra_lookaround_assertions {
         // Lookaround followed by more content.
         assert!(
             rule_ids_for("const a = /(?=(?=a)b)/u;", "no-extra-lookaround-assertions").is_empty()
+        );
+    }
+}
+
+mod prefer_character_class {
+    use super::*;
+
+    #[test]
+    fn reports_non_cap_alternation_of_single_literals() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|b)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|b|c)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+        // Digits and letters mix is fine — both alphanumeric.
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|1|b)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_alts_with_multi_byte_or_escapes_or_groups() {
+        // Multi-byte alt.
+        assert!(rule_ids_for("const a = /(?:a|bc)/u;", "prefer-character-class").is_empty());
+        // Escape inside.
+        assert!(rule_ids_for("const a = /(?:a|\\d)/u;", "prefer-character-class").is_empty());
+        // Class inside.
+        assert!(rule_ids_for("const a = /(?:a|[b])/u;", "prefer-character-class").is_empty());
+        // No alternation.
+        assert!(rule_ids_for("const a = /(?:a)/u;", "prefer-character-class").is_empty());
+        // Capturing group.
+        assert!(rule_ids_for("const a = /(a|b)/u;", "prefer-character-class").is_empty());
+    }
+}
+
+mod no_trivially_nested_quantifier {
+    use super::*;
+
+    #[test]
+    fn reports_non_cap_with_quantified_atom_body_and_outer_quantifier() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:a+)+/u;", "no-trivially-nested-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:b*)*/u;", "no-trivially-nested-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:c?)+/u;", "no-trivially-nested-quantifier").as_slice(),
+            &["unexpected"]
+        );
+        // Braced outer quantifier also counts.
+        assert_eq!(
+            rule_ids_for("const a = /(?:a+){2}/u;", "no-trivially-nested-quantifier").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_group_shapes() {
+        // No outer quantifier — handled by other rules.
+        assert!(rule_ids_for("const a = /(?:a+)/u;", "no-trivially-nested-quantifier").is_empty());
+        // Inner has no quantifier.
+        assert!(rule_ids_for("const a = /(?:a)+/u;", "no-trivially-nested-quantifier").is_empty());
+        // Multi-byte body — deferred.
+        assert!(
+            rule_ids_for("const a = /(?:ab+)+/u;", "no-trivially-nested-quantifier").is_empty()
+        );
+        // Capturing group.
+        assert!(rule_ids_for("const a = /(a+)+/u;", "no-trivially-nested-quantifier").is_empty());
+        // Alternation in body.
+        assert!(
+            rule_ids_for("const a = /(?:a+|b)+/u;", "no-trivially-nested-quantifier").is_empty()
         );
     }
 }

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -210,6 +210,10 @@ const messages = Object.freeze({
     unexpected:
       'Lookaround assertion whose body is exactly one nested lookaround; drop the outer assertion.',
   },
+  'no-trivially-nested-quantifier': {
+    unexpected:
+      'Non-capturing group with a quantified single-character body that is itself quantified; drop the wrapper and combine the quantifiers.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -293,6 +297,7 @@ const ruleDescriptions = Object.freeze({
     'disallow non-capturing groups whose entire body is a single lookaround assertion',
   'no-extra-lookaround-assertions':
     'disallow lookaround assertions whose entire body is a single nested lookaround',
+  'no-trivially-nested-quantifier': 'disallow trivially nested quantifiers like `(?:X+)+`',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -350,6 +355,8 @@ const ruleTypes = Object.freeze({
   'sort-character-class-elements': 'suggestion',
   'no-trivially-nested-assertion': 'suggestion',
   'no-extra-lookaround-assertions': 'suggestion',
+  'no-trivially-nested-quantifier': 'suggestion',
+  'prefer-character-class': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -508,7 +515,8 @@ function ruleCategory(ruleName) {
     ruleName === 'no-useless-string-literal' ||
     ruleName === 'sort-character-class-elements' ||
     ruleName === 'no-trivially-nested-assertion' ||
-    ruleName === 'no-extra-lookaround-assertions'
+    ruleName === 'no-extra-lookaround-assertions' ||
+    ruleName === 'no-trivially-nested-quantifier'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -60,6 +60,8 @@ describe('regexp native API', () => {
       'sort-character-class-elements',
       'no-trivially-nested-assertion',
       'no-extra-lookaround-assertions',
+      'no-trivially-nested-quantifier',
+      'prefer-character-class',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -110,6 +110,14 @@ const validCases = [
   // no-extra-lookaround-assertions
   ['no-extra-lookaround-assertions', 'lookaround with literal body', 'const re = /(?=a)/u;\n'],
   ['no-extra-lookaround-assertions', 'non-cap wrapping lookaround', 'const re = /(?:(?=a))/u;\n'],
+  // no-trivially-nested-quantifier
+  ['no-trivially-nested-quantifier', 'no outer quantifier', 'const re = /(?:a+)/u;\n'],
+  ['no-trivially-nested-quantifier', 'no inner quantifier', 'const re = /(?:a)+/u;\n'],
+  ['no-trivially-nested-quantifier', 'multi-byte body', 'const re = /(?:ab+)+/u;\n'],
+  // prefer-character-class
+  ['prefer-character-class', 'multi-byte alt', 'const re = /(?:a|bc)/u;\n'],
+  ['prefer-character-class', 'escape alt', 'const re = /(?:a|\\d)/u;\n'],
+  ['prefer-character-class', 'no alternation', 'const re = /(?:a)/u;\n'],
 ];
 
 const invalidCases = [
@@ -332,6 +340,27 @@ const invalidCases = [
     'no-extra-lookaround-assertions',
     'nested negative lookbehind',
     'const re = /(?<!(?!b))/u;\n',
+    ['unexpected'],
+  ],
+  // no-trivially-nested-quantifier
+  [
+    'no-trivially-nested-quantifier',
+    'plus inside plus',
+    'const re = /(?:a+)+/u;\n',
+    ['unexpected'],
+  ],
+  [
+    'no-trivially-nested-quantifier',
+    'star inside star',
+    'const re = /(?:b*)*/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-character-class
+  ['prefer-character-class', 'two letters', 'const re = /(?:a|b)/u;\n', ['unexpected']],
+  [
+    'prefer-character-class',
+    'mixed letters and digits',
+    'const re = /(?:a|1|b)/u;\n',
     ['unexpected'],
   ],
 ];

--- a/status.json
+++ b/status.json
@@ -9035,19 +9035,19 @@
       },
       {
         "name": "no-trivially-nested-quantifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-trivially-nested-quantifier."
+        "notes": "Reuses GroupState.body_start tracker plus a narrow byte-shape check at close: when a non-capturing group has body of exactly two bytes (ASCII alphanumeric + */+/?) AND the byte after the close paren is itself a quantifier, the wrapper is redundant. Multi-byte bodies, escapes, classes, and braced inner quantifiers are deferred."
       },
       {
         "name": "no-unused-capturing-group",
@@ -9307,19 +9307,19 @@
       },
       {
         "name": "prefer-character-class",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-character-class."
+        "notes": "GroupState tracks current_alt_start (byte offset of the alternative being parsed) and all_alts_single_literal (a running bool). At each | and at close ), the current alternative is inspected: alt_len must be 1 AND that byte must be ASCII alphanumeric. When the non-capturing group has seen at least one | and the flag is still true, prefer-character-class fires. Escapes, classes, groups, and multi-byte alts are deferred."
       },
       {
         "name": "prefer-d",


### PR DESCRIPTION
One more rule on top of the freshly-landed #95. Regexp port advances **56 → 57 / 82**.

## How it works

Reuses `GroupState.body_start` plus a narrow byte-shape check at close `)`: when a non-capturing group has body of exactly two bytes — an ASCII alphanumeric atom followed by `*`/`+`/`?` — AND the byte after the close paren is itself a quantifier (`*`/`+`/`?`/`{`), both quantifiers apply to the bare atom so the wrapper is redundant. The canonical case is `(?:a+)+`, which collapses to `a+`.

Multi-byte bodies, escapes inside the group, character classes, and braced inner quantifiers (`{n,m}`) are intentionally deferred to keep the check sound. Capturing groups `(a+)+` and alternation `(?:a+|b)+` are also excluded.

## Verification

- 129 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 5 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 56 ported names

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.