### PR TITLE
port(sonarjs): port no-nested-switch (S1821)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 1] = ["no-nested-template-literals"];
+pub const RULE_NAMES: [&str; 2] = ["no-nested-template-literals", "no-nested-switch"];
 
 /// Returns the implemented rule names as a static slice.
 pub fn implemented_sonarjs_rule_names() -> &'static [&'static str] {
@@ -51,6 +51,7 @@ pub fn scan_sonarjs(
         options,
         diagnostics: SmallVec::new(),
         template_literal_depth: 0,
+        switch_depth: 0,
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,4 +1,5 @@
 //! Clean-room rule implementations for the sonarjs port. Each module attaches
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
+mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_nested_switch.rs
+++ b/crates/sonarjs/src/rules/no_nested_switch.rs
@@ -1,0 +1,31 @@
+//! Rule `no-nested-switch` (SonarJS key S1821).
+//!
+//! Clean-room port. Reports a `switch` statement that appears anywhere inside
+//! another `switch` statement, because nested switches are hard to read.
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! Semantics: a switch is flagged when at least one enclosing switch is open on
+//! the traversal stack, so every nested switch is reported at its own `switch`
+//! keyword regardless of nesting depth or any intervening statements (including
+//! function bodies).
+
+use oxc_ast::ast::SwitchStatement;
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-nested-switch";
+
+/// Byte length of the `switch` keyword, used to report only the keyword token.
+const SWITCH_KEYWORD_LEN: u32 = 6;
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_nested_switch(&mut self, statement: &SwitchStatement<'_>) {
+        if self.switch_depth > 0 {
+            let start = statement.span.start;
+            let keyword = Span::new(start, start + SWITCH_KEYWORD_LEN);
+            self.report(RULE_NAME, "nestedSwitch", keyword);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -2,7 +2,7 @@
 //! sonarjs port. Traversal uses the Oxc visitor so every node is reached; each
 //! `check_*` rule body lives under [`crate::rules`].
 
-use oxc_ast::ast::TemplateLiteral;
+use oxc_ast::ast::{SwitchStatement, TemplateLiteral};
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
@@ -16,6 +16,8 @@ pub(crate) struct Scanner<'a> {
     pub(crate) diagnostics: SmallVec<[Diagnostic; 32]>,
     /// Number of template literals currently open on the traversal stack.
     pub(crate) template_literal_depth: u32,
+    /// Number of switch statements currently open on the traversal stack.
+    pub(crate) switch_depth: u32,
 }
 
 impl Scanner<'_> {
@@ -50,5 +52,12 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.template_literal_depth += 1;
         walk::walk_template_literal(self, it);
         self.template_literal_depth -= 1;
+    }
+
+    fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
+        self.check_no_nested_switch(it);
+        self.switch_depth += 1;
+        walk::walk_switch_statement(self, it);
+        self.switch_depth -= 1;
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -49,6 +49,36 @@ fn reports_each_nested_level() {
 }
 
 #[test]
+fn reports_switch_nested_in_another_switch() {
+    let source = "switch (a) {\n  case 1:\n    switch (b) {\n      case 2:\n        break;\n    }\n    break;\n}";
+    let diagnostics = scan("no-nested-switch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-nested-switch");
+    assert_eq!(diagnostics[0].message_id, "nestedSwitch");
+    assert_eq!(diagnostics[0].loc.start_line, 3);
+}
+
+#[test]
+fn does_not_report_single_switch() {
+    let diagnostics = scan("no-nested-switch", "switch (a) {\n  case 1:\n    break;\n}");
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_sequential_switches() {
+    let source = "switch (a) {\n  default:\n    break;\n}\nswitch (b) {\n  default:\n    break;\n}";
+    let diagnostics = scan("no-nested-switch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_each_inner_switch_of_doubly_nested() {
+    let source = "switch (a) {\n  case 1:\n    switch (b) {\n      case 2:\n        switch (c) {\n          case 3:\n            break;\n        }\n    }\n}";
+    let diagnostics = scan("no-nested-switch", source);
+    assert_eq!(diagnostics.len(), 2);
+}
+
+#[test]
 fn disabled_rule_reports_nothing() {
     let options = SonarjsOptions {
         rule_names: SmallVec::new(),

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -18,18 +18,25 @@ const messages = Object.freeze({
     nestedTemplateLiteral:
       'Do not nest template literals. Extract the inner template literal into a separate variable.',
   },
+  'no-nested-switch': {
+    nestedSwitch:
+      'Do not nest switch statements. Extract the nested switch into a separate function.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
   'no-nested-template-literals': 'Disallow nested template literals',
+  'no-nested-switch': 'Disallow nested switch statements',
 });
 
 const ruleTypes = Object.freeze({
   'no-nested-template-literals': 'suggestion',
+  'no-nested-switch': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
   'no-nested-template-literals': 'error',
+  'no-nested-switch': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { implementedSonarjsRuleNames, scanSonarjs } from '../api.js';
 
-const expectedRuleNames = ['no-nested-template-literals'];
+const expectedRuleNames = ['no-nested-template-literals', 'no-nested-switch'];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
   return scanSonarjs(sourceText, filename, { ruleNames: [ruleName] });
@@ -29,6 +29,22 @@ describe('sonarjs native API', () => {
   it('reports each nested level independently', () => {
     const diagnostics = scan('no-nested-template-literals', 'const x = `a ${`b ${`c`}`}`;');
     expect(diagnostics).toHaveLength(2);
+  });
+
+  it('reports a switch nested inside another switch', () => {
+    const diagnostics = scan(
+      'no-nested-switch',
+      'switch (a) {\n  case 1:\n    switch (b) {\n      case 2:\n        break;\n    }\n    break;\n}',
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-nested-switch');
+    expect(diagnostics[0].messageId).toBe('nestedSwitch');
+    expect(diagnostics[0].loc.startLine).toBe(3);
+  });
+
+  it('does not report a single switch', () => {
+    const diagnostics = scan('no-nested-switch', 'switch (a) {\n  case 1:\n    break;\n}');
+    expect(diagnostics).toHaveLength(0);
   });
 
   it('ignores rules that are not enabled', () => {

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -93,10 +93,15 @@ function runOxlint(ruleName, code, filename = 'sample.ts') {
 describe('sonarjs plugin shape', () => {
   it('exposes rules and the recommended config', () => {
     expect(plugin.meta?.name).toBe('sonarjs');
-    expect(plugin.implementedSonarjsRuleNames).toEqual(['no-nested-template-literals']);
+    expect(plugin.implementedSonarjsRuleNames).toEqual([
+      'no-nested-template-literals',
+      'no-nested-switch',
+    ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
+    expect(typeof plugin.rules['no-nested-switch']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
   });
 });
 
@@ -111,6 +116,15 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-nested-template-literals', 'const x = `value ${y}`;');
     expect(reports).toHaveLength(0);
   });
+
+  it('reports nested switch statements', () => {
+    const reports = runRule(
+      'no-nested-switch',
+      'switch (a) {\n  case 1:\n    switch (b) {\n      default:\n        break;\n    }\n}',
+    );
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('nestedSwitch');
+  });
 });
 
 describe('sonarjs rules through oxlint jsPlugins', () => {
@@ -121,5 +135,17 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-template-literals)');
+  });
+
+  it('reports no-nested-switch through the CLI', () => {
+    const result = runOxlint(
+      'no-nested-switch',
+      'switch (a) {\n  case 1:\n    switch (b) {\n      default:\n        break;\n    }\n}',
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-switch)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12686,19 +12686,19 @@
       },
       {
         "name": "no-nested-switch",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-nested-switch (Sonar key S1821). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of upstream rule no-nested-switch (Sonar key S1821). Reports a switch statement nested inside another switch. SonarJS upstream is LGPL-3.0; implemented from observed behavior only — no upstream source, fixtures, tests, or messages were copied."
       },
       {
         "name": "no-nested-template-literals",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-nested-switch`** (Sonar key S1821) for the `sonarjs` plugin. Reports a `switch` statement nested anywhere inside another `switch`. Implemented with the Oxc visitor + a switch-depth counter; reports the inner `switch` keyword token.

## Tests
- Rust unit tests: nested, single, sequential, doubly-nested (2 reports), disabled-rule.
- Native-API vitest + adapter vitest + oxlint `jsPlugins` CLI integration test (`sonarjs(no-nested-switch)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages were copied; the diagnostic message is authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)