### PR TITLE
fix(regexp): prefer-unicode-codepoint-escapes must only fire with u or v flag

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -883,19 +883,22 @@ impl<'a> Scanner<'a> {
                 span,
             );
         }
-        if flags.contains('u') || flags.contains('v') {
-            if let Some((escape, replacement)) = first_surrogate_pair_escape(pattern) {
-                self.report_with_data(
-                    "prefer-unicode-codepoint-escapes",
-                    "unexpected",
-                    DiagnosticData {
-                        expr: Some(CompactString::from(escape)),
-                        replacement: Some(replacement),
-                        ..DiagnosticData::default()
-                    },
-                    span,
-                );
-            }
+        // Surrogate-pair escapes are only meaningful with the `u`/`v` flag;
+        // without it `\uHHHH\uHHHH` is two independent code units, so upstream
+        // leaves them alone.
+        if (flags.contains('u') || flags.contains('v'))
+            && let Some((escape, replacement)) = first_surrogate_pair_escape(pattern)
+        {
+            self.report_with_data(
+                "prefer-unicode-codepoint-escapes",
+                "unexpected",
+                DiagnosticData {
+                    expr: Some(CompactString::from(escape)),
+                    replacement: Some(replacement),
+                    ..DiagnosticData::default()
+                },
+                span,
+            );
         }
     }
 }

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -883,17 +883,19 @@ impl<'a> Scanner<'a> {
                 span,
             );
         }
-        if let Some((escape, replacement)) = first_surrogate_pair_escape(pattern) {
-            self.report_with_data(
-                "prefer-unicode-codepoint-escapes",
-                "unexpected",
-                DiagnosticData {
-                    expr: Some(CompactString::from(escape)),
-                    replacement: Some(replacement),
-                    ..DiagnosticData::default()
-                },
-                span,
-            );
+        if flags.contains('u') || flags.contains('v') {
+            if let Some((escape, replacement)) = first_surrogate_pair_escape(pattern) {
+                self.report_with_data(
+                    "prefer-unicode-codepoint-escapes",
+                    "unexpected",
+                    DiagnosticData {
+                        expr: Some(CompactString::from(escape)),
+                        replacement: Some(replacement),
+                        ..DiagnosticData::default()
+                    },
+                    span,
+                );
+            }
         }
     }
 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1907,6 +1907,32 @@ mod prefer_unicode_codepoint_escapes {
             .is_empty()
         );
     }
+
+    #[test]
+    fn ignores_surrogate_pair_without_unicode_flag() {
+        // Without u/v flag, \uHHHH pairs are two separate code units, not a
+        // surrogate pair — upstream does not flag them.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\uD83D\\\\uDE00');",
+                "prefer-unicode-codepoint-escapes"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn still_reports_with_u_flag() {
+        // With the u flag the pair IS a surrogate pair and must be flagged.
+        assert_eq!(
+            rule_ids_for(
+                "const a = new RegExp('\\\\uD83D\\\\uDE00', 'u');",
+                "prefer-unicode-codepoint-escapes"
+            )
+            .as_slice(),
+            &["unexpected"]
+        );
+    }
 }
 
 mod no_dupe_characters_character_class {

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -65,10 +65,6 @@
       "level": "off",
       "reason": "Flags short runs like /[abc]/ that are valid under the default option."
     },
-    "prefer-unicode-codepoint-escapes": {
-      "level": "off",
-      "reason": "Flags surrogate escapes without the u flag (e.g. /\\ud83d\\ude00/) where no codepoint escape applies."
-    },
     "require-unicode-regexp": {
       "level": "off",
       "reason": "Flags constructors whose flags are an unknown variable (e.g. new RegExp('', flags))."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -118,6 +118,12 @@ const validCases = [
   ['prefer-character-class', 'multi-byte alt', 'const re = /(?:a|bc)/u;\n'],
   ['prefer-character-class', 'escape alt', 'const re = /(?:a|\\d)/u;\n'],
   ['prefer-character-class', 'no alternation', 'const re = /(?:a)/u;\n'],
+  // prefer-unicode-codepoint-escapes
+  [
+    'prefer-unicode-codepoint-escapes',
+    'surrogate pair without u flag',
+    "const re = new RegExp('\\\\uD83D\\\\uDE00');\n",
+  ],
 ];
 
 const invalidCases = [


### PR DESCRIPTION
## Summary

- `first_surrogate_pair_escape` was called unconditionally regardless of flags.
- Upstream `eslint-plugin-regexp` only reports surrogate-pair escapes when the regex has the `u` or `v` flag; without those flags `\uHHHH` pairs are two independent code units.
- Failing valid cases: `/😀/` and `/[😀]/` (no flag).
- Added a flag guard in `check_pattern_rules` so `first_surrogate_pair_escape` is only called when `flags.contains('u') || flags.contains('v')`.

## Test plan

- [ ] New `ignores_surrogate_pair_without_unicode_flag` test in `tests.rs`
- [ ] New `still_reports_with_u_flag` regression test in `tests.rs`
- [ ] `plugin.test.mjs` valid section updated with no-flag surrogate pair case
- [ ] CI validates no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967205&installation_id=136613492&pr_number=117&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F117&signature=9d26a46bd6061d865bdd70d2ab7018c3f685faed25061e9c8cb771ae6ffe0f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->