### PR TITLE
port(functional): emit upstream messageIds and port no-loop-statements

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -19,6 +19,7 @@ impl<'a> Scanner<'a> {
                 if identifier.name == "arguments" && !self.options.allow_arguments_keyword {
                     self.report(
                         "functional-parameters",
+                        "arguments",
                         "Unexpected use of `arguments`. Use regular function arguments instead.",
                         identifier.span,
                     );
@@ -27,6 +28,7 @@ impl<'a> Scanner<'a> {
             Expression::ThisExpression(expression) => {
                 self.report(
                     "no-this-expressions",
+                    "generic",
                     "Unexpected this, use functions not classes.",
                     expression.span,
                 );
@@ -52,6 +54,7 @@ impl<'a> Scanner<'a> {
             Expression::UpdateExpression(expression) => {
                 self.report(
                     "immutable-data",
+                    "generic",
                     "Modifying an existing object/array is not allowed.",
                     expression.span,
                 );
@@ -218,6 +221,7 @@ impl<'a> Scanner<'a> {
         if assignment_target_is_member(&expression.left) {
             self.report(
                 "immutable-data",
+                "generic",
                 "Modifying an existing object/array is not allowed.",
                 expression.span,
             );
@@ -282,6 +286,7 @@ impl<'a> Scanner<'a> {
         if is_static_call(call, "Promise", "reject") {
             self.report(
                 "no-promise-reject",
+                "generic",
                 "Unexpected rejection, resolve an error instead.",
                 call.span,
             );
@@ -289,6 +294,7 @@ impl<'a> Scanner<'a> {
         if is_mutating_call(call) {
             self.report(
                 "immutable-data",
+                "generic",
                 "Modifying an existing object/array is not allowed.",
                 call.span,
             );
@@ -309,6 +315,7 @@ impl<'a> Scanner<'a> {
         {
             self.report(
                 "no-promise-reject",
+                "generic",
                 "Unexpected rejection, resolve an error instead.",
                 expression.span,
             );

--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -51,6 +51,9 @@ pub struct DiagnosticLoc {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Diagnostic {
     pub rule_name: &'static str,
+    /// The upstream eslint-plugin-functional messageId for this diagnostic, so
+    /// the JS wrapper can report it and the upstream replay suite can assert it.
+    pub message_id: &'static str,
     pub message: CompactString,
     pub loc: DiagnosticLoc,
 }

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -22,10 +22,17 @@ pub(crate) struct Scanner<'a> {
 }
 
 impl<'a> Scanner<'a> {
-    pub(crate) fn report(&mut self, rule_name: &'static str, message: &'static str, span: Span) {
+    pub(crate) fn report(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        message: &'static str,
+        span: Span,
+    ) {
         if self.options.has_rule(rule_name) {
             self.diagnostics.push(Diagnostic {
                 rule_name,
+                message_id,
                 message: message.into(),
                 loc: self.line_index.loc_for_span(self.source_text, span),
             });
@@ -71,6 +78,7 @@ impl<'a> Scanner<'a> {
         if params.items.is_empty() && params.rest.is_none() {
             self.report(
                 "functional-parameters",
+                "paramCountAtLeastOne",
                 "Functions must have at least one parameter.",
                 span,
             );
@@ -80,6 +88,7 @@ impl<'a> Scanner<'a> {
         {
             self.report(
                 "functional-parameters",
+                "restParam",
                 "Unexpected rest parameter. Use a regular parameter of type array instead.",
                 rest.span,
             );
@@ -90,6 +99,7 @@ impl<'a> Scanner<'a> {
                 if is_mutable_type(&type_annotation.type_annotation) {
                     self.report(
                         "prefer-immutable-types",
+                        "parameter",
                         "Only readonly types allowed.",
                         type_annotation.span,
                     );
@@ -98,6 +108,7 @@ impl<'a> Scanner<'a> {
             if param.readonly {
                 self.report(
                     "readonly-type",
+                    "generic",
                     "Readonly type using 'readonly' keyword is forbidden. Use 'Readonly<T>' instead.",
                     param.span,
                 );
@@ -122,6 +133,7 @@ impl<'a> Scanner<'a> {
             TSType::TSVoidKeyword(_) => {
                 self.report(
                     "no-return-void",
+                    "generic",
                     "Function must return a value.",
                     return_type.span,
                 );
@@ -129,6 +141,7 @@ impl<'a> Scanner<'a> {
             TSType::TSNullKeyword(_) => {
                 self.report(
                     "no-return-void",
+                    "generic",
                     "Function must return a value.",
                     return_type.span,
                 );
@@ -136,6 +149,7 @@ impl<'a> Scanner<'a> {
             TSType::TSUndefinedKeyword(_) => {
                 self.report(
                     "no-return-void",
+                    "generic",
                     "Function must return a value.",
                     return_type.span,
                 );
@@ -148,12 +162,14 @@ impl<'a> Scanner<'a> {
     pub(crate) fn scan_class(&mut self, class: &'a Class<'a>, context: FunctionContext) {
         self.report(
             "no-classes",
+            "generic",
             "Unexpected class, use functions not classes.",
             class.span,
         );
         if class.super_class.is_some() {
             self.report(
                 "no-class-inheritance",
+                "extends",
                 "Unexpected class inheritance.",
                 class.span,
             );
@@ -171,6 +187,7 @@ impl<'a> Scanner<'a> {
                         if is_mutable_type(&type_annotation.type_annotation) && !property.readonly {
                             self.report(
                                 "prefer-readonly-type",
+                                "property",
                                 "A readonly modifier is required.",
                                 property.span,
                             );
@@ -189,6 +206,7 @@ impl<'a> Scanner<'a> {
                     if !signature.readonly {
                         self.report(
                             "prefer-readonly-type",
+                            "property",
                             "A readonly modifier is required.",
                             signature.span,
                         );

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -20,6 +20,7 @@ impl<'a> Scanner<'a> {
                 ) {
                     self.report(
                         "no-expression-statements",
+                        "generic",
                         "Using expressions to cause side-effects not allowed.",
                         statement.span,
                     );
@@ -30,6 +31,7 @@ impl<'a> Scanner<'a> {
             Statement::IfStatement(statement) => {
                 self.report(
                     "no-conditional-statements",
+                    "unexpectedIf",
                     "Unexpected if, use a conditional expression (ternary operator) instead.",
                     statement.span,
                 );
@@ -42,6 +44,7 @@ impl<'a> Scanner<'a> {
             Statement::SwitchStatement(statement) => {
                 self.report(
                     "no-conditional-statements",
+                    "unexpectedSwitch",
                     "Unexpected switch, use a conditional expression instead.",
                     statement.span,
                 );
@@ -56,6 +59,7 @@ impl<'a> Scanner<'a> {
             Statement::ForStatement(statement) => {
                 self.report(
                     "no-loop-statements",
+                    "generic",
                     "Unexpected loop, use map or reduce instead.",
                     statement.span,
                 );
@@ -73,6 +77,7 @@ impl<'a> Scanner<'a> {
             Statement::ForInStatement(statement) => {
                 self.report(
                     "no-loop-statements",
+                    "generic",
                     "Unexpected loop, use map or reduce instead.",
                     statement.span,
                 );
@@ -83,6 +88,7 @@ impl<'a> Scanner<'a> {
             Statement::ForOfStatement(statement) => {
                 self.report(
                     "no-loop-statements",
+                    "generic",
                     "Unexpected loop, use map or reduce instead.",
                     statement.span,
                 );
@@ -93,6 +99,7 @@ impl<'a> Scanner<'a> {
             Statement::WhileStatement(statement) => {
                 self.report(
                     "no-loop-statements",
+                    "generic",
                     "Unexpected loop, use map or reduce instead.",
                     statement.span,
                 );
@@ -102,6 +109,7 @@ impl<'a> Scanner<'a> {
             Statement::DoWhileStatement(statement) => {
                 self.report(
                     "no-loop-statements",
+                    "generic",
                     "Unexpected loop, use map or reduce instead.",
                     statement.span,
                 );
@@ -112,12 +120,14 @@ impl<'a> Scanner<'a> {
                 if statement.handler.is_some() && !self.options.allow_try_catch {
                     self.report(
                         "no-try-statements",
+                        "catch",
                         "Unexpected try-catch, this pattern is not functional.",
                         statement.span,
                     );
                 } else if statement.finalizer.is_some() && !self.options.allow_try_finally {
                     self.report(
                         "no-try-statements",
+                        "finally",
                         "Unexpected try-finally, this pattern is not functional.",
                         statement.span,
                     );
@@ -134,6 +144,7 @@ impl<'a> Scanner<'a> {
                 if !(self.options.allow_throw_to_reject_promises && context.in_async_function) {
                     self.report(
                         "no-throw-statements",
+                        "generic",
                         "Unexpected throw, throwing exceptions is not functional.",
                         statement.span,
                     );
@@ -141,6 +152,7 @@ impl<'a> Scanner<'a> {
                 if context.in_async_function {
                     self.report(
                         "no-promise-reject",
+                        "generic",
                         "Unexpected rejection, resolve an error instead.",
                         statement.span,
                     );
@@ -243,6 +255,7 @@ impl<'a> Scanner<'a> {
         {
             self.report(
                 "no-let",
+                "generic",
                 "Unexpected let, use const instead.",
                 declaration.span,
             );
@@ -253,6 +266,7 @@ impl<'a> Scanner<'a> {
                 if is_mutable_type(&type_annotation.type_annotation) {
                     self.report(
                         "prefer-immutable-types",
+                        "parameter",
                         "Only readonly types allowed.",
                         type_annotation.span,
                     );

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -66,6 +66,30 @@ const takes = (items: string[]): void => {};
 }
 
 #[test]
+fn no_loop_statements_reports_every_loop_form_with_generic_message_id() {
+    let options = FunctionalOptions {
+        rule_names: ["no-loop-statements".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let source = r#"
+for (let i = 0; i < 1; i++) {}
+for (const k in obj) {}
+for (const v of list) {}
+while (cond) {}
+do {} while (cond);
+"#;
+    let diagnostics = scan_functional(source, "fixture.ts", &options);
+    assert_eq!(diagnostics.len(), 5);
+    for diagnostic in &diagnostics {
+        assert_eq!(diagnostic.rule_name, "no-loop-statements");
+        assert_eq!(diagnostic.message_id, "generic");
+    }
+
+    // `if` is not a loop, so nothing is reported.
+    assert!(scan_functional("if (cond) {}", "fixture.ts", &options).is_empty());
+}
+
+#[test]
 fn honors_core_options() {
     let mut options = FunctionalOptions {
         rule_names: ["no-let".into()].into_iter().collect(),

--- a/crates/functional/src/types.rs
+++ b/crates/functional/src/types.rs
@@ -21,6 +21,7 @@ impl<'a> Scanner<'a> {
         }
         self.report(
             "prefer-tacit",
+            "generic",
             "Potentially unnecessary function wrapper.",
             function.span,
         );
@@ -35,6 +36,7 @@ impl<'a> Scanner<'a> {
         {
             self.report(
                 "no-mixed-types",
+                "generic",
                 "Only the same kind of members allowed in types.",
                 declaration.span,
             );
@@ -42,6 +44,7 @@ impl<'a> Scanner<'a> {
         if is_mutable_type(&declaration.type_annotation) {
             self.report(
                 "type-declaration-immutability",
+                "AtLeast",
                 "This type declaration contains mutable members.",
                 declaration.span,
             );
@@ -56,6 +59,7 @@ impl<'a> Scanner<'a> {
         if has_mixed_signatures(&declaration.body.body) {
             self.report(
                 "no-mixed-types",
+                "generic",
                 "Only the same kind of members allowed in types.",
                 declaration.span,
             );
@@ -63,6 +67,7 @@ impl<'a> Scanner<'a> {
         if interface_has_mutable_members(&declaration.body.body) {
             self.report(
                 "type-declaration-immutability",
+                "AtLeast",
                 "This type declaration contains mutable members.",
                 declaration.span,
             );
@@ -77,6 +82,7 @@ impl<'a> Scanner<'a> {
             TSSignature::TSMethodSignature(method) => {
                 self.report(
                     "prefer-property-signatures",
+                    "generic",
                     "Use a property signature instead of a method signature",
                     method.span,
                 );
@@ -88,6 +94,7 @@ impl<'a> Scanner<'a> {
                 if property.readonly && self.options.readonly_type_mode == "generic" {
                     self.report(
                         "readonly-type",
+                        "generic",
                         "Readonly type using 'readonly' keyword is forbidden. Use 'Readonly<T>' instead.",
                         property.span,
                     );
@@ -95,6 +102,7 @@ impl<'a> Scanner<'a> {
                 if !property.readonly {
                     self.report(
                         "prefer-readonly-type",
+                        "property",
                         "A readonly modifier is required.",
                         property.span,
                     );
@@ -107,6 +115,7 @@ impl<'a> Scanner<'a> {
                 if !signature.readonly {
                     self.report(
                         "prefer-readonly-type",
+                        "property",
                         "A readonly modifier is required.",
                         signature.span,
                     );
@@ -131,11 +140,13 @@ impl<'a> Scanner<'a> {
             TSType::TSArrayType(array) => {
                 self.report(
                     "prefer-readonly-type",
+                    "array",
                     "Only readonly arrays allowed.",
                     array.span,
                 );
                 self.report(
                     "prefer-immutable-types",
+                    "parameter",
                     "Only readonly types allowed.",
                     array.span,
                 );
@@ -144,6 +155,7 @@ impl<'a> Scanner<'a> {
             TSType::TSTupleType(tuple) => {
                 self.report(
                     "prefer-readonly-type",
+                    "tuple",
                     "Only readonly tuples allowed.",
                     tuple.span,
                 );
@@ -152,11 +164,13 @@ impl<'a> Scanner<'a> {
                 if type_reference_name(reference).is_some_and(is_mutable_collection_name) {
                     self.report(
                         "prefer-readonly-type",
+                        "type",
                         "Only readonly types allowed.",
                         reference.span,
                     );
                     self.report(
                         "prefer-immutable-types",
+                        "parameter",
                         "Only readonly types allowed.",
                         reference.span,
                     );
@@ -174,6 +188,7 @@ impl<'a> Scanner<'a> {
                 if has_mixed_signatures(&literal.members) {
                     self.report(
                         "no-mixed-types",
+                        "generic",
                         "Only the same kind of members allowed in types.",
                         literal.span,
                     );
@@ -207,6 +222,7 @@ impl<'a> Scanner<'a> {
             if self.options.readonly_type_mode == "keyword" {
                 self.report(
                     "readonly-type",
+                    "keyword",
                     "Readonly type using 'Readonly<T>' is forbidden. Use 'readonly' keyword instead.",
                     operator.span,
                 );

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -7,6 +7,7 @@ export type FunctionalDiagnosticLoc = {
 
 export type FunctionalDiagnostic = {
   ruleName: string;
+  messageId: string;
   message: string;
   loc: FunctionalDiagnosticLoc;
 };

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -62,6 +62,58 @@ const recommendedRuleConfig = Object.freeze({
   'type-declaration-immutability': 'error',
 });
 
+// Upstream eslint-plugin-functional messageIds per rule. The Rust core tags
+// each diagnostic with its messageId; the wrapper reports it (rendered through
+// the `{{message}}` template so the displayed text stays our own copy and no
+// upstream message strings are vendored). The upstream replay suite asserts
+// these ids.
+const ruleMessageIds = Object.freeze({
+  'functional-parameters': [
+    'restParam',
+    'arguments',
+    'paramCountAtLeastOne',
+    'paramCountExactlyOne',
+  ],
+  'immutable-data': ['generic', 'object', 'array', 'map', 'set'],
+  'no-class-inheritance': ['abstract', 'extends'],
+  'no-classes': ['generic'],
+  'no-conditional-statements': [
+    'incompleteBranch',
+    'incompleteIf',
+    'incompleteSwitch',
+    'unexpectedIf',
+    'unexpectedSwitch',
+  ],
+  'no-expression-statements': ['generic'],
+  'no-let': ['generic'],
+  'no-loop-statements': ['generic'],
+  'no-mixed-types': ['generic'],
+  'no-promise-reject': ['generic'],
+  'no-return-void': ['generic'],
+  'no-this-expressions': ['generic'],
+  'no-throw-statements': ['generic'],
+  'no-try-statements': ['catch', 'finally'],
+  'prefer-immutable-types': [
+    'parameter',
+    'returnType',
+    'variable',
+    'propertyImmutability',
+    'propertyModifier',
+    'propertyModifierSuggestion',
+    'userDefined',
+  ],
+  'prefer-property-signatures': ['generic'],
+  'prefer-readonly-type': ['array', 'implicit', 'property', 'tuple', 'type'],
+  'prefer-tacit': ['generic', 'genericSuggestion'],
+  'readonly-type': ['generic', 'keyword'],
+  'type-declaration-immutability': ['Less', 'AtLeast', 'Exactly', 'AtMost', 'More', 'userDefined'],
+});
+
+function messagesForRule(ruleName) {
+  const ids = ruleMessageIds[ruleName] ?? ['generic'];
+  return Object.fromEntries(ids.map((messageId) => [messageId, '{{message}}']));
+}
+
 const implementedRuleNames = Object.freeze(implementedFunctionalRuleNames());
 const rules = Object.freeze(
   Object.fromEntries(
@@ -115,9 +167,7 @@ function createFunctionalRule(ruleName) {
         recommended: recommendedRuleConfig[ruleName] !== 'off',
         url: `${DOCS_BASE}#${ruleName}`,
       },
-      messages: {
-        unexpected: '{{message}}',
-      },
+      messages: messagesForRule(ruleName),
       schema: schemaForRule(ruleName),
     },
     createOnce(context) {
@@ -244,7 +294,7 @@ function sourceTextForContext(context) {
 
 function reportDiagnostic(context, diagnostic) {
   context.report({
-    messageId: 'unexpected',
+    messageId: diagnostic.messageId,
     data: {
       message: diagnostic.message,
     },

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -41,6 +41,7 @@ mod napi_abi {
     #[derive(Clone, Debug)]
     pub struct Diagnostic {
         pub rule_name: String,
+        pub message_id: String,
         pub message: String,
         pub loc: DiagnosticLoc,
     }
@@ -92,6 +93,7 @@ mod napi_abi {
             .into_iter()
             .map(|diagnostic| Diagnostic {
                 rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
                 message: diagnostic.message.into_string(),
                 loc: DiagnosticLoc {
                     start_line: diagnostic.loc.start_line,

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -27,7 +27,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
-const FULL_PARITY = new Set([]);
+const FULL_PARITY = new Set(['no-loop-statements']);
 
 function runRule(ruleName, testCase) {
   const sourceText = testCase.code;


### PR DESCRIPTION
## Summary

First rule port on top of the upstream replay harness (#100). Establishes the messageId pipeline shared by every functional rule, and brings **no-loop-statements** to full upstream parity.

## Changes

- **messageId pipeline (shared infrastructure):**
  - Core `Diagnostic` gains `message_id: &'static str`; `report(...)` takes it and every existing call site passes the matching upstream messageId. Message text and spans are unchanged — only the id is threaded through, so behavior is identical.
  - NAPI `Diagnostic` exposes `messageId`; `api.d.ts` mirrors it.
  - The JS wrapper builds per-rule `meta.messages` from a messageId table; each id renders through the `{{message}}` template, so our own message strings are preserved and **no upstream message text is vendored**. `reportDiagnostic` now reports the diagnostic's real messageId.
- **no-loop-statements → full parity:** added to the harness `FULL_PARITY` set. Its 7 syntactic upstream cases (every loop form: `for` / `for-in` / `for-of` / `for await-of` / `while` / `do-while`, plus a non-loop `if` control case) now assert reported messageIds **and count**, not just smoke-run. Adds a Rust unit test pinning the messageId contract.

The other 19 rules keep their (now messageId-tagged) diagnostics and remain smoke-run until their own porting PRs flip them to full parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783964759&installation_id=136613492&pr_number=104&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F104&signature=bee6fa4cc288fcbf120d679f5a52be32d2a1cb7dc1da45a6d36e4d48fac51e56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->