### PR TITLE
fix(regexp): no-useless-escape must not flag escaped literal delimiter `\/`

### DIFF
--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -933,6 +933,10 @@ pub(crate) fn first_useless_escape(pattern: &str) -> Option<u8> {
     None
 }
 
+// Note: `/` is intentionally absent. Escaping the forward slash in a regex
+// literal (`/\//`) is necessary — an unescaped `/` would terminate the literal
+// — so upstream `no-useless-escape` treats `\/` as a required, non-useless
+// escape.
 fn is_pointlessly_escaped(byte: u8) -> bool {
     matches!(
         byte,
@@ -950,7 +954,6 @@ fn is_pointlessly_escaped(byte: u8) -> bool {
             | b'~'
             | b'\''
             | b'"'
-            | b'/'
     )
 }
 

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -2001,6 +2001,8 @@ mod no_useless_escape {
         assert!(rule_ids_for("const a = /\\./u;", "no-useless-escape").is_empty());
         // Inside a character class — deferred to keep the check sound.
         assert!(rule_ids_for("const a = /[\\:]/u;", "no-useless-escape").is_empty());
+        // Escaping the literal delimiter is required, not useless.
+        assert!(rule_ids_for("const a = /\\//u;", "no-useless-escape").is_empty());
     }
 }
 

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -41,10 +41,6 @@
       "level": "off",
       "reason": "Flags $0 in String#replaceAll where it is a literal substitution, not a useless backreference."
     },
-    "no-useless-escape": {
-      "level": "off",
-      "reason": "Flags required escapes such as /\\// — escaping '/' inside a regex literal is necessary."
-    },
     "no-useless-non-capturing-group": {
       "level": "off",
       "reason": "Flags non-capturing groups that disambiguate adjacent tokens, e.g. /\\1(?:0)/, /{(?:2)}/."


### PR DESCRIPTION
## Summary
`no-useless-escape` wrongly flagged `/\//`. `is_pointlessly_escaped` included `/`, but escaping the forward slash in a regex literal is **required** (an unescaped `/` terminates the literal), so upstream treats `\/` as a necessary escape.

This was surfaced by the upstream-parity harness (PR #103): `no-useless-escape` was 105/106 on upstream valid cases, failing only `/\//`.

## Change
- Remove `/` from `is_pointlessly_escaped` (+ explanatory comment).
- Add a Rust regression test (`/\//u` reports nothing).
- Promote `no-useless-escape` to enforced valid-soundness parity (drop its `parity.json` quarantine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)