### PR TITLE
port(sonarjs): port no-nested-conditional (S3358)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,11 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 2] = ["no-nested-template-literals", "no-nested-switch"];
+pub const RULE_NAMES: [&str; 3] = [
+    "no-nested-template-literals",
+    "no-nested-switch",
+    "no-nested-conditional",
+];
 
 /// Returns the implemented rule names as a static slice.
 pub fn implemented_sonarjs_rule_names() -> &'static [&'static str] {
@@ -52,6 +56,7 @@ pub fn scan_sonarjs(
         diagnostics: SmallVec::new(),
         template_literal_depth: 0,
         switch_depth: 0,
+        conditional_depth: 0,
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,5 +1,6 @@
 //! Clean-room rule implementations for the sonarjs port. Each module attaches
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
+mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_nested_conditional.rs
+++ b/crates/sonarjs/src/rules/no_nested_conditional.rs
@@ -1,0 +1,27 @@
+//! Rule `no-nested-conditional` (SonarJS key S3358).
+//!
+//! Clean-room port. Reports a conditional (ternary) expression that appears
+//! nested inside another conditional expression, in any of the outer ternary's
+//! three parts (test, consequent, or alternate). Nested ternaries hurt
+//! readability and make control flow difficult to follow at a glance.
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! Semantics: a conditional expression is flagged when at least one enclosing
+//! conditional expression is open on the traversal stack, so every nested
+//! ternary is reported at its own span regardless of nesting depth.
+
+use oxc_ast::ast::ConditionalExpression;
+use oxc_span::GetSpan;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-nested-conditional";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_nested_conditional(&mut self, expr: &ConditionalExpression<'_>) {
+        if self.conditional_depth > 0 {
+            self.report(RULE_NAME, "nestedConditional", expr.span());
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -2,7 +2,7 @@
 //! sonarjs port. Traversal uses the Oxc visitor so every node is reached; each
 //! `check_*` rule body lives under [`crate::rules`].
 
-use oxc_ast::ast::{SwitchStatement, TemplateLiteral};
+use oxc_ast::ast::{ConditionalExpression, SwitchStatement, TemplateLiteral};
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
@@ -18,6 +18,8 @@ pub(crate) struct Scanner<'a> {
     pub(crate) template_literal_depth: u32,
     /// Number of switch statements currently open on the traversal stack.
     pub(crate) switch_depth: u32,
+    /// Number of conditional (ternary) expressions currently open on the traversal stack.
+    pub(crate) conditional_depth: u32,
 }
 
 impl Scanner<'_> {
@@ -59,5 +61,12 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;
+    }
+
+    fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
+        self.check_no_nested_conditional(it);
+        self.conditional_depth += 1;
+        walk::walk_conditional_expression(self, it);
+        self.conditional_depth -= 1;
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -104,7 +104,10 @@ fn does_not_report_flat_conditional() {
 
 #[test]
 fn reports_two_diagnostics_for_doubly_nested_conditional() {
-    let diagnostics = scan("no-nested-conditional", "const x = a ? (b ? c : d) : (e ? f : g);");
+    let diagnostics = scan(
+        "no-nested-conditional",
+        "const x = a ? (b ? c : d) : (e ? f : g);",
+    );
     assert_eq!(diagnostics.len(), 2);
 }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -79,6 +79,36 @@ fn reports_each_inner_switch_of_doubly_nested() {
 }
 
 #[test]
+fn reports_conditional_nested_in_alternate() {
+    let diagnostics = scan("no-nested-conditional", "const x = a ? b : (c ? d : e);");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-nested-conditional");
+    assert_eq!(diagnostics[0].message_id, "nestedConditional");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_conditional_nested_in_consequent() {
+    let diagnostics = scan("no-nested-conditional", "const x = a ? (b ? c : d) : e;");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-nested-conditional");
+    assert_eq!(diagnostics[0].message_id, "nestedConditional");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn does_not_report_flat_conditional() {
+    let diagnostics = scan("no-nested-conditional", "const x = a ? b : c;");
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_two_diagnostics_for_doubly_nested_conditional() {
+    let diagnostics = scan("no-nested-conditional", "const x = a ? (b ? c : d) : (e ? f : g);");
+    assert_eq!(diagnostics.len(), 2);
+}
+
+#[test]
 fn disabled_rule_reports_nothing() {
     let options = SonarjsOptions {
         rule_names: SmallVec::new(),

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -22,21 +22,28 @@ const messages = Object.freeze({
     nestedSwitch:
       'Do not nest switch statements. Extract the nested switch into a separate function.',
   },
+  'no-nested-conditional': {
+    nestedConditional:
+      'Do not nest ternary/conditional expressions; extract the nested conditional into an independent statement.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
   'no-nested-template-literals': 'Disallow nested template literals',
   'no-nested-switch': 'Disallow nested switch statements',
+  'no-nested-conditional': 'Disallow nested conditional (ternary) expressions',
 });
 
 const ruleTypes = Object.freeze({
   'no-nested-template-literals': 'suggestion',
   'no-nested-switch': 'suggestion',
+  'no-nested-conditional': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
   'no-nested-template-literals': 'error',
   'no-nested-switch': 'error',
+  'no-nested-conditional': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { implementedSonarjsRuleNames, scanSonarjs } from '../api.js';
 
-const expectedRuleNames = ['no-nested-template-literals', 'no-nested-switch'];
+const expectedRuleNames = [
+  'no-nested-template-literals',
+  'no-nested-switch',
+  'no-nested-conditional',
+];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
   return scanSonarjs(sourceText, filename, { ruleNames: [ruleName] });
@@ -45,6 +49,24 @@ describe('sonarjs native API', () => {
   it('does not report a single switch', () => {
     const diagnostics = scan('no-nested-switch', 'switch (a) {\n  case 1:\n    break;\n}');
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports a conditional nested in the alternate of another conditional', () => {
+    const diagnostics = scan('no-nested-conditional', 'const x = a ? b : (c ? d : e);');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-nested-conditional');
+    expect(diagnostics[0].messageId).toBe('nestedConditional');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('does not report a single (non-nested) conditional expression', () => {
+    const diagnostics = scan('no-nested-conditional', 'const x = a ? b : c;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports each nested level of a doubly-nested conditional', () => {
+    const diagnostics = scan('no-nested-conditional', 'const x = a ? (b ? c : d) : (e ? f : g);');
+    expect(diagnostics).toHaveLength(2);
   });
 
   it('ignores rules that are not enabled', () => {

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -96,12 +96,15 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.implementedSonarjsRuleNames).toEqual([
       'no-nested-template-literals',
       'no-nested-switch',
+      'no-nested-conditional',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
+    expect(typeof plugin.rules['no-nested-conditional']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-nested-conditional']).toBe('error');
   });
 });
 
@@ -125,6 +128,12 @@ describe('sonarjs rules through direct adapter harness', () => {
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('nestedSwitch');
   });
+
+  it('reports a nested conditional expression', () => {
+    const reports = runRule('no-nested-conditional', 'const x = a ? b : (c ? d : e);');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('nestedConditional');
+  });
 });
 
 describe('sonarjs rules through oxlint jsPlugins', () => {
@@ -147,5 +156,14 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-switch)');
+  });
+
+  it('reports no-nested-conditional through the CLI', () => {
+    const result = runOxlint('no-nested-conditional', 'const x = a ? b : (c ? d : e);');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-conditional)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12638,19 +12638,19 @@
       },
       {
         "name": "no-nested-conditional",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-nested-conditional (Sonar key S3358). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S3358. Reports every ConditionalExpression (ternary) that appears nested inside another ConditionalExpression, in any of the outer ternary's three positions (test, consequent, alternate). Implemented via a depth counter in the Oxc AST visitor; each nested ternary is reported at its own span."
       },
       {
         "name": "no-nested-functions",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-nested-conditional`** (Sonar key S3358). Reports a conditional (ternary) expression nested inside another conditional expression — in the test, consequent, or alternate of the outer ternary. Implemented with the Oxc visitor + a conditional-depth counter; reports the nested expression's span.

## Tests
- Rust unit tests: nested-in-alternate, nested-in-consequent, flat (0), doubly-nested (2).
- Native-API vitest + adapter vitest + oxlint `jsPlugins` CLI integration test (`sonarjs(no-nested-conditional)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967377&installation_id=136613492&pr_number=118&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F118&signature=6a0fc9a8c44e89ee3fba93064ac4c3ea42b01cf80217e604af0c562f41403c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->