### PR TITLE
chore(eslint-comments): drop dead code and refresh stale comment

### DIFF
--- a/crates/eslint_comments/src/directive.rs
+++ b/crates/eslint_comments/src/directive.rs
@@ -102,12 +102,10 @@ fn divide_directive_comment(value: &str) -> (&str, Option<&str>) {
     };
 
     let text = value[..first.0].trim();
-    let rest = &value[first.1..];
     let description_end = find_separator(value, first.1)
         .map(|(start, _)| start)
         .unwrap_or(value.len());
     let description = value[first.1..description_end].trim();
-    let _ = rest;
 
     (text, Some(description))
 }

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -380,8 +380,9 @@ const rules = {
   'require-description': requireDescription,
 };
 
-// Mirror of upstream's `recommended` config, limited to the rules ported so far.
-// (no-use and require-description are not part of upstream's recommended set.)
+// Mirror of upstream's `recommended` config. Upstream recommends exactly these
+// five rules; no-restricted-disable, no-unused-disable (deprecated), no-use, and
+// require-description are intentionally excluded from upstream's recommended set.
 const recommendedRuleNames = [
   'disable-enable-pair',
   'no-aggregating-enable',


### PR DESCRIPTION
Small cleanups surfaced during a full review of the eslint-comments port:

- **`directive.rs`** — remove the dead `rest` binding in `divide_directive_comment` (and its `let _ = rest;` suppression). `description_end` is computed from `value` directly, so `rest` was never used; behavior is unchanged.
- **`index.js`** — refresh the `recommendedRuleNames` comment. The previous note said "limited to the rules ported so far" (all are ported now) and listed only two excluded rules; it now correctly states upstream recommends exactly the five listed rules.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)