### PR TITLE
port(functional): bring prefer-property-signatures to full upstream parity

### DIFF
--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -68,6 +68,7 @@ pub struct FunctionalOptions {
     pub allow_try_catch: bool,
     pub allow_try_finally: bool,
     pub readonly_type_mode: CompactString,
+    pub ignore_if_readonly_wrapped: bool,
 }
 
 impl Default for FunctionalOptions {
@@ -84,6 +85,7 @@ impl Default for FunctionalOptions {
             allow_try_catch: false,
             allow_try_finally: false,
             readonly_type_mode: "generic".into(),
+            ignore_if_readonly_wrapped: false,
         }
     }
 }
@@ -166,6 +168,7 @@ pub fn scan_functional(
         line_index: LineIndex::new(source_text),
         diagnostics: SmallVec::new(),
         options,
+        within_readonly: false,
     };
     scanner.scan_statement_list(
         &parser_return.program.body,

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -19,6 +19,9 @@ pub(crate) struct Scanner<'a> {
     pub(crate) line_index: LineIndex,
     pub(crate) diagnostics: SmallVec<[Diagnostic; 32]>,
     pub(crate) options: &'a FunctionalOptions,
+    /// True while traversing the type arguments of a `Readonly<...>` reference,
+    /// so `prefer-property-signatures` can honor `ignoreIfReadonlyWrapped`.
+    pub(crate) within_readonly: bool,
 }
 
 impl<'a> Scanner<'a> {

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -1,6 +1,31 @@
 use super::{FunctionalOptions, implemented_functional_rule_names, scan_functional};
 
 #[test]
+fn prefer_property_signatures_honors_ignore_if_readonly_wrapped() {
+    let base = || FunctionalOptions {
+        rule_names: ["prefer-property-signatures".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let count = |source: &str, options: &FunctionalOptions| {
+        scan_functional(source, "fixture.ts", options).len()
+    };
+
+    // A bare method signature is always reported.
+    assert_eq!(count("type Foo = { bar(): number };", &base()), 1);
+
+    // Wrapped in Readonly<...> with the option enabled, it is ignored; without
+    // the option it is still reported.
+    let wrapped = "type Foo = Readonly<{ bar(): number }>;";
+    assert_eq!(count(wrapped, &base()), 1);
+    let mut ignoring = base();
+    ignoring.ignore_if_readonly_wrapped = true;
+    assert_eq!(count(wrapped, &ignoring), 0);
+
+    // Property signatures are never reported.
+    assert_eq!(count("type Foo = { bar: () => number };", &base()), 0);
+}
+
+#[test]
 fn exposes_all_rule_names() {
     assert_eq!(implemented_functional_rule_names().len(), 20);
     assert!(implemented_functional_rule_names().contains(&"no-let"));

--- a/crates/functional/src/types.rs
+++ b/crates/functional/src/types.rs
@@ -80,12 +80,14 @@ impl<'a> Scanner<'a> {
     pub(crate) fn scan_signature(&mut self, signature: &'a TSSignature<'a>) {
         match signature {
             TSSignature::TSMethodSignature(method) => {
-                self.report(
-                    "prefer-property-signatures",
-                    "generic",
-                    "Use a property signature instead of a method signature",
-                    method.span,
-                );
+                if !(self.options.ignore_if_readonly_wrapped && self.within_readonly) {
+                    self.report(
+                        "prefer-property-signatures",
+                        "generic",
+                        "Use a property signature instead of a method signature",
+                        method.span,
+                    );
+                }
                 if let Some(return_type) = &method.return_type {
                     self.scan_return_type(return_type);
                 }
@@ -176,9 +178,16 @@ impl<'a> Scanner<'a> {
                     );
                 }
                 if let Some(arguments) = &reference.type_arguments {
+                    // Members nested (transitively) inside `Readonly<...>` count
+                    // as readonly-wrapped for `ignoreIfReadonlyWrapped`.
+                    let previously_within = self.within_readonly;
+                    if type_reference_name(reference) == Some("Readonly") {
+                        self.within_readonly = true;
+                    }
                     for ty in &arguments.params {
                         self.scan_type(ty);
                     }
+                    self.within_readonly = previously_within;
                 }
             }
             TSType::TSTypeOperatorType(operator) => {

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -21,6 +21,7 @@ export type FunctionalScanOptions = {
   allowTryCatch?: boolean;
   allowTryFinally?: boolean;
   readonlyTypeMode?: 'generic' | 'keyword';
+  ignoreIfReadonlyWrapped?: boolean;
 };
 
 export function implementedFunctionalRuleNames(): string[];

--- a/npm/functional/api.js
+++ b/npm/functional/api.js
@@ -30,6 +30,7 @@ function normalizeOptions(options) {
       raw.readonlyTypeMode === 'keyword' || raw.readonlyTypeMode === 'generic'
         ? raw.readonlyTypeMode
         : undefined,
+    ignoreIfReadonlyWrapped: raw.ignoreIfReadonlyWrapped === true,
   };
 }
 

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -232,6 +232,17 @@ function schemaForRule(ruleName) {
   if (ruleName === 'readonly-type') {
     return [{ type: 'string', enum: ['generic', 'keyword'] }];
   }
+  if (ruleName === 'prefer-property-signatures') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          ignoreIfReadonlyWrapped: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
   return [];
 }
 
@@ -278,6 +289,8 @@ function scanOptionsForRule(context, ruleName) {
     allowTryFinally: ruleName === 'no-try-statements' && options.allowFinally === true,
     readonlyTypeMode:
       ruleName === 'readonly-type' && (raw === 'keyword' || raw === 'generic') ? raw : undefined,
+    ignoreIfReadonlyWrapped:
+      ruleName === 'prefer-property-signatures' && options.ignoreIfReadonlyWrapped === true,
   };
 }
 

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -26,6 +26,7 @@ mod napi_abi {
         pub allow_try_catch: Option<bool>,
         pub allow_try_finally: Option<bool>,
         pub readonly_type_mode: Option<String>,
+        pub ignore_if_readonly_wrapped: Option<bool>,
     }
 
     #[napi(object)]
@@ -87,6 +88,9 @@ mod napi_abi {
                 .filter(|value| value == "generic" || value == "keyword")
                 .map(CompactString::from)
                 .unwrap_or(default_options.readonly_type_mode),
+            ignore_if_readonly_wrapped: options
+                .ignore_if_readonly_wrapped
+                .unwrap_or(default_options.ignore_if_readonly_wrapped),
         };
 
         core::scan_functional(&source_text, &filename, &core_options)

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -4,16 +4,18 @@
 //
 // Each fixture case carries a `typeAware` flag derived from the upstream config
 // it ran under (the TypeScript `projectService` config vs the syntax-only babel
-// config). The Rust port is syntax-only, so type-aware cases cannot be replayed:
-// they are skipped and counted (logged in the parity ledger — no silent
-// truncation). Syntactic cases are checked against the rule's parity level:
+// config). Behavior depends on the rule's parity level:
 //
-//   - FULL_PARITY: valid -> no reports; invalid -> reported messageIds (and
-//     count) match the upstream-declared `errors`. A rule joins this set in its
-//     own porting PR once the Rust core emits the upstream messageIds.
-//   - otherwise (pending): the case is smoke-run — it must not throw and must
-//     return an array — which exercises the whole upstream syntactic corpus
-//     through the NAPI binding before per-rule parity assertions land.
+//   - FULL_PARITY: every upstream case is asserted (valid -> no reports;
+//     invalid -> reported messageIds and count match the upstream-declared
+//     `errors`). This includes cases that ran under the TypeScript config but
+//     need no type information (e.g. TS-only syntax). A rule joins this set in
+//     its own porting PR, once the syntax-only port handles ALL of its cases.
+//   - otherwise (pending): only the syntactic (non-`typeAware`) cases are
+//     smoke-run (must not throw, must return an array) to exercise the upstream
+//     corpus through the NAPI binding; the `typeAware` cases — which need type
+//     information the syntax-only port lacks — are skipped and counted in the
+//     parity ledger (no silent truncation).
 
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -32,6 +34,7 @@ const FULL_PARITY = new Set([
   'no-this-expressions',
   'no-try-statements',
   'no-promise-reject',
+  'prefer-property-signatures',
 ]);
 
 function runRule(ruleName, testCase) {
@@ -119,11 +122,19 @@ describe('eslint-plugin-functional upstream parity', () => {
       invalidSyntactic.length;
     const full = FULL_PARITY.has(ruleName);
 
+    // Full-parity rules assert EVERY upstream case, including TypeScript-syntax
+    // cases that need no type information (the syntax-only port handles them). A
+    // rule only joins FULL_PARITY once it handles all of its cases. Pending rules
+    // only smoke-run their syntactic cases; their type-aware cases (which need
+    // type information the syntax-only port lacks) are skipped and counted.
+    const validCases = full ? fixture.valid : validSyntactic;
+    const invalidCases = full ? fixture.invalid : invalidSyntactic;
+
     ledger.push({
       ruleName,
       parity: fixture.__generated.noUpstreamTests ? 'none' : full ? 'full' : 'smoke',
-      syntactic: validSyntactic.length + invalidSyntactic.length,
-      typeAware: typeAwareCount,
+      asserted: validCases.length + invalidCases.length,
+      skipped: full ? 0 : typeAwareCount,
     });
 
     describe(ruleName, () => {
@@ -132,12 +143,11 @@ describe('eslint-plugin-functional upstream parity', () => {
         expect(fixture.__generated.ref).toBeTruthy();
       });
 
-      // Guard against empty suites: rules whose upstream cases are entirely
-      // type-aware have no syntactic cases to register (Vitest fails on an
-      // empty describe block).
-      if (validSyntactic.length > 0) {
+      // Guard against empty suites (Vitest fails on a describe block with no
+      // tests) — e.g. a pending rule whose upstream cases are all type-aware.
+      if (validCases.length > 0) {
         describe('valid', () => {
-          validSyntactic.forEach((testCase, index) => {
+          validCases.forEach((testCase, index) => {
             it(label(testCase, index), () => {
               const reports = runRule(ruleName, testCase);
               if (full) {
@@ -150,9 +160,9 @@ describe('eslint-plugin-functional upstream parity', () => {
         });
       }
 
-      if (invalidSyntactic.length > 0) {
+      if (invalidCases.length > 0) {
         describe('invalid', () => {
-          invalidSyntactic.forEach((testCase, index) => {
+          invalidCases.forEach((testCase, index) => {
             it(label(testCase, index), () => {
               const reports = runRule(ruleName, testCase);
               if (full) {
@@ -171,7 +181,7 @@ describe('eslint-plugin-functional upstream parity', () => {
     for (const entry of ledger) {
       console.log(
         `[functional] ${entry.ruleName}: parity=${entry.parity} ` +
-          `syntactic=${entry.syntactic} type-aware-skipped=${entry.typeAware}`,
+          `asserted=${entry.asserted} type-aware-skipped=${entry.skipped}`,
       );
     }
     expect(ledger).toHaveLength(plugin.implementedFunctionalRuleNames.length);


### PR DESCRIPTION
## Summary

Implements `prefer-property-signatures`' `ignoreIfReadonlyWrapped` option (AST-only, no type information) and teaches the replay harness to assert TypeScript-syntax cases for full-parity rules, so this rule's 7 valid / 2 invalid upstream cases are checked exactly.

## Changes

- **core**: `FunctionalOptions.ignore_if_readonly_wrapped`; the `Scanner` tracks `within_readonly` while descending into `Readonly<...>` type arguments and skips the `TSMethodSignature` report when the option is set and the signature is (transitively) readonly-wrapped.
- **NAPI / api.js / api.d.ts / index.js**: plumb the option and its schema.
- **harness**: full-parity rules now assert **every** upstream case, including cases that ran under the TypeScript config but need no type information (TS-only syntax). Pending rules still smoke-run their syntactic cases and skip+count type-aware ones. The ledger now reports `asserted` / `type-aware-skipped` counts.
- Rust unit test for wrapped / unwrapped / property-signature cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967414&installation_id=136613492&pr_number=119&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F119&signature=96821f6d3d66048cea7ea536eb0df86c6d05588eed08d5078333fd7960e630dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->