### PR TITLE
fix(regexp): prefer-named-backreference only flags \N when group N is named

### DIFF
--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -885,15 +885,62 @@ pub(crate) fn pattern_ends_with_lazy_quantifier(pattern: &str) -> bool {
 }
 
 /// Returns `Some(text)` for the first numbered backreference `\N` (N in 1-9)
-/// inside `pattern` when the same pattern contains at least one named capture
-/// group `(?<name>...)`. Numbered backreferences alongside named groups are
-/// the canonical case for `prefer-named-backreference`. Backreferences inside
-/// classes are skipped because they are literal characters there.
+/// inside `pattern` where capture group N is itself a named capture group
+/// `(?<name>...)`. Only named-group backreferences have a `\k<name>` alternative,
+/// so `\N` referring to an unnamed group must not be flagged. Backreferences
+/// inside character classes are skipped because they are literal characters there.
 pub(crate) fn first_numbered_backreference_with_named_group(pattern: &str) -> Option<&str> {
     let bytes = pattern.as_bytes();
+    // Fast path: no named group syntax at all.
     if !pattern.contains("(?<") {
         return None;
     }
+
+    // Pass 1: walk the pattern and record which 1-based capture group indices
+    // are named.  A `(` that is NOT `(?:`, `(?=`, `(?!`, `(?<=`, `(?<!`
+    // increments the group counter; `(?<name>...)` marks that index as named.
+    // We use a u32 bitmask (bits 1-9 = groups 1-9) because the rule only
+    // checks single-digit backreferences \1..\9.
+    let mut named_mask: u32 = 0;
+    {
+        let mut group_counter: u32 = 0;
+        let mut index = 0;
+        while index < bytes.len() {
+            if bytes[index] == b'[' {
+                if let Some(close) = find_class_end(bytes, index) {
+                    index = close + 1;
+                } else {
+                    index += 1;
+                }
+                continue;
+            }
+            if bytes[index] == b'\\' {
+                index = skip_escape(bytes, index).max(index + 1);
+                continue;
+            }
+            if bytes[index] == b'(' {
+                // Classify the group via the existing helper.
+                let gp = group_prefix(bytes, index);
+                if gp.capturing {
+                    group_counter += 1;
+                    if gp.named && group_counter <= 9 {
+                        named_mask |= 1 << group_counter;
+                    }
+                }
+                // Advance past the group prefix (the helper already skipped
+                // the opening `(` plus any `?<name>` prefix).
+                index = gp.next;
+                continue;
+            }
+            index += 1;
+        }
+    }
+
+    if named_mask == 0 {
+        return None;
+    }
+
+    // Pass 2: find the first \N where group N is named.
     let mut index = 0;
     while index < bytes.len() {
         if bytes[index] == b'[' {
@@ -907,7 +954,13 @@ pub(crate) fn first_numbered_backreference_with_named_group(pattern: &str) -> Op
             && let Some(&next) = bytes.get(index + 1)
             && matches!(next, b'1'..=b'9')
         {
-            return Some(&pattern[index..index + 2]);
+            let group_num = (next - b'0') as u32;
+            if named_mask & (1 << group_num) != 0 {
+                return Some(&pattern[index..index + 2]);
+            }
+            // Not a named group — skip past this escape and continue.
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
         }
         if bytes[index] == b'\\' {
             index = skip_escape(bytes, index).max(index + 1);

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -2132,6 +2132,12 @@ mod prefer_named_backreference {
         assert!(
             rule_ids_for("const a = /(?<n>a)[\\1b]/u;", "prefer-named-backreference").is_empty()
         );
+        // \1 refers to an unnamed group (group 1); group 2 is named — must NOT flag.
+        assert!(rule_ids_for(
+            "const a = /(a)\\1 (?<foo>a)\\k<foo>/;",
+            "prefer-named-backreference"
+        )
+        .is_empty());
     }
 }
 

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -2133,11 +2133,13 @@ mod prefer_named_backreference {
             rule_ids_for("const a = /(?<n>a)[\\1b]/u;", "prefer-named-backreference").is_empty()
         );
         // \1 refers to an unnamed group (group 1); group 2 is named — must NOT flag.
-        assert!(rule_ids_for(
-            "const a = /(a)\\1 (?<foo>a)\\k<foo>/;",
-            "prefer-named-backreference"
-        )
-        .is_empty());
+        assert!(
+            rule_ids_for(
+                "const a = /(a)\\1 (?<foo>a)\\k<foo>/;",
+                "prefer-named-backreference"
+            )
+            .is_empty()
+        );
     }
 }
 

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -45,10 +45,6 @@
       "level": "off",
       "reason": "Flags a lone trailing $ in a replacement string that upstream treats as valid."
     },
-    "prefer-named-backreference": {
-      "level": "off",
-      "reason": "Flags \\1 referring to an unnamed group, which has no named-backreference alternative."
-    },
     "prefer-named-replacement": {
       "level": "off",
       "reason": "Flags $1 referring to an unnamed group, which has no named-replacement alternative."


### PR DESCRIPTION
## Summary

- **Bug**: `prefer-named-backreference` was flagging any `\1`–`\9` backreference whenever the pattern contained *any* named capture group (`(?<`). The rule should only flag `\N` when capture group N itself is a named group — only then does a `\k<name>` alternative exist.
- **Fix**: replaced the single-pass implementation of `first_numbered_backreference_with_named_group` in `helpers.rs` with a two-pass approach:
  - Pass 1: count capture groups in order (skipping non-capturing groups and lookarounds via the existing `group_prefix` helper) and build a bitmask of the 1-based indices that are named.
  - Pass 2: scan for `\N` backreferences and only report when bit N is set.
- **Removed** the `prefer-named-backreference` entry from `parity.json` — the rule now agrees with upstream on all fixture valid/invalid cases.
- **Added** a regression test for the previously failing valid case `/(a)\1 (?<foo>a)\k<foo>/`.

## Failing valid case fixed

| Pattern | Before | After |
|---|---|---|
| `/(a)\1 (?<foo>a)\k<foo>/` | ❌ flagged `\1` (false positive) | ✅ silent |
| `/(?<foo>a)\1/` | ✅ flagged `\1` | ✅ flagged `\1` |
| `/(?<foo>a)\1/v` | ✅ flagged `\1` | ✅ flagged `\1` |

## Test plan

- [ ] All three fixture `valid[]` cases produce zero diagnostics.
- [ ] Both fixture `invalid[]` cases still produce exactly one diagnostic.
- [ ] New regression test `ignores_numbered_backref_without_named_group_and_class_contents` covers the `/(a)\1 (?<foo>a)\k<foo>/` case.
- [ ] `prefer-named-backreference` removed from `parity.json` (no longer quarantined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)