### PR TITLE
port(sonarjs): port no-duplicate-in-composite (S4621)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,13 +22,14 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 6] = [
+pub const RULE_NAMES: [&str; 7] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
     "no-collapsible-if",
     "no-redundant-boolean",
     "comma-or-logical-or-case",
+    "no-duplicate-in-composite",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -3,6 +3,7 @@
 
 mod comma_or_logical_or_case;
 mod no_collapsible_if;
+mod no_duplicate_in_composite;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_duplicate_in_composite.rs
+++ b/crates/sonarjs/src/rules/no_duplicate_in_composite.rs
@@ -22,7 +22,7 @@ impl<'a> Scanner<'a> {
         let mut duplicates: SmallVec<[Span; 4]> = SmallVec::new();
         for member in types {
             let t = self.text(member.span());
-            if seen.iter().any(|s| *s == t) {
+            if seen.contains(&t) {
                 duplicates.push(member.span());
             } else {
                 seen.push(t);

--- a/crates/sonarjs/src/rules/no_duplicate_in_composite.rs
+++ b/crates/sonarjs/src/rules/no_duplicate_in_composite.rs
@@ -1,0 +1,35 @@
+//! Rule `no-duplicate-in-composite` (SonarJS key S4621).
+//!
+//! Clean-room port. Reports a type member that appears more than once in a
+//! TypeScript union (`A | B | A`) or intersection (`A & B & A`) type. Only the
+//! second and later occurrences of a repeated member are flagged; the first
+//! occurrence is left alone. Members are compared by their source text.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::TSType;
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-duplicate-in-composite";
+
+impl<'a> Scanner<'a> {
+    pub(crate) fn check_no_duplicate_in_composite(&mut self, types: &[TSType<'a>]) {
+        let mut seen: SmallVec<[&'a str; 8]> = SmallVec::new();
+        let mut duplicates: SmallVec<[Span; 4]> = SmallVec::new();
+        for member in types {
+            let t = self.text(member.span());
+            if seen.iter().any(|s| *s == t) {
+                duplicates.push(member.span());
+            } else {
+                seen.push(t);
+            }
+        }
+        for span in duplicates {
+            self.report(RULE_NAME, "duplicateType", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,7 +4,7 @@
 
 use oxc_ast::ast::{
     BinaryExpression, ConditionalExpression, IfStatement, SwitchCase, SwitchStatement,
-    TemplateLiteral, UnaryExpression,
+    TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -23,6 +23,12 @@ pub(crate) struct Scanner<'a> {
     pub(crate) switch_depth: u32,
     /// Number of conditional (ternary) expressions currently open on the traversal stack.
     pub(crate) conditional_depth: u32,
+}
+
+impl<'a> Scanner<'a> {
+    pub(crate) fn text(&self, span: Span) -> &'a str {
+        &self.source_text[span.start as usize..span.end as usize]
+    }
 }
 
 impl Scanner<'_> {
@@ -92,5 +98,15 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
         self.check_no_collapsible_if(it);
         walk::walk_if_statement(self, it);
+    }
+
+    fn visit_ts_union_type(&mut self, it: &TSUnionType<'a>) {
+        self.check_no_duplicate_in_composite(&it.types);
+        walk::walk_ts_union_type(self, it);
+    }
+
+    fn visit_ts_intersection_type(&mut self, it: &TSIntersectionType<'a>) {
+        self.check_no_duplicate_in_composite(&it.types);
+        walk::walk_ts_intersection_type(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -253,3 +253,41 @@ fn does_not_report_logical_and_as_case_label() {
     let diagnostics = scan("comma-or-logical-or-case", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_duplicate_type_in_union() {
+    let source = "type T = A | B | A;";
+    let diagnostics = scan("no-duplicate-in-composite", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-duplicate-in-composite");
+    assert_eq!(diagnostics[0].message_id, "duplicateType");
+}
+
+#[test]
+fn reports_duplicate_type_in_intersection() {
+    let source = "type T = A & B & A;";
+    let diagnostics = scan("no-duplicate-in-composite", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "duplicateType");
+}
+
+#[test]
+fn does_not_report_union_with_all_unique_members() {
+    let source = "type T = A | B | C;";
+    let diagnostics = scan("no-duplicate-in-composite", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_intersection_with_all_unique_members() {
+    let source = "type T = A & B;";
+    let diagnostics = scan("no-duplicate-in-composite", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_two_diagnostics_for_triple_duplicate_in_union() {
+    let source = "type T = A | A | A;";
+    let diagnostics = scan("no-duplicate-in-composite", source);
+    assert_eq!(diagnostics.len(), 2);
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -36,6 +36,9 @@ const messages = Object.freeze({
     commaOrLogicalOrInCase:
       "This 'case' label uses '||' or ',', which does not compare against multiple values as it appears to.",
   },
+  'no-duplicate-in-composite': {
+    duplicateType: 'Remove this duplicated type or replace with another one.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -45,6 +48,8 @@ const ruleDescriptions = Object.freeze({
   'no-collapsible-if': 'Disallow collapsible if statements that should be merged',
   'no-redundant-boolean': 'Disallow redundant boolean literals in expressions',
   'comma-or-logical-or-case': "Disallow '||' or ',' expressions as switch case labels",
+  'no-duplicate-in-composite':
+    'Disallow duplicate type members in TypeScript union or intersection types',
 });
 
 const ruleTypes = Object.freeze({
@@ -54,6 +59,7 @@ const ruleTypes = Object.freeze({
   'no-collapsible-if': 'suggestion',
   'no-redundant-boolean': 'suggestion',
   'comma-or-logical-or-case': 'suggestion',
+  'no-duplicate-in-composite': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -63,6 +69,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-collapsible-if': 'error',
   'no-redundant-boolean': 'error',
   'comma-or-logical-or-case': 'error',
+  'no-duplicate-in-composite': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -9,6 +9,7 @@ const expectedRuleNames = [
   'no-collapsible-if',
   'no-redundant-boolean',
   'comma-or-logical-or-case',
+  'no-duplicate-in-composite',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -165,5 +166,38 @@ describe('sonarjs native API', () => {
     const source = 'switch (x) { case 1 && 2: break; }';
     const diagnostics = scan('comma-or-logical-or-case', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports a duplicate type in a union type', () => {
+    const source = 'type T = A | B | A;';
+    const diagnostics = scan('no-duplicate-in-composite', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('duplicateType');
+  });
+
+  it('reports a duplicate type in an intersection type', () => {
+    const source = 'type T = A & B & A;';
+    const diagnostics = scan('no-duplicate-in-composite', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('duplicateType');
+  });
+
+  it('does not report a union type with all unique members', () => {
+    const source = 'type T = A | B | C;';
+    const diagnostics = scan('no-duplicate-in-composite', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report an intersection type with all unique members', () => {
+    const source = 'type T = A & B;';
+    const diagnostics = scan('no-duplicate-in-composite', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports one diagnostic for a union with a repeated primitive type', () => {
+    const source = 'type T = string | string | number;';
+    const diagnostics = scan('no-duplicate-in-composite', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('duplicateType');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -100,6 +100,7 @@ describe('sonarjs plugin shape', () => {
       'no-collapsible-if',
       'no-redundant-boolean',
       'comma-or-logical-or-case',
+      'no-duplicate-in-composite',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -107,6 +108,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-collapsible-if']).toBe('object');
     expect(typeof plugin.rules['no-redundant-boolean']).toBe('object');
     expect(typeof plugin.rules['comma-or-logical-or-case']).toBe('object');
+    expect(typeof plugin.rules['no-duplicate-in-composite']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -114,6 +116,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-collapsible-if']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-boolean']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/comma-or-logical-or-case']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-in-composite']).toBe('error');
   });
 });
 
@@ -160,6 +163,14 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('comma-or-logical-or-case', 'switch (x) { case 1 || 2: break; }');
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('commaOrLogicalOrInCase');
+  });
+
+  it('reports a duplicate type in a union through the adapter', () => {
+    const reports = runRule('no-duplicate-in-composite', 'type T = A | B | A;', {
+      filename: 'sample.ts',
+    });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('duplicateType');
   });
 });
 
@@ -219,5 +230,14 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(comma-or-logical-or-case)');
+  });
+
+  it('reports no-duplicate-in-composite through the CLI', () => {
+    const result = runOxlint('no-duplicate-in-composite', 'type T = A | B | A;', 'sample.ts');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-duplicate-in-composite)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11886,19 +11886,19 @@
       },
       {
         "name": "no-duplicate-in-composite",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-duplicate-in-composite (Sonar key S4621). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S4621. Reports duplicate type members in TypeScript union or intersection types by comparing member source text. Two-phase borrow approach used (collect spans first, then report). No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-duplicate-string",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-duplicate-in-composite`** (Sonar key S4621). Reports a type member that appears more than once in a TypeScript union (`A | B | A`) or intersection (`A & B & A`) type — the 2nd and later occurrences are flagged, compared by source text. Adds `visit_ts_union_type` / `visit_ts_intersection_type` hooks and a `text(span)` helper on `Scanner`; uses a two-phase collect-then-report to avoid borrow conflicts.

## Tests
Rust unit tests (union dup, intersection dup, no-dup, triple `A|A|A` → 2), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-duplicate-in-composite)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783970797&installation_id=136613492&pr_number=134&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F134&signature=04af92f8db70605b01f98b564c51e19bcc73a5c40fa0c7ec31376a0877d5e599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->