### PR TITLE
fix(regexp): prefer-range should only collapse runs of four or more

### DIFF
--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -1103,10 +1103,12 @@ pub(crate) fn class_first_duplicate_literal(bytes: &[u8], open: usize) -> Option
 }
 
 /// Returns `Some((start, end))` when the `[...]` class at `open` contains
-/// three or more consecutive ASCII characters (digits, lower-case, or
+/// four or more consecutive ASCII characters (digits, lower-case, or
 /// upper-case letters) at the top level — these collapse into the equivalent
-/// range `start-end`. Used by `prefer-range`. Escapes and existing ranges
-/// are intentionally skipped to keep the check conservative.
+/// range `start-end`. Used by `prefer-range`. A run of three (e.g. `[abc]`)
+/// is left alone to match upstream, which only collapses runs of four or
+/// more. Escapes and existing ranges are intentionally skipped to keep the
+/// check conservative.
 pub(crate) fn class_first_collapsible_run(bytes: &[u8], open: usize) -> Option<(char, char)> {
     debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
     let end = find_class_end(bytes, open)?;
@@ -1134,7 +1136,7 @@ pub(crate) fn class_first_collapsible_run(bytes: &[u8], open: usize) -> Option<(
                 run_end = bytes[cursor];
                 cursor += 1;
             }
-            if run_end >= start + 2 {
+            if run_end >= start + 3 {
                 return Some((start as char, run_end as char));
             }
             index = cursor.max(index + 1);

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1947,12 +1947,12 @@ mod prefer_range {
     use super::*;
 
     #[test]
-    fn reports_three_or_more_consecutive_literals() {
-        let data = first_data("const a = /[abc]/u;", "prefer-range");
-        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("abc"));
+    fn reports_four_or_more_consecutive_literals() {
+        let data = first_data("const a = /[abcd]/u;", "prefer-range");
+        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("abcd"));
         assert_eq!(
             data.replacement.as_ref().map(CompactString::as_str),
-            Some("a-c")
+            Some("a-d")
         );
         // Digits collapse just like letters.
         assert_eq!(
@@ -1964,6 +1964,9 @@ mod prefer_range {
     #[test]
     fn ignores_short_runs_and_existing_ranges() {
         assert!(rule_ids_for("const a = /[ab]/u;", "prefer-range").is_empty());
+        // A run of three is left alone — upstream only collapses runs of four
+        // or more (`[abc]` is valid, `[abcd]` is not).
+        assert!(rule_ids_for("const a = /[abc]/u;", "prefer-range").is_empty());
         // A range already covers the chars; no further reduction needed.
         assert!(rule_ids_for("const a = /[a-c]/u;", "prefer-range").is_empty());
         // Non-consecutive bytes break the run.

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -65,10 +65,6 @@
       "level": "off",
       "reason": "Flags $1 referring to an unnamed group, which has no named-replacement alternative."
     },
-    "prefer-range": {
-      "level": "off",
-      "reason": "Flags short runs like /[abc]/ that are valid under the default option."
-    },
     "prefer-unicode-codepoint-escapes": {
       "level": "off",
       "reason": "Flags surrogate escapes without the u flag (e.g. /\\ud83d\\ude00/) where no codepoint escape applies."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -230,7 +230,7 @@ const invalidCases = [
     ['unexpected'],
   ],
   // prefer-range
-  ['prefer-range', 'three consecutive letters', 'const re = /[abc]/u;\n', ['unexpected']],
+  ['prefer-range', 'four consecutive letters', 'const re = /[abcd]/u;\n', ['unexpected']],
   ['prefer-range', 'five consecutive digits', 'const re = /[12345]/u;\n', ['unexpected']],
   // no-useless-escape
   ['no-useless-escape', 'escaped colon', 'const re = /\\:/u;\n', ['unexpected']],


### PR DESCRIPTION
## Summary
`prefer-range` flagged `/[abc]/` (a run of three). Upstream only collapses runs of **four or more** (`/[abc]/` is valid, `/[abcd]/` is not) — confirmed by the synced upstream fixtures.

## Change
- `class_first_collapsible_run`: threshold `run_end >= start + 2` → `+ 3` (+ doc).
- Update the Rust unit test and the JS `plugin.test.mjs` case to use a 4-char run; add `/[abc]/` as a valid case.
- Promote `prefer-range` to enforced valid-soundness parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)