### PR TITLE
port(functional): bring no-this-expressions to full upstream parity

### DIFF
--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -27,7 +27,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
-const FULL_PARITY = new Set(['no-loop-statements']);
+const FULL_PARITY = new Set(['no-loop-statements', 'no-this-expressions']);
 
 function runRule(ruleName, testCase) {
   const sourceText = testCase.code;


### PR DESCRIPTION
Adds no-this-expressions to the upstream replay FULL_PARITY set. The rule already reports every `this` expression (messageId `generic`); this asserts its upstream cases (1 valid, 1 invalid) exactly instead of smoke-running them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)