### PR TITLE
fix(regexp): unicode-escape must not flag surrogate halves

### DIFF
--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -605,6 +605,13 @@ pub(crate) fn first_fixed_unicode_escape(pattern: &str) -> Option<(&str, Compact
             && bytes[index + 4].is_ascii_hexdigit()
             && bytes[index + 5].is_ascii_hexdigit()
         {
+            // Surrogate halves (U+D800..=U+DFFF) belong to surrogate pairs handled
+            // by `prefer-unicode-codepoint-escapes`; skip them here.
+            let value = read_fixed_hex4(&bytes[index + 2..index + 6]).unwrap_or(0);
+            if (0xD800..=0xDFFF).contains(&value) {
+                index = skip_escape(bytes, index);
+                continue;
+            }
             let original = &pattern[index..index + 6];
             let mut replacement = CompactString::new("\\u{");
             for offset in 2..6 {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1573,6 +1573,18 @@ mod unicode_escape {
         assert!(rule_ids_for("const a = /\\xab/u;", "unicode-escape").is_empty());
         assert!(rule_ids_for("const a = /\\d/u;", "unicode-escape").is_empty());
     }
+
+    #[test]
+    fn ignores_surrogate_halves() {
+        // Surrogate halves belong to `prefer-unicode-codepoint-escapes`, not here.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\ud83d\\\\ude00', 'u');",
+                "unicode-escape"
+            )
+            .is_empty()
+        );
+    }
 }
 
 mod no_useless_range {

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -118,6 +118,11 @@ const validCases = [
   ['prefer-character-class', 'multi-byte alt', 'const re = /(?:a|bc)/u;\n'],
   ['prefer-character-class', 'escape alt', 'const re = /(?:a|\\d)/u;\n'],
   ['prefer-character-class', 'no alternation', 'const re = /(?:a)/u;\n'],
+  [
+    'unicode-escape',
+    'surrogate half \\uHHHH',
+    "const re = new RegExp('\\\\ud83d\\\\ude00', 'u');\n",
+  ],
 ];
 
 const invalidCases = [


### PR DESCRIPTION
## Summary

- `first_fixed_unicode_escape` in `helpers.rs` was flagging all `\uHHHH` escapes including surrogate halves (`\ud83d`, `\ude00`, etc.).
- Upstream `eslint-plugin-regexp` leaves surrogate halves for `prefer-unicode-codepoint-escapes` to handle; `unicode-escape` should not flag them.
- Added a surrogate range check (0xD800..=0xDFFF) that skips and continues when the value is a surrogate half.

## Test plan

- [ ] New `ignores_surrogate_halves` test in `tests.rs`
- [ ] `plugin.test.mjs` valid section updated with surrogate-half case
- [ ] CI validates no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967167&installation_id=136613492&pr_number=115&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F115&signature=c472a0cffcdade5503b07aed0acedb16a55219a79b9ddcbd4a6d531bc74b5170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->