### PR TITLE
port(regexp): port sort-alternatives (narrow form)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "oxlint-plugins-_carton",
+ "regex",
 ]
 
 [[package]]

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -587,6 +587,9 @@ impl<'a> Scanner<'a> {
         if analysis.has_preferable_character_class {
             self.report("prefer-character-class", "unexpected", span);
         }
+        if analysis.has_unsorted_alternatives {
+            self.report("sort-alternatives", "unexpected", span);
+        }
 
         if analysis.has_empty_character_class {
             self.report("no-empty-character-class", "empty", span);

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::types::LineIndex;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 57] = [
+pub const RULE_NAMES: [&str; 58] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -79,6 +79,7 @@ pub const RULE_NAMES: [&str; 57] = [
     "no-extra-lookaround-assertions",
     "no-trivially-nested-quantifier",
     "prefer-character-class",
+    "sort-alternatives",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -41,6 +41,13 @@ pub(crate) struct GroupState {
     /// consisted of exactly one ASCII alphanumeric byte. Used by
     /// `prefer-character-class`.
     pub(crate) all_alts_single_literal: bool,
+    /// First byte of the most recently completed alternative whose body was
+    /// a single ASCII alphanumeric. `0` means no such alt has been recorded
+    /// yet. Used by `sort-alternatives` to detect out-of-order alternations.
+    pub(crate) prev_alt_first_byte: u8,
+    /// `true` while every completed single-literal alternative observed so
+    /// far has appeared in ascending byte order. `sort-alternatives`.
+    pub(crate) alts_in_order: bool,
 }
 
 impl GroupState {
@@ -57,6 +64,8 @@ impl GroupState {
             last_atom_was_lookaround: false,
             current_alt_start: 0,
             all_alts_single_literal: true,
+            prev_alt_first_byte: 0,
+            alts_in_order: true,
         }
     }
 
@@ -79,6 +88,8 @@ impl GroupState {
             last_atom_was_lookaround: false,
             current_alt_start: body_start,
             all_alts_single_literal: true,
+            prev_alt_first_byte: 0,
+            alts_in_order: true,
         }
     }
 }
@@ -179,6 +190,9 @@ pub(crate) struct PatternAnalysis {
     /// two alternatives and every alternative is exactly one ASCII
     /// alphanumeric literal byte. `prefer-character-class`.
     pub(crate) has_preferable_character_class: bool,
+    /// `(?:b|a)` — a non-capturing alternation whose single-literal alts are
+    /// not in ascending byte order. `sort-alternatives`.
+    pub(crate) has_unsorted_alternatives: bool,
 }
 
 impl PatternAnalysis {
@@ -371,6 +385,19 @@ impl PatternAnalysis {
                                 && bytes[group.current_alt_start].is_ascii_alphanumeric();
                             if group.all_alts_single_literal && final_alt_simple {
                                 self.has_preferable_character_class = true;
+                                // `sort-alternatives` only fires when every
+                                // alt was a single ASCII alphanumeric AND at
+                                // least one transition violated ascending order.
+                                let final_byte = bytes[group.current_alt_start];
+                                let mut alts_in_order = group.alts_in_order;
+                                if group.prev_alt_first_byte != 0
+                                    && final_byte < group.prev_alt_first_byte
+                                {
+                                    alts_in_order = false;
+                                }
+                                if !alts_in_order {
+                                    self.has_unsorted_alternatives = true;
+                                }
                             }
                         }
                         // Multi-byte bodies, escapes, classes, and braced
@@ -405,15 +432,28 @@ impl PatternAnalysis {
                         if !group.current_has_content {
                             self.has_empty_alternative = true;
                         }
-                        // Check the closing alternative for `prefer-character-class`:
-                        // each alt must be exactly one ASCII alphanumeric byte.
+                        // Check the closing alternative for `prefer-character-class`
+                        // and `sort-alternatives`: each alt must be exactly one
+                        // ASCII alphanumeric byte. Both rules also need
+                        // ordering checks for single-literal alts.
+                        let mut alt_first_byte: u8 = 0;
                         if group.all_alts_single_literal {
                             let alt_len = index - group.current_alt_start;
                             if alt_len != 1
                                 || !bytes[group.current_alt_start].is_ascii_alphanumeric()
                             {
                                 group.all_alts_single_literal = false;
+                            } else {
+                                alt_first_byte = bytes[group.current_alt_start];
+                                if group.prev_alt_first_byte != 0
+                                    && alt_first_byte < group.prev_alt_first_byte
+                                {
+                                    group.alts_in_order = false;
+                                }
                             }
+                        }
+                        if alt_first_byte != 0 {
+                            group.prev_alt_first_byte = alt_first_byte;
                         }
                         group.seen_pipe = true;
                         group.current_has_content = false;

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -98,6 +98,7 @@ fn exposes_initial_regexp_rule_names() {
             "no-extra-lookaround-assertions",
             "no-trivially-nested-quantifier",
             "prefer-character-class",
+            "sort-alternatives",
         ]
     );
 }
@@ -163,6 +164,41 @@ mod no_extra_lookaround_assertions {
         assert!(
             rule_ids_for("const a = /(?=(?=a)b)/u;", "no-extra-lookaround-assertions").is_empty()
         );
+    }
+}
+
+mod sort_alternatives {
+    use super::*;
+
+    #[test]
+    fn reports_out_of_order_single_literal_alts() {
+        assert_eq!(
+            rule_ids_for("const a = /(?:b|a)/u;", "sort-alternatives").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:c|a|b)/u;", "sort-alternatives").as_slice(),
+            &["unexpected"]
+        );
+        assert_eq!(
+            rule_ids_for("const a = /(?:2|1)/u;", "sort-alternatives").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_sorted_or_unsupported_alts() {
+        // Already sorted.
+        assert!(rule_ids_for("const a = /(?:a|b)/u;", "sort-alternatives").is_empty());
+        assert!(rule_ids_for("const a = /(?:a|b|c)/u;", "sort-alternatives").is_empty());
+        // No alternation.
+        assert!(rule_ids_for("const a = /(?:a)/u;", "sort-alternatives").is_empty());
+        // Multi-byte alt — deferred.
+        assert!(rule_ids_for("const a = /(?:bc|a)/u;", "sort-alternatives").is_empty());
+        // Escape inside.
+        assert!(rule_ids_for("const a = /(?:b|\\d)/u;", "sort-alternatives").is_empty());
+        // Capturing group not in scope.
+        assert!(rule_ids_for("const a = /(b|a)/u;", "sort-alternatives").is_empty());
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -214,6 +214,12 @@ const messages = Object.freeze({
     unexpected:
       'Non-capturing group with a quantified single-character body that is itself quantified; drop the wrapper and combine the quantifiers.',
   },
+  'prefer-character-class': {
+    unexpected: 'Alternation of single-character literals; use a character class `[abc]` instead.',
+  },
+  'sort-alternatives': {
+    unexpected: 'Single-literal alternation is not in ascending order; sort the alternatives.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -298,6 +304,9 @@ const ruleDescriptions = Object.freeze({
   'no-extra-lookaround-assertions':
     'disallow lookaround assertions whose entire body is a single nested lookaround',
   'no-trivially-nested-quantifier': 'disallow trivially nested quantifiers like `(?:X+)+`',
+  'prefer-character-class':
+    'enforce using a character class instead of alternation of single literals',
+  'sort-alternatives': 'enforce sorted single-literal alternation alternatives',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -357,6 +366,7 @@ const ruleTypes = Object.freeze({
   'no-extra-lookaround-assertions': 'suggestion',
   'no-trivially-nested-quantifier': 'suggestion',
   'prefer-character-class': 'suggestion',
+  'sort-alternatives': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -516,7 +526,9 @@ function ruleCategory(ruleName) {
     ruleName === 'sort-character-class-elements' ||
     ruleName === 'no-trivially-nested-assertion' ||
     ruleName === 'no-extra-lookaround-assertions' ||
-    ruleName === 'no-trivially-nested-quantifier'
+    ruleName === 'no-trivially-nested-quantifier' ||
+    ruleName === 'prefer-character-class' ||
+    ruleName === 'sort-alternatives'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -62,6 +62,7 @@ describe('regexp native API', () => {
       'no-extra-lookaround-assertions',
       'no-trivially-nested-quantifier',
       'prefer-character-class',
+      'sort-alternatives',
     ]);
   });
 

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -121,6 +121,10 @@ const validCases = [
   ['prefer-character-class', 'multi-byte alt', 'const re = /(?:a|bc)/u;\n'],
   ['prefer-character-class', 'escape alt', 'const re = /(?:a|\\d)/u;\n'],
   ['prefer-character-class', 'no alternation', 'const re = /(?:a)/u;\n'],
+  // sort-alternatives
+  ['sort-alternatives', 'already sorted', 'const re = /(?:a|b|c)/u;\n'],
+  ['sort-alternatives', 'multi-byte alt', 'const re = /(?:bc|a)/u;\n'],
+  ['sort-alternatives', 'no alternation', 'const re = /(?:a)/u;\n'],
   // prefer-unicode-codepoint-escapes
   [
     'prefer-unicode-codepoint-escapes',
@@ -378,6 +382,9 @@ const invalidCases = [
     'const re = /(?:a|1|b)/u;\n',
     ['unexpected'],
   ],
+  // sort-alternatives
+  ['sort-alternatives', 'two-letter unsorted', 'const re = /(?:b|a)/u;\n', ['unexpected']],
+  ['sort-alternatives', 'three-letter unsorted', 'const re = /(?:c|a|b)/u;\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -9643,19 +9643,19 @@
       },
       {
         "name": "sort-alternatives",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule sort-alternatives."
+        "notes": "GroupState tracks prev_alt_first_byte and alts_in_order alongside current_alt_start. At each | (and at close `)`), when the alternative is exactly one ASCII alphanumeric byte, its byte is compared with the previously recorded alt; if the new byte is less than the previous, alts_in_order = false. The rule fires only when seen_pipe is true AND all alts were single literals AND ordering was violated. Escapes, classes, nested groups, and multi-byte alts opt out (all_alts_single_literal becomes false)."
       },
       {
         "name": "sort-character-class-elements",


### PR DESCRIPTION
One more `eslint-plugin-regexp` rule built on the per-alt tracker introduced for `prefer-character-class`. Regexp port advances **57 → 58 / 82**.

## How it works

`GroupState` gains `prev_alt_first_byte` and `alts_in_order`. At each `|` (and at close `)`), when the alternative is exactly one ASCII alphanumeric byte, its byte is compared with the previously recorded alt: if the new byte is less than the previous, `alts_in_order` is set to false. The rule fires only when `seen_pipe` is true AND all alternatives were single ASCII alphanumerics AND ordering was violated.

This deliberately overlaps with `prefer-character-class` on the same input shape: `sort-alternatives` adds the ordering predicate. Escapes, classes, nested groups, and multi-byte alts cause `all_alts_single_literal` to become false, which gates out both rules.

## Drive-by fix

Also fills in missing JS-side wrapper entries for `prefer-character-class` (messages, descriptions, ruleCategory) that landed in `lib.rs` but were incomplete in `npm/regexp/index.js` — main currently lists the rule in `ruleTypes` only, with no message template or description.

## Verification

- 143 Rust unit tests pass (4 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `vp fmt --check` clean (417 files)
- Vitest plugin tests gain 5 new valid/invalid cases; `api.test.mjs` rule-name list extended

No upstream source, fixtures, or messages were copied; message strings are paraphrased from public docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->