### PR TITLE
test(security): replay upstream eslint-plugin-security suite via generated fixtures

### DIFF
--- a/npm/security/test/fixtures/detect-bidi-characters.json
+++ b/npm/security/test/fixtures/detect-bidi-characters.json
@@ -1,0 +1,149 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-bidi-characters.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n  var accessLevel = \"user\";\n  if (accessLevel != \"user\") { // Check if admin\n    console.log(\"You are an admin.\");\n  }\n  "
+    },
+    {
+      "code": "\n  var isAdmin = false;\n  /* begin admins only */ if (isAdmin) {\n    console.log(\"You are an admin.\");\n  /* end admins only */ }\n  "
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n      var accessLevel = \"user\";\n      if (accessLevel != \"user‮ ⁦// Check if admin⁩ ⁦\") {\n          console.log(\"You are an admin.\");\n      }\n      ",
+      "errors": [
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this code",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 31,
+          "endColumn": 32
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this code",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 33,
+          "endColumn": 34
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this code",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 51,
+          "endColumn": 52
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this code",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 53,
+          "endColumn": 54
+        }
+      ]
+    },
+    {
+      "code": "\n      var isAdmin = false;\n      /*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */\n          console.log(\"You are an admin.\");\n      /* end admins only ‮\n⁦*/\n      /* end admins only ‮\n { ⁦*/\n        ",
+      "errors": [
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 9,
+          "endColumn": 10
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 13,
+          "endColumn": 14
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 26,
+          "endColumn": 27
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 3,
+          "endLine": 3,
+          "column": 28,
+          "endColumn": 29
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 5,
+          "endLine": 5,
+          "column": 26,
+          "endColumn": 27
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 6,
+          "endLine": 6,
+          "column": 1,
+          "endColumn": 2
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 7,
+          "endLine": 7,
+          "column": 26,
+          "endColumn": 27
+        },
+        {
+          "message": {
+            "__regex": "Detected potential trojan source attack with unicode bidi introduced in this comment",
+            "__flags": "i"
+          },
+          "line": 8,
+          "endLine": 8,
+          "column": 4,
+          "endColumn": 5
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-buffer-noassert.json
+++ b/npm/security/test/fixtures/detect-buffer-noassert.json
@@ -1,0 +1,413 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-buffer-noassert.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "a.readUInt8(0)"
+    },
+    {
+      "code": "a.readUInt16LE(0)"
+    },
+    {
+      "code": "a.readUInt16BE(0)"
+    },
+    {
+      "code": "a.readUInt32LE(0)"
+    },
+    {
+      "code": "a.readUInt32BE(0)"
+    },
+    {
+      "code": "a.readInt8(0)"
+    },
+    {
+      "code": "a.readInt16LE(0)"
+    },
+    {
+      "code": "a.readInt16BE(0)"
+    },
+    {
+      "code": "a.readInt32LE(0)"
+    },
+    {
+      "code": "a.readInt32BE(0)"
+    },
+    {
+      "code": "a.readFloatLE(0)"
+    },
+    {
+      "code": "a.readFloatBE(0)"
+    },
+    {
+      "code": "a.readDoubleLE(0)"
+    },
+    {
+      "code": "a.readDoubleBE(0)"
+    },
+    {
+      "code": "a.writeUInt8(0)"
+    },
+    {
+      "code": "a.writeUInt16LE(0)"
+    },
+    {
+      "code": "a.writeUInt16BE(0)"
+    },
+    {
+      "code": "a.writeUInt32LE(0)"
+    },
+    {
+      "code": "a.writeUInt32BE(0)"
+    },
+    {
+      "code": "a.writeInt8(0)"
+    },
+    {
+      "code": "a.writeInt16LE(0)"
+    },
+    {
+      "code": "a.writeInt16BE(0)"
+    },
+    {
+      "code": "a.writeInt32LE(0)"
+    },
+    {
+      "code": "a.writeInt32BE(0)"
+    },
+    {
+      "code": "a.writeFloatLE(0)"
+    },
+    {
+      "code": "a.writeFloatBE(0)"
+    },
+    {
+      "code": "a.writeDoubleLE(0)"
+    },
+    {
+      "code": "a.writeDoubleBE(0)"
+    },
+    {
+      "code": "a.readUInt8(0, false)"
+    },
+    {
+      "code": "a.readUInt16LE(0, false)"
+    },
+    {
+      "code": "a.readUInt16BE(0, false)"
+    },
+    {
+      "code": "a.readUInt32LE(0, false)"
+    },
+    {
+      "code": "a.readUInt32BE(0, false)"
+    },
+    {
+      "code": "a.readInt8(0, false)"
+    },
+    {
+      "code": "a.readInt16LE(0, false)"
+    },
+    {
+      "code": "a.readInt16BE(0, false)"
+    },
+    {
+      "code": "a.readInt32LE(0, false)"
+    },
+    {
+      "code": "a.readInt32BE(0, false)"
+    },
+    {
+      "code": "a.readFloatLE(0, false)"
+    },
+    {
+      "code": "a.readFloatBE(0, false)"
+    },
+    {
+      "code": "a.readDoubleLE(0, false)"
+    },
+    {
+      "code": "a.readDoubleBE(0, false)"
+    },
+    {
+      "code": "a.writeUInt8(0, false)"
+    },
+    {
+      "code": "a.writeUInt16LE(0, false)"
+    },
+    {
+      "code": "a.writeUInt16BE(0, false)"
+    },
+    {
+      "code": "a.writeUInt32LE(0, false)"
+    },
+    {
+      "code": "a.writeUInt32BE(0, false)"
+    },
+    {
+      "code": "a.writeInt8(0, false)"
+    },
+    {
+      "code": "a.writeInt16LE(0, false)"
+    },
+    {
+      "code": "a.writeInt16BE(0, false)"
+    },
+    {
+      "code": "a.writeInt32LE(0, false)"
+    },
+    {
+      "code": "a.writeInt32BE(0, false)"
+    },
+    {
+      "code": "a.writeFloatLE(0, false)"
+    },
+    {
+      "code": "a.writeFloatBE(0, false)"
+    },
+    {
+      "code": "a.writeDoubleLE(0, false)"
+    },
+    {
+      "code": "a.writeDoubleBE(0, false)"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "a.readUInt8(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readUInt8 with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readUInt16LE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readUInt16LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readUInt16BE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readUInt16BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readUInt32LE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readUInt32LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readUInt32BE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readUInt32BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readInt8(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readInt8 with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readInt16LE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readInt16LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readInt16BE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readInt16BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readInt32LE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readInt32LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readInt32BE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readInt32BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readFloatLE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readFloatLE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readFloatBE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readFloatBE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readDoubleLE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readDoubleLE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readDoubleBE(0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.readDoubleBE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeUInt8(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeUInt8 with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeUInt16LE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeUInt16LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeUInt16BE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeUInt16BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeUInt32LE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeUInt32LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeUInt32BE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeUInt32BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeInt8(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeInt8 with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeInt16LE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeInt16LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeInt16BE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeInt16BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeInt32LE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeInt32LE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeInt32BE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeInt32BE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeFloatLE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeFloatLE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeFloatBE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeFloatBE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeDoubleLE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeDoubleLE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.writeDoubleBE(0, 0, true)",
+      "errors": [
+        {
+          "message": "Found Buffer.writeDoubleBE with noAssert flag set true"
+        }
+      ]
+    },
+    {
+      "code": "a.readDoubleLE(0, true);",
+      "errors": [
+        {
+          "message": "Found Buffer.readDoubleLE with noAssert flag set true"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-child-process.json
+++ b/npm/security/test/fixtures/detect-child-process.json
@@ -1,0 +1,197 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-child-process.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "child_process.exec('ls')"
+    },
+    {
+      "code": "\n    var {} = require('child_process');\n    var result = /hello/.exec(str);"
+    },
+    {
+      "code": "\n    var {} = require('node:child_process');\n    var result = /hello/.exec(str);"
+    },
+    {
+      "code": "\n    import {} from 'child_process';\n    var result = /hello/.exec(str);"
+    },
+    {
+      "code": "\n    import {} from 'node:child_process';\n    var result = /hello/.exec(str);"
+    },
+    {
+      "code": "var { spawn } = require('child_process'); spawn(str);"
+    },
+    {
+      "code": "var { spawn } = require('node:child_process'); spawn(str);"
+    },
+    {
+      "code": "import { spawn } from 'child_process'; spawn(str);"
+    },
+    {
+      "code": "import { spawn } from 'node:child_process'; spawn(str);"
+    },
+    {
+      "code": "\n    var foo = require('child_process');\n    function fn () {\n      var foo = /hello/;\n      var result = foo.exec(str);\n    }"
+    },
+    {
+      "code": "var child = require('child_process'); child.spawn(str)"
+    },
+    {
+      "code": "var child = require('node:child_process'); child.spawn(str)"
+    },
+    {
+      "code": "import child from 'child_process'; child.spawn(str)"
+    },
+    {
+      "code": "import child from 'node:child_process'; child.spawn(str)"
+    },
+    {
+      "code": "\n    var foo = require('child_process');\n    function fn () {\n      var result = foo.spawn(str);\n    }"
+    },
+    {
+      "code": "require('child_process').spawn(str)"
+    },
+    {
+      "code": "\n    function fn () {\n      require('child_process').spawn(str)\n    }"
+    },
+    {
+      "code": "\n    var child_process = require('child_process');\n    var FOO = 'ls';\n    child_process.exec(FOO);"
+    },
+    {
+      "code": "\n    import child_process from 'child_process';\n    const FOO = 'ls';\n    child_process.exec(FOO);"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "require('child_process')",
+      "errors": [
+        {
+          "message": "Found require(\"child_process\")"
+        }
+      ]
+    },
+    {
+      "code": "require('node:child_process')",
+      "errors": [
+        {
+          "message": "Found require(\"node:child_process\")"
+        }
+      ]
+    },
+    {
+      "code": "var child = require('child_process'); child.exec(com)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument"
+        }
+      ]
+    },
+    {
+      "code": "var child = require('node:child_process'); child.exec(com)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument"
+        }
+      ]
+    },
+    {
+      "code": "import child from 'child_process'; child.exec(com)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument"
+        }
+      ]
+    },
+    {
+      "code": "import child from 'node:child_process'; child.exec(com)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument"
+        }
+      ]
+    },
+    {
+      "code": "var child = sinon.stub(require('child_process')); child.exec.returns({});",
+      "errors": [
+        {
+          "message": "Found require(\"child_process\")"
+        }
+      ]
+    },
+    {
+      "code": "var child = sinon.stub(require('node:child_process')); child.exec.returns({});",
+      "errors": [
+        {
+          "message": "Found require(\"node:child_process\")"
+        }
+      ]
+    },
+    {
+      "code": "\n      var foo = require('child_process');\n      function fn () {\n        var result = foo.exec(str);\n      }",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 4
+        }
+      ]
+    },
+    {
+      "code": "\n      import foo from 'child_process';\n      function fn () {\n        var result = foo.exec(str);\n      }",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 4
+        }
+      ]
+    },
+    {
+      "code": "\n      import foo from 'node:child_process';\n      function fn () {\n        var result = foo.exec(str);\n      }",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 4
+        }
+      ]
+    },
+    {
+      "code": "\n      require('child_process').exec(str)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 2
+        }
+      ]
+    },
+    {
+      "code": "\n      function fn () {\n        require('child_process').exec(str)\n      }",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 3
+        }
+      ]
+    },
+    {
+      "code": "\n      const {exec} = require('child_process');\n      exec(str)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 3
+        }
+      ]
+    },
+    {
+      "code": "\n      const {exec} = require('node:child_process');\n      exec(str)",
+      "errors": [
+        {
+          "message": "Found child_process.exec() with non Literal first argument",
+          "line": 3
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-disable-mustache-escape.json
+++ b/npm/security/test/fixtures/detect-disable-mustache-escape.json
@@ -1,0 +1,24 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-disable-mustache-escape.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "escapeMarkup = false"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "a.escapeMarkup = false",
+      "errors": [
+        {
+          "message": "Markup escaping disabled."
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-eval-with-expression.json
+++ b/npm/security/test/fixtures/detect-eval-with-expression.json
@@ -1,0 +1,30 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-eval-with-expression.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "eval('alert()')"
+    },
+    {
+      "code": "eval(\"some nefarious code\");"
+    },
+    {
+      "code": "eval()"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "eval(a);",
+      "errors": [
+        {
+          "message": "eval with argument of type Identifier"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-new-buffer.json
+++ b/npm/security/test/fixtures/detect-new-buffer.json
@@ -1,0 +1,24 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-new-buffer.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "var a = new Buffer('test')"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "var a = new Buffer(c)",
+      "errors": [
+        {
+          "message": "Found new Buffer"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-no-csrf-before-method-override.json
+++ b/npm/security/test/fixtures/detect-no-csrf-before-method-override.json
@@ -1,0 +1,24 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-no-csrf-before-method-override.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "express.methodOverride();express.csrf()"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "express.csrf();express.methodOverride()",
+      "errors": [
+        {
+          "message": "express.csrf() middleware found before express.methodOverride()"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-non-literal-fs-filename.json
+++ b/npm/security/test/fixtures/detect-non-literal-fs-filename.json
@@ -1,0 +1,254 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-non-literal-fs-filename.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "var fs = require('fs');\n             var a = fs.open('test')"
+    },
+    {
+      "code": "var something = require('some');\n             var a = something.readFile(c);"
+    },
+    {
+      "code": "var something = require('fs').readFile, readFile = require('foo').readFile;\n             readFile(c);"
+    },
+    {
+      "code": "\n            import { promises as fsp } from 'fs';\n            import fs from 'fs';\n            import path from 'path';\n\n            const index = await fsp.readFile(path.resolve(__dirname, './index.html'), 'utf-8');\n            const key = fs.readFileSync(path.join(__dirname, './ssl.key'));\n            await fsp.writeFile(path.resolve(__dirname, './sitemap.xml'), sitemap);",
+      "languageOptions": {
+        "globals": {
+          "__dirname": "readonly"
+        }
+      }
+    },
+    {
+      "code": "\n            import fs from 'fs';\n            import path from 'path';\n            const dirname = path.dirname(__filename)\n            const key = fs.readFileSync(path.resolve(dirname, './index.html'));",
+      "languageOptions": {
+        "globals": {
+          "__filename": "readonly"
+        }
+      }
+    },
+    {
+      "code": "\n            import fs from 'fs';\n            const key = fs.readFileSync(`${process.cwd()}/path/to/foo.json`);",
+      "languageOptions": {
+        "globals": {
+          "process": "readonly"
+        }
+      }
+    },
+    {
+      "code": "\n    import fs from 'fs';\n    import path from 'path';\n    import url from 'url';\n    const dirname = path.dirname(url.fileURLToPath(import.meta.url));\n    const html = fs.readFileSync(path.resolve(dirname, './index.html'), 'utf-8');"
+    },
+    {
+      "code": "\n      import fs from 'fs';\n      const pkg = fs.readFileSync(require.resolve('eslint/package.json'), 'utf-8');",
+      "languageOptions": {
+        "globals": {
+          "require": "readonly"
+        }
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "code": "var something = require('fs');\n             var a = something.open(c);",
+      "errors": [
+        {
+          "message": "Found open from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var one = require('fs').readFile;\n             one(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var one = require('node:fs').readFile;\n             one(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var one = require('fs/promises').readFile;\n             one(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs/promises\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('fs/promises');\n             something.readFile(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs/promises\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('node:fs/promises');\n             something.readFile(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs/promises\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('fs-extra');\n             something.readFile(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs-extra\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var { readFile: something } = require('fs');\n             something(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import { readFile as something } from 'fs';\n             something(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import { readFile as something } from 'node:fs';\n             something(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import { readFile as something } from 'fs-extra';\n             something(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs-extra\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import { readFile as something } from 'fs/promises'\n             something(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs/promises\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import { readFile as something } from 'node:fs/promises'\n             something(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs/promises\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import * as something from 'fs';\n             something.readFile(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "import * as something from 'node:fs';\n             something.readFile(filename);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('fs').promises;\n             something.readFile(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('node:fs').promises;\n             something.readFile(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('fs');\n             something.promises.readFile(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var something = require('node:fs');\n             something.promises.readFile(filename)",
+      "errors": [
+        {
+          "message": "Found readFile from package \"node:fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var fs = require('fs');\nfs.readFile(`template with ${filename}`);",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "function foo () {\nvar fs = require('fs');\nfs.readFile(filename);\n}",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "function foo () {\nvar { readFile: something } = require('fs');\nsomething(filename);\n}",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "var fs = require('fs');\nfunction foo () {\nvar { readFile: something } = fs.promises;\nsomething(filename);\n}",
+      "errors": [
+        {
+          "message": "Found readFile from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    },
+    {
+      "code": "\n            import fs from 'fs';\n            import path from 'path';\n            const key = fs.readFileSync(path.resolve(__dirname, foo));",
+      "languageOptions": {
+        "globals": {
+          "__filename": "readonly"
+        }
+      },
+      "errors": [
+        {
+          "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-non-literal-regexp.json
+++ b/npm/security/test/fixtures/detect-non-literal-regexp.json
@@ -1,0 +1,27 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-non-literal-regexp.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "var a = new RegExp('ab+c', 'i')"
+    },
+    {
+      "code": "\n            var source = 'ab+c'\n            var a = new RegExp(source, 'i')"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "var a = new RegExp(c, 'i')",
+      "errors": [
+        {
+          "message": "Found non-literal argument to RegExp Constructor"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-non-literal-require.json
+++ b/npm/security/test/fixtures/detect-non-literal-require.json
@@ -1,0 +1,46 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-non-literal-require.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "var a = require('b')"
+    },
+    {
+      "code": "var a = require(`b`)"
+    },
+    {
+      "code": "\n  const d = 'debounce'\n  var a = require(`lodash/${d}`)"
+    },
+    {
+      "code": "const utils = require(__dirname + '/utils');",
+      "languageOptions": {
+        "globals": {
+          "__dirname": "readonly"
+        }
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "code": "var a = require(c)",
+      "errors": [
+        {
+          "message": "Found non-literal argument in require"
+        }
+      ]
+    },
+    {
+      "code": "var a = require(`${c}`)",
+      "errors": [
+        {
+          "message": "Found non-literal argument in require"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-object-injection.json
+++ b/npm/security/test/fixtures/detect-object-injection.json
@@ -1,0 +1,24 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-object-injection.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "var a = {};"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "var a = {}; a[b] = 4",
+      "errors": [
+        {
+          "message": "Generic Object Injection Sink"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-possible-timing-attacks.json
+++ b/npm/security/test/fixtures/detect-possible-timing-attacks.json
@@ -1,0 +1,35 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-possible-timing-attacks.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "if (age === 5) {}"
+    },
+    {
+      "code": "if (age === 5) {}"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "if (password === 'mypass') {}",
+      "errors": [
+        {
+          "message": "Potential timing attack, left side: true"
+        }
+      ]
+    },
+    {
+      "code": "if ('mypass' === password) {}",
+      "errors": [
+        {
+          "message": "Potential timing attack, right side: true"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-pseudoRandomBytes.json
+++ b/npm/security/test/fixtures/detect-pseudoRandomBytes.json
@@ -1,0 +1,24 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-pseudoRandomBytes.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "crypto.randomBytes"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "crypto.pseudoRandomBytes",
+      "errors": [
+        {
+          "message": "Found crypto.pseudoRandomBytes which does not produce cryptographically strong numbers"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-unsafe-regex.json
+++ b/npm/security/test/fixtures/detect-unsafe-regex.json
@@ -1,0 +1,35 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-security",
+    "version": "4.0.0",
+    "sourceFile": "test/rules/detect-unsafe-regex.js",
+    "license": "Apache-2.0",
+    "tool": "tools/tasks/sync-eslint-security-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "/^d+1337d+$/"
+    },
+    {
+      "code": "new RegExp('^d+1337d+$')"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "/(x+x+)+y/",
+      "errors": [
+        {
+          "message": "Unsafe Regular Expression"
+        }
+      ]
+    },
+    {
+      "code": "new RegExp('x+x+)+y')",
+      "errors": [
+        {
+          "message": "Unsafe Regular Expression (new RegExp)"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/security/test/fixtures/detect-unsafe-regex.json
+++ b/npm/security/test/fixtures/detect-unsafe-regex.json
@@ -2,7 +2,7 @@
   "__generated": {
     "source": "eslint-plugin-security",
     "version": "4.0.0",
-    "sourceFile": "test/rules/detect-unsafe-regex.js",
+    "sourceFile": "test/rules/detect-unsafe-regexp.js",
     "license": "Apache-2.0",
     "tool": "tools/tasks/sync-eslint-security-tests.ts"
   },

--- a/npm/security/test/upstream-harness.mjs
+++ b/npm/security/test/upstream-harness.mjs
@@ -1,0 +1,125 @@
+// Replay harness for upstream eslint-plugin-security RuleTester cases.
+//
+// Unlike a typical ESLint plugin, security's rule logic runs entirely in Rust
+// (`scanSecurity`); the JS layer is only an Oxlint/NAPI adapter. So each case's
+// `code` is fed to the plugin's `createOnce` adapter (which calls the Rust
+// scanner and filters to the rule under test), and the reported descriptors are
+// formatted into ESLint's reported shape for comparison against the case's
+// declared `errors`.
+
+import plugin from '../index.js';
+
+// Drive one rule's adapter over `code` and return ESLint-shaped reports.
+export function runRule(ruleName, testCase) {
+  const rule = plugin.rules[ruleName];
+  if (!rule) {
+    throw new Error(`Unknown rule: ${ruleName}`);
+  }
+
+  const code = testCase.code;
+  const sourceCode = {
+    text: code,
+    getText() {
+      return this.text;
+    },
+  };
+
+  const reports = [];
+  const context = {
+    id: ruleName,
+    options: testCase.options ?? [],
+    sourceCode,
+    filename: testCase.filename ?? 'file.js',
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  };
+
+  const visitor = rule.createOnce(context);
+  visitor.before?.();
+  visitor.Program?.({ type: 'Program', range: [0, code.length] });
+  visitor.after?.();
+
+  return reports.map((descriptor) => formatReport(rule, descriptor));
+}
+
+function interpolate(template, data) {
+  if (!data) {
+    return template;
+  }
+  return template.replace(/\{\{\s*([^}\s]+)\s*\}\}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(data, key) ? String(data[key]) : match,
+  );
+}
+
+// Turn a `context.report` descriptor into ESLint's reported error shape.
+// ESLint reports 1-indexed columns (`loc.column + 1`); the Rust scanner and the
+// adapter both emit 0-indexed UTF-16 columns, matching ESLint's internal `loc`.
+function formatReport(rule, descriptor) {
+  const messages = rule.meta.messages ?? {};
+  const message = descriptor.messageId
+    ? interpolate(messages[descriptor.messageId], descriptor.data)
+    : descriptor.message;
+
+  const result = { message };
+  if (descriptor.messageId) {
+    result.messageId = descriptor.messageId;
+  }
+  if (descriptor.data) {
+    result.data = descriptor.data;
+  }
+
+  const loc = descriptor.loc;
+  if (loc) {
+    if (loc.start) {
+      result.line = loc.start.line;
+      result.column = loc.start.column + 1;
+    }
+    if (loc.end) {
+      result.endLine = loc.end.line;
+      result.endColumn = loc.end.column + 1;
+    }
+  }
+
+  return result;
+}
+
+// Assert one reported error matches one declared expectation. A string
+// expectation checks only the message; an object checks each declared field.
+// `message` may be a literal string or a `{ __regex, __flags }` matcher.
+export function matchError(actual, expected) {
+  if (typeof expected === 'string') {
+    return { ok: actual.message === expected, field: 'message' };
+  }
+
+  for (const key of Object.keys(expected)) {
+    if (key === 'type' || key === 'suggestions') {
+      continue;
+    }
+    if (key === 'message') {
+      if (!messageMatches(actual.message, expected.message)) {
+        return { ok: false, field: 'message' };
+      }
+      continue;
+    }
+    if (key === 'data') {
+      if (JSON.stringify(actual.data ?? {}) !== JSON.stringify(expected.data)) {
+        return { ok: false, field: 'data' };
+      }
+      continue;
+    }
+    if (actual[key] !== expected[key]) {
+      return { ok: false, field: key };
+    }
+  }
+
+  return { ok: true, field: null };
+}
+
+function messageMatches(actualMessage, expectedMessage) {
+  if (expectedMessage && typeof expectedMessage === 'object' && '__regex' in expectedMessage) {
+    const regex = new RegExp(expectedMessage.__regex, expectedMessage.__flags ?? '');
+    return regex.test(actualMessage ?? '');
+  }
+  return actualMessage === expectedMessage;
+}

--- a/npm/security/test/upstream-harness.mjs
+++ b/npm/security/test/upstream-harness.mjs
@@ -57,9 +57,18 @@ function interpolate(template, data) {
 // adapter both emit 0-indexed UTF-16 columns, matching ESLint's internal `loc`.
 function formatReport(rule, descriptor) {
   const messages = rule.meta.messages ?? {};
-  const message = descriptor.messageId
-    ? interpolate(messages[descriptor.messageId], descriptor.data)
-    : descriptor.message;
+  let message;
+  if (descriptor.messageId) {
+    const template = messages[descriptor.messageId];
+    if (template === undefined) {
+      throw new Error(
+        `Rule reported unknown messageId "${descriptor.messageId}" (not in meta.messages)`,
+      );
+    }
+    message = interpolate(template, descriptor.data);
+  } else {
+    message = descriptor.message;
+  }
 
   const result = { message };
   if (descriptor.messageId) {

--- a/npm/security/test/upstream.test.mjs
+++ b/npm/security/test/upstream.test.mjs
@@ -54,7 +54,7 @@ describe('eslint-plugin-security upstream parity', () => {
 
     describe(ruleName, () => {
       describe('valid', () => {
-        fixture.valid.forEach((testCase, index) => {
+        (fixture.valid ?? []).forEach((testCase, index) => {
           it(label(testCase, index), () => {
             expect(runRule(ruleName, testCase)).toEqual([]);
           });
@@ -62,7 +62,7 @@ describe('eslint-plugin-security upstream parity', () => {
       });
 
       describe('invalid', () => {
-        fixture.invalid.forEach((testCase, index) => {
+        (fixture.invalid ?? []).forEach((testCase, index) => {
           it(label(testCase, index), () => {
             assertErrors(runRule(ruleName, testCase), testCase.errors);
           });

--- a/npm/security/test/upstream.test.mjs
+++ b/npm/security/test/upstream.test.mjs
@@ -1,0 +1,73 @@
+// Replays the upstream eslint-plugin-security test suite (captured verbatim into
+// test/fixtures/*.json by `pnpm run port:tests:security`) against this plugin,
+// so behavior stays faithful to upstream as the submodule is bumped.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { matchError, runRule } from './upstream-harness.mjs';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const fixtureFiles = readdirSync(FIXTURES_DIR).filter((name) => name.endsWith('.json'));
+
+function label(testCase, index) {
+  const code = JSON.stringify(testCase.code);
+  const truncated = code.length > 80 ? `${code.slice(0, 80)}…` : code;
+  return `#${index} ${truncated}`;
+}
+
+// Match a list of actual reports against declared expectations. `errors` may be
+// a count (number) or a list of string/object expectations.
+function assertErrors(actual, expectedErrors) {
+  if (typeof expectedErrors === 'number') {
+    expect(actual.length).toBe(expectedErrors);
+    return;
+  }
+
+  expect(
+    actual.length,
+    `error count mismatch\n  actual:   ${JSON.stringify(actual)}\n  expected: ${JSON.stringify(
+      expectedErrors,
+    )}`,
+  ).toBe(expectedErrors.length);
+
+  expectedErrors.forEach((expected, index) => {
+    const result = matchError(actual[index], expected);
+    expect(
+      result.ok,
+      `error #${index} mismatch on "${result.field}"\n  actual:   ${JSON.stringify(
+        actual[index],
+      )}\n  expected: ${JSON.stringify(expected)}`,
+    ).toBe(true);
+  });
+}
+
+describe('eslint-plugin-security upstream parity', () => {
+  expect(fixtureFiles.length).toBeGreaterThan(0);
+
+  for (const file of fixtureFiles) {
+    const ruleName = file.replace(/\.json$/, '');
+    const fixture = JSON.parse(readFileSync(join(FIXTURES_DIR, file), 'utf8'));
+
+    describe(ruleName, () => {
+      describe('valid', () => {
+        fixture.valid.forEach((testCase, index) => {
+          it(label(testCase, index), () => {
+            expect(runRule(ruleName, testCase)).toEqual([]);
+          });
+        });
+      });
+
+      describe('invalid', () => {
+        fixture.invalid.forEach((testCase, index) => {
+          it(label(testCase, index), () => {
+            assertErrors(runRule(ruleName, testCase), testCase.errors);
+          });
+        });
+      });
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "port:rules": "node tools/tasks/enumerate-port-rules.ts",
     "port:status": "node tools/tasks/sync-status-from-port-targets.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
+    "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",
     "profile": "node tools/tasks/profile.ts",
     "release": "node tools/tasks/release.ts",
     "security:audit": "node tools/tasks/security-audit.ts",

--- a/tools/tasks/sync-eslint-security-tests.ts
+++ b/tools/tasks/sync-eslint-security-tests.ts
@@ -30,7 +30,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 type Manifest = {
@@ -107,23 +107,31 @@ function collect(bucket: NormalizedCase[], cases: RawCase[], rule: string): void
   }
 }
 
-const testFiles = listTestFiles(TESTS_DIR);
-for (const file of testFiles) {
-  const runs = captureRuns(file);
-  for (const run of runs) {
-    const rule = baseRuleName(run.name, portedRules);
-    if (!rule) {
-      // A run for a rule we have not ported yet; record it so it is visible.
-      skippedRuns.push(run.name);
-      continue;
-    }
-    const bucket = grouped.get(rule)!;
-    collect(bucket.valid, run.valid, rule);
-    collect(bucket.invalid, run.invalid, rule);
-  }
-}
+// Records the actual upstream file each rule's cases came from, so the
+// generated metadata is accurate even when the file name differs from the rule
+// id (e.g. detect-unsafe-regex lives in test/rules/detect-unsafe-regexp.js).
+const sourceFileByRule = new Map<string, string>();
 
-rmSync(tempDir, { recursive: true, force: true });
+try {
+  const testFiles = listTestFiles(TESTS_DIR);
+  for (const file of testFiles) {
+    const runs = captureRuns(file);
+    for (const run of runs) {
+      const rule = baseRuleName(run.name, portedRules);
+      if (!rule) {
+        // A run for a rule we have not ported yet; record it so it is visible.
+        skippedRuns.push(run.name);
+        continue;
+      }
+      sourceFileByRule.set(rule, basename(file));
+      const bucket = grouped.get(rule)!;
+      collect(bucket.valid, run.valid, rule);
+      collect(bucket.invalid, run.invalid, rule);
+    }
+  }
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
 
 const summary: string[] = [];
 for (const rule of portedRules) {
@@ -135,7 +143,7 @@ for (const rule of portedRules) {
     __generated: {
       source: plugin.npm,
       version: plugin.baselineVersion,
-      sourceFile: `test/rules/${rule}.js`,
+      sourceFile: `test/rules/${sourceFileByRule.get(rule) ?? `${rule}.js`}`,
       license: plugin.license,
       tool: 'tools/tasks/sync-eslint-security-tests.ts',
     },
@@ -196,12 +204,13 @@ function registerStubHooks(): void {
 
   const eslintStub = [
     'class RuleTester {',
-    '  constructor(config) { this.config = config || {}; }',
+    // Constructor config (e.g. `languageOptions.sourceType`) is irrelevant to
+    // the Rust scanner, so it is accepted and ignored rather than captured.
+    '  constructor() {}',
     '  run(name, _rule, tests) {',
     `    const store = globalThis['${CAPTURE_KEY}'] || (globalThis['${CAPTURE_KEY}'] = []);`,
     '    store.push({',
     '      name,',
-    '      defaults: this.config,',
     '      valid: (tests && tests.valid) || [],',
     '      invalid: (tests && tests.invalid) || [],',
     '    });',

--- a/tools/tasks/sync-eslint-security-tests.ts
+++ b/tools/tasks/sync-eslint-security-tests.ts
@@ -45,6 +45,8 @@ type Manifest = {
 
 type RawCase = Record<string, unknown> | string;
 type CapturedRun = { name: string; valid: RawCase[]; invalid: RawCase[] };
+type NormalizedCase = Record<string, unknown>;
+type RuleBucket = { valid: NormalizedCase[]; invalid: NormalizedCase[] };
 
 const ROOT = process.cwd();
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -84,7 +86,7 @@ const tempDir = mkdtempSync(join(tmpdir(), 'security-sync-'));
 registerStubHooks();
 
 // rule name -> { valid, invalid } accumulated across every test file / run.
-const grouped = new Map<string, { valid: Record<string, unknown>[]; invalid: Record<string, unknown>[] }>();
+const grouped = new Map<string, RuleBucket>();
 for (const rule of portedRules) {
   grouped.set(rule, { valid: [], invalid: [] });
 }

--- a/tools/tasks/sync-eslint-security-tests.ts
+++ b/tools/tasks/sync-eslint-security-tests.ts
@@ -91,28 +91,35 @@ for (const rule of portedRules) {
   grouped.set(rule, { valid: [], invalid: [] });
 }
 
+// Drop accounting, so truncation is never silent (cases that cannot be
+// replayed, or whole runs for rules we have not ported).
+const dropped = new Map<string, number>();
+const skippedRuns: string[] = [];
+
+function collect(bucket: NormalizedCase[], cases: RawCase[], rule: string): void {
+  for (const raw of cases) {
+    const normalized = normalizeCase(raw);
+    if (normalized) {
+      bucket.push(normalized);
+    } else {
+      dropped.set(rule, (dropped.get(rule) ?? 0) + 1);
+    }
+  }
+}
+
 const testFiles = listTestFiles(TESTS_DIR);
 for (const file of testFiles) {
   const runs = captureRuns(file);
   for (const run of runs) {
     const rule = baseRuleName(run.name, portedRules);
     if (!rule) {
-      // A run for a rule we have not ported; skip silently (not our target).
+      // A run for a rule we have not ported yet; record it so it is visible.
+      skippedRuns.push(run.name);
       continue;
     }
     const bucket = grouped.get(rule)!;
-    for (const raw of run.valid) {
-      const normalized = normalizeCase(raw);
-      if (normalized) {
-        bucket.valid.push(normalized);
-      }
-    }
-    for (const raw of run.invalid) {
-      const normalized = normalizeCase(raw);
-      if (normalized) {
-        bucket.invalid.push(normalized);
-      }
-    }
+    collect(bucket.valid, run.valid, rule);
+    collect(bucket.invalid, run.invalid, rule);
   }
 }
 
@@ -136,12 +143,22 @@ for (const rule of portedRules) {
     invalid: bucket.invalid,
   };
   writeFileSync(join(FIXTURES_DIR, `${rule}.json`), `${JSON.stringify(fixture, null, 2)}\n`);
-  summary.push(`${rule}: ${bucket.valid.length} valid, ${bucket.invalid.length} invalid`);
+  const drops = dropped.get(rule) ?? 0;
+  summary.push(
+    `${rule}: ${bucket.valid.length} valid, ${bucket.invalid.length} invalid${
+      drops > 0 ? ` (${drops} non-replayable case(s) dropped)` : ''
+    }`,
+  );
 }
 
 console.log('Synced eslint-plugin-security fixtures from upstream:');
 for (const line of summary) {
   console.log(`- ${line}`);
+}
+if (skippedRuns.length > 0) {
+  console.log(
+    `Skipped ${skippedRuns.length} upstream run(s) for not-yet-ported rules: ${skippedRuns.join(', ')}`,
+  );
 }
 
 // --- helpers ---------------------------------------------------------------

--- a/tools/tasks/sync-eslint-security-tests.ts
+++ b/tools/tasks/sync-eslint-security-tests.ts
@@ -1,0 +1,324 @@
+// Captures the upstream eslint-plugin-security test suite straight from the
+// vendored submodule and writes it to committed JSON fixtures, so our Vitest
+// suite replays the real upstream cases and tracks behavior as the submodule is
+// bumped (oxc-style test syncing).
+//
+// The upstream tests drive cases through ESLint's `RuleTester`. We register
+// synchronous module hooks (`module.registerHooks`) that stub `eslint`
+// (capturing every `RuleTester.run` call — several upstream files run the same
+// rule more than once) and the rule modules under test. Most rule modules are
+// stubbed to `{}` (we only need the captured cases, not the rule object), but
+// `detect-buffer-noassert` is loaded for real because its test file reads
+// `rule.meta.__methodsToCheck` to generate one case per Buffer accessor; that
+// rule has no third-party dependencies, so loading it is self-contained.
+//
+// Each upstream test file is copied to a temp location before being required,
+// because bare specifiers resolved in-place under the submodule bypass the hook
+// chain on Node 24. Regex message matchers (`message: /.../i`) are preserved as
+// `{ __regex, __flags }` so the replay harness can apply them faithfully.
+//
+// Re-run with `pnpm run port:tests:security`.
+
+import { createRequire, registerHooks } from 'node:module';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    license: string;
+  }>;
+};
+
+type RawCase = Record<string, unknown> | string;
+type CapturedRun = { name: string; valid: RawCase[]; invalid: RawCase[] };
+
+const ROOT = process.cwd();
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// `RuleTester.run` from the eslint stub appends each captured run here, keyed on
+// the shared global so the value crosses the hook-loaded module boundary.
+const CAPTURE_KEY = '__eslintSecuritySyncCapture__';
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-security');
+if (!plugin) {
+  throw new Error('eslint-plugin-security is not registered in tools/port-targets.json');
+}
+
+const SUBMODULE = join(ROOT, plugin.submodule);
+const RULES_DIR = join(SUBMODULE, 'rules');
+const TESTS_DIR = join(SUBMODULE, 'test', 'rules');
+const FIXTURES_DIR = join(ROOT, 'npm', 'security', 'test', 'fixtures');
+
+// The rule that must be loaded for real (its test reads `meta.__methodsToCheck`).
+const REAL_RULE = 'detect-buffer-noassert';
+
+// The rules currently implemented by our plugin. Only these get fixtures, so the
+// replay harness never references a rule we have not ported yet.
+const portedRules = getPortedRules();
+
+if (!existsSync(TESTS_DIR)) {
+  throw new Error(
+    `Upstream tests not found at ${TESTS_DIR}. Run: git submodule update --init --depth 1 ${plugin.submodule}`,
+  );
+}
+
+mkdirSync(FIXTURES_DIR, { recursive: true });
+
+const tempDir = mkdtempSync(join(tmpdir(), 'security-sync-'));
+registerStubHooks();
+
+// rule name -> { valid, invalid } accumulated across every test file / run.
+const grouped = new Map<string, { valid: Record<string, unknown>[]; invalid: Record<string, unknown>[] }>();
+for (const rule of portedRules) {
+  grouped.set(rule, { valid: [], invalid: [] });
+}
+
+const testFiles = listTestFiles(TESTS_DIR);
+for (const file of testFiles) {
+  const runs = captureRuns(file);
+  for (const run of runs) {
+    const rule = baseRuleName(run.name, portedRules);
+    if (!rule) {
+      // A run for a rule we have not ported; skip silently (not our target).
+      continue;
+    }
+    const bucket = grouped.get(rule)!;
+    for (const raw of run.valid) {
+      const normalized = normalizeCase(raw);
+      if (normalized) {
+        bucket.valid.push(normalized);
+      }
+    }
+    for (const raw of run.invalid) {
+      const normalized = normalizeCase(raw);
+      if (normalized) {
+        bucket.invalid.push(normalized);
+      }
+    }
+  }
+}
+
+rmSync(tempDir, { recursive: true, force: true });
+
+const summary: string[] = [];
+for (const rule of portedRules) {
+  const bucket = grouped.get(rule)!;
+  if (bucket.valid.length === 0 && bucket.invalid.length === 0) {
+    throw new Error(`No upstream cases captured for rule "${rule}"`);
+  }
+  const fixture = {
+    __generated: {
+      source: plugin.npm,
+      version: plugin.baselineVersion,
+      sourceFile: `test/rules/${rule}.js`,
+      license: plugin.license,
+      tool: 'tools/tasks/sync-eslint-security-tests.ts',
+    },
+    valid: bucket.valid,
+    invalid: bucket.invalid,
+  };
+  writeFileSync(join(FIXTURES_DIR, `${rule}.json`), `${JSON.stringify(fixture, null, 2)}\n`);
+  summary.push(`${rule}: ${bucket.valid.length} valid, ${bucket.invalid.length} invalid`);
+}
+
+console.log('Synced eslint-plugin-security fixtures from upstream:');
+for (const line of summary) {
+  console.log(`- ${line}`);
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function listTestFiles(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => join(dir, name))
+    .sort();
+}
+
+function captureRuns(testFile: string): CapturedRun[] {
+  // Require a copy in a temp dir: bare specifiers resolved in-place under the
+  // submodule bypass the hook chain, but resolve through the hooks from a temp
+  // file. Rule requires are intercepted by specifier substring, so the original
+  // `../../rules/...` path never needs to resolve on disk.
+  const tempFile = join(tempDir, `${Date.now()}-${Math.random().toString(36).slice(2)}.cjs`);
+  writeFileSync(tempFile, readFileSync(testFile, 'utf8'));
+
+  (globalThis as Record<string, unknown>)[CAPTURE_KEY] = [];
+  const require = createRequire(tempFile);
+  require(tempFile);
+
+  const captured = (globalThis as Record<string, unknown>)[CAPTURE_KEY] as CapturedRun[];
+  if (!captured || captured.length === 0) {
+    throw new Error(`No RuleTester.run() call captured from ${testFile}`);
+  }
+  return captured;
+}
+
+// Synchronous module hooks that replace the upstream test files' dependencies
+// with capturing/no-op stubs (works for CommonJS via `module.registerHooks`).
+function registerStubHooks(): void {
+  const realRuleSource = readFileSync(join(RULES_DIR, `${REAL_RULE}.js`), 'utf8');
+
+  const eslintStub = [
+    'class RuleTester {',
+    '  constructor(config) { this.config = config || {}; }',
+    '  run(name, _rule, tests) {',
+    `    const store = globalThis['${CAPTURE_KEY}'] || (globalThis['${CAPTURE_KEY}'] = []);`,
+    '    store.push({',
+    '      name,',
+    '      defaults: this.config,',
+    '      valid: (tests && tests.valid) || [],',
+    '      invalid: (tests && tests.invalid) || [],',
+    '    });',
+    '  }',
+    '}',
+    'class Linter { getRules() { return new Map(); } }',
+    "Linter.version = '8.57.0';",
+    'module.exports = { RuleTester, Linter };',
+  ].join('\n');
+
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (specifier === 'eslint') {
+        return { url: 'stub:///eslint', shortCircuit: true };
+      }
+      if (specifier.startsWith('eslint/')) {
+        return { url: 'stub:///eslint-internal', shortCircuit: true };
+      }
+      // Rule modules: load the real source only for the rule whose test reads
+      // `meta.__methodsToCheck`; stub the rest so their third-party deps
+      // (e.g. safe-regex) are never required.
+      if (/[\\/]rules[\\/]/.test(specifier) || specifier.startsWith('../../rules/')) {
+        if (specifier.endsWith(REAL_RULE)) {
+          return { url: 'stub:///real-rule', shortCircuit: true };
+        }
+        return { url: 'stub:///rule', shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+    load(url, context, nextLoad) {
+      if (url === 'stub:///eslint') {
+        return { format: 'commonjs', source: eslintStub, shortCircuit: true };
+      }
+      if (url === 'stub:///eslint-internal') {
+        return {
+          format: 'commonjs',
+          source: 'module.exports = { builtinRules: new Map() };',
+          shortCircuit: true,
+        };
+      }
+      if (url === 'stub:///real-rule') {
+        return { format: 'commonjs', source: realRuleSource, shortCircuit: true };
+      }
+      if (url === 'stub:///rule') {
+        return { format: 'commonjs', source: 'module.exports = {};', shortCircuit: true };
+      }
+      return nextLoad(url, context);
+    },
+  });
+}
+
+// Map an upstream run name back to the ported rule it exercises. Several files
+// run the same rule under suffixed names (e.g. "detect-unsafe-regex (new
+// RegExp)"); we attribute them to the longest matching ported rule id.
+function baseRuleName(runName: string, rules: string[]): string | null {
+  let match: string | null = null;
+  for (const rule of rules) {
+    if (runName === rule || runName.startsWith(`${rule} `)) {
+      if (!match || rule.length > match.length) {
+        match = rule;
+      }
+    }
+  }
+  return match;
+}
+
+// Recursively convert a captured value to a JSON-serializable form, preserving
+// RegExp matchers as `{ __regex, __flags }` and dropping function-valued fields.
+function toSerializable(value: unknown): unknown {
+  if (value instanceof RegExp) {
+    return { __regex: value.source, __flags: value.flags };
+  }
+  if (Array.isArray(value)) {
+    return value.map(toSerializable);
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const serialized = toSerializable(entry);
+      if (serialized !== undefined) {
+        out[key] = serialized;
+      }
+    }
+    return out;
+  }
+  if (typeof value === 'function') {
+    return undefined;
+  }
+  return value;
+}
+
+// Keep only cases that run under our Rust scanner (plain JS, no extra language
+// or plugins). Returns null for cases we cannot replay.
+function normalizeCase(raw: RawCase): Record<string, unknown> | null {
+  const value = typeof raw === 'string' ? { code: raw } : raw;
+  if (value == null || typeof value !== 'object') {
+    return null;
+  }
+  if ('language' in value || 'plugins' in value || 'processor' in value) {
+    return null;
+  }
+  const languageOptions = (value as { languageOptions?: { parser?: unknown } }).languageOptions;
+  if (languageOptions && 'parser' in languageOptions) {
+    return null;
+  }
+
+  const serialized = toSerializable(value) as Record<string, unknown>;
+  if (typeof serialized.code !== 'string') {
+    return null;
+  }
+  return serialized;
+}
+
+function getPortedRules(): string[] {
+  // Prefer the built plugin's actual rule set; fall back to the upstream rules
+  // directory when the native binding is not built (so the fixtures can be
+  // regenerated without a full `vp build`). All upstream rules are ported.
+  try {
+    const pkgRequire = createRequire(join(ROOT, 'npm', 'security', 'index.js'));
+    const loaded = pkgRequire(resolve(ROOT, 'npm', 'security', 'index.js')) as {
+      rules?: Record<string, unknown>;
+    };
+    const rules = loaded.rules ? Object.keys(loaded.rules) : [];
+    if (rules.length > 0) {
+      return rules.sort();
+    }
+  } catch {
+    // Native binding unavailable; fall back to the upstream rule inventory.
+  }
+  const rules = readdirSync(RULES_DIR)
+    .filter((name) => name.endsWith('.js') && name.startsWith('detect-'))
+    .map((name) => name.replace(/\.js$/, ''));
+  if (rules.length === 0) {
+    throw new Error('No rules found in the security plugin or upstream rules directory.');
+  }
+  return rules.sort();
+}
+
+void HERE;


### PR DESCRIPTION
## Summary

Closes the test-fidelity gap for #7. The 14 `eslint-plugin-security` rules were already ported to Rust (#44) with hand-written tests; this PR **guarantees they stay faithful to upstream** by capturing the real upstream `RuleTester` suite and replaying it against the Rust-backed Oxlint adapter — exactly the oxc-style sync already used for `eslint-plugin-eslint-comments`.

All upstream rules are already implemented and pass, so this is delivered as a single test-infrastructure PR rather than one-rule-at-a-time (there is no per-rule implementation work left; the harness covers all 14 rules at once).

## What's here

- **`tools/tasks/sync-eslint-security-tests.ts`** (`pnpm run port:tests:security`) — captures **every** `RuleTester.run()` call from the vendored submodule. Handles the security-specific wrinkles:
  - several upstream files run a rule more than once (`detect-bidi-characters`, `detect-possible-timing-attacks`, `detect-unsafe-regexp`) — all runs are merged per rule;
  - `detect-buffer-noassert` is loaded for real so its `meta.__methodsToCheck` drives the per-accessor cases;
  - regex message matchers (`/.../i`) are preserved as `{__regex,__flags}`;
  - `line`/`column`/`endColumn` expectations are preserved;
  - any non-replayable case or skipped run is **reported, never dropped silently** (security drops zero).
- **`npm/security/test/upstream.test.mjs` + `upstream-harness.mjs`** — replay the fixtures through the plugin adapter (Rust `scanSecurity`), comparing rendered messages, regex matchers, and 1-indexed line/column locations.
- **14 generated fixtures** — **103 valid + 83 invalid = 186 upstream cases**, all green in CI.

## Verification

Full CI green (Format, Lint, Typecheck, Build, JS Tests, Rust Tests, Policy, Publish Readiness, Bench Check). The Rust implementation required no changes — it already reproduces all 186 upstream cases exactly, including bidi character positions and the `detect-non-literal-fs-filename` static-expression analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)