### PR TITLE
port(sonarjs): port comma-or-logical-or-case (S3616)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,12 +22,13 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 5] = [
+pub const RULE_NAMES: [&str; 6] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
     "no-collapsible-if",
     "no-redundant-boolean",
+    "comma-or-logical-or-case",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,6 +1,7 @@
 //! Clean-room rule implementations for the sonarjs port. Each module attaches
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
+mod comma_or_logical_or_case;
 mod no_collapsible_if;
 mod no_nested_conditional;
 mod no_nested_switch;

--- a/crates/sonarjs/src/rules/comma_or_logical_or_case.rs
+++ b/crates/sonarjs/src/rules/comma_or_logical_or_case.rs
@@ -1,0 +1,37 @@
+//! Rule `comma-or-logical-or-case` (SonarJS key S3616).
+//!
+//! Clean-room port. Reports a `switch` `case` label whose test expression is a
+//! logical-OR (`case a || b:`) or a comma/sequence expression (`case a, b:`),
+//! because such a label evaluates to a single value rather than matching multiple
+//! values as the author likely intended.
+//!
+//! Only the test expression's span is reported. The `default:` label (no test)
+//! and `case a && b:` are intentionally left alone.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Expression, SwitchCase};
+use oxc_span::GetSpan;
+use oxc_syntax::operator::LogicalOperator;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "comma-or-logical-or-case";
+
+impl Scanner<'_> {
+    pub(crate) fn check_comma_or_logical_or_case(&mut self, case: &SwitchCase<'_>) {
+        let Some(test) = &case.test else {
+            return;
+        };
+        let flagged = match test.get_inner_expression() {
+            Expression::LogicalExpression(logical) => logical.operator == LogicalOperator::Or,
+            Expression::SequenceExpression(_) => true,
+            _ => false,
+        };
+        if !flagged {
+            return;
+        }
+        self.report(RULE_NAME, "commaOrLogicalOrInCase", test.span());
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,8 +3,8 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    BinaryExpression, ConditionalExpression, IfStatement, SwitchStatement, TemplateLiteral,
-    UnaryExpression,
+    BinaryExpression, ConditionalExpression, IfStatement, SwitchCase, SwitchStatement,
+    TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -64,6 +64,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;
+    }
+
+    fn visit_switch_case(&mut self, it: &SwitchCase<'a>) {
+        self.check_comma_or_logical_or_case(it);
+        walk::walk_switch_case(self, it);
     }
 
     fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -221,3 +221,35 @@ fn does_not_report_ternary_with_non_boolean_branches() {
     let diagnostics = scan("no-redundant-boolean", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_logical_or_as_case_label() {
+    let source = "switch (x) { case 1 || 2: break; }";
+    let diagnostics = scan("comma-or-logical-or-case", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "comma-or-logical-or-case");
+    assert_eq!(diagnostics[0].message_id, "commaOrLogicalOrInCase");
+}
+
+#[test]
+fn reports_sequence_expression_as_case_label() {
+    let source = "switch (x) { case (1, 2): break; }";
+    let diagnostics = scan("comma-or-logical-or-case", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "comma-or-logical-or-case");
+    assert_eq!(diagnostics[0].message_id, "commaOrLogicalOrInCase");
+}
+
+#[test]
+fn does_not_report_plain_case_or_default() {
+    let source = "switch (x) { case 1: break; default: break; }";
+    let diagnostics = scan("comma-or-logical-or-case", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_logical_and_as_case_label() {
+    let source = "switch (x) { case 1 && 2: break; }";
+    let diagnostics = scan("comma-or-logical-or-case", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -32,6 +32,10 @@ const messages = Object.freeze({
   'no-redundant-boolean': {
     redundantBoolean: 'Remove this redundant boolean literal.',
   },
+  'comma-or-logical-or-case': {
+    commaOrLogicalOrInCase:
+      "This 'case' label uses '||' or ',', which does not compare against multiple values as it appears to.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -40,6 +44,7 @@ const ruleDescriptions = Object.freeze({
   'no-nested-conditional': 'Disallow nested conditional (ternary) expressions',
   'no-collapsible-if': 'Disallow collapsible if statements that should be merged',
   'no-redundant-boolean': 'Disallow redundant boolean literals in expressions',
+  'comma-or-logical-or-case': "Disallow '||' or ',' expressions as switch case labels",
 });
 
 const ruleTypes = Object.freeze({
@@ -48,6 +53,7 @@ const ruleTypes = Object.freeze({
   'no-nested-conditional': 'suggestion',
   'no-collapsible-if': 'suggestion',
   'no-redundant-boolean': 'suggestion',
+  'comma-or-logical-or-case': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -56,6 +62,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-nested-conditional': 'error',
   'no-collapsible-if': 'error',
   'no-redundant-boolean': 'error',
+  'comma-or-logical-or-case': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -8,6 +8,7 @@ const expectedRuleNames = [
   'no-nested-conditional',
   'no-collapsible-if',
   'no-redundant-boolean',
+  'comma-or-logical-or-case',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -137,6 +138,32 @@ describe('sonarjs native API', () => {
 
   it('does not report a ternary with non-boolean branches', () => {
     const diagnostics = scan('no-redundant-boolean', 'c ? a : b');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports a logical-OR expression as a case label', () => {
+    const source = 'switch (x) { case 1 || 2: break; }';
+    const diagnostics = scan('comma-or-logical-or-case', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('commaOrLogicalOrInCase');
+  });
+
+  it('reports a comma/sequence expression as a case label', () => {
+    const source = 'switch (x) { case (1, 2): break; }';
+    const diagnostics = scan('comma-or-logical-or-case', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('commaOrLogicalOrInCase');
+  });
+
+  it('does not report a plain case label or default', () => {
+    const source = 'switch (x) { case 1: break; default: break; }';
+    const diagnostics = scan('comma-or-logical-or-case', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report a logical-AND expression as a case label', () => {
+    const source = 'switch (x) { case 1 && 2: break; }';
+    const diagnostics = scan('comma-or-logical-or-case', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -99,18 +99,21 @@ describe('sonarjs plugin shape', () => {
       'no-nested-conditional',
       'no-collapsible-if',
       'no-redundant-boolean',
+      'comma-or-logical-or-case',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
     expect(typeof plugin.rules['no-nested-conditional']).toBe('object');
     expect(typeof plugin.rules['no-collapsible-if']).toBe('object');
     expect(typeof plugin.rules['no-redundant-boolean']).toBe('object');
+    expect(typeof plugin.rules['comma-or-logical-or-case']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-conditional']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-collapsible-if']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-boolean']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/comma-or-logical-or-case']).toBe('error');
   });
 });
 
@@ -151,6 +154,12 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-redundant-boolean', 'x === true');
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('redundantBoolean');
+  });
+
+  it('reports a logical-OR case label through the adapter', () => {
+    const reports = runRule('comma-or-logical-or-case', 'switch (x) { case 1 || 2: break; }');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('commaOrLogicalOrInCase');
   });
 });
 
@@ -201,5 +210,14 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-redundant-boolean)');
+  });
+
+  it('reports comma-or-logical-or-case through the CLI', () => {
+    const result = runOxlint('comma-or-logical-or-case', 'switch (x) { case 1 || 2: break; }');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(comma-or-logical-or-case)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10638,19 +10638,19 @@
       },
       {
         "name": "comma-or-logical-or-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule comma-or-logical-or-case (Sonar key S3616). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port from public RSPEC S3616. Reports case labels that use '||' or ',' (sequence expression), as these evaluate to a single value rather than matching multiple values. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "comment-regex",


### PR DESCRIPTION
## Summary
Clean-room port of **`comma-or-logical-or-case`** (Sonar key S3616). Reports a `switch` `case` label whose test expression is a logical-OR (`case a || b:`) or a comma/sequence expression (`case a, b:`) — such labels evaluate to a single value rather than matching multiple values as the author likely intended. `default:` and `case a && b:` are intentionally not flagged. Adds a stateless `visit_switch_case` hook.

## Tests
Rust unit tests (`||`, comma, plain/default → 0, `&&` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(comma-or-logical-or-case)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)