### PR TITLE
port(sonarjs): port non-existent-operator (S2757)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 7] = [
+pub const RULE_NAMES: [&str; 8] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -30,6 +30,7 @@ pub const RULE_NAMES: [&str; 7] = [
     "no-redundant-boolean",
     "comma-or-logical-or-case",
     "no-duplicate-in-composite",
+    "non-existent-operator",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -8,3 +8,4 @@ mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_redundant_boolean;
+mod non_existent_operator;

--- a/crates/sonarjs/src/rules/non_existent_operator.rs
+++ b/crates/sonarjs/src/rules/non_existent_operator.rs
@@ -1,0 +1,59 @@
+//! Rule `non-existent-operator` (SonarJS key S2757).
+//!
+//! Clean-room port. Detects a likely typo where the programmer wrote `=-`, `=+`,
+//! or `=!` by placing a plain assignment (`=`) immediately adjacent (no whitespace)
+//! to a unary `-`, `+`, or `!` operator. The code parses validly — `x =- 1` is
+//! `x = (-1)` — but the visual resemblance to the compound operators `-=`, `+=`,
+//! and the comparison `!=` makes it a frequent source of bugs.
+//!
+//! **Detection heuristic**: The rule triggers when ALL of the following hold:
+//!
+//! 1. The expression is an `AssignmentExpression` with the plain `=` operator.
+//! 2. The right-hand side (after stripping parentheses) is a `UnaryExpression`
+//!    with operator `-`, `+`, or `!`.
+//! 3. The source byte immediately *before* the unary operator is `=` (i.e. no
+//!    whitespace between the `=` and the unary symbol).
+//!
+//! Condition 3 is what distinguishes the suspicious `x =- 1` from the intentional
+//! `x = -1` (which has a space and is NOT flagged).
+//!
+//! The entire `AssignmentExpression` span is reported.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{AssignmentExpression, Expression};
+use oxc_span::GetSpan;
+use oxc_syntax::operator::{AssignmentOperator, UnaryOperator};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "non-existent-operator";
+
+impl Scanner<'_> {
+    pub(crate) fn check_non_existent_operator(&mut self, assign: &AssignmentExpression<'_>) {
+        if assign.operator != AssignmentOperator::Assign {
+            return;
+        }
+        let Expression::UnaryExpression(unary) = assign.right.get_inner_expression() else {
+            return;
+        };
+        let is_target_op = matches!(
+            unary.operator,
+            UnaryOperator::UnaryNegation | UnaryOperator::UnaryPlus | UnaryOperator::LogicalNot
+        );
+        if !is_target_op {
+            return;
+        }
+        // The unary expression's span starts at the unary operator character (e.g. `-`).
+        // If the byte immediately before it is `=`, the two tokens are adjacent — the
+        // suspicious `=-` / `=+` / `=!` pattern. A space between them means the
+        // assignment is intentional and should not be flagged.
+        let start = unary.span.start as usize;
+        let adjacent = start >= 1 && self.source_text.as_bytes().get(start - 1) == Some(&b'=');
+        if !adjacent {
+            return;
+        }
+        self.report(RULE_NAME, "nonExistentOperator", assign.span());
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,8 +3,8 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    BinaryExpression, ConditionalExpression, IfStatement, SwitchCase, SwitchStatement,
-    TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, IfStatement, SwitchCase,
+    SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -98,6 +98,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
         self.check_no_collapsible_if(it);
         walk::walk_if_statement(self, it);
+    }
+
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        self.check_non_existent_operator(it);
+        walk::walk_assignment_expression(self, it);
     }
 
     fn visit_ts_union_type(&mut self, it: &TSUnionType<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -291,3 +291,49 @@ fn reports_two_diagnostics_for_triple_duplicate_in_union() {
     let diagnostics = scan("no-duplicate-in-composite", source);
     assert_eq!(diagnostics.len(), 2);
 }
+
+#[test]
+fn reports_non_existent_operator_for_equals_minus() {
+    let source = "let x = 0; x =- 1;";
+    let diagnostics = scan("non-existent-operator", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "non-existent-operator");
+    assert_eq!(diagnostics[0].message_id, "nonExistentOperator");
+}
+
+#[test]
+fn reports_non_existent_operator_for_equals_plus() {
+    let source = "let x = 0; x =+ 1;";
+    let diagnostics = scan("non-existent-operator", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "nonExistentOperator");
+}
+
+#[test]
+fn reports_non_existent_operator_for_equals_not() {
+    let source = "let x = false; let y = true; x =! y;";
+    let diagnostics = scan("non-existent-operator", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "nonExistentOperator");
+}
+
+#[test]
+fn does_not_report_non_existent_operator_when_space_before_unary() {
+    let source = "let x = 0; x = -1;";
+    let diagnostics = scan("non-existent-operator", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_non_existent_operator_for_compound_assignment() {
+    let source = "let x = 0; x -= 1;";
+    let diagnostics = scan("non-existent-operator", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_non_existent_operator_for_plain_assign_non_unary() {
+    let source = "let x = 0; let y = 1; x = y;";
+    let diagnostics = scan("non-existent-operator", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -39,6 +39,10 @@ const messages = Object.freeze({
   'no-duplicate-in-composite': {
     duplicateType: 'Remove this duplicated type or replace with another one.',
   },
+  'non-existent-operator': {
+    nonExistentOperator:
+      "Was this '=-', '=+', or '=!' meant to be a compound assignment or comparison? Add a space to clarify, or fix the operator.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -50,6 +54,8 @@ const ruleDescriptions = Object.freeze({
   'comma-or-logical-or-case': "Disallow '||' or ',' expressions as switch case labels",
   'no-duplicate-in-composite':
     'Disallow duplicate type members in TypeScript union or intersection types',
+  'non-existent-operator':
+    "Disallow the suspicious '=-', '=+', or '=!' operator typos adjacent to a plain assignment",
 });
 
 const ruleTypes = Object.freeze({
@@ -60,6 +66,7 @@ const ruleTypes = Object.freeze({
   'no-redundant-boolean': 'suggestion',
   'comma-or-logical-or-case': 'suggestion',
   'no-duplicate-in-composite': 'suggestion',
+  'non-existent-operator': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -70,6 +77,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-redundant-boolean': 'error',
   'comma-or-logical-or-case': 'error',
   'no-duplicate-in-composite': 'error',
+  'non-existent-operator': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -10,6 +10,7 @@ const expectedRuleNames = [
   'no-redundant-boolean',
   'comma-or-logical-or-case',
   'no-duplicate-in-composite',
+  'non-existent-operator',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -199,5 +200,45 @@ describe('sonarjs native API', () => {
     const diagnostics = scan('no-duplicate-in-composite', source);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].messageId).toBe('duplicateType');
+  });
+
+  it('reports non-existent-operator for x =- 1 (negation adjacent to assign)', () => {
+    const source = 'let x = 0; x =- 1;';
+    const diagnostics = scan('non-existent-operator', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('non-existent-operator');
+    expect(diagnostics[0].messageId).toBe('nonExistentOperator');
+  });
+
+  it('reports non-existent-operator for x =+ 1 (unary plus adjacent to assign)', () => {
+    const source = 'let x = 0; x =+ 1;';
+    const diagnostics = scan('non-existent-operator', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('nonExistentOperator');
+  });
+
+  it('reports non-existent-operator for x =! y (logical not adjacent to assign)', () => {
+    const source = 'let x = false; let y = true; x =! y;';
+    const diagnostics = scan('non-existent-operator', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('nonExistentOperator');
+  });
+
+  it('does not report non-existent-operator for x = -1 (space before unary)', () => {
+    const source = 'let x = 0; x = -1;';
+    const diagnostics = scan('non-existent-operator', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report non-existent-operator for x -= 1 (compound assignment)', () => {
+    const source = 'let x = 0; x -= 1;';
+    const diagnostics = scan('non-existent-operator', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report non-existent-operator for plain assignment x = y', () => {
+    const source = 'let x = 0; let y = 1; x = y;';
+    const diagnostics = scan('non-existent-operator', source);
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -101,6 +101,7 @@ describe('sonarjs plugin shape', () => {
       'no-redundant-boolean',
       'comma-or-logical-or-case',
       'no-duplicate-in-composite',
+      'non-existent-operator',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -109,6 +110,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-redundant-boolean']).toBe('object');
     expect(typeof plugin.rules['comma-or-logical-or-case']).toBe('object');
     expect(typeof plugin.rules['no-duplicate-in-composite']).toBe('object');
+    expect(typeof plugin.rules['non-existent-operator']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -117,6 +119,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-boolean']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/comma-or-logical-or-case']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-in-composite']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/non-existent-operator']).toBe('error');
   });
 });
 
@@ -171,6 +174,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     });
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('duplicateType');
+  });
+
+  it('reports non-existent-operator through the adapter', () => {
+    const source = 'let x = 0; x =- 1;';
+    const reports = runRule('non-existent-operator', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('nonExistentOperator');
   });
 });
 
@@ -239,5 +249,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-duplicate-in-composite)');
+  });
+
+  it('reports non-existent-operator through the CLI', () => {
+    const source = 'let x = 0; x =- 1;';
+    const result = runOxlint('non-existent-operator', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(non-existent-operator)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13390,19 +13390,19 @@
       },
       {
         "name": "non-existent-operator",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule non-existent-operator (Sonar key S2757). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S2757. Detects the adjacent '=-', '=+', '=!' typo heuristic via a source-byte adjacency check (no whitespace between the plain '=' and the unary operator). Implemented in Rust via visit_assignment_expression; never read upstream source, fixtures, tests, or messages."
       },
       {
         "name": "non-number-in-arithmetic-expression",


### PR DESCRIPTION
## Summary
Clean-room port of **`non-existent-operator`** (Sonar key S2757). Flags the `=-` / `=+` / `=!` typo — a plain `=` written immediately adjacent (no whitespace) to a unary `-`/`+`/`!`, which resembles `-=`/`+=`/`!=`. `x = -1` (spaced) is intentional and **not** flagged; the rule keys on source-byte adjacency before the RHS unary operator. Adds a `visit_assignment_expression` hook; `type: problem`.

## Tests
Rust unit tests (`=-`, `=+`, `=!`, spaced `= -1`, compound `-=`, plain `= y`), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(non-existent-operator)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783971674&installation_id=136613492&pr_number=140&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F140&signature=1778d0e04322426aa4ad3e892b2e959810866ad4652a6f96d8f9be5c18cb3066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->