### PR TITLE
port(functional): bring no-let to full upstream parity

### DIFF
--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -64,6 +64,7 @@ pub struct FunctionalOptions {
     pub allow_rest_parameter: bool,
     pub allow_arguments_keyword: bool,
     pub allow_let_in_for_loop_init: bool,
+    pub allow_in_functions: bool,
     pub allow_throw_to_reject_promises: bool,
     pub allow_try_catch: bool,
     pub allow_try_finally: bool,
@@ -83,6 +84,7 @@ impl Default for FunctionalOptions {
             allow_rest_parameter: false,
             allow_arguments_keyword: false,
             allow_let_in_for_loop_init: false,
+            allow_in_functions: false,
             allow_throw_to_reject_promises: false,
             allow_try_catch: false,
             allow_try_finally: false,
@@ -147,6 +149,8 @@ pub(crate) struct FunctionContext {
     /// `try`/`catch` (a thrown value would be caught, so an async `throw` here is
     /// not a promise rejection). Reset at each function boundary.
     pub(crate) in_try_with_catch: bool,
+    /// True when inside any function/arrow/method body; used by no-let allowInFunctions.
+    pub(crate) in_function: bool,
 }
 
 pub fn implemented_functional_rule_names() -> &'static [&'static str] {
@@ -188,6 +192,7 @@ pub fn scan_functional(
         FunctionContext {
             in_async_function: false,
             in_try_with_catch: false,
+            in_function: false,
         },
     );
     scanner.diagnostics

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -62,6 +62,7 @@ impl<'a> Scanner<'a> {
         let context = FunctionContext {
             in_async_function: function.r#async,
             in_try_with_catch: false,
+            in_function: true,
         };
         if let Some(body) = &function.body {
             self.scan_function_body(body, context);
@@ -77,6 +78,7 @@ impl<'a> Scanner<'a> {
         let context = FunctionContext {
             in_async_function: function.r#async,
             in_try_with_catch: false,
+            in_function: true,
         };
         self.scan_function_body(&function.body, context);
     }
@@ -126,6 +128,7 @@ impl<'a> Scanner<'a> {
                     FunctionContext {
                         in_async_function: false,
                         in_try_with_catch: false,
+                        in_function: false,
                     },
                 );
             }
@@ -165,6 +168,15 @@ impl<'a> Scanner<'a> {
             _ => {}
         }
         self.scan_type(&return_type.type_annotation);
+    }
+
+    pub(crate) fn matches_ignore_identifier(&self, name: &str) -> bool {
+        for regex in &self.ignore_identifier_regexes {
+            if regex.is_match(name) {
+                return true;
+            }
+        }
+        false
     }
 
     pub(crate) fn class_is_ignored(&self, class: &Class<'a>) -> bool {

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -252,6 +252,21 @@ impl<'a> Scanner<'a> {
         }
     }
 
+    fn declaration_identifiers_ignored(&self, declaration: &VariableDeclaration<'a>) -> bool {
+        if self.ignore_identifier_regexes.is_empty() {
+            return false;
+        }
+        for declarator in &declaration.declarations {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                return false;
+            };
+            if !self.matches_ignore_identifier(id.name.as_str()) {
+                return false;
+            }
+        }
+        true
+    }
+
     fn scan_variable_declaration(
         &mut self,
         declaration: &'a VariableDeclaration<'a>,
@@ -260,6 +275,8 @@ impl<'a> Scanner<'a> {
     ) {
         if declaration.kind == VariableDeclarationKind::Let
             && !(in_for_init && self.options.allow_let_in_for_loop_init)
+            && !(self.options.allow_in_functions && context.in_function)
+            && !self.declaration_identifiers_ignored(declaration)
         {
             self.report(
                 "no-let",

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -273,11 +273,11 @@ impl<'a> Scanner<'a> {
         context: FunctionContext,
         in_for_init: bool,
     ) {
-        if declaration.kind == VariableDeclarationKind::Let
-            && !(in_for_init && self.options.allow_let_in_for_loop_init)
-            && !(self.options.allow_in_functions && context.in_function)
-            && !self.declaration_identifiers_ignored(declaration)
-        {
+        let is_let = declaration.kind == VariableDeclarationKind::Let;
+        let allowed_in_for_init = in_for_init && self.options.allow_let_in_for_loop_init;
+        let allowed_in_function = self.options.allow_in_functions && context.in_function;
+        let ignored = self.declaration_identifiers_ignored(declaration);
+        if is_let && !allowed_in_for_init && !allowed_in_function && !ignored {
             self.report(
                 "no-let",
                 "generic",

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -1,6 +1,39 @@
 use super::{FunctionalOptions, implemented_functional_rule_names, scan_functional};
 
 #[test]
+fn no_let_honors_options() {
+    let base = || FunctionalOptions {
+        rule_names: ["no-let".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let count = |source: &str, options: &FunctionalOptions| {
+        scan_functional(source, "fixture.ts", options).len()
+    };
+
+    // Plain let reports 1 diagnostic.
+    assert_eq!(count("let x;", &base()), 1);
+
+    // With allow_in_functions, let inside a function body is allowed.
+    let allow_fn = FunctionalOptions {
+        rule_names: ["no-let".into()].into_iter().collect(),
+        allow_in_functions: true,
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("function f() { let x; }", &allow_fn), 0);
+    // But top-level let is still reported.
+    assert_eq!(count("let x;", &allow_fn), 1);
+
+    // With ignore_identifier_pattern, matching names are allowed.
+    let ignore_mutable = FunctionalOptions {
+        rule_names: ["no-let".into()].into_iter().collect(),
+        ignore_identifier_pattern: ["^mutable".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("let mutable;", &ignore_mutable), 0);
+    assert_eq!(count("let immutable;", &ignore_mutable), 1);
+}
+
+#[test]
 fn prefer_property_signatures_honors_ignore_if_readonly_wrapped() {
     let base = || FunctionalOptions {
         rule_names: ["prefer-property-signatures".into()].into_iter().collect(),

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -17,6 +17,7 @@ export type FunctionalScanOptions = {
   allowRestParameter?: boolean;
   allowArgumentsKeyword?: boolean;
   allowLetInForLoopInit?: boolean;
+  allowInFunctions?: boolean;
   allowThrowToRejectPromises?: boolean;
   allowTryCatch?: boolean;
   allowTryFinally?: boolean;

--- a/npm/functional/api.js
+++ b/npm/functional/api.js
@@ -23,6 +23,7 @@ function normalizeOptions(options) {
     allowRestParameter: raw.allowRestParameter === true,
     allowArgumentsKeyword: raw.allowArgumentsKeyword === true,
     allowLetInForLoopInit: raw.allowLetInForLoopInit === true,
+    allowInFunctions: raw.allowInFunctions === true,
     allowThrowToRejectPromises: raw.allowThrowToRejectPromises === true,
     allowTryCatch: raw.allowTryCatch === true,
     allowTryFinally: raw.allowTryFinally === true,

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -219,6 +219,8 @@ function schemaForRule(ruleName) {
         type: 'object',
         properties: {
           allowInForLoopInit: { type: 'boolean' },
+          allowInFunctions: { type: 'boolean' },
+          ignoreIdentifierPattern: stringOrStringArraySchema(),
         },
         additionalProperties: true,
       },
@@ -305,6 +307,7 @@ function scanOptionsForRule(context, ruleName) {
     allowArgumentsKeyword:
       ruleName === 'functional-parameters' && options.allowArgumentsKeyword === true,
     allowLetInForLoopInit: ruleName === 'no-let' && options.allowInForLoopInit === true,
+    allowInFunctions: ruleName === 'no-let' && options.allowInFunctions === true,
     allowThrowToRejectPromises:
       ruleName === 'no-throw-statements' && options.allowToRejectPromises === true,
     allowTryCatch: ruleName === 'no-try-statements' && options.allowCatch === true,
@@ -313,9 +316,10 @@ function scanOptionsForRule(context, ruleName) {
       ruleName === 'readonly-type' && (raw === 'keyword' || raw === 'generic') ? raw : undefined,
     ignoreIfReadonlyWrapped:
       ruleName === 'prefer-property-signatures' && options.ignoreIfReadonlyWrapped === true,
-    ignoreIdentifierPattern: classRuleUsesIgnorePatterns(ruleName)
-      ? options.ignoreIdentifierPattern
-      : undefined,
+    ignoreIdentifierPattern:
+      classRuleUsesIgnorePatterns(ruleName) || ruleName === 'no-let'
+        ? options.ignoreIdentifierPattern
+        : undefined,
     ignoreCodePattern: classRuleUsesIgnorePatterns(ruleName)
       ? options.ignoreCodePattern
       : undefined,

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -22,6 +22,7 @@ mod napi_abi {
         pub allow_rest_parameter: Option<bool>,
         pub allow_arguments_keyword: Option<bool>,
         pub allow_let_in_for_loop_init: Option<bool>,
+        pub allow_in_functions: Option<bool>,
         pub allow_throw_to_reject_promises: Option<bool>,
         pub allow_try_catch: Option<bool>,
         pub allow_try_finally: Option<bool>,
@@ -76,6 +77,9 @@ mod napi_abi {
             allow_let_in_for_loop_init: options
                 .allow_let_in_for_loop_init
                 .unwrap_or(default_options.allow_let_in_for_loop_init),
+            allow_in_functions: options
+                .allow_in_functions
+                .unwrap_or(default_options.allow_in_functions),
             allow_throw_to_reject_promises: options
                 .allow_throw_to_reject_promises
                 .unwrap_or(default_options.allow_throw_to_reject_promises),

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -32,6 +32,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 const FULL_PARITY = new Set([
   'no-class-inheritance',
   'no-classes',
+  'no-let',
   'no-loop-statements',
   'no-promise-reject',
   'no-this-expressions',


### PR DESCRIPTION
Implements no-let's `allowInFunctions` (via a new `in_function` context flag) and `ignoreIdentifierPattern` (reusing the shared regex infra; a `let` is ignored when every declared identifier matches). no-let joins FULL_PARITY — all its upstream cases (41) are asserted. Adds a Rust unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)