### PR TITLE
port(functional): bring no-class-inheritance to full upstream parity

### DIFF
--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -196,14 +196,22 @@ impl<'a> Scanner<'a> {
                 "Unexpected class, use functions not classes.",
                 class.span,
             );
-        }
-        if class.super_class.is_some() {
-            self.report(
-                "no-class-inheritance",
-                "extends",
-                "Unexpected class inheritance.",
-                class.span,
-            );
+            if class.r#abstract {
+                self.report(
+                    "no-class-inheritance",
+                    "abstract",
+                    "Unexpected abstract class.",
+                    class.span,
+                );
+            }
+            if class.super_class.is_some() {
+                self.report(
+                    "no-class-inheritance",
+                    "extends",
+                    "Unexpected class inheritance.",
+                    class.span,
+                );
+            }
         }
         if let Some(super_class) = &class.super_class {
             self.scan_expression(super_class, context);

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -202,12 +202,12 @@ fn no_class_inheritance_reports_abstract_and_extends() {
         ids
     };
 
-    assert_eq!(message_ids("class Foo {}"), Vec::<&'static str>::new());
-    assert_eq!(message_ids("class Foo extends Bar {}"), vec!["extends"]);
-    assert_eq!(message_ids("abstract class Foo {}"), vec!["abstract"]);
+    assert!(message_ids("class Foo {}").is_empty());
+    assert_eq!(message_ids("class Foo extends Bar {}"), ["extends"]);
+    assert_eq!(message_ids("abstract class Foo {}"), ["abstract"]);
     assert_eq!(
         message_ids("abstract class Foo extends Bar {}"),
-        vec!["abstract", "extends"]
+        ["abstract", "extends"]
     );
 
     // Ignore patterns suppress both reports.

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -188,6 +188,40 @@ fn no_classes_honors_ignore_patterns() {
 }
 
 #[test]
+fn no_class_inheritance_reports_abstract_and_extends() {
+    let options = FunctionalOptions {
+        rule_names: ["no-class-inheritance".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let message_ids = |source: &str| -> Vec<&'static str> {
+        let mut ids: Vec<&'static str> = scan_functional(source, "fixture.ts", &options)
+            .iter()
+            .map(|diagnostic| diagnostic.message_id)
+            .collect();
+        ids.sort_unstable();
+        ids
+    };
+
+    assert_eq!(message_ids("class Foo {}"), Vec::<&'static str>::new());
+    assert_eq!(message_ids("class Foo extends Bar {}"), vec!["extends"]);
+    assert_eq!(message_ids("abstract class Foo {}"), vec!["abstract"]);
+    assert_eq!(
+        message_ids("abstract class Foo extends Bar {}"),
+        vec!["abstract", "extends"]
+    );
+
+    // Ignore patterns suppress both reports.
+    let ignoring = FunctionalOptions {
+        rule_names: ["no-class-inheritance".into()].into_iter().collect(),
+        ignore_identifier_pattern: ["^Foo$".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    assert!(
+        scan_functional("abstract class Foo extends Bar {}", "fixture.ts", &ignoring).is_empty()
+    );
+}
+
+#[test]
 fn honors_core_options() {
     let mut options = FunctionalOptions {
         rule_names: ["no-let".into()].into_iter().collect(),

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -189,7 +189,7 @@ function stringOrStringArraySchema() {
 }
 
 function schemaForRule(ruleName) {
-  if (ruleName === 'no-classes') {
+  if (ruleName === 'no-classes' || ruleName === 'no-class-inheritance') {
     return [
       {
         type: 'object',
@@ -292,6 +292,10 @@ function diagnosticsForContext(context, options) {
   return diagnostics;
 }
 
+function classRuleUsesIgnorePatterns(ruleName) {
+  return ruleName === 'no-classes' || ruleName === 'no-class-inheritance';
+}
+
 function scanOptionsForRule(context, ruleName) {
   const raw = context.options?.[0];
   const options = raw && typeof raw === 'object' ? raw : {};
@@ -309,9 +313,12 @@ function scanOptionsForRule(context, ruleName) {
       ruleName === 'readonly-type' && (raw === 'keyword' || raw === 'generic') ? raw : undefined,
     ignoreIfReadonlyWrapped:
       ruleName === 'prefer-property-signatures' && options.ignoreIfReadonlyWrapped === true,
-    ignoreIdentifierPattern:
-      ruleName === 'no-classes' ? options.ignoreIdentifierPattern : undefined,
-    ignoreCodePattern: ruleName === 'no-classes' ? options.ignoreCodePattern : undefined,
+    ignoreIdentifierPattern: classRuleUsesIgnorePatterns(ruleName)
+      ? options.ignoreIdentifierPattern
+      : undefined,
+    ignoreCodePattern: classRuleUsesIgnorePatterns(ruleName)
+      ? options.ignoreCodePattern
+      : undefined,
   };
 }
 

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -30,6 +30,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
 const FULL_PARITY = new Set([
+  'no-class-inheritance',
   'no-classes',
   'no-loop-statements',
   'no-promise-reject',


### PR DESCRIPTION
Detect abstract classes (messageId `abstract`) alongside the existing `extends` report, both gated by the shared ignore-pattern infrastructure (reusing `class_is_ignored`). no-class-inheritance joins FULL_PARITY — all 13 upstream cases are asserted, including the TypeScript-syntax `abstract` cases (which need no type information). Adds a Rust unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783968807&installation_id=136613492&pr_number=124&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F124&signature=75fa62083525ac7d39e673c52028ce7b2528347f28edc354f41bd4c5f5981d39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->