### PR TITLE
fix(regexp): enforce minAlternatives=3 threshold for prefer-character-class

### DIFF
--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -48,6 +48,11 @@ pub(crate) struct GroupState {
     /// `true` while every completed single-literal alternative observed so
     /// far has appeared in ascending byte order. `sort-alternatives`.
     pub(crate) alts_in_order: bool,
+    /// Number of `|` separators seen so far in this group. Total number of
+    /// alternatives = `pipe_count + 1`. Used by `prefer-character-class` to
+    /// enforce the upstream default of `minAlternatives: 3` (i.e. at least
+    /// two `|` separators).
+    pub(crate) pipe_count: u32,
 }
 
 impl GroupState {
@@ -66,6 +71,7 @@ impl GroupState {
             all_alts_single_literal: true,
             prev_alt_first_byte: 0,
             alts_in_order: true,
+            pipe_count: 0,
         }
     }
 
@@ -90,6 +96,7 @@ impl GroupState {
             all_alts_single_literal: true,
             prev_alt_first_byte: 0,
             alts_in_order: true,
+            pipe_count: 0,
         }
     }
 }
@@ -377,17 +384,24 @@ impl PatternAnalysis {
                         // `prefer-character-class`. We tracked per-alt
                         // single-literal shape during scanning; combined with
                         // the final-alt check here, an alternation with at
-                        // least one `|` and every alt being a bare
-                        // alphanumeric letter/digit is reported.
+                        // least two `|` separators (i.e. ≥ 3 total alts) and
+                        // every alt being a bare alphanumeric letter/digit is
+                        // reported. The threshold of 3 matches upstream's
+                        // default `minAlternatives` option.
+                        //
+                        // `sort-alternatives` shares the same single-literal
+                        // tracking but fires for ≥ 2 alts (pipe_count ≥ 1).
                         if group.is_non_capturing && group.seen_pipe {
                             let alt_len = index - group.current_alt_start;
                             let final_alt_simple = alt_len == 1
                                 && bytes[group.current_alt_start].is_ascii_alphanumeric();
                             if group.all_alts_single_literal && final_alt_simple {
-                                self.has_preferable_character_class = true;
-                                // `sort-alternatives` only fires when every
-                                // alt was a single ASCII alphanumeric AND at
-                                // least one transition violated ascending order.
+                                // `prefer-character-class` requires ≥ 3 alternatives.
+                                if group.pipe_count >= 2 {
+                                    self.has_preferable_character_class = true;
+                                }
+                                // `sort-alternatives` fires for ≥ 2 alternatives
+                                // when at least one transition violated ascending order.
                                 let final_byte = bytes[group.current_alt_start];
                                 let mut alts_in_order = group.alts_in_order;
                                 if group.prev_alt_first_byte != 0
@@ -456,6 +470,7 @@ impl PatternAnalysis {
                             group.prev_alt_first_byte = alt_first_byte;
                         }
                         group.seen_pipe = true;
+                        group.pipe_count = group.pipe_count.saturating_add(1);
                         group.current_has_content = false;
                         group.current_alt_atom_count = 0;
                         group.last_atom_was_lookaround = false;

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -206,11 +206,8 @@ mod prefer_character_class {
     use super::*;
 
     #[test]
-    fn reports_non_cap_alternation_of_single_literals() {
-        assert_eq!(
-            rule_ids_for("const a = /(?:a|b)/u;", "prefer-character-class").as_slice(),
-            &["unexpected"]
-        );
+    fn reports_non_cap_alternation_with_three_or_more_single_literals() {
+        // Upstream default minAlternatives is 3; needs ≥ 3 single-char alts.
         assert_eq!(
             rule_ids_for("const a = /(?:a|b|c)/u;", "prefer-character-class").as_slice(),
             &["unexpected"]
@@ -219,6 +216,20 @@ mod prefer_character_class {
         assert_eq!(
             rule_ids_for("const a = /(?:a|1|b)/u;", "prefer-character-class").as_slice(),
             &["unexpected"]
+        );
+        // Four alternatives.
+        assert_eq!(
+            rule_ids_for("const a = /(?:a|b|c|d)/u;", "prefer-character-class").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_two_alt_non_cap_group() {
+        // Exactly 2 alternatives: valid per upstream (minAlternatives default 3).
+        assert!(
+            rule_ids_for("const a = /(?:a|b)/u;", "prefer-character-class").is_empty(),
+            "/(?:a|b)/ must not be flagged (only 2 alternatives)"
         );
     }
 

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -21,10 +21,6 @@
       "level": "off",
       "reason": "Flags replaceAll on an unknown receiver where upstream only reports a known string receiver."
     },
-    "prefer-character-class": {
-      "level": "off",
-      "reason": "Flags single-character alternations like /(?:a|b)/ that upstream allows by default."
-    },
     "prefer-named-replacement": {
       "level": "off",
       "reason": "Flags $1 referring to an unnamed group, which has no named-replacement alternative."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -126,6 +126,7 @@ const validCases = [
   ['prefer-character-class', 'multi-byte alt', 'const re = /(?:a|bc)/u;\n'],
   ['prefer-character-class', 'escape alt', 'const re = /(?:a|\\d)/u;\n'],
   ['prefer-character-class', 'no alternation', 'const re = /(?:a)/u;\n'],
+  ['prefer-character-class', 'two alternatives below threshold', 'const re = /(?:a|b)/u;\n'],
   // sort-alternatives
   ['sort-alternatives', 'already sorted', 'const re = /(?:a|b|c)/u;\n'],
   ['sort-alternatives', 'multi-byte alt', 'const re = /(?:bc|a)/u;\n'],
@@ -380,7 +381,6 @@ const invalidCases = [
     ['unexpected'],
   ],
   // prefer-character-class
-  ['prefer-character-class', 'two letters', 'const re = /(?:a|b)/u;\n', ['unexpected']],
   [
     'prefer-character-class',
     'mixed letters and digits',


### PR DESCRIPTION
## Summary

- **Root cause**: The `prefer-character-class` check in `pattern.rs` fired for any non-capturing group with ≥ 2 single-literal alternatives (e.g. `/(?:a|b)/`). Upstream `eslint-plugin-regexp` defaults `minAlternatives` to **3**, requiring at least 3 character alternatives before reporting.
- **Fix**: Added `pipe_count: u32` to `GroupState` (incremented on each `|` separator). In the `)` close handler, `has_preferable_character_class` is now guarded by `pipe_count >= 2` (i.e. ≥ 3 total alternatives). The `sort-alternatives` rule was separated from this block so it continues to fire at ≥ 2 alternatives unchanged.
- **parity.json**: Removed the `prefer-character-class` quarantine entry (promoted from `off` to default `valid` level).

## Files changed

- `crates/regexp/src/pattern.rs` — added `pipe_count` field to `GroupState`, increment on `|`, gate `prefer-character-class` on `pipe_count >= 2`, separate `sort-alternatives` threshold
- `crates/regexp/src/tests.rs` — updated tests: 2-alt `/(?:a|b)/` now valid, regression test for 2-alt threshold
- `npm/regexp/test/parity.json` — removed quarantine entry
- `npm/regexp/test/plugin.test.mjs` — moved `/(?:a|b)/` from `invalidCases` to `validCases`; added "two alternatives below threshold" valid case

## Test plan

- [ ] `/(?:a|b)/` → no diagnostic (2 alts, below threshold)
- [ ] `/(?:a|b|c)/` → reports `prefer-character-class` (3 alts, at threshold)
- [ ] `/(?:a|1|b)/` → reports `prefer-character-class` (3 alts, mixed)
- [ ] `/(?:b|a)/` → still reports `sort-alternatives` (2 alts, out of order)
- [ ] `/(?:a|bc)/` → no diagnostic (multi-byte alt)
- [ ] `/(?:a|b|c\b)/` → no diagnostic (escape in alt)
- [ ] `/(a|b|c)/` → no diagnostic (capturing group, not non-capturing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783972180&installation_id=136613492&pr_number=142&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F142&signature=041ed8a39098bd256d7a6d4aa818cf1714abc48347013eb128f7768f540d9783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->