### PR TITLE
port(regexp): port prefer-character-class (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -564,6 +564,9 @@ impl<'a> Scanner<'a> {
         if analysis.has_trivially_nested_quantifier {
             self.report("no-trivially-nested-quantifier", "unexpected", span);
         }
+        if analysis.has_preferable_character_class {
+            self.report("prefer-character-class", "unexpected", span);
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 56] = [
+pub const RULE_NAMES: [&str; 57] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -78,6 +78,7 @@ pub const RULE_NAMES: [&str; 56] = [
     "no-trivially-nested-assertion",
     "no-extra-lookaround-assertions",
     "no-trivially-nested-quantifier",
+    "prefer-character-class",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -32,6 +32,15 @@ pub(crate) struct GroupState {
     /// was a lookaround group closing. Pairs with `current_alt_atom_count`
     /// to identify single-assertion bodies.
     pub(crate) last_atom_was_lookaround: bool,
+    /// Byte offset where the current alternative began. For the first
+    /// alternative this equals `body_start`; for subsequent alts it is the
+    /// position immediately after the previous `|`. Used by
+    /// `prefer-character-class` to inspect each alternative's literal shape.
+    pub(crate) current_alt_start: usize,
+    /// `true` while every alternative observed so far in this group has
+    /// consisted of exactly one ASCII alphanumeric byte. Used by
+    /// `prefer-character-class`.
+    pub(crate) all_alts_single_literal: bool,
 }
 
 impl GroupState {
@@ -46,6 +55,8 @@ impl GroupState {
             current_has_content: false,
             current_alt_atom_count: 0,
             last_atom_was_lookaround: false,
+            current_alt_start: 0,
+            all_alts_single_literal: true,
         }
     }
 
@@ -66,6 +77,8 @@ impl GroupState {
             current_has_content: false,
             current_alt_atom_count: 0,
             last_atom_was_lookaround: false,
+            current_alt_start: body_start,
+            all_alts_single_literal: true,
         }
     }
 }
@@ -162,6 +175,10 @@ pub(crate) struct PatternAnalysis {
     /// quantified ASCII alphanumeric atom AND is itself followed by a
     /// quantifier. `no-trivially-nested-quantifier`.
     pub(crate) has_trivially_nested_quantifier: bool,
+    /// `(?:a|b|c)` — a non-capturing group whose alternation has at least
+    /// two alternatives and every alternative is exactly one ASCII
+    /// alphanumeric literal byte. `prefer-character-class`.
+    pub(crate) has_preferable_character_class: bool,
 }
 
 impl PatternAnalysis {
@@ -334,6 +351,20 @@ impl PatternAnalysis {
                         // by `*`/`+`/`?`, and is itself followed by a
                         // quantifier. Both quantifiers apply to the same bare
                         // atom so the outer wrapper carries no meaning.
+                        // `(?:a|b|c)` with all-single-literal alternatives ->
+                        // `prefer-character-class`. We tracked per-alt
+                        // single-literal shape during scanning; combined with
+                        // the final-alt check here, an alternation with at
+                        // least one `|` and every alt being a bare
+                        // alphanumeric letter/digit is reported.
+                        if group.is_non_capturing && group.seen_pipe {
+                            let alt_len = index - group.current_alt_start;
+                            let final_alt_simple = alt_len == 1
+                                && bytes[group.current_alt_start].is_ascii_alphanumeric();
+                            if group.all_alts_single_literal && final_alt_simple {
+                                self.has_preferable_character_class = true;
+                            }
+                        }
                         // Multi-byte bodies, escapes, classes, and braced
                         // quantifiers are deferred to keep the check sound.
                         if group.is_non_capturing
@@ -366,10 +397,21 @@ impl PatternAnalysis {
                         if !group.current_has_content {
                             self.has_empty_alternative = true;
                         }
+                        // Check the closing alternative for `prefer-character-class`:
+                        // each alt must be exactly one ASCII alphanumeric byte.
+                        if group.all_alts_single_literal {
+                            let alt_len = index - group.current_alt_start;
+                            if alt_len != 1
+                                || !bytes[group.current_alt_start].is_ascii_alphanumeric()
+                            {
+                                group.all_alts_single_literal = false;
+                            }
+                        }
                         group.seen_pipe = true;
                         group.current_has_content = false;
                         group.current_alt_atom_count = 0;
                         group.last_atom_was_lookaround = false;
+                        group.current_alt_start = index + 1;
                     }
                     index += 1;
                 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -97,6 +97,7 @@ fn exposes_initial_regexp_rule_names() {
             "no-trivially-nested-assertion",
             "no-extra-lookaround-assertions",
             "no-trivially-nested-quantifier",
+            "prefer-character-class",
         ]
     );
 }
@@ -162,6 +163,41 @@ mod no_extra_lookaround_assertions {
         assert!(
             rule_ids_for("const a = /(?=(?=a)b)/u;", "no-extra-lookaround-assertions").is_empty()
         );
+    }
+}
+
+mod prefer_character_class {
+    use super::*;
+
+    #[test]
+    fn reports_non_cap_alternation_of_single_literals() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|b)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|b|c)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+        // Digits and letters mix is fine — both alphanumeric.
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|1|b)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_alts_with_multi_byte_or_escapes_or_groups() {
+        // Multi-byte alt.
+        assert!(rule_ids_for("const a = /(?:a|bc)/u;", "prefer-character-class").is_empty());
+        // Escape inside.
+        assert!(rule_ids_for("const a = /(?:a|\\d)/u;", "prefer-character-class").is_empty());
+        // Class inside.
+        assert!(rule_ids_for("const a = /(?:a|[b])/u;", "prefer-character-class").is_empty());
+        // No alternation.
+        assert!(rule_ids_for("const a = /(?:a)/u;", "prefer-character-class").is_empty());
+        // Capturing group.
+        assert!(rule_ids_for("const a = /(a|b)/u;", "prefer-character-class").is_empty());
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -356,6 +356,7 @@ const ruleTypes = Object.freeze({
   'no-trivially-nested-assertion': 'suggestion',
   'no-extra-lookaround-assertions': 'suggestion',
   'no-trivially-nested-quantifier': 'suggestion',
+  'prefer-character-class': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -61,6 +61,7 @@ describe('regexp native API', () => {
       'no-trivially-nested-assertion',
       'no-extra-lookaround-assertions',
       'no-trivially-nested-quantifier',
+      'prefer-character-class',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -114,6 +114,10 @@ const validCases = [
   ['no-trivially-nested-quantifier', 'no outer quantifier', 'const re = /(?:a+)/u;\n'],
   ['no-trivially-nested-quantifier', 'no inner quantifier', 'const re = /(?:a)+/u;\n'],
   ['no-trivially-nested-quantifier', 'multi-byte body', 'const re = /(?:ab+)+/u;\n'],
+  // prefer-character-class
+  ['prefer-character-class', 'multi-byte alt', 'const re = /(?:a|bc)/u;\n'],
+  ['prefer-character-class', 'escape alt', 'const re = /(?:a|\\d)/u;\n'],
+  ['prefer-character-class', 'no alternation', 'const re = /(?:a)/u;\n'],
 ];
 
 const invalidCases = [
@@ -349,6 +353,14 @@ const invalidCases = [
     'no-trivially-nested-quantifier',
     'star inside star',
     'const re = /(?:b*)*/u;\n',
+    ['unexpected'],
+  ],
+  // prefer-character-class
+  ['prefer-character-class', 'two letters', 'const re = /(?:a|b)/u;\n', ['unexpected']],
+  [
+    'prefer-character-class',
+    'mixed letters and digits',
+    'const re = /(?:a|1|b)/u;\n',
     ['unexpected'],
   ],
 ];

--- a/status.json
+++ b/status.json
@@ -9307,19 +9307,19 @@
       },
       {
         "name": "prefer-character-class",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-character-class."
+        "notes": "GroupState tracks current_alt_start (byte offset of the alternative being parsed) and all_alts_single_literal (a running bool). At each | and at close ), the current alternative is inspected: alt_len must be 1 AND that byte must be ASCII alphanumeric. When the non-capturing group has seen at least one | and the flag is still true, prefer-character-class fires. Escapes, classes, groups, and multi-byte alts are deferred."
       },
       {
         "name": "prefer-d",


### PR DESCRIPTION
Stacked on top of #96. Regexp port advances **57 → 58 / 82**.

## How it works

`GroupState` tracks `current_alt_start` (the byte offset where the current alternative began) and `all_alts_single_literal` (a running bool, true while every alternative observed so far has consisted of exactly one ASCII alphanumeric byte). At each `|` and at close `)`, the current alternative is inspected — `index - current_alt_start` must equal 1 AND the byte there must be ASCII alphanumeric. When the non-capturing group has seen at least one `|` and the flag is still true, `prefer-character-class` fires.

Escapes inside an alt, character classes, nested groups, and multi-byte alternatives are intentionally deferred to keep the check sound (no false positives). Capturing groups are excluded by design — they retain match-group semantics that a character class cannot.

## Verification

- 131 Rust unit tests pass (2 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (326 files)
- Vitest plugin tests gain 5 new valid/invalid cases; `api.test.mjs` rule-name list extended to all 57 ported names

## Stacked dependency

Targets `port/regexp-no-trivially-nested-quantifier` (PR #96, auto-merge enabled).

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.