### PR TITLE
port(sonarjs): scaffold plugin + first rule (no-nested-template-literals)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-sonarjs"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-sonarjs",
+]
+
+[[package]]
 name = "oxlint-plugin-storybook"
 version = "0.0.0"
 dependencies = [
@@ -1182,6 +1193,19 @@ dependencies = [
  "oxc_span",
  "oxlint-plugins-_carton",
  "regex",
+]
+
+[[package]]
+name = "oxlint-plugins-sonarjs"
+version = "0.0.0"
+dependencies = [
+ "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_parser",
+ "oxc_span",
+ "oxlint-plugins-_carton",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "crates/regexp",
   "crates/security",
   "crates/simple_import_sort",
+  "crates/sonarjs",
   "crates/storybook",
   "crates/stylistic",
   "crates/testing_library",
@@ -37,6 +38,7 @@ members = [
   "npm/regexp",
   "npm/security",
   "npm/simple-import-sort",
+  "npm/sonarjs",
   "npm/storybook",
   "npm/stylistic",
   "npm/testing-library",
@@ -63,6 +65,7 @@ napi-build = "2.3.2"
 napi-derive = "3.5.6"
 oxc_allocator = "0.135.0"
 oxc_ast = "0.135.0"
+oxc_ast_visit = "0.135.0"
 oxc_parser = "0.135.0"
 oxc_regular_expression = "0.135.0"
 oxc_semantic = "0.135.0"
@@ -84,6 +87,7 @@ oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0
 oxlint-plugins-regexp = { path = "crates/regexp", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
 oxlint-plugins-simple-import-sort = { path = "crates/simple_import_sort", version = "0.0.0" }
+oxlint-plugins-sonarjs = { path = "crates/sonarjs", version = "0.0.0" }
 oxlint-plugins-storybook = { path = "crates/storybook", version = "0.0.0" }
 oxlint-plugins-stylistic = { path = "crates/stylistic", version = "0.0.0" }
 oxlint-plugins-testing-library = { path = "crates/testing_library", version = "0.0.0" }

--- a/crates/sonarjs/Cargo.toml
+++ b/crates/sonarjs/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "oxlint-plugins-sonarjs"
+description = "Rust core for the sonarjs oxlint JavaScript plugin (clean-room port; upstream eslint-plugin-sonarjs is LGPL-3.0 and is never copied)."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_ast_visit.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -1,0 +1,57 @@
+#![doc = "Rust implementation of eslint-plugin-sonarjs rule logic (clean-room port)."]
+//!
+//! Upstream `eslint-plugin-sonarjs` is LGPL-3.0. Every rule here is implemented
+//! clean-room from the public RSPEC documentation and observed behaviour only;
+//! no upstream source, tests, fixtures, helper code, or messages are copied.
+
+mod rules;
+mod scanner;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+use oxc_allocator::Allocator;
+use oxc_ast_visit::Visit;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+pub(crate) use crate::types::LineIndex;
+pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
+
+/// Names of every rule implemented by the sonarjs core, in registration order.
+pub const RULE_NAMES: [&str; 1] = ["no-nested-template-literals"];
+
+/// Returns the implemented rule names as a static slice.
+pub fn implemented_sonarjs_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+/// Parses `source_text` and returns the diagnostics produced by the rules
+/// enabled in `options`. Files that fail to parse produce no diagnostics.
+pub fn scan_sonarjs(
+    source_text: &str,
+    filename: &str,
+    options: &SonarjsOptions,
+) -> SmallVec<[Diagnostic; 32]> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::tsx())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let mut scanner = Scanner {
+        source_text,
+        line_index: LineIndex::new(source_text),
+        options,
+        diagnostics: SmallVec::new(),
+        template_literal_depth: 0,
+    };
+    scanner.visit_program(&parser_return.program);
+    scanner.diagnostics
+}

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,0 +1,4 @@
+//! Clean-room rule implementations for the sonarjs port. Each module attaches
+//! one `check_*` method to [`crate::scanner::Scanner`].
+
+mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_nested_template_literals.rs
+++ b/crates/sonarjs/src/rules/no_nested_template_literals.rs
@@ -1,0 +1,27 @@
+//! Rule `no-nested-template-literals` (SonarJS key S4624).
+//!
+//! Clean-room port. Reports a template literal that appears inside the
+//! interpolated expressions of another template literal, because such nesting
+//! is hard to read. Behaviour is reproduced from the public RSPEC description
+//! only; no upstream source, tests, fixtures, or message strings were consulted
+//! or copied.
+//!
+//! Semantics: a template literal is flagged when at least one enclosing
+//! template literal is open on the traversal stack, so every nested literal is
+//! reported at its own location regardless of nesting depth or any intervening
+//! expressions (including function bodies).
+
+use oxc_ast::ast::TemplateLiteral;
+use oxc_span::GetSpan;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-nested-template-literals";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_nested_template_literals(&mut self, template: &TemplateLiteral<'_>) {
+        if self.template_literal_depth > 0 {
+            self.report(RULE_NAME, "nestedTemplateLiteral", template.span());
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -1,0 +1,54 @@
+//! Top-level scanner state, `report*` helpers, and AST traversal for the
+//! sonarjs port. Traversal uses the Oxc visitor so every node is reached; each
+//! `check_*` rule body lives under [`crate::rules`].
+
+use oxc_ast::ast::TemplateLiteral;
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::{Diagnostic, DiagnosticData, DiagnosticFix, LineIndex, SonarjsOptions};
+
+pub(crate) struct Scanner<'a> {
+    pub(crate) source_text: &'a str,
+    pub(crate) line_index: LineIndex,
+    pub(crate) options: &'a SonarjsOptions,
+    pub(crate) diagnostics: SmallVec<[Diagnostic; 32]>,
+    /// Number of template literals currently open on the traversal stack.
+    pub(crate) template_literal_depth: u32,
+}
+
+impl Scanner<'_> {
+    pub(crate) fn report(&mut self, rule_name: &'static str, message_id: &'static str, span: Span) {
+        self.report_with_data(rule_name, message_id, DiagnosticData::default(), span, None);
+    }
+
+    pub(crate) fn report_with_data(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        data: DiagnosticData,
+        span: Span,
+        fix: Option<DiagnosticFix>,
+    ) {
+        if !self.options.has_rule(rule_name) {
+            return;
+        }
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+            fix,
+        });
+    }
+}
+
+impl<'a> Visit<'a> for Scanner<'a> {
+    fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {
+        self.check_no_nested_template_literals(it);
+        self.template_literal_depth += 1;
+        walk::walk_template_literal(self, it);
+        self.template_literal_depth -= 1;
+    }
+}

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1,0 +1,58 @@
+//! Rust unit tests for the sonarjs core. All test inputs are independently
+//! authored (clean-room); no upstream SonarJS fixtures or expectations are used.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::{Diagnostic, SonarjsOptions, scan_sonarjs};
+
+fn scan(rule_name: &str, source: &str) -> SmallVec<[Diagnostic; 32]> {
+    let options = SonarjsOptions {
+        rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+    };
+    scan_sonarjs(source, "sample.ts", &options)
+}
+
+#[test]
+fn reports_template_literal_nested_in_another() {
+    let diagnostics = scan(
+        "no-nested-template-literals",
+        "const x = `outer ${`inner`} end`;",
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-nested-template-literals");
+    assert_eq!(diagnostics[0].message_id, "nestedTemplateLiteral");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn does_not_report_flat_template_literal() {
+    let diagnostics = scan("no-nested-template-literals", "const x = `value ${y}`;");
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_adjacent_template_literals() {
+    let diagnostics = scan(
+        "no-nested-template-literals",
+        "const a = `x ${y}`;\nconst b = `z ${w}`;",
+    );
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_each_nested_level() {
+    let diagnostics = scan(
+        "no-nested-template-literals",
+        "const x = `a ${`b ${`c`}`}`;",
+    );
+    assert_eq!(diagnostics.len(), 2);
+}
+
+#[test]
+fn disabled_rule_reports_nothing() {
+    let options = SonarjsOptions {
+        rule_names: SmallVec::new(),
+    };
+    let diagnostics = scan_sonarjs("const x = `outer ${`inner`}`;", "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -1,0 +1,105 @@
+//! Public-facing diagnostic and option types for the sonarjs port.
+
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::RULE_NAMES;
+
+/// Interpolation values forwarded to the JavaScript message templates.
+///
+/// Message text lives in the JS adapter (`npm/sonarjs/index.js`); the Rust core
+/// only emits a `message_id` plus any placeholder values. Fields are added as
+/// rules need them.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub value: Option<CompactString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiagnosticFix {
+    pub start: u32,
+    pub end: u32,
+    pub replacement: CompactString,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: DiagnosticData,
+    pub loc: DiagnosticLoc,
+    pub fix: Option<DiagnosticFix>,
+}
+
+/// Per-scan options: the set of enabled rule names.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SonarjsOptions {
+    pub rule_names: SmallVec<[CompactString; 32]>,
+}
+
+impl Default for SonarjsOptions {
+    fn default() -> Self {
+        Self {
+            rule_names: RULE_NAMES
+                .iter()
+                .map(|rule_name| CompactString::from(*rule_name))
+                .collect(),
+        }
+    }
+}
+
+impl SonarjsOptions {
+    pub(crate) fn has_rule(&self, rule_name: &str) -> bool {
+        self.rule_names.iter().any(|name| name == rule_name)
+    }
+}
+
+/// Maps byte offsets to 1-based lines and 0-based UTF-16 columns, matching the
+/// `loc` convention expected by Oxlint/ESLint reports.
+pub(crate) struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    pub(crate) fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    pub(crate) fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}

--- a/npm/sonarjs/Cargo.toml
+++ b/npm/sonarjs/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "oxlint-plugin-sonarjs"
+description = "NAPI package for the sonarjs oxlint plugin."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
+oxlint-plugins-sonarjs.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints]
+workspace = true

--- a/npm/sonarjs/api.d.ts
+++ b/npm/sonarjs/api.d.ts
@@ -1,0 +1,35 @@
+export interface SonarjsScanOptions {
+  ruleNames?: string[];
+}
+
+export interface DiagnosticData {
+  value?: string;
+}
+
+export interface DiagnosticLoc {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+export interface DiagnosticFix {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+export interface Diagnostic {
+  ruleName: string;
+  messageId: string;
+  data: DiagnosticData;
+  loc: DiagnosticLoc;
+  fix?: DiagnosticFix;
+}
+
+export function implementedSonarjsRuleNames(): string[];
+export function scanSonarjs(
+  sourceText: string,
+  filename: string,
+  options?: SonarjsScanOptions,
+): Diagnostic[];

--- a/npm/sonarjs/api.js
+++ b/npm/sonarjs/api.js
@@ -1,0 +1,17 @@
+'use strict';
+
+try {
+  const native = require('./native.js');
+  module.exports = {
+    ...native,
+    implementedSonarjsRuleNames: native.implementedSonarjsRuleNames,
+    scanSonarjs: native.scanSonarjs,
+  };
+} catch (error) {
+  if (error && error.code === 'MODULE_NOT_FOUND') {
+    throw new Error(
+      'Native sonarjs binding is missing. Run `pnpm --filter @oxlint-plugins/oxlint-plugin-sonarjs build`.',
+    );
+  }
+  throw error;
+}

--- a/npm/sonarjs/build.rs
+++ b/npm/sonarjs/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -1,0 +1,173 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-sonarjs (upstream is LGPL-3.0).
+// Clean-room implementation: behaviour is reproduced from public RSPEC docs and
+// observed output only. The JavaScript layer adapts Oxlint's ESLint-compatible
+// plugin API; parsing and rule checks run in Rust through Oxc. Message strings
+// live here (independently authored), not in the Rust core.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedSonarjsRuleNames, scanSonarjs } = require('./api.js');
+
+const PLUGIN_NAME = 'sonarjs';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/sonarjs';
+const diagnosticsCache = new WeakMap();
+
+const messages = Object.freeze({
+  'no-nested-template-literals': {
+    nestedTemplateLiteral:
+      'Do not nest template literals. Extract the inner template literal into a separate variable.',
+  },
+});
+
+const ruleDescriptions = Object.freeze({
+  'no-nested-template-literals': 'Disallow nested template literals',
+});
+
+const ruleTypes = Object.freeze({
+  'no-nested-template-literals': 'suggestion',
+});
+
+const recommendedRuleConfig = Object.freeze({
+  'no-nested-template-literals': 'error',
+});
+
+const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createSonarjsRule(ruleName)]),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: configFromRuleConfig('recommended', recommendedRuleConfig),
+  },
+});
+
+plugin.implementedSonarjsRuleNames = implementedRuleNames;
+plugin.scanSonarjs = scanSonarjs;
+
+function configFromRuleConfig(name, ruleConfig) {
+  return {
+    name: `${PLUGIN_NAME}/${name}`,
+    plugins: [PLUGIN_NAME],
+    rules: Object.fromEntries(
+      Object.entries(ruleConfig).map(([ruleName, config]) => [
+        `${PLUGIN_NAME}/${ruleName}`,
+        config,
+      ]),
+    ),
+  };
+}
+
+function createSonarjsRule(ruleName) {
+  return {
+    meta: {
+      type: ruleTypes[ruleName],
+      docs: {
+        description: ruleDescriptions[ruleName],
+        recommended: recommendedRuleConfig[ruleName] !== undefined,
+        url: `${DOCS_BASE}#${ruleName}`,
+      },
+      messages: messages[ruleName],
+      schema: [],
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForRule(context, ruleName)) {
+            reportDiagnostic(context, diagnostic);
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForRule(context, ruleName) {
+  return diagnosticsForContext(context, { ruleNames: [ruleName] }).filter(
+    (diagnostic) => diagnostic.ruleName === ruleName,
+  );
+}
+
+function diagnosticsForContext(context, options) {
+  const sourceCode = context.sourceCode ?? context.getSourceCode?.() ?? {};
+  const sourceText = sourceTextForContext(context);
+  const filename = context.filename ?? context.getFilename?.() ?? 'file.js';
+  const key = JSON.stringify(options);
+  let sourceCache = diagnosticsCache.get(sourceCode);
+
+  if (!sourceCache) {
+    sourceCache = new Map();
+    diagnosticsCache.set(sourceCode, sourceCache);
+  }
+
+  const cached = sourceCache.get(key);
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanSonarjs(sourceText, filename, options);
+  sourceCache.set(key, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode ?? context.getSourceCode?.() ?? {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function reportDiagnostic(context, diagnostic) {
+  const report = {
+    messageId: diagnostic.messageId,
+    data: compactData(diagnostic.data),
+    loc: {
+      start: {
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn,
+      },
+      end: {
+        line: diagnostic.loc.endLine,
+        column: diagnostic.loc.endColumn,
+      },
+    },
+  };
+
+  if (diagnostic.fix) {
+    report.fix = (fixer) =>
+      fixer.replaceTextRange(
+        [diagnostic.fix.start, diagnostic.fix.end],
+        diagnostic.fix.replacement,
+      );
+  }
+
+  context.report(report);
+}
+
+function compactData(data) {
+  const out = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    if (value != null) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.implementedSonarjsRuleNames = implementedRuleNames;
+module.exports.scanSonarjs = scanSonarjs;

--- a/npm/sonarjs/package.json
+++ b/npm/sonarjs/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@oxlint-plugins/oxlint-plugin-sonarjs",
   "version": "0.0.0",
-  "private": true,
-  "description": "Rust-backed oxlint plugin port of eslint-plugin-sonarjs (clean-room scaffold; upstream is LGPL-3.0 and must not be copied).",
+  "description": "Rust-backed Oxlint plugin port of eslint-plugin-sonarjs (clean-room; upstream is LGPL-3.0 and is not redistributed).",
   "keywords": [
     "code-quality",
+    "eslint-plugin",
+    "napi-rs",
     "oxlint",
     "oxlint-plugin",
     "rust",
@@ -36,11 +37,56 @@
     "directory": "npm/sonarjs"
   },
   "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
     "README.md",
     "LICENSE"
   ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_sonarjs",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
   }
 }

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -1,0 +1,116 @@
+//! NAPI boundary for the sonarjs oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsScanOptions,
+    implemented_sonarjs_rule_names, scan_sonarjs,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use oxlint_plugins_sonarjs as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct SonarjsScanOptions {
+        pub rule_names: Option<Vec<String>>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct DiagnosticData {
+        pub value: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticFix {
+        pub start: u32,
+        pub end: u32,
+        pub replacement: String,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub data: DiagnosticData,
+        pub loc: DiagnosticLoc,
+        pub fix: Option<DiagnosticFix>,
+    }
+
+    #[napi]
+    pub fn implemented_sonarjs_rule_names() -> Vec<String> {
+        core::implemented_sonarjs_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_sonarjs(
+        source_text: String,
+        filename: String,
+        options: Option<SonarjsScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::SonarjsOptions {
+            rule_names: compact_rule_names(options.rule_names),
+        };
+
+        core::scan_sonarjs(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                data: DiagnosticData {
+                    value: diagnostic.data.value.map(|value| value.into_string()),
+                },
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+                fix: diagnostic.fix.map(|fix| DiagnosticFix {
+                    start: fix.start,
+                    end: fix.end,
+                    replacement: fix.replacement.into_string(),
+                }),
+            })
+            .collect()
+    }
+
+    fn compact_rule_names(values: Option<Vec<String>>) -> SmallVec<[CompactString; 32]> {
+        values.map_or_else(
+            || {
+                core::implemented_sonarjs_rule_names()
+                    .iter()
+                    .map(|name| CompactString::from(*name))
+                    .collect()
+            },
+            |values| {
+                values
+                    .into_iter()
+                    .filter(|value| core::implemented_sonarjs_rule_names().contains(&value.as_str()))
+                    .map(CompactString::from)
+                    .collect()
+            },
+        )
+    }
+}

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -107,7 +107,9 @@ mod napi_abi {
             |values| {
                 values
                     .into_iter()
-                    .filter(|value| core::implemented_sonarjs_rule_names().contains(&value.as_str()))
+                    .filter(|value| {
+                        core::implemented_sonarjs_rule_names().contains(&value.as_str())
+                    })
                     .map(CompactString::from)
                     .collect()
             },

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedSonarjsRuleNames, scanSonarjs } from '../api.js';
+
+const expectedRuleNames = ['no-nested-template-literals'];
+
+function scan(ruleName, sourceText, filename = 'sample.ts') {
+  return scanSonarjs(sourceText, filename, { ruleNames: [ruleName] });
+}
+
+describe('sonarjs native API', () => {
+  it('exposes all implemented sonarjs rule names', () => {
+    expect(implementedSonarjsRuleNames()).toEqual(expectedRuleNames);
+  });
+
+  it('reports a template literal nested inside another', () => {
+    const diagnostics = scan('no-nested-template-literals', 'const x = `outer ${`inner`} end`;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-nested-template-literals');
+    expect(diagnostics[0].messageId).toBe('nestedTemplateLiteral');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('does not report a flat template literal', () => {
+    const diagnostics = scan('no-nested-template-literals', 'const x = `value ${y}`;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports each nested level independently', () => {
+    const diagnostics = scan('no-nested-template-literals', 'const x = `a ${`b ${`c`}`}`;');
+    expect(diagnostics).toHaveLength(2);
+  });
+
+  it('ignores rules that are not enabled', () => {
+    const diagnostics = scanSonarjs('const x = `outer ${`inner`}`;', 'sample.ts', {
+      ruleNames: [],
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+});

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -1,0 +1,125 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+
+function runRule(ruleName, sourceText, { filename = 'sample.ts', options = [] } = {}) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename,
+    options,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code, filename = 'sample.ts') {
+  const oxlint = findOxlintCli();
+  const temp = mkdtempSync(join(tmpdir(), 'sonarjs-plugin-'));
+
+  try {
+    const sourcePath = join(temp, filename);
+    const configPath = join(temp, 'oxlint.config.jsonc');
+
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [
+          {
+            name: 'sonarjs',
+            specifier: join(packageRoot, 'index.js'),
+          },
+        ],
+        rules: {
+          [`sonarjs/${ruleName}`]: 'error',
+        },
+      }),
+    );
+
+    const result = spawnSync(
+      oxlint,
+      ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+      {
+        encoding: 'utf8',
+      },
+    );
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+describe('sonarjs plugin shape', () => {
+  it('exposes rules and the recommended config', () => {
+    expect(plugin.meta?.name).toBe('sonarjs');
+    expect(plugin.implementedSonarjsRuleNames).toEqual(['no-nested-template-literals']);
+    expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
+    expect(Object.keys(plugin.configs)).toEqual(['recommended']);
+    expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
+  });
+});
+
+describe('sonarjs rules through direct adapter harness', () => {
+  it('reports nested template literals', () => {
+    const reports = runRule('no-nested-template-literals', 'const x = `outer ${`inner`} end`;');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('nestedTemplateLiteral');
+  });
+
+  it('does not report flat template literals', () => {
+    const reports = runRule('no-nested-template-literals', 'const x = `value ${y}`;');
+    expect(reports).toHaveLength(0);
+  });
+});
+
+describe('sonarjs rules through oxlint jsPlugins', () => {
+  it('reports no-nested-template-literals through the CLI', () => {
+    const result = runOxlint('no-nested-template-literals', 'const x = `outer ${`inner`} end`;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-template-literals)');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/sonarjs:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/storybook:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -10041,7 +10041,7 @@
       "repository": "https://github.com/SonarSource/SonarJS",
       "license": "LGPL-3.0-only"
     },
-    "status": "pending",
+    "status": "in-progress",
     "typeAware": false,
     "rules": [
       {
@@ -12702,19 +12702,19 @@
       },
       {
         "name": "no-nested-template-literals",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-nested-template-literals (Sonar key S4624). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of upstream rule no-nested-template-literals (Sonar key S4624). Reports a template literal nested in another template literal's interpolations. SonarJS upstream is LGPL-3.0; implemented from observed behavior only — no upstream source, fixtures, tests, or messages were copied."
       },
       {
         "name": "no-os-command-from-path",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -100,6 +100,10 @@ const nativePackages = [
     name: '@oxlint-plugins/oxlint-plugin-unocss',
     binding: 'npm/unocss/native.js',
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-sonarjs',
+    binding: 'npm/sonarjs/native.js',
+  },
 ];
 
 function lockPathFor(pkg) {

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -119,6 +119,11 @@ const packages: PackageToPack[] = [
     dir: 'npm/unocss',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-sonarjs',
+    dir: 'npm/sonarjs',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
 ];
 
 for (const pkg of packages) {


### PR DESCRIPTION
## Summary

Stands up the **`sonarjs`** Oxlint plugin (port target of [#9](https://github.com/ubugeeei-prod/oxlint-plugins/issues/9), `eslint-plugin-sonarjs`, 269 rules) as a Rust-backed NAPI package, and ports the **first clean-room rule end to end** so the build/test/CI pipeline is proven before the remaining 268 rules land one PR at a time.

### Infrastructure
- **`crates/sonarjs`** — domain core (`lib`/`types`/`scanner`/`rules`) using the Oxc `Visit` traversal. Entry point `scan_sonarjs(source, filename, options)` returns `Diagnostic { rule_name, message_id, data, loc, fix }`. Hot-path types (`CompactString`, `SmallVec`) per workspace clippy policy.
- **`npm/sonarjs`** — NAPI boundary (`Cargo.toml`/`build.rs`/`src/lib.rs`), JS adapter (`index.js`) over `eslintCompatPlugin`, `api.js`/`api.d.ts`, and a real `package.json` (replacing the private stub). Message strings live in the JS adapter, not the Rust core.
- **Registrations** — workspace members + deps (incl. `oxc_ast_visit`) in `Cargo.toml`/`Cargo.lock`; `pnpm-lock.yaml` importer; `test/setup.mjs` native package; `verify-package-publish-ready.ts`; `status.json`.

### First rule: `no-nested-template-literals` (Sonar key S4624)
Reports a template literal nested inside another template literal's interpolations.

### Tests
Rust unit tests, native-API vitest, adapter vitest, and an **oxlint `jsPlugins` CLI integration test** asserting `sonarjs(no-nested-template-literals)`.

## Clean-room compliance (LGPL-3.0)
Upstream `eslint-plugin-sonarjs` is **LGPL-3.0**. This rule — and every rule that follows — is implemented from the public RSPEC description and observed behaviour only. **No upstream source, tests, fixtures, helpers, or messages were copied.** This means upstream test suites cannot be auto-imported (unlike MIT-licensed ports); tests here are independently authored from documented behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)