### PR TITLE
test(regexp): enforce parity for match-any and unicode-escape

### DIFF
--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -9,10 +9,6 @@
       "level": "off",
       "reason": "Diverges on mixed escape forms under the u flag (e.g. /a \\x0a \\cM \\0 \\u0100 \\u{100}/u)."
     },
-    "match-any": {
-      "level": "off",
-      "reason": "Flags /[\\s\\S]/ which upstream allows under the default option."
-    },
     "no-control-character": {
       "level": "off",
       "reason": "Flags a literal newline (new RegExp('\\n')) which upstream does not treat as a control character."
@@ -72,10 +68,6 @@
     "require-unicode-regexp": {
       "level": "off",
       "reason": "Flags constructors whose flags are an unknown variable (e.g. new RegExp('', flags))."
-    },
-    "unicode-escape": {
-      "level": "off",
-      "reason": "Diverges on mixed escape forms under the u flag."
     },
     "use-ignore-case": {
       "level": "off",


### PR DESCRIPTION
Promotes match-any and unicode-escape out of the parity quarantine. Their behavioral fixes already merged (#114, #115); this removes their `parity.json` entries so the upstream-parity harness enforces valid-soundness for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783968582&installation_id=136613492&pr_number=123&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F123&signature=adffef1513acc7a18051fd8616f333dff80f3308ca9d554258ea54ab10f38ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->