### PR TITLE
port(functional): bring no-try-statements to full upstream parity

### DIFF
--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -27,7 +27,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
-const FULL_PARITY = new Set(['no-loop-statements', 'no-this-expressions']);
+const FULL_PARITY = new Set(['no-loop-statements', 'no-this-expressions', 'no-try-statements']);
 
 function runRule(ruleName, testCase) {
   const sourceText = testCase.code;


### PR DESCRIPTION
Adds no-try-statements to the replay FULL_PARITY set. The rule already reports `catch`/`finally` honoring `allowCatch`/`allowFinally`; this asserts its 7 upstream syntactic cases (4 valid, 3 invalid) exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)