### PR TITLE
test(functional): complete replay expectations from upstream snapshots

### DIFF
--- a/npm/functional/test/fixtures/immutable-data.json
+++ b/npm/functional/test/fixtures/immutable-data.json
@@ -338,40 +338,13 @@
       ],
       "errors": [
         {
-          "messageId": "generic"
+          "messageId": "set"
         },
         {
-          "messageId": "generic"
+          "messageId": "set"
         },
         {
-          "messageId": "generic"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
+          "messageId": "set"
         }
       ]
     },
@@ -385,16 +358,13 @@
       ],
       "errors": [
         {
-          "messageId": "array"
+          "messageId": "set"
         },
         {
-          "messageId": "array"
+          "messageId": "set"
         },
         {
-          "messageId": "array"
-        },
-        {
-          "messageId": "array"
+          "messageId": "set"
         }
       ]
     },
@@ -423,13 +393,13 @@
       ],
       "errors": [
         {
-          "messageId": "map"
+          "messageId": "set"
         },
         {
-          "messageId": "map"
+          "messageId": "set"
         },
         {
-          "messageId": "map"
+          "messageId": "set"
         }
       ]
     },
@@ -443,13 +413,13 @@
       ],
       "errors": [
         {
-          "messageId": "map"
+          "messageId": "set"
         },
         {
-          "messageId": "map"
+          "messageId": "set"
         },
         {
-          "messageId": "map"
+          "messageId": "set"
         }
       ]
     },

--- a/npm/functional/test/fixtures/no-let.json
+++ b/npm/functional/test/fixtures/no-let.json
@@ -281,8 +281,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "let immutable = 0;\nlet immutableX = 0;",
@@ -291,8 +290,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "for (let immutableX = 0; immutableX < 1; immutableX++);",
@@ -301,8 +299,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "for (let immutableX in {});",
@@ -311,8 +308,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "for (let immutableX of []);",
@@ -321,8 +317,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "function foo() {\n  let immutableX;\n  let immutableY = 0;\n}",
@@ -331,8 +326,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "const foo = () => {\n  let immutableX;\n  let immutableY = 0;\n}",
@@ -341,8 +335,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "class Foo {\n  foo() {\n    let immutableX;\n    let immutableY = 0;\n  }\n}",
@@ -351,8 +344,7 @@
         {
           "ignoreIdentifierPattern": "^mutable"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "let Immutable;\nlet xImmutable;",
@@ -361,8 +353,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "let Immutable = 0;\nlet xImmutable = 0;",
@@ -371,8 +362,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "for (let xImmutable = 0; x < 1; x++);",
@@ -381,8 +371,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "for (let xImmutable in {});",
@@ -391,8 +380,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "for (let xImmutable of []);",
@@ -401,8 +389,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "function foo() {\n  let xImmutable;\n  let yImmutable = 0;\n}",
@@ -411,8 +398,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "const foo = () => {\n  let xImmutable;\n  let yImmutable = 0;\n}",
@@ -421,8 +407,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     },
     {
       "code": "class Foo {\n  foo() {\n    let xImmutable;\n    let yImmutable = 0;\n  }\n}",
@@ -431,8 +416,7 @@
         {
           "ignoreIdentifierPattern": "Mutable$"
         }
-      ],
-      "errors": []
+      ]
     }
   ]
 }

--- a/npm/functional/test/fixtures/no-this-expressions.json
+++ b/npm/functional/test/fixtures/no-this-expressions.json
@@ -18,7 +18,11 @@
     {
       "code": "function foo() {\n  this.bar();\n}",
       "typeAware": false,
-      "errors": []
+      "errors": [
+        {
+          "messageId": "generic"
+        }
+      ]
     }
   ]
 }

--- a/npm/functional/test/fixtures/prefer-immutable-types.json
+++ b/npm/functional/test/fixtures/prefer-immutable-types.json
@@ -1527,7 +1527,13 @@
           "messageId": "parameter"
         },
         {
+          "messageId": "userDefined"
+        },
+        {
           "messageId": "parameter"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1536,13 +1542,16 @@
       "typeAware": true,
       "errors": [
         {
-          "messageId": "propertyModifier"
+          "messageId": "propertyImmutability"
         },
         {
-          "messageId": "propertyModifier"
+          "messageId": "propertyImmutability"
         },
         {
-          "messageId": "propertyModifier"
+          "messageId": "propertyImmutability"
+        },
+        {
+          "messageId": "propertyImmutability"
         }
       ]
     },
@@ -1559,10 +1568,19 @@
           "messageId": "propertyModifier"
         },
         {
-          "messageId": "propertyModifier"
+          "messageId": "propertyModifierSuggestion"
         },
         {
           "messageId": "propertyModifier"
+        },
+        {
+          "messageId": "propertyModifierSuggestion"
+        },
+        {
+          "messageId": "propertyModifier"
+        },
+        {
+          "messageId": "propertyModifierSuggestion"
         }
       ]
     },
@@ -1577,6 +1595,9 @@
       "errors": [
         {
           "messageId": "parameter"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1590,16 +1611,40 @@
       ],
       "errors": [
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "userDefined"
         },
         {
-          "messageId": "parameter"
+          "messageId": "userDefined"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1623,7 +1668,10 @@
       ],
       "errors": [
         {
-          "messageId": "parameter"
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1645,28 +1693,28 @@
       ],
       "errors": [
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         },
         {
-          "messageId": "parameter"
+          "messageId": "variable"
         }
       ]
     },
@@ -1708,6 +1756,9 @@
       "errors": [
         {
           "messageId": "returnType"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1721,16 +1772,40 @@
       ],
       "errors": [
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "userDefined"
         },
         {
-          "messageId": "returnType"
+          "messageId": "userDefined"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1754,7 +1829,10 @@
       ],
       "errors": [
         {
-          "messageId": "returnType"
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1776,28 +1854,28 @@
       ],
       "errors": [
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         },
         {
-          "messageId": "returnType"
+          "messageId": "variable"
         }
       ]
     },
@@ -1839,6 +1917,9 @@
       "errors": [
         {
           "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1855,13 +1936,37 @@
           "messageId": "variable"
         },
         {
-          "messageId": "variable"
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
         },
         {
           "messageId": "variable"
         },
         {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
           "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },
@@ -1904,6 +2009,9 @@
       "errors": [
         {
           "messageId": "variable"
+        },
+        {
+          "messageId": "userDefined"
         }
       ]
     },

--- a/npm/functional/test/fixtures/prefer-tacit.json
+++ b/npm/functional/test/fixtures/prefer-tacit.json
@@ -71,6 +71,9 @@
       "errors": [
         {
           "messageId": "generic"
+        },
+        {
+          "messageId": "genericSuggestion"
         }
       ]
     },
@@ -80,6 +83,9 @@
       "errors": [
         {
           "messageId": "generic"
+        },
+        {
+          "messageId": "genericSuggestion"
         }
       ]
     },
@@ -89,6 +95,9 @@
       "errors": [
         {
           "messageId": "generic"
+        },
+        {
+          "messageId": "genericSuggestion"
         }
       ]
     },
@@ -103,6 +112,9 @@
       "errors": [
         {
           "messageId": "generic"
+        },
+        {
+          "messageId": "genericSuggestion"
         }
       ]
     },
@@ -117,6 +129,9 @@
       "errors": [
         {
           "messageId": "generic"
+        },
+        {
+          "messageId": "genericSuggestion"
         }
       ]
     }

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -60,10 +60,16 @@ function reportMessageId(report) {
   return report.messageId ?? 'unexpected';
 }
 
-// Compare reported errors against the upstream-declared expectations: a count
-// (number) or a list of `{ messageId }` objects. messageIds are compared as a
-// sorted multiset so report ordering does not matter.
+// Compare reported errors against the upstream-declared expectations: a list of
+// `{ messageId }` objects (from inline `errors` or the upstream snapshot), a
+// count (number), or `undefined` when the upstream `invalid()` call declared no
+// expectations and only asserted "at least one error". messageIds are compared
+// as a sorted multiset so report ordering does not matter.
 function assertErrors(reports, expectedErrors) {
+  if (expectedErrors === undefined) {
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    return;
+  }
   if (typeof expectedErrors === 'number') {
     expect(reports.length).toBe(expectedErrors);
     return;

--- a/tools/tasks/sync-functional-tests.ts
+++ b/tools/tasks/sync-functional-tests.ts
@@ -24,6 +24,14 @@
 //   - `is-immutable-type` -> an `Immutability` proxy yielding member names, so the
 //                            type-aware rules' enum option values serialize readably.
 //
+// Many upstream invalid tests assert their reported errors via
+// `toMatchSnapshot()` rather than inline `errors`, so the captured expectations
+// are completed from the committed Vitest `__snapshots__` (the `expect(result)
+// .toMatchSnapshot()` call is matched to its snapshot key and the messageIds are
+// extracted). When a case has neither inline `errors` nor a snapshot, the
+// upstream `invalid()` only asserts "at least one error", so `errors` is left
+// omitted and the replay harness checks `>= 1`.
+//
 // The upstream `.ts` test files run directly through Node's native type stripping
 // (Node >= 24). Type-aware cases (TypeScript `projectService` config) are captured
 // and tagged but cannot be replayed by the syntax-only Rust port; the replay
@@ -34,7 +42,7 @@
 
 import { registerHooks } from 'node:module';
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 type Manifest = {
@@ -56,12 +64,22 @@ type CapturedCase = {
   errors?: unknown;
   output?: string | null;
   typeAware: boolean;
+  // Authoritative expected messageIds extracted from the upstream Vitest
+  // snapshot when the test relied on `toMatchSnapshot()` instead of declaring
+  // inline `errors`. Preferred over `errors` during normalization.
+  snapshotMessageIds?: string[];
 };
 type Capture = { valid: CapturedCase[]; invalid: CapturedCase[] };
-type CollectedTest = { name: string; fn: () => unknown };
+type CollectedTest = { name: string; fullName: string; fn: () => unknown };
 
 type SyncGlobal = {
   capture: Capture;
+  // Describe-name stack (maintained while test files are imported) and the
+  // running snapshot key state (maintained while collected `it`s execute), so
+  // `expect(result).toMatchSnapshot()` can be matched to the upstream snapshot.
+  stack: string[];
+  currentTest: { fullName: string; snapCounter: number } | null;
+  snapshotsByKey: Record<string, string[]>;
   collected: CollectedTest[];
 };
 
@@ -90,7 +108,13 @@ if (!existsSync(SRC_RULES_DIR) || !existsSync(TESTS_DIR)) {
 
 mkdirSync(FIXTURES_DIR, { recursive: true });
 
-const state: SyncGlobal = { capture: { valid: [], invalid: [] }, collected: [] };
+const state: SyncGlobal = {
+  capture: { valid: [], invalid: [] },
+  stack: [],
+  currentTest: null,
+  snapshotsByKey: {},
+  collected: [],
+};
 (globalThis as Record<string, unknown>)[SYNC_KEY] = state;
 
 registerStubHooks();
@@ -113,16 +137,24 @@ for (const rule of ruleNames) {
 
   state.capture = { valid: [], invalid: [] };
   state.collected = [];
+  state.stack = [];
+  state.currentTest = null;
+  state.snapshotsByKey = loadSnapshots(testFiles);
 
   // Sequential import + run keeps the shared capture buffer deterministic:
-  // `it()` callbacks are only registered during import, then run in order so the
-  // imperative `valid()`/`invalid()` calls inside them fire and are captured.
+  // `it()` callbacks are only registered during import (building the describe
+  // stack), then run in order so the imperative `valid()`/`invalid()` calls
+  // inside them fire and are captured. Before each `it` runs we publish its full
+  // name + a fresh snapshot counter so `toMatchSnapshot()` resolves the matching
+  // upstream snapshot key (`<describe> > … > <it> <n>`).
   for (const file of testFiles) {
     await import(pathToFileURL(file).href);
   }
   for (const test of state.collected) {
+    state.currentTest = { fullName: test.fullName, snapCounter: 0 };
     await test.fn();
   }
+  state.currentTest = null;
 
   const captured = state.capture;
   const result = normalizeCapture(captured);
@@ -160,6 +192,32 @@ function testFilesForRule(rule: string): string[] {
     }
   }
   return files;
+}
+
+// Parse the Vitest snapshot files alongside the given test files into a map of
+// snapshot key -> ordered list of expected messageIds. Many upstream invalid
+// tests assert via `toMatchSnapshot()` rather than inline `errors`, and the
+// snapshot is the authoritative expected output. A snapshot body nests the same
+// messages under a `steps` array, so only the messageIds before `"steps"` (the
+// top-level `messages`) are taken to avoid double-counting.
+function loadSnapshots(testFiles: string[]): Record<string, string[]> {
+  const map: Record<string, string[]> = {};
+  for (const file of testFiles) {
+    const snapFile = join(dirname(file), '__snapshots__', `${basename(file)}.snap`);
+    if (!existsSync(snapFile)) {
+      continue;
+    }
+    const text = readFileSync(snapFile, 'utf8');
+    const entry = /exports\[`([\s\S]*?)`\]\s*=\s*`([\s\S]*?)`;/g;
+    let match: RegExpExecArray | null;
+    while ((match = entry.exec(text)) !== null) {
+      const key = match[1];
+      const topLevel = match[2].split('"steps"')[0];
+      const ids = [...topLevel.matchAll(/"messageId":\s*"([^"]+)"/g)].map((m) => m[1]);
+      map[key] = ids;
+    }
+  }
+  return map;
 }
 
 function writeFixture(
@@ -228,7 +286,19 @@ function normalizeCase(raw: CapturedCase, isInvalid: boolean): CapturedCase | nu
     out.filename = raw.filename;
   }
   if (isInvalid) {
-    out.errors = normalizeErrors(raw.errors);
+    // Prefer the snapshot's messageIds (authoritative, present even when the
+    // test declared no inline `errors`); otherwise fall back to inline `errors`.
+    // When neither is present the upstream `invalid()` call only asserts "at
+    // least one error" — leave `errors` omitted so the harness checks that.
+    if (Array.isArray(raw.snapshotMessageIds)) {
+      out.errors = raw.snapshotMessageIds.map((messageId) => ({ messageId }));
+    } else {
+      const inline = normalizeErrors(raw.errors);
+      const hasInline = typeof inline === 'number' || (Array.isArray(inline) && inline.length > 0);
+      if (hasInline) {
+        out.errors = inline;
+      }
+    }
     if (typeof raw.output === 'string') {
       out.output = raw.output;
     }
@@ -345,19 +415,52 @@ function vitestStub(): string {
     `const KEY = ${JSON.stringify(SYNC_KEY)};`,
     'function state() { return globalThis[KEY]; }',
     'function callRow(fn, row) { return Array.isArray(row) ? fn(...row) : fn(row); }',
-    'export function describe(_name, fn) { if (typeof fn === "function") { fn(); } }',
+    'function fullName(name) { return [...state().stack, name].join(" > "); }',
+    'export function describe(name, fn) {',
+    '  state().stack.push(String(name));',
+    '  try { if (typeof fn === "function") fn(); } finally { state().stack.pop(); }',
+    '}',
     'describe.only = describe; describe.skip = function () {}; describe.todo = function () {};',
-    'describe.each = (table) => (_name, fn) => { for (const row of table || []) callRow(fn, row); };',
-    'export function it(name, fn) { if (typeof fn === "function") { state().collected.push({ name, fn }); } }',
+    'describe.each = (table) => (name, fn) => {',
+    '  for (const row of table || []) {',
+    '    state().stack.push(String(name));',
+    '    try { callRow(fn, row); } finally { state().stack.pop(); }',
+    '  }',
+    '};',
+    'export function it(name, fn) {',
+    '  if (typeof fn === "function") state().collected.push({ name, fullName: fullName(name), fn });',
+    '}',
     'it.only = it; it.skip = function () {}; it.todo = function () {};',
-    'it.each = (table) => (name, fn) => { for (const row of table || []) state().collected.push({ name, fn: () => callRow(fn, row) }); };',
+    'it.each = (table) => (name, fn) => {',
+    '  for (const row of table || [])',
+    '    state().collected.push({ name, fullName: fullName(name), fn: () => callRow(fn, row) });',
+    '};',
     'export const test = it;',
-    'function noop() { return chain; }',
-    'const chain = new Proxy(function () {}, {',
-    '  get(_t, prop) { if (prop === "resolves" || prop === "rejects" || prop === "not") return chain; return noop; },',
-    '  apply() { return chain; },',
-    '});',
-    'export function expect() { return chain; }',
+    // `expect(value)` keeps `value` bound so `toMatchSnapshot()` can attach the
+    // matching upstream snapshot (keyed `<full test name> <n>`) to the invalid
+    // case the result came from. Every other matcher is a chainable no-op.
+    'function chainFor(value) {',
+    '  return new Proxy(function () {}, {',
+    '    get(_t, prop) {',
+    '      if (prop === "toMatchSnapshot" || prop === "toMatchInlineSnapshot") {',
+    '        return function () {',
+    '          const ct = state().currentTest;',
+    '          if (ct) {',
+    '            const ids = state().snapshotsByKey[ct.fullName + " " + ++ct.snapCounter];',
+    '            if (ids && value && typeof value === "object" && value.__caseRef) {',
+    '              value.__caseRef.snapshotMessageIds = ids;',
+    '            }',
+    '          }',
+    '          return chainFor(value);',
+    '        };',
+    '      }',
+    '      if (prop === "resolves" || prop === "rejects" || prop === "not") return chainFor(value);',
+    '      return function () { return chainFor(value); };',
+    '    },',
+    '    apply() { return chainFor(value); },',
+    '  });',
+    '}',
+    'export function expect(value) { return chainFor(value); }',
     'expect.any = function () { return {}; }; expect.objectContaining = function (o) { return o; };',
     'expect.stringContaining = function (s) { return s; }; expect.arrayContaining = function (a) { return a; };',
     'export function beforeAll() {} export function afterAll() {}',
@@ -390,8 +493,9 @@ function ruleTesterStub(): string {
     '  };',
     '  const invalid = async (input) => {',
     '    const items = Array.isArray(input) ? input : [input];',
-    '    for (const item of items) state().capture.invalid.push(toCase(item, typeAware));',
-    '    return { result: { messages: [], output: null, fixed: false, steps: [] } };',
+    '    let last = null;',
+    '    for (const item of items) { last = toCase(item, typeAware); state().capture.invalid.push(last); }',
+    '    return { result: { __caseRef: last, messages: [], output: null, fixed: false, steps: [] } };',
     '  };',
     '  return { valid, invalid, rule: opts && opts.rule, name: opts && opts.name };',
     '}',


### PR DESCRIPTION
## Summary

Makes the upstream replay fixtures faithfully capture **every** invalid test's expectations. Many upstream `eslint-plugin-functional` invalid tests assert via `toMatchSnapshot()` instead of inline `errors`, so the initial fixtures (#100) recorded empty/partial `errors` for those cases. This completes them from the committed Vitest snapshots.

## Changes

- **`tools/tasks/sync-functional-tests.ts`**: while replaying the upstream tests, track the describe/it stack and a per-test snapshot counter so each `expect(result).toMatchSnapshot()` resolves its snapshot key (`<describe> > … > <it> <n>`). Parse the sibling `__snapshots__/*.snap` files and extract the expected messageIds (top-level `messages`, ignoring the duplicated `steps`). The snapshot messageIds are authoritative and preferred over inline `errors`. When a case has **neither** inline `errors` nor a snapshot, upstream's `invalid()` only asserts "at least one error", so `errors` is left omitted.
- **`npm/functional/test/upstream.test.mjs`**: `assertErrors` treats omitted `errors` as "≥ 1 report".
- **Regenerated fixtures** (`immutable-data`, `no-let`, `no-this-expressions`, `prefer-immutable-types`, `prefer-tacit`) now carry authoritative expectations. The other 15 fixtures were already complete and are unchanged.

This strengthens the parity guarantee before more rules join `FULL_PARITY`. `no-loop-statements` (the only current full-parity rule) is unaffected — its cases declared inline errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783965199&installation_id=136613492&pr_number=105&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F105&signature=6c16e008ac6bf75f3b2c3207821642637d2b4f97dec184b4719ddb3d00aaa185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->