### PR TITLE
port(functional): bring no-classes to full upstream parity

### DIFF
--- a/crates/functional/Cargo.toml
+++ b/crates/functional/Cargo.toml
@@ -14,6 +14,7 @@ oxc_ast.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -69,6 +69,8 @@ pub struct FunctionalOptions {
     pub allow_try_finally: bool,
     pub readonly_type_mode: CompactString,
     pub ignore_if_readonly_wrapped: bool,
+    pub ignore_identifier_pattern: SmallVec<[CompactString; 4]>,
+    pub ignore_code_pattern: SmallVec<[CompactString; 4]>,
 }
 
 impl Default for FunctionalOptions {
@@ -86,6 +88,8 @@ impl Default for FunctionalOptions {
             allow_try_finally: false,
             readonly_type_mode: "generic".into(),
             ignore_if_readonly_wrapped: false,
+            ignore_identifier_pattern: SmallVec::new(),
+            ignore_code_pattern: SmallVec::new(),
         }
     }
 }
@@ -149,6 +153,13 @@ pub fn implemented_functional_rule_names() -> &'static [&'static str] {
     &RULE_NAMES
 }
 
+fn compile_patterns(patterns: &[CompactString]) -> SmallVec<[regex::Regex; 4]> {
+    patterns
+        .iter()
+        .filter_map(|pattern| regex::Regex::new(pattern).ok())
+        .collect()
+}
+
 pub fn scan_functional(
     source_text: &str,
     filename: &str,
@@ -169,6 +180,8 @@ pub fn scan_functional(
         diagnostics: SmallVec::new(),
         options,
         within_readonly: false,
+        ignore_identifier_regexes: compile_patterns(&options.ignore_identifier_pattern),
+        ignore_code_regexes: compile_patterns(&options.ignore_code_pattern),
     };
     scanner.scan_statement_list(
         &parser_return.program.body,

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -170,14 +170,22 @@ impl<'a> Scanner<'a> {
     pub(crate) fn class_is_ignored(&self, class: &Class<'a>) -> bool {
         if let Some(id) = &class.id {
             let name = id.name.as_str();
-            if self.ignore_identifier_regexes.iter().any(|re| re.is_match(name)) {
+            if self
+                .ignore_identifier_regexes
+                .iter()
+                .any(|re| re.is_match(name))
+            {
                 return true;
             }
         }
         if !self.ignore_code_regexes.is_empty() {
             let span = class.span;
             let code = &self.source_text[span.start as usize..span.end as usize];
-            if self.ignore_code_regexes.iter().any(|re| re.is_match(code)) {
+            if self
+                .ignore_code_regexes
+                .iter()
+                .any(|re| re.is_match(code))
+            {
                 return true;
             }
         }

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -181,11 +181,7 @@ impl<'a> Scanner<'a> {
         if !self.ignore_code_regexes.is_empty() {
             let span = class.span;
             let code = &self.source_text[span.start as usize..span.end as usize];
-            if self
-                .ignore_code_regexes
-                .iter()
-                .any(|re| re.is_match(code))
-            {
+            if self.ignore_code_regexes.iter().any(|re| re.is_match(code)) {
                 return true;
             }
         }

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -22,6 +22,8 @@ pub(crate) struct Scanner<'a> {
     /// True while traversing the type arguments of a `Readonly<...>` reference,
     /// so `prefer-property-signatures` can honor `ignoreIfReadonlyWrapped`.
     pub(crate) within_readonly: bool,
+    pub(crate) ignore_identifier_regexes: SmallVec<[regex::Regex; 4]>,
+    pub(crate) ignore_code_regexes: SmallVec<[regex::Regex; 4]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -165,13 +167,32 @@ impl<'a> Scanner<'a> {
         self.scan_type(&return_type.type_annotation);
     }
 
+    pub(crate) fn class_is_ignored(&self, class: &Class<'a>) -> bool {
+        if let Some(id) = &class.id {
+            let name = id.name.as_str();
+            if self.ignore_identifier_regexes.iter().any(|re| re.is_match(name)) {
+                return true;
+            }
+        }
+        if !self.ignore_code_regexes.is_empty() {
+            let span = class.span;
+            let code = &self.source_text[span.start as usize..span.end as usize];
+            if self.ignore_code_regexes.iter().any(|re| re.is_match(code)) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub(crate) fn scan_class(&mut self, class: &'a Class<'a>, context: FunctionContext) {
-        self.report(
-            "no-classes",
-            "generic",
-            "Unexpected class, use functions not classes.",
-            class.span,
-        );
+        if !self.class_is_ignored(class) {
+            self.report(
+                "no-classes",
+                "generic",
+                "Unexpected class, use functions not classes.",
+                class.span,
+            );
+        }
         if class.super_class.is_some() {
             self.report(
                 "no-class-inheritance",

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -149,6 +149,45 @@ fn no_promise_reject_matches_upstream_syntactic_behavior() {
 }
 
 #[test]
+fn no_classes_honors_ignore_patterns() {
+    let base_options = FunctionalOptions {
+        rule_names: ["no-classes".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+
+    // Plain class reports 1 diagnostic.
+    let diagnostics = scan_functional("class Foo {}", "fixture.ts", &base_options);
+    assert_eq!(diagnostics.len(), 1);
+
+    // ignoreIdentifierPattern matching the class name suppresses the report.
+    let id_pattern_options = FunctionalOptions {
+        rule_names: ["no-classes".into()].into_iter().collect(),
+        ignore_identifier_pattern: ["^Foo$".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let diagnostics = scan_functional("class Foo {}", "fixture.ts", &id_pattern_options);
+    assert_eq!(diagnostics.len(), 0);
+
+    // ignoreCodePattern matching the class source text suppresses the report.
+    let code_pattern_options = FunctionalOptions {
+        rule_names: ["no-classes".into()].into_iter().collect(),
+        ignore_code_pattern: ["class Foo".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let diagnostics = scan_functional("class Foo {}", "fixture.ts", &code_pattern_options);
+    assert_eq!(diagnostics.len(), 0);
+
+    // A non-matching identifier pattern still reports 1 diagnostic.
+    let non_matching_options = FunctionalOptions {
+        rule_names: ["no-classes".into()].into_iter().collect(),
+        ignore_identifier_pattern: ["^Bar$".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let diagnostics = scan_functional("class Foo {}", "fixture.ts", &non_matching_options);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
 fn honors_core_options() {
     let mut options = FunctionalOptions {
         rule_names: ["no-let".into()].into_iter().collect(),

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -22,6 +22,8 @@ export type FunctionalScanOptions = {
   allowTryFinally?: boolean;
   readonlyTypeMode?: 'generic' | 'keyword';
   ignoreIfReadonlyWrapped?: boolean;
+  ignoreIdentifierPattern?: string | string[];
+  ignoreCodePattern?: string | string[];
 };
 
 export function implementedFunctionalRuleNames(): string[];

--- a/npm/functional/api.js
+++ b/npm/functional/api.js
@@ -31,7 +31,19 @@ function normalizeOptions(options) {
         ? raw.readonlyTypeMode
         : undefined,
     ignoreIfReadonlyWrapped: raw.ignoreIfReadonlyWrapped === true,
+    ignoreIdentifierPattern: normalizeStringList(raw.ignoreIdentifierPattern),
+    ignoreCodePattern: normalizeStringList(raw.ignoreCodePattern),
   };
+}
+
+function normalizeStringList(value) {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string');
+  }
+  return undefined;
 }
 
 function normalizeRuleNames(ruleNames) {

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -182,7 +182,25 @@ function createFunctionalRule(ruleName) {
   };
 }
 
+function stringOrStringArraySchema() {
+  return {
+    anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+  };
+}
+
 function schemaForRule(ruleName) {
+  if (ruleName === 'no-classes') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          ignoreIdentifierPattern: stringOrStringArraySchema(),
+          ignoreCodePattern: stringOrStringArraySchema(),
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
   if (ruleName === 'functional-parameters') {
     return [
       {
@@ -291,6 +309,9 @@ function scanOptionsForRule(context, ruleName) {
       ruleName === 'readonly-type' && (raw === 'keyword' || raw === 'generic') ? raw : undefined,
     ignoreIfReadonlyWrapped:
       ruleName === 'prefer-property-signatures' && options.ignoreIfReadonlyWrapped === true,
+    ignoreIdentifierPattern:
+      ruleName === 'no-classes' ? options.ignoreIdentifierPattern : undefined,
+    ignoreCodePattern: ruleName === 'no-classes' ? options.ignoreCodePattern : undefined,
   };
 }
 

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -27,6 +27,8 @@ mod napi_abi {
         pub allow_try_finally: Option<bool>,
         pub readonly_type_mode: Option<String>,
         pub ignore_if_readonly_wrapped: Option<bool>,
+        pub ignore_identifier_pattern: Option<Vec<String>>,
+        pub ignore_code_pattern: Option<Vec<String>>,
     }
 
     #[napi(object)]
@@ -91,6 +93,8 @@ mod napi_abi {
             ignore_if_readonly_wrapped: options
                 .ignore_if_readonly_wrapped
                 .unwrap_or(default_options.ignore_if_readonly_wrapped),
+            ignore_identifier_pattern: compact_pattern_list(options.ignore_identifier_pattern),
+            ignore_code_pattern: compact_pattern_list(options.ignore_code_pattern),
         };
 
         core::scan_functional(&source_text, &filename, &core_options)
@@ -106,6 +110,14 @@ mod napi_abi {
                     end_column: diagnostic.loc.end_column,
                 },
             })
+            .collect()
+    }
+
+    fn compact_pattern_list(values: Option<Vec<String>>) -> SmallVec<[CompactString; 4]> {
+        values
+            .unwrap_or_default()
+            .into_iter()
+            .map(CompactString::from)
             .collect()
     }
 

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -30,10 +30,11 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
 const FULL_PARITY = new Set([
+  'no-classes',
   'no-loop-statements',
+  'no-promise-reject',
   'no-this-expressions',
   'no-try-statements',
-  'no-promise-reject',
   'prefer-property-signatures',
 ]);
 


### PR DESCRIPTION
## Summary

Adds the shared regex-based ignore-option infrastructure and uses it to bring `no-classes` to full upstream parity (3 valid, 4 invalid syntactic cases).

## Changes

- **shared regex infra**: the functional crate now depends on `regex`. `FunctionalOptions` gains `ignore_identifier_pattern` / `ignore_code_pattern` (pattern lists); the `Scanner` compiles them once per scan and exposes `class_is_ignored`, which matches the class name against `ignoreIdentifierPattern` and the class source text against `ignoreCodePattern`. Invalid patterns are skipped.
- **no-classes**: its report is gated on `class_is_ignored`.
- **NAPI / api.js / api.d.ts / index.js**: plumb the two options (`string | string[]`, normalized to a string list) and the schema (`stringOrStringArraySchema`).
- `no-classes` joins `FULL_PARITY`; Rust unit test covers identifier/code matches and a non-matching pattern.

This infrastructure is reused by the upcoming `no-class-inheritance` and `no-let` ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967958&installation_id=136613492&pr_number=121&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F121&signature=181c56b2a7ce2fb60c6f3924146560eb635574d5c239348307faff8432b139bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->