### PR TITLE
port(functional): bring no-promise-reject to full upstream parity

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -310,9 +310,18 @@ impl<'a> Scanner<'a> {
         expression: &'a NewExpression<'a>,
         context: FunctionContext,
     ) {
-        if is_identifier_expression(&expression.callee, "Promise")
-            && expression.arguments.len() >= 2
-        {
+        // `new Promise(executor)` can reject only when the executor declares a
+        // second `reject` parameter, mirroring upstream's `arguments[0].params
+        // .length >= 2` check.
+        let executor_can_reject = expression.arguments.first().is_some_and(|argument| {
+            let params = match argument {
+                Argument::ArrowFunctionExpression(function) => Some(&function.params),
+                Argument::FunctionExpression(function) => Some(&function.params),
+                _ => None,
+            };
+            params.is_some_and(|params| params.items.len() >= 2)
+        });
+        if is_identifier_expression(&expression.callee, "Promise") && executor_can_reject {
             self.report(
                 "no-promise-reject",
                 "generic",

--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -137,6 +137,10 @@ impl LineIndex {
 #[derive(Clone, Copy)]
 pub(crate) struct FunctionContext {
     pub(crate) in_async_function: bool,
+    /// True when the current statement is inside the `try` block of a
+    /// `try`/`catch` (a thrown value would be caught, so an async `throw` here is
+    /// not a promise rejection). Reset at each function boundary.
+    pub(crate) in_try_with_catch: bool,
 }
 
 pub fn implemented_functional_rule_names() -> &'static [&'static str] {
@@ -167,6 +171,7 @@ pub fn scan_functional(
         &parser_return.program.body,
         FunctionContext {
             in_async_function: false,
+            in_try_with_catch: false,
         },
     );
     scanner.diagnostics

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -56,6 +56,7 @@ impl<'a> Scanner<'a> {
         }
         let context = FunctionContext {
             in_async_function: function.r#async,
+            in_try_with_catch: false,
         };
         if let Some(body) = &function.body {
             self.scan_function_body(body, context);
@@ -70,6 +71,7 @@ impl<'a> Scanner<'a> {
         }
         let context = FunctionContext {
             in_async_function: function.r#async,
+            in_try_with_catch: false,
         };
         self.scan_function_body(&function.body, context);
     }
@@ -118,6 +120,7 @@ impl<'a> Scanner<'a> {
                     init,
                     FunctionContext {
                         in_async_function: false,
+                        in_try_with_catch: false,
                     },
                 );
             }

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -132,7 +132,15 @@ impl<'a> Scanner<'a> {
                         statement.span,
                     );
                 }
-                self.scan_statement_list(&statement.block.body, context);
+                // A throw inside this try's block is caught when the try has a
+                // catch handler, so it is not a promise rejection. The catch and
+                // finally bodies are not protected by this try's own catch; they
+                // inherit the enclosing context.
+                let block_context = FunctionContext {
+                    in_try_with_catch: context.in_try_with_catch || statement.handler.is_some(),
+                    ..context
+                };
+                self.scan_statement_list(&statement.block.body, block_context);
                 if let Some(handler) = &statement.handler {
                     self.scan_statement_list(&handler.body.body, context);
                 }
@@ -149,7 +157,7 @@ impl<'a> Scanner<'a> {
                         statement.span,
                     );
                 }
-                if context.in_async_function {
+                if context.in_async_function && !context.in_try_with_catch {
                     self.report(
                         "no-promise-reject",
                         "generic",

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -90,6 +90,37 @@ do {} while (cond);
 }
 
 #[test]
+fn no_promise_reject_matches_upstream_syntactic_behavior() {
+    let options = FunctionalOptions {
+        rule_names: ["no-promise-reject".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let count = |source: &str| scan_functional(source, "fixture.ts", &options).len();
+
+    // Reports `Promise.reject`, `new Promise` with a `reject` param, and async
+    // throws that escape (no enclosing catch).
+    assert_eq!(count("function f() { return Promise.reject('e'); }"), 1);
+    assert_eq!(
+        count("function f() { return new Promise((resolve, reject) => { reject('e'); }); }"),
+        1
+    );
+    assert_eq!(count("async function f() { throw new Error('e'); }"), 1);
+    assert_eq!(
+        count("async function f() { try { throw new Error('e'); } finally { g(); } }"),
+        1
+    );
+
+    // Does not report resolves, executors without a reject param, or async
+    // throws caught by an enclosing try/catch.
+    assert_eq!(count("function f() { return Promise.resolve('x'); }"), 0);
+    assert_eq!(count("function f() { return new Promise((resolve) => resolve('x')); }"), 0);
+    assert_eq!(
+        count("async function f() { try { throw new Error('e'); } catch (e) { g(e); } }"),
+        0
+    );
+}
+
+#[test]
 fn honors_core_options() {
     let mut options = FunctionalOptions {
         rule_names: ["no-let".into()].into_iter().collect(),

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -113,7 +113,10 @@ fn no_promise_reject_matches_upstream_syntactic_behavior() {
     // Does not report resolves, executors without a reject param, or async
     // throws caught by an enclosing try/catch.
     assert_eq!(count("function f() { return Promise.resolve('x'); }"), 0);
-    assert_eq!(count("function f() { return new Promise((resolve) => resolve('x')); }"), 0);
+    assert_eq!(
+        count("function f() { return new Promise((resolve) => resolve('x')); }"),
+        0
+    );
     assert_eq!(
         count("async function f() { try { throw new Error('e'); } catch (e) { g(e); } }"),
         0

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -27,7 +27,12 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
-const FULL_PARITY = new Set(['no-loop-statements', 'no-this-expressions', 'no-try-statements']);
+const FULL_PARITY = new Set([
+  'no-loop-statements',
+  'no-this-expressions',
+  'no-try-statements',
+  'no-promise-reject',
+]);
 
 function runRule(ruleName, testCase) {
   const sourceText = testCase.code;


### PR DESCRIPTION
## Summary

Fixes two syntax-level mismatches so `no-promise-reject` matches upstream, and adds it to the replay `FULL_PARITY` set (3 valid, 4 invalid syntactic cases).

## Fixes

- **`new Promise` rejection detection**: a `new Promise(executor)` can reject only when the executor declares a second `reject` parameter. The port checked the outer argument count (`new Promise(cb)` has one argument, so it never reached 2 → rejections were missed). Now it checks `arguments[0].params.length >= 2`, mirroring upstream.
- **async `throw` inside `try`/`catch`**: a throw in the `try` block of a `try`/`catch` is caught, so it is not a promise rejection. The function context now tracks `in_try_with_catch` (reset at each function boundary, inherited by nested try blocks and by catch/finally bodies) and suppresses the report there. A throw under `try`/`finally` (no catch) still reports.

Adds a Rust unit test covering resolve vs reject, executor arity, and the try/catch vs try/finally distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)