### PR TITLE
fix(regexp): suppress no-control-character false positive for constructor named escapes

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -688,15 +688,25 @@ impl<'a> Scanner<'a> {
             );
         }
         if let Some(ch) = first_control_character(pattern) {
-            self.report_with_data(
-                "no-control-character",
-                "unexpected",
-                DiagnosticData {
-                    char_text: Some(mention_char(ch)),
-                    ..DiagnosticData::default()
-                },
-                span,
-            );
+            // When the pattern comes from a RegExp constructor argument, the six
+            // characters with well-known named JS string escapes (\0 \t \n \v \f \r)
+            // are delivered as literal bytes by the JS escape (e.g. '\n' → U+000A).
+            // Upstream marks these valid (new RegExp('\n') is accepted), so suppress
+            // here. For regex literals ALL control characters must be flagged.
+            // Known gap: hex-escaped constructor args like new RegExp('\x0a') still
+            // reach us as the literal char and would be suppressed — acceptable.
+            let named_escape = matches!(ch, '\0' | '\t'..='\r');
+            if !(is_constructor && named_escape) {
+                self.report_with_data(
+                    "no-control-character",
+                    "unexpected",
+                    DiagnosticData {
+                        char_text: Some(mention_char(ch)),
+                        ..DiagnosticData::default()
+                    },
+                    span,
+                );
+            }
         }
         if let Some(ch) = first_literal_control_character(pattern) {
             // When the pattern comes from a RegExp constructor argument (not a

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1114,6 +1114,40 @@ mod no_control_character {
             .is_empty()
         );
     }
+
+    #[test]
+    fn suppresses_named_escape_chars_in_constructor_false_positive() {
+        // Regression: new RegExp('\n') delivers a literal newline (U+000A) to
+        // the pattern via the JS string escape. Upstream marks this valid because
+        // the author expressed it as a named escape, so we must NOT fire here.
+        assert!(
+            rule_ids_for("const a = new RegExp('\n', 'u');", "no-control-character").is_empty(),
+            "constructor newline (U+000A named escape) must not fire"
+        );
+        // Same for the other named-escape control characters.
+        assert!(
+            rule_ids_for("const a = new RegExp('\t', 'u');", "no-control-character").is_empty(),
+            "constructor tab (U+0009 named escape) must not fire"
+        );
+        assert!(
+            rule_ids_for("const a = new RegExp('\r', 'u');", "no-control-character").is_empty(),
+            "constructor carriage-return (U+000D named escape) must not fire"
+        );
+        // Regex literals with a raw control character MUST still fire.
+        assert!(
+            rule_ids_for("const a = /a\x01b/u;", "no-control-character").contains(&"unexpected"),
+            "regex literal raw SOH (U+0001) must still fire"
+        );
+        // Constructor with a hex-escaped non-named control char still fires.
+        assert!(
+            rule_ids_for(
+                "const a = new RegExp('\\x01', 'u');",
+                "no-control-character"
+            )
+            .contains(&"unexpected"),
+            "constructor hex escape \\x01 must still fire"
+        );
+    }
 }
 
 mod sort_flags {

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -5,10 +5,6 @@
       "level": "off",
       "reason": "Diverges on mixed escape forms under the u flag (e.g. /a \\x0a \\cM \\0 \\u0100 \\u{100}/u)."
     },
-    "no-control-character": {
-      "level": "off",
-      "reason": "Flags a literal newline (new RegExp('\\n')) which upstream does not treat as a control character."
-    },
     "no-dupe-characters-character-class": {
       "level": "off",
       "reason": "False duplicate in nested v-mode classes / set operations, e.g. /[\\q{a}\\q{ab}\\q{abc}[\\w--[ab]][\\w&&b]]/v. The \\q{...} body is now skipped (so simple cases pass), but nested [...] operands still need set-aware handling."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -41,6 +41,11 @@ const validCases = [
   ['no-control-character', 'named tab escape', 'const re = /\\t/u;\n'],
   ['no-control-character', 'named newline escape', 'const re = /\\n/u;\n'],
   ['no-control-character', 'printable hex escape', "const re = new RegExp('\\\\u0041', 'u');\n"],
+  [
+    'no-control-character',
+    'constructor named newline escape',
+    "const re = new RegExp('\\n', 'u');\n",
+  ],
   // control-character-escape
   ['control-character-escape', 'named tab in constructor arg', "new RegExp('\\t');\n"],
   // sort-flags


### PR DESCRIPTION
## Summary

- `no-control-character` incorrectly fired on `new RegExp('\n')` and similar constructor calls where a JS named string escape (`\n`, `\t`, `\r`, `\v`, `\f`, `\0`) delivers a literal control character to the pattern.
- Upstream `eslint-plugin-regexp` marks these valid because the author deliberately wrote the named escape form.
- Fix: when `is_constructor` is true and the offending character is one of the six named-escape chars (U+0000, U+0009–U+000D), suppress the diagnostic.
- Regex literals with raw control characters are still flagged.

## Known gap

A hex-escaped constructor arg like `new RegExp('\x0a')` also delivers the literal char but is indistinguishable from a named escape at the pattern-string level. It is suppressed too — an acceptable false negative. The `hexadecimal-escape` rule still fires on the raw `\xHH` form.

## Test plan

- [x] New Rust regression test `suppresses_named_escape_chars_in_constructor_false_positive` in `mod no_control_character` covering `'\n'`, `'\t'`, `'\r'` constructor cases and confirming regex literals still fire
- [x] New valid case added to `npm/regexp/test/plugin.test.mjs`: `constructor named newline escape`
- [x] Existing invalid case (`new RegExp('\\x01', 'u')` hex-escaped control char) still fires — no test updates needed
- [x] `cargo fmt --check` equivalent: `rustfmt --edition 2024` applied to all `.rs` files
- [x] `prettier` applied to all `.mjs` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783971244&installation_id=136613492&pr_number=136&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F136&signature=9d8bc6b1eaaadc3a3c41e405c7672aaed8fc478a0f15ba7ec0804b34dba8db2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->