### PR TITLE
fix(regexp): prefer-escape-replacement-dollar-char requires regex literal first arg and string literal receiver

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -172,7 +172,10 @@ impl<'a> Scanner<'a> {
             return;
         }
         // Only fire when the receiver is a string literal.
-        if !matches!(member.object.get_inner_expression(), Expression::StringLiteral(_)) {
+        if !matches!(
+            member.object.get_inner_expression(),
+            Expression::StringLiteral(_)
+        ) {
             return;
         }
         // Only fire when the first argument is a regex literal.

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -171,6 +171,17 @@ impl<'a> Scanner<'a> {
         if method != "replace" && method != "replaceAll" {
             return;
         }
+        // Only fire when the receiver is a string literal.
+        if !matches!(member.object.get_inner_expression(), Expression::StringLiteral(_)) {
+            return;
+        }
+        // Only fire when the first argument is a regex literal.
+        let Some(arg0) = call.arguments.first().and_then(Argument::as_expression) else {
+            return;
+        };
+        if !matches!(arg0.get_inner_expression(), Expression::RegExpLiteral(_)) {
+            return;
+        }
         let Some(arg1) = call.arguments.get(1).and_then(Argument::as_expression) else {
             return;
         };

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -499,7 +499,7 @@ mod prefer_escape_replacement_dollar_char {
     fn reports_dollar_followed_by_invalid_char() {
         assert_eq!(
             rule_ids_for(
-                "str.replace(/foo/u, 'pre $ post');",
+                "'str'.replace(/foo/u, 'pre $ post');",
                 "prefer-escape-replacement-dollar-char"
             )
             .as_slice(),
@@ -508,7 +508,7 @@ mod prefer_escape_replacement_dollar_char {
         // Trailing dollar.
         assert_eq!(
             rule_ids_for(
-                "str.replace(/foo/u, 'price$');",
+                "'str'.replace(/foo/u, 'price$');",
                 "prefer-escape-replacement-dollar-char"
             )
             .as_slice(),
@@ -520,21 +520,21 @@ mod prefer_escape_replacement_dollar_char {
     fn accepts_valid_references_and_escaped_dollars() {
         assert!(
             rule_ids_for(
-                "str.replace(/(a)/u, '$1');",
+                "'str'.replace(/(a)/u, '$1');",
                 "prefer-escape-replacement-dollar-char"
             )
             .is_empty()
         );
         assert!(
             rule_ids_for(
-                "str.replace(/a/u, '$$');",
+                "'str'.replace(/a/u, '$$');",
                 "prefer-escape-replacement-dollar-char"
             )
             .is_empty()
         );
         assert!(
             rule_ids_for(
-                "str.replace(/a/u, '$&');",
+                "'str'.replace(/a/u, '$&');",
                 "prefer-escape-replacement-dollar-char"
             )
             .is_empty()
@@ -542,7 +542,23 @@ mod prefer_escape_replacement_dollar_char {
         // No dollar at all.
         assert!(
             rule_ids_for(
-                "str.replace(/a/u, 'bar');",
+                "'str'.replace(/a/u, 'bar');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        // Non-string-literal receiver: should not report.
+        assert!(
+            rule_ids_for(
+                "foo.replace(/./, '$');",
+                "prefer-escape-replacement-dollar-char"
+            )
+            .is_empty()
+        );
+        // Non-regex first argument: should not report.
+        assert!(
+            rule_ids_for(
+                "'abc'.replace(foo, '$');",
                 "prefer-escape-replacement-dollar-char"
             )
             .is_empty()

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -41,10 +41,6 @@
       "level": "off",
       "reason": "Flags single-character alternations like /(?:a|b)/ that upstream allows by default."
     },
-    "prefer-escape-replacement-dollar-char": {
-      "level": "off",
-      "reason": "Flags a lone trailing $ in a replacement string that upstream treats as valid."
-    },
     "prefer-named-backreference": {
       "level": "off",
       "reason": "Flags \\1 referring to an unnamed group, which has no named-backreference alternative."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -284,13 +284,13 @@ const invalidCases = [
   [
     'prefer-escape-replacement-dollar-char',
     'dollar followed by space',
-    "str.replace(/a/u, 'pre $ post');\n",
+    "'str'.replace(/a/u, 'pre $ post');\n",
     ['unexpected'],
   ],
   [
     'prefer-escape-replacement-dollar-char',
     'trailing dollar',
-    "str.replace(/a/u, 'price$');\n",
+    "'str'.replace(/a/u, 'price$');\n",
     ['unexpected'],
   ],
   // use-ignore-case


### PR DESCRIPTION
## Summary

- The rule was firing as a false positive on `'abc'.replace(foo, '$')` (non-regex first arg) and `foo.replace(/./, '$')` (non-string-literal receiver).
- Added two guards to `check_prefer_escape_replacement_dollar_char` in `checks.rs`: (1) receiver must be a `StringLiteral`, (2) first argument must be a `RegExpLiteral`.
- Updated hand-written tests in `tests.rs` and `plugin.test.mjs` to use string literal receivers in the invalid cases, and added assertions for the two previously false-positive shapes.
- Removed `prefer-escape-replacement-dollar-char` from `parity.json` — the rule now matches upstream behaviour for all fixture cases.

## Test plan

- [ ] All `valid[]` cases in `npm/regexp/test/fixtures/prefer-escape-replacement-dollar-char.json` produce zero diagnostics.
- [ ] All `invalid[]` cases still report `unexpected`.
- [ ] `parity.json` no longer lists `prefer-escape-replacement-dollar-char` as a known deviation.
- [ ] `pnpm dlx prettier@3 --print-width 100 --single-quote --write npm/regexp/test/parity.json` leaves the file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)