### PR TITLE
fix(regexp): match-any should not flag the canonical [\s\S] form

### DIFF
--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -302,6 +302,11 @@ pub(crate) fn class_matches_anything(bytes: &[u8], open: usize) -> bool {
     if bytes.get(index) == Some(&b'^') {
         return false;
     }
+    // `[\s\S]` is the canonical form the rule itself recommends — treat it as valid.
+    let body = &bytes[open + 1..end];
+    if body == b"\\s\\S" {
+        return false;
+    }
     let mut has_lower = [false; 3]; // s, d, w
     let mut has_upper = [false; 3]; // S, D, W
     let mut count = 0usize;

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1244,10 +1244,8 @@ mod match_any {
 
     #[test]
     fn reports_anti_pair_character_classes() {
-        assert_eq!(
-            rule_ids_for("const a = /[\\s\\S]/u;", "match-any").as_slice(),
-            &["unexpected"]
-        );
+        // `[\s\S]` is the canonical recommended form — it is valid.
+        assert!(rule_ids_for("const a = /[\\s\\S]/u;", "match-any").is_empty());
         assert_eq!(
             rule_ids_for("const a = /[\\d\\D]/u;", "match-any").as_slice(),
             &["unexpected"]
@@ -1274,6 +1272,16 @@ mod match_any {
         assert!(rule_ids_for("const a = /[\\s\\Sa]/u;", "match-any").is_empty());
         // Negated classes never match anything; do not flag.
         assert!(rule_ids_for("const a = /[^\\s\\S]/u;", "match-any").is_empty());
+        // The canonical `[\s\S]` is the recommended form; only the reverse and other families are flagged.
+        assert!(rule_ids_for("const a = /[\\s\\S]/u;", "match-any").is_empty());
+    }
+
+    #[test]
+    fn reversed_order_still_reports() {
+        assert_eq!(
+            rule_ids_for("const a = /[\\S\\s]/u;", "match-any").as_slice(),
+            &["unexpected"]
+        );
     }
 }
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -74,6 +74,7 @@ const validCases = [
   ['match-any', 'half anti-pair', 'const re = /[\\s]/u;\n'],
   ['match-any', 'mixed family', 'const re = /[\\s\\D]/u;\n'],
   ['match-any', 'negated anti-pair', 'const re = /[^\\s\\S]/u;\n'],
+  ['match-any', 'canonical \\s\\S form', 'const re = /[\\s\\S]/u;\n'],
   // no-legacy-features
   ['no-legacy-features', 'unrelated identifier', 'Foo.$1;\n'],
   ['no-legacy-features', 'lowercase regexp', 'regexp.lastMatch;\n'],
@@ -525,7 +526,7 @@ describe('regexp rules through direct Oxlint plugin adapter', () => {
         runRule('prefer-named-capture-group', 'const re = /(a)/u;\n')[0],
       ),
     ).toBe('Capturing group should be converted to a named or non-capturing group.');
-    expect(renderMessage('match-any', runRule('match-any', 'const re = /[\\s\\S]/u;\n')[0])).toBe(
+    expect(renderMessage('match-any', runRule('match-any', 'const re = /[\\S\\s]/u;\n')[0])).toBe(
       'Unexpected any character class. Use `.` with the `s` flag instead.',
     );
     expect(


### PR DESCRIPTION
## Summary

- `class_matches_anything` in `helpers.rs` returned `true` for `[\s\S]` even though upstream `eslint-plugin-regexp` treats this as valid (it is the canonical recommended form).
- Added a short-circuit that returns `false` when the class body is exactly `\s\S` in that order.
- Only the reversed `[\S\s]` and other anti-pair families (`[\d\D]`, `[\w\W]`, etc.) remain flagged.

## Test plan

- [ ] Existing `reports_anti_pair_character_classes` test updated: removed `[\s\S]` from reported cases, added valid assertion
- [ ] New `reversed_order_still_reports` test confirms `[\S\s]` is still flagged
- [ ] `plugin.test.mjs` valid section updated with canonical `[\s\S]` case
- [ ] `plugin.test.mjs` renderMessage test updated to use `[\S\s]`
- [ ] CI validates no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967147&installation_id=136613492&pr_number=114&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F114&signature=60e96120facffafe31ef281c061829d4859d0131b5d7163d9333907fc07b444a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->