### PR TITLE
port(sonarjs): port no-collapsible-if (S1066)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,10 +22,11 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 3] = [
+pub const RULE_NAMES: [&str; 4] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
+    "no-collapsible-if",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,6 +1,7 @@
 //! Clean-room rule implementations for the sonarjs port. Each module attaches
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
+mod no_collapsible_if;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_collapsible_if.rs
+++ b/crates/sonarjs/src/rules/no_collapsible_if.rs
@@ -1,0 +1,50 @@
+//! Rule `no-collapsible-if` (SonarJS key S1066).
+//!
+//! Clean-room port. Reports an outer `if` statement whose sole purpose is to
+//! contain a single nested `if` statement, signalling that the two conditions
+//! should be merged with `&&` to reduce unnecessary nesting. Behaviour is
+//! reproduced from the public RSPEC description only; no upstream source,
+//! tests, fixtures, or message strings were consulted or copied.
+//!
+//! Semantics: the outer `if` is flagged when (1) it has no `else` clause,
+//! (2) its consequent is either directly an inner `if` statement or a block
+//! containing exactly one `if` statement, and (3) that inner `if` also has no
+//! `else` clause. The diagnostic is reported on the outer `if` keyword only.
+
+use oxc_ast::ast::{IfStatement, Statement};
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-collapsible-if";
+
+/// Returns the inner `IfStatement` when `consequent` is collapsible, i.e.
+/// when it is either a direct `if` or a single-statement block containing an
+/// `if`. Returns `None` otherwise.
+fn inner_collapsible_if<'a, 'b>(consequent: &'b Statement<'a>) -> Option<&'b IfStatement<'a>> {
+    match consequent {
+        Statement::IfStatement(inner) => Some(inner),
+        Statement::BlockStatement(block) if block.body.len() == 1 => match &block.body[0] {
+            Statement::IfStatement(inner) => Some(inner),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_collapsible_if(&mut self, if_stmt: &IfStatement<'_>) {
+        if if_stmt.alternate.is_some() {
+            return;
+        }
+        let Some(inner) = inner_collapsible_if(&if_stmt.consequent) else {
+            return;
+        };
+        if inner.alternate.is_some() {
+            return;
+        }
+        let start = if_stmt.span.start;
+        let keyword = Span::new(start, start + 2);
+        self.report(RULE_NAME, "collapsibleIf", keyword);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -2,7 +2,7 @@
 //! sonarjs port. Traversal uses the Oxc visitor so every node is reached; each
 //! `check_*` rule body lives under [`crate::rules`].
 
-use oxc_ast::ast::{ConditionalExpression, SwitchStatement, TemplateLiteral};
+use oxc_ast::ast::{ConditionalExpression, IfStatement, SwitchStatement, TemplateLiteral};
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
@@ -68,5 +68,10 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.conditional_depth += 1;
         walk::walk_conditional_expression(self, it);
         self.conditional_depth -= 1;
+    }
+
+    fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
+        self.check_no_collapsible_if(it);
+        walk::walk_if_statement(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -119,3 +119,43 @@ fn disabled_rule_reports_nothing() {
     let diagnostics = scan_sonarjs("const x = `outer ${`inner`}`;", "sample.ts", &options);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_collapsible_if_direct_inner() {
+    let source = "if (a) if (b) {}";
+    let diagnostics = scan("no-collapsible-if", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-collapsible-if");
+    assert_eq!(diagnostics[0].message_id, "collapsibleIf");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_collapsible_if_block_with_single_inner() {
+    let source = "if (a) { if (b) {} }";
+    let diagnostics = scan("no-collapsible-if", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-collapsible-if");
+    assert_eq!(diagnostics[0].message_id, "collapsibleIf");
+}
+
+#[test]
+fn does_not_report_collapsible_if_outer_has_else() {
+    let source = "if (a) { if (b) {} } else {}";
+    let diagnostics = scan("no-collapsible-if", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_collapsible_if_inner_has_else() {
+    let source = "if (a) { if (b) {} else {} }";
+    let diagnostics = scan("no-collapsible-if", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_collapsible_if_block_has_two_statements() {
+    let source = "if (a) { if (b) {} doSomething(); }";
+    let diagnostics = scan("no-collapsible-if", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -26,24 +26,30 @@ const messages = Object.freeze({
     nestedConditional:
       'Do not nest ternary/conditional expressions; extract the nested conditional into an independent statement.',
   },
+  'no-collapsible-if': {
+    collapsibleIf: "Merge this 'if' statement with the nested one to reduce nesting.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
   'no-nested-template-literals': 'Disallow nested template literals',
   'no-nested-switch': 'Disallow nested switch statements',
   'no-nested-conditional': 'Disallow nested conditional (ternary) expressions',
+  'no-collapsible-if': 'Disallow collapsible if statements that should be merged',
 });
 
 const ruleTypes = Object.freeze({
   'no-nested-template-literals': 'suggestion',
   'no-nested-switch': 'suggestion',
   'no-nested-conditional': 'suggestion',
+  'no-collapsible-if': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
   'no-nested-template-literals': 'error',
   'no-nested-switch': 'error',
   'no-nested-conditional': 'error',
+  'no-collapsible-if': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -6,6 +6,7 @@ const expectedRuleNames = [
   'no-nested-template-literals',
   'no-nested-switch',
   'no-nested-conditional',
+  'no-collapsible-if',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -73,6 +74,29 @@ describe('sonarjs native API', () => {
     const diagnostics = scanSonarjs('const x = `outer ${`inner`}`;', 'sample.ts', {
       ruleNames: [],
     });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports a collapsible if when the outer if contains only a nested if', () => {
+    const diagnostics = scan('no-collapsible-if', 'if (a) { if (b) {} }');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-collapsible-if');
+    expect(diagnostics[0].messageId).toBe('collapsibleIf');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('does not report when the outer if has an else clause', () => {
+    const diagnostics = scan('no-collapsible-if', 'if (a) { if (b) {} } else {}');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report when the inner if has an else clause', () => {
+    const diagnostics = scan('no-collapsible-if', 'if (a) { if (b) {} else {} }');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report when the block contains more than one statement', () => {
+    const diagnostics = scan('no-collapsible-if', 'if (a) { if (b) {} doSomething(); }');
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -97,14 +97,17 @@ describe('sonarjs plugin shape', () => {
       'no-nested-template-literals',
       'no-nested-switch',
       'no-nested-conditional',
+      'no-collapsible-if',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
     expect(typeof plugin.rules['no-nested-conditional']).toBe('object');
+    expect(typeof plugin.rules['no-collapsible-if']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-conditional']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-collapsible-if']).toBe('error');
   });
 });
 
@@ -133,6 +136,12 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-nested-conditional', 'const x = a ? b : (c ? d : e);');
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('nestedConditional');
+  });
+
+  it('reports a collapsible if through the adapter', () => {
+    const reports = runRule('no-collapsible-if', 'if (a) { if (b) {} }');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('collapsibleIf');
   });
 });
 
@@ -165,5 +174,14 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-conditional)');
+  });
+
+  it('reports no-collapsible-if through the CLI', () => {
+    const result = runOxlint('no-collapsible-if', 'if (a) { if (b) {} }');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-collapsible-if)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11790,19 +11790,19 @@
       },
       {
         "name": "no-collapsible-if",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-collapsible-if (Sonar key S1066). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S1066. Reports an outer if statement (at its if keyword) when it has no else clause and its consequent is either a direct inner if or a single-statement block containing an if, and that inner if also has no else clause. The two conditions should be merged with &&. Message and tests independently authored."
       },
       {
         "name": "no-collection-size-mischeck",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-collapsible-if`** (Sonar key S1066). Reports an outer `if` whose sole content is a single nested `if` — directly, or as the one statement in a block — where neither the outer nor inner `if` has an `else`. Such pairs should be merged with `&&`. Reports the outer `if` keyword. Implemented with the Oxc visitor (early-return guard style).

## Tests
- Rust unit tests: direct inner if, block-wrapped inner if, outer-has-else (0), inner-has-else (0), two-statement block (0).
- Native-API vitest + adapter vitest + oxlint `jsPlugins` CLI integration test (`sonarjs(no-collapsible-if)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783968343&installation_id=136613492&pr_number=122&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F122&signature=95cc05b3abfc2786f4ef48399b8768d7744e9871799c67fb89f31605e252f507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->