### PR TITLE
port(sonarjs): port no-redundant-boolean (S1125)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
+ "oxc_syntax",
  "oxlint-plugins-_carton",
 ]
 

--- a/crates/sonarjs/Cargo.toml
+++ b/crates/sonarjs/Cargo.toml
@@ -14,6 +14,7 @@ oxc_ast.workspace = true
 oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
+oxc_syntax.workspace = true
 oxlint-plugins-carton.workspace = true
 
 [dev-dependencies]

--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,11 +22,12 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 4] = [
+pub const RULE_NAMES: [&str; 5] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
     "no-collapsible-if",
+    "no-redundant-boolean",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -5,3 +5,4 @@ mod no_collapsible_if;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;
+mod no_redundant_boolean;

--- a/crates/sonarjs/src/rules/no_redundant_boolean.rs
+++ b/crates/sonarjs/src/rules/no_redundant_boolean.rs
@@ -1,0 +1,85 @@
+//! Rule `no-redundant-boolean` (SonarJS key S1125).
+//!
+//! Clean-room port. Reports boolean literals that serve no purpose because the
+//! surrounding expression already conveys the same intent without them. Three
+//! patterns are flagged:
+//!
+//! 1. **Equality comparison with a boolean literal** — a `BinaryExpression`
+//!    whose operator is `==`, `===`, `!=`, or `!==` where either operand is a
+//!    boolean literal. The span reported is the boolean literal itself (left
+//!    preferred when both sides are boolean literals).
+//! 2. **Negation of a boolean literal** — a `UnaryExpression` with operator
+//!    `!` whose argument is a boolean literal. The whole unary expression is
+//!    reported.
+//! 3. **Ternary returning only boolean literals** — a `ConditionalExpression`
+//!    whose `consequent` AND `alternate` are both boolean literals (covers all
+//!    four combinations of `true`/`false`). The whole conditional expression is
+//!    reported.
+//!
+//! **Out of scope**: `&&` and `||` with boolean literals are intentionally NOT
+//! flagged by this rule. Those patterns belong to a separate rule and are
+//! excluded here to avoid false positives in common idioms such as
+//! `flag && doSomething()`.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{BinaryExpression, ConditionalExpression, Expression, UnaryExpression};
+use oxc_span::GetSpan;
+use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-redundant-boolean";
+
+/// Returns `true` when `expr` (after stripping parentheses) is a boolean literal.
+fn is_boolean_literal(expr: &Expression<'_>) -> bool {
+    matches!(expr.get_inner_expression(), Expression::BooleanLiteral(_))
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_redundant_boolean_binary(&mut self, expr: &BinaryExpression<'_>) {
+        let is_eq_op = matches!(
+            expr.operator,
+            BinaryOperator::Equality
+                | BinaryOperator::StrictEquality
+                | BinaryOperator::Inequality
+                | BinaryOperator::StrictInequality
+        );
+        if !is_eq_op {
+            return;
+        }
+        let left_is_bool = is_boolean_literal(&expr.left);
+        let right_is_bool = is_boolean_literal(&expr.right);
+        if !left_is_bool && !right_is_bool {
+            return;
+        }
+        // Report the boolean literal's span; prefer left when both are boolean literals.
+        let span = if left_is_bool {
+            expr.left.span()
+        } else {
+            expr.right.span()
+        };
+        self.report(RULE_NAME, "redundantBoolean", span);
+    }
+
+    pub(crate) fn check_no_redundant_boolean_unary(&mut self, expr: &UnaryExpression<'_>) {
+        if expr.operator != UnaryOperator::LogicalNot {
+            return;
+        }
+        if !is_boolean_literal(&expr.argument) {
+            return;
+        }
+        self.report(RULE_NAME, "redundantBoolean", expr.span());
+    }
+
+    pub(crate) fn check_no_redundant_boolean_conditional(
+        &mut self,
+        expr: &ConditionalExpression<'_>,
+    ) {
+        if !is_boolean_literal(&expr.consequent) || !is_boolean_literal(&expr.alternate) {
+            return;
+        }
+        self.report(RULE_NAME, "redundantBoolean", expr.span());
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -2,7 +2,10 @@
 //! sonarjs port. Traversal uses the Oxc visitor so every node is reached; each
 //! `check_*` rule body lives under [`crate::rules`].
 
-use oxc_ast::ast::{ConditionalExpression, IfStatement, SwitchStatement, TemplateLiteral};
+use oxc_ast::ast::{
+    BinaryExpression, ConditionalExpression, IfStatement, SwitchStatement, TemplateLiteral,
+    UnaryExpression,
+};
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
@@ -63,8 +66,19 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.switch_depth -= 1;
     }
 
+    fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {
+        self.check_no_redundant_boolean_binary(it);
+        walk::walk_binary_expression(self, it);
+    }
+
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        self.check_no_redundant_boolean_unary(it);
+        walk::walk_unary_expression(self, it);
+    }
+
     fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
         self.check_no_nested_conditional(it);
+        self.check_no_redundant_boolean_conditional(it);
         self.conditional_depth += 1;
         walk::walk_conditional_expression(self, it);
         self.conditional_depth -= 1;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -159,3 +159,65 @@ fn does_not_report_collapsible_if_block_has_two_statements() {
     let diagnostics = scan("no-collapsible-if", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_boolean_literal_in_strict_equality() {
+    let source = "x === true";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-redundant-boolean");
+    assert_eq!(diagnostics[0].message_id, "redundantBoolean");
+}
+
+#[test]
+fn reports_boolean_literal_on_left_of_strict_inequality() {
+    let source = "false !== y";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantBoolean");
+}
+
+#[test]
+fn reports_negation_of_boolean_literal() {
+    let source = "!true";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantBoolean");
+}
+
+#[test]
+fn reports_ternary_true_false() {
+    let source = "cond ? true : false";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantBoolean");
+}
+
+#[test]
+fn reports_ternary_false_true() {
+    let source = "cond ? false : true";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantBoolean");
+}
+
+#[test]
+fn does_not_report_equality_without_boolean_literal() {
+    let source = "x === y";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_logical_not_of_non_boolean() {
+    let source = "!x";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_ternary_with_non_boolean_branches() {
+    let source = "cond ? a : b";
+    let diagnostics = scan("no-redundant-boolean", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -29,6 +29,9 @@ const messages = Object.freeze({
   'no-collapsible-if': {
     collapsibleIf: "Merge this 'if' statement with the nested one to reduce nesting.",
   },
+  'no-redundant-boolean': {
+    redundantBoolean: 'Remove this redundant boolean literal.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -36,6 +39,7 @@ const ruleDescriptions = Object.freeze({
   'no-nested-switch': 'Disallow nested switch statements',
   'no-nested-conditional': 'Disallow nested conditional (ternary) expressions',
   'no-collapsible-if': 'Disallow collapsible if statements that should be merged',
+  'no-redundant-boolean': 'Disallow redundant boolean literals in expressions',
 });
 
 const ruleTypes = Object.freeze({
@@ -43,6 +47,7 @@ const ruleTypes = Object.freeze({
   'no-nested-switch': 'suggestion',
   'no-nested-conditional': 'suggestion',
   'no-collapsible-if': 'suggestion',
+  'no-redundant-boolean': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -50,6 +55,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-nested-switch': 'error',
   'no-nested-conditional': 'error',
   'no-collapsible-if': 'error',
+  'no-redundant-boolean': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -7,6 +7,7 @@ const expectedRuleNames = [
   'no-nested-switch',
   'no-nested-conditional',
   'no-collapsible-if',
+  'no-redundant-boolean',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -97,6 +98,45 @@ describe('sonarjs native API', () => {
 
   it('does not report when the block contains more than one statement', () => {
     const diagnostics = scan('no-collapsible-if', 'if (a) { if (b) {} doSomething(); }');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports a boolean literal on the right side of a strict equality', () => {
+    const diagnostics = scan('no-redundant-boolean', 'x === true');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantBoolean');
+  });
+
+  it('reports a boolean literal on the left side of a strict inequality', () => {
+    const diagnostics = scan('no-redundant-boolean', 'false !== y');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantBoolean');
+  });
+
+  it('reports negation of a boolean literal', () => {
+    const diagnostics = scan('no-redundant-boolean', '!false');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantBoolean');
+  });
+
+  it('reports a ternary whose both branches are boolean literals', () => {
+    const diagnostics = scan('no-redundant-boolean', 'c ? true : false');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantBoolean');
+  });
+
+  it('does not report a regular equality comparison without boolean literals', () => {
+    const diagnostics = scan('no-redundant-boolean', 'x === y');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report negation of a non-boolean expression', () => {
+    const diagnostics = scan('no-redundant-boolean', '!x');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report a ternary with non-boolean branches', () => {
+    const diagnostics = scan('no-redundant-boolean', 'c ? a : b');
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -98,16 +98,19 @@ describe('sonarjs plugin shape', () => {
       'no-nested-switch',
       'no-nested-conditional',
       'no-collapsible-if',
+      'no-redundant-boolean',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
     expect(typeof plugin.rules['no-nested-conditional']).toBe('object');
     expect(typeof plugin.rules['no-collapsible-if']).toBe('object');
+    expect(typeof plugin.rules['no-redundant-boolean']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-conditional']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-collapsible-if']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-redundant-boolean']).toBe('error');
   });
 });
 
@@ -142,6 +145,12 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-collapsible-if', 'if (a) { if (b) {} }');
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('collapsibleIf');
+  });
+
+  it('reports a redundant boolean literal through the adapter', () => {
+    const reports = runRule('no-redundant-boolean', 'x === true');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('redundantBoolean');
   });
 });
 
@@ -183,5 +192,14 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-collapsible-if)');
+  });
+
+  it('reports no-redundant-boolean through the CLI', () => {
+    const result = runOxlint('no-redundant-boolean', 'x === true');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-redundant-boolean)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12782,19 +12782,19 @@
       },
       {
         "name": "no-redundant-boolean",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-redundant-boolean (Sonar key S1125). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S1125. Reports redundant boolean literals in equality comparisons (==, ===, !=, !==), boolean negation (!true/!false), and ternaries whose both branches are boolean literals. &&/|| with boolean literals are intentionally out of scope. No upstream source, tests, fixtures, or messages were copied."
       },
       {
         "name": "no-redundant-jump",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-redundant-boolean`** (Sonar key S1125). Flags redundant boolean literals in three patterns:
1. Equality comparison with a boolean literal — `x === true`, `false != y` (`==`/`===`/`!=`/`!==`).
2. Logical negation of a boolean literal — `!true`, `!false`.
3. Ternary whose both branches are boolean literals — `c ? true : false`, etc.

`&&`/`||` with boolean literals are intentionally **out of scope** (documented in the rule) to avoid false positives. Adds `visit_binary_expression` / `visit_unary_expression` hooks and extends the shared `visit_conditional_expression`. Adds the `oxc_syntax` dependency for the operator enums.

## Tests
Rust unit tests (5 positive / 3 negative), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-redundant-boolean)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783969053&installation_id=136613492&pr_number=125&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F125&signature=2f6209c71af861532041ff78dbfbb0fd4c93f26c06bb8ba97b01b2cee0f17917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->