### PR TITLE
fix(regexp): control-character-escape must not flag named escape chars in constructor args

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -476,7 +476,13 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn check_pattern_rules(&mut self, pattern: &str, flags: &str, span: Span, is_constructor: bool) {
+    fn check_pattern_rules(
+        &mut self,
+        pattern: &str,
+        flags: &str,
+        span: Span,
+        is_constructor: bool,
+    ) {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern);
 

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -424,7 +424,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.check_flag_style(flags, span);
-        self.check_pattern_rules(pattern, flags, span);
+        self.check_pattern_rules(pattern, flags, span, is_constructor);
     }
 
     #[allow(
@@ -476,7 +476,7 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn check_pattern_rules(&mut self, pattern: &str, flags: &str, span: Span) {
+    fn check_pattern_rules(&mut self, pattern: &str, flags: &str, span: Span, is_constructor: bool) {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern);
 
@@ -606,15 +606,29 @@ impl<'a> Scanner<'a> {
             );
         }
         if let Some(ch) = first_literal_control_character(pattern) {
-            self.report_with_data(
-                "control-character-escape",
-                "unexpected",
-                DiagnosticData {
-                    char_text: Some(mention_char(ch)),
-                    ..DiagnosticData::default()
-                },
-                span,
-            );
+            // When the pattern comes from a RegExp constructor argument (not a
+            // regex literal), the six characters that have well-known named
+            // regex escapes (\0 \t \n \v \f \r) are written as JS string
+            // escape sequences by the author (e.g. '\t') and are already
+            // conceptually "named". Flagging them here would produce false
+            // positives — upstream marks `new RegExp('\t')` as valid.
+            // For regex literals, ALL literal control characters must be
+            // escaped, because the author could have written \t instead of a
+            // raw tab inside /.../.
+            const NAMED_ESCAPES: &[char] =
+                &['\u{0000}', '\u{0009}', '\u{000A}', '\u{000B}', '\u{000C}', '\u{000D}'];
+            let skip = is_constructor && NAMED_ESCAPES.contains(&ch);
+            if !skip {
+                self.report_with_data(
+                    "control-character-escape",
+                    "unexpected",
+                    DiagnosticData {
+                        char_text: Some(mention_char(ch)),
+                        ..DiagnosticData::default()
+                    },
+                    span,
+                );
+            }
         }
         if analysis.has_escape_backspace_in_class {
             self.report("no-escape-backspace", "unexpected", span);

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -615,10 +615,10 @@ impl<'a> Scanner<'a> {
             // For regex literals, ALL literal control characters must be
             // escaped, because the author could have written \t instead of a
             // raw tab inside /.../.
-            const NAMED_ESCAPES: &[char] =
-                &['\u{0000}', '\u{0009}', '\u{000A}', '\u{000B}', '\u{000C}', '\u{000D}'];
-            let skip = is_constructor && NAMED_ESCAPES.contains(&ch);
-            if !skip {
+            // The named-escape set is \0 (U+0000) and \t \n \v \f \r
+            // (U+0009..=U+000D, contiguous).
+            let named_escape = matches!(ch, '\0' | '\t'..='\r');
+            if !(is_constructor && named_escape) {
                 self.report_with_data(
                     "control-character-escape",
                     "unexpected",

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -436,6 +436,35 @@ mod control_character_escape {
         // Plain ASCII pattern.
         assert!(rule_ids_for("const a = /abc/u;", "control-character-escape").is_empty());
     }
+
+    #[test]
+    fn ignores_named_escape_chars_in_constructor_args() {
+        // The six characters that have well-known named regex escapes (\0 \t \n
+        // \v \f \r) are valid when passed as a literal JS string escape to a
+        // RegExp constructor. In JS source `'\t'` is a string with a real tab
+        // byte (0x09), but the author used a JS escape so it is already
+        // "named". Upstream marks all of these as valid.
+        for code in [
+            "new RegExp('\t')",
+            "RegExp(\"\0\t\n\x0B\x0C\r\", \"i\")",
+        ] {
+            assert!(
+                rule_ids_for(code, "control-character-escape").is_empty(),
+                "expected no diagnostic for: {code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn still_reports_literal_tab_in_regex_literal() {
+        // A literal tab inside a regex literal MUST be flagged — the author
+        // should write /\t/ instead of /TAB/.
+        assert_eq!(
+            rule_ids_for("/\t/", "control-character-escape").as_slice(),
+            &["unexpected"],
+            "literal tab in regex literal must be flagged"
+        );
+    }
 }
 
 mod use_ignore_case {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -444,10 +444,7 @@ mod control_character_escape {
         // RegExp constructor. In JS source `'\t'` is a string with a real tab
         // byte (0x09), but the author used a JS escape so it is already
         // "named". Upstream marks all of these as valid.
-        for code in [
-            "new RegExp('\t')",
-            "RegExp(\"\0\t\n\x0B\x0C\r\", \"i\")",
-        ] {
+        for code in ["new RegExp('\t')", "RegExp(\"\0\t\n\x0B\x0C\r\", \"i\")"] {
             assert!(
                 rule_ids_for(code, "control-character-escape").is_empty(),
                 "expected no diagnostic for: {code:?}"

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -1,10 +1,6 @@
 {
   "_doc": "Per-rule upstream-parity enforcement level for the synced eslint-plugin-regexp fixtures (see test/upstream.test.mjs). Levels: 'off' = quarantined; the rule's behavior diverges from upstream defaults, so its valid and invalid cases are skipped until the port is fixed (the reason is the parity-debt backlog entry). 'valid' (the default for any rule not listed here) = every upstream VALID case must emit zero diagnostics for the rule (soundness). 'full' = 'valid' plus invalid-case COUNT parity (same number of diagnostics per case as upstream). Diagnostic message text and span are intentionally NOT asserted: the port rewords messages and may flag a different span (e.g. the whole literal) than upstream by design; the recorded fixture locations are reference data for a future strict-location pass.",
   "rules": {
-    "control-character-escape": {
-      "level": "off",
-      "reason": "Over-reports literal whitespace such as \\t/\\n that upstream does not treat as control characters (e.g. new RegExp('\\t'))."
-    },
     "hexadecimal-escape": {
       "level": "off",
       "reason": "Diverges on mixed escape forms under the u flag (e.g. /a \\x0a \\cM \\0 \\u0100 \\u{100}/u)."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -41,6 +41,8 @@ const validCases = [
   ['no-control-character', 'named tab escape', 'const re = /\\t/u;\n'],
   ['no-control-character', 'named newline escape', 'const re = /\\n/u;\n'],
   ['no-control-character', 'printable hex escape', "const re = new RegExp('\\\\u0041', 'u');\n"],
+  // control-character-escape
+  ['control-character-escape', 'named tab in constructor arg', "new RegExp('\\t');\n"],
   // sort-flags
   ['sort-flags', 'sorted flags', 'const re = /a/im;\n'],
   ['sort-flags', 'no flags', 'const re = /a/;\n'],


### PR DESCRIPTION
## Summary

- \`first_literal_control_character\` was called unconditionally, flagging any literal control byte in the pattern regardless of whether it came from a regex literal or a constructor argument.
- Upstream \`eslint-plugin-regexp\` marks \`new RegExp('\t')\` as **valid** because the author already used a JS string escape (\`\t\`) to produce the tab byte — the intent is clear.
- For regex literals (\`/TAB/\`), literal control characters are still flagged because the author could write \`/\t/\` instead.
- Fixed by threading \`is_constructor\` into \`check_pattern_rules\` and suppressing the diagnostic for the six characters with well-known named regex escapes (\`\0 \t \n \v \f \r\`, U+0000, U+0009–U+000D) when the pattern comes from a constructor argument.

## Files changed

- \`crates/regexp/src/checks.rs\` — thread \`is_constructor\` into \`check_pattern_rules\`; add allowlist guard
- \`crates/regexp/src/tests.rs\` — add \`ignores_named_escape_chars_in_constructor_args\` and \`still_reports_literal_tab_in_regex_literal\` tests
- \`npm/regexp/test/plugin.test.mjs\` — add valid case for named-tab in constructor arg

## Test plan

- [ ] New \`ignores_named_escape_chars_in_constructor_args\` test verifies \`new RegExp('\t')\` and \`RegExp("\0\t\n\v\f\r", "i")\` produce no diagnostic
- [ ] New \`still_reports_literal_tab_in_regex_literal\` test verifies \`/TAB/\` (literal tab in regex literal) is still flagged
- [ ] \`plugin.test.mjs\` valid section updated with named-tab constructor case
- [ ] CI validates no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967943&installation_id=136613492&pr_number=120&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F120&signature=fdf016ad9cd230e5c38f5dca943c02d4069d762fcc9d185934108cefbca9c195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->