### PR TITLE
port(sonarjs): port no-identical-conditions (S1862)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 8] = [
+pub const RULE_NAMES: [&str; 9] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -31,6 +31,7 @@ pub const RULE_NAMES: [&str; 8] = [
     "comma-or-logical-or-case",
     "no-duplicate-in-composite",
     "non-existent-operator",
+    "no-identical-conditions",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -62,6 +63,7 @@ pub fn scan_sonarjs(
         template_literal_depth: 0,
         switch_depth: 0,
         conditional_depth: 0,
+        if_chain_seen: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -4,6 +4,7 @@
 mod comma_or_logical_or_case;
 mod no_collapsible_if;
 mod no_duplicate_in_composite;
+mod no_identical_conditions;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_identical_conditions.rs
+++ b/crates/sonarjs/src/rules/no_identical_conditions.rs
@@ -1,0 +1,76 @@
+//! Rule `no-identical-conditions` (SonarJS key S1862).
+//!
+//! Clean-room port. Within a single `if / else if / else if …` chain, two
+//! branches must not test the same condition. A later branch whose condition
+//! is textually identical to an earlier one in the same chain is dead code
+//! because the first matching branch will always be taken first.
+//!
+//! Scope is strictly one chain: the head `if` plus any `else if` branches
+//! that follow it directly. A nested `if` inside a branch body is a separate
+//! chain and is evaluated independently. Only the later (duplicate) condition
+//! span is reported; the first occurrence is left alone.
+//!
+//! Conditions are compared by their source text (via `Scanner::text`), which
+//! is the same strategy used by `no-duplicate-in-composite`. This is a
+//! best-effort syntactic check; semantically equivalent but textually distinct
+//! conditions are not detected.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{IfStatement, Statement};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-identical-conditions";
+
+impl<'a> Scanner<'a> {
+    pub(crate) fn check_no_identical_conditions(&mut self, if_stmt: &IfStatement<'a>) {
+        // Skip else-if nodes that were already processed as part of their head's chain.
+        if self.if_chain_seen.contains(&if_stmt.span.start) {
+            return;
+        }
+
+        // Treat this node as the chain head.  Walk the chain following
+        // `alternate` while it is itself an IfStatement (i.e. `else if`).
+        //
+        // Phase 1 — immutable pass: collect (condition_text, condition_span)
+        // pairs for every branch in the chain, and record the span.start of
+        // every else-if node so they can be skipped later.
+        let mut conditions: SmallVec<[(&'a str, Span); 8]> = SmallVec::new();
+        let mut else_if_starts: SmallVec<[u32; 8]> = SmallVec::new();
+
+        conditions.push((self.text(if_stmt.test.span()), if_stmt.test.span()));
+
+        let mut alternate = if_stmt.alternate.as_ref();
+        while let Some(Statement::IfStatement(next)) = alternate {
+            else_if_starts.push(next.span.start);
+            conditions.push((self.text(next.test.span()), next.test.span()));
+            alternate = next.alternate.as_ref();
+        }
+
+        // Phase 2 — mutable pass: record else-if starts so they are skipped
+        // when the visitor reaches them later.
+        for start in else_if_starts {
+            self.if_chain_seen.push(start);
+        }
+
+        // Phase 3 — detect duplicates and collect spans to report.
+        let mut seen_texts: SmallVec<[&'a str; 8]> = SmallVec::new();
+        let mut duplicates: SmallVec<[Span; 4]> = SmallVec::new();
+        for (text, span) in &conditions {
+            if seen_texts.contains(text) {
+                duplicates.push(*span);
+            } else {
+                seen_texts.push(*text);
+            }
+        }
+
+        // Phase 4 — report.
+        for span in duplicates {
+            self.report(RULE_NAME, "identicalConditions", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -23,6 +23,10 @@ pub(crate) struct Scanner<'a> {
     pub(crate) switch_depth: u32,
     /// Number of conditional (ternary) expressions currently open on the traversal stack.
     pub(crate) conditional_depth: u32,
+    /// Span start offsets of IfStatement nodes that are `else if` members of a
+    /// chain already processed by their head; used by `no-identical-conditions`
+    /// to avoid double-processing a chain.
+    pub(crate) if_chain_seen: SmallVec<[u32; 16]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -97,6 +101,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
         self.check_no_collapsible_if(it);
+        self.check_no_identical_conditions(it);
         walk::walk_if_statement(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -337,3 +337,51 @@ fn does_not_report_non_existent_operator_for_plain_assign_non_unary() {
     let diagnostics = scan("non-existent-operator", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_identical_condition_in_three_branch_chain() {
+    let source = "if (a) {} else if (b) {} else if (a) {}";
+    let diagnostics = scan("no-identical-conditions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-identical-conditions");
+    assert_eq!(diagnostics[0].message_id, "identicalConditions");
+}
+
+#[test]
+fn reports_identical_condition_in_two_branch_chain() {
+    let source = "if (a) {} else if (a) {}";
+    let diagnostics = scan("no-identical-conditions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalConditions");
+}
+
+#[test]
+fn does_not_report_when_else_is_a_plain_block() {
+    let source = "if (a) {} else if (b) {} else {}";
+    let diagnostics = scan("no-identical-conditions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_standalone_if_with_no_else_if() {
+    let source = "if (a) {}";
+    let diagnostics = scan("no-identical-conditions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_one_identical_condition_in_four_branch_chain() {
+    let source = "if (a) {} else if (b) {} else if (c) {} else if (b) {}";
+    let diagnostics = scan("no-identical-conditions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalConditions");
+}
+
+#[test]
+fn does_not_report_identical_condition_in_nested_separate_chain() {
+    // The inner `if (a)` is a separate chain; identical condition across
+    // different chains must NOT be reported.
+    let source = "if (a) { if (a) {} }";
+    let diagnostics = scan("no-identical-conditions", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -43,6 +43,10 @@ const messages = Object.freeze({
     nonExistentOperator:
       "Was this '=-', '=+', or '=!' meant to be a compound assignment or comparison? Add a space to clarify, or fix the operator.",
   },
+  'no-identical-conditions': {
+    identicalConditions:
+      "This branch's condition duplicates an earlier one in the same if/else-if chain, so it can never be reached.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -56,6 +60,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow duplicate type members in TypeScript union or intersection types',
   'non-existent-operator':
     "Disallow the suspicious '=-', '=+', or '=!' operator typos adjacent to a plain assignment",
+  'no-identical-conditions':
+    'Disallow duplicate conditions in the same if/else-if chain (dead branch)',
 });
 
 const ruleTypes = Object.freeze({
@@ -67,6 +73,7 @@ const ruleTypes = Object.freeze({
   'comma-or-logical-or-case': 'suggestion',
   'no-duplicate-in-composite': 'suggestion',
   'non-existent-operator': 'problem',
+  'no-identical-conditions': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -78,6 +85,7 @@ const recommendedRuleConfig = Object.freeze({
   'comma-or-logical-or-case': 'error',
   'no-duplicate-in-composite': 'error',
   'non-existent-operator': 'error',
+  'no-identical-conditions': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -11,6 +11,7 @@ const expectedRuleNames = [
   'comma-or-logical-or-case',
   'no-duplicate-in-composite',
   'non-existent-operator',
+  'no-identical-conditions',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -240,5 +241,39 @@ describe('sonarjs native API', () => {
     const source = 'let x = 0; let y = 1; x = y;';
     const diagnostics = scan('non-existent-operator', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports one identical condition in an if/else-if/else-if chain', () => {
+    const source = 'if (a) {} else if (b) {} else if (a) {}';
+    const diagnostics = scan('no-identical-conditions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-identical-conditions');
+    expect(diagnostics[0].messageId).toBe('identicalConditions');
+  });
+
+  it('reports one identical condition in a two-branch if/else-if chain', () => {
+    const source = 'if (a) {} else if (a) {}';
+    const diagnostics = scan('no-identical-conditions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalConditions');
+  });
+
+  it('does not report when the else branch is a plain block (no condition)', () => {
+    const source = 'if (a) {} else if (b) {} else {}';
+    const diagnostics = scan('no-identical-conditions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report a standalone if with no else-if', () => {
+    const source = 'if (a) {}';
+    const diagnostics = scan('no-identical-conditions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports one identical condition in a four-branch chain', () => {
+    const source = 'if (a) {} else if (b) {} else if (c) {} else if (b) {}';
+    const diagnostics = scan('no-identical-conditions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalConditions');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -102,6 +102,7 @@ describe('sonarjs plugin shape', () => {
       'comma-or-logical-or-case',
       'no-duplicate-in-composite',
       'non-existent-operator',
+      'no-identical-conditions',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -111,6 +112,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['comma-or-logical-or-case']).toBe('object');
     expect(typeof plugin.rules['no-duplicate-in-composite']).toBe('object');
     expect(typeof plugin.rules['non-existent-operator']).toBe('object');
+    expect(typeof plugin.rules['no-identical-conditions']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -120,6 +122,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/comma-or-logical-or-case']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-in-composite']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/non-existent-operator']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-identical-conditions']).toBe('error');
   });
 });
 
@@ -181,6 +184,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('non-existent-operator', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('nonExistentOperator');
+  });
+
+  it('reports no-identical-conditions through the adapter', () => {
+    const source = 'if (a) {} else if (b) {} else if (a) {}';
+    const reports = runRule('no-identical-conditions', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('identicalConditions');
   });
 });
 
@@ -259,5 +269,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(non-existent-operator)');
+  });
+
+  it('reports no-identical-conditions through the CLI', () => {
+    const source = 'if (a) {} else if (b) {} else if (a) {}';
+    const result = runOxlint('no-identical-conditions', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-identical-conditions)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12254,19 +12254,19 @@
       },
       {
         "name": "no-identical-conditions",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-identical-conditions (Sonar key S1862). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S1862. Rust core uses chain-head detection via if_chain_seen to process each if/else-if chain exactly once; conditions compared by source text; duplicate later conditions reported. No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "no-identical-expressions",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-identical-conditions`** (Sonar key S1862). Within a single `if / else if …` chain, reports a branch whose condition is textually identical to an earlier condition in the same chain (dead code). Introduces **chain-head detection** (an `if_chain_seen` set of else-if span starts) so each chain is processed exactly once and duplicates across *different* chains are not flagged. Conditions are compared by source text.

## Tests
Rust unit tests (dup across chain, adjacent dup, no-dup, single if, later dup in a long chain, nested separate chain → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-identical-conditions)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783972423&installation_id=136613492&pr_number=143&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F143&signature=344ea5b9b15b4957bb4486788a272576e5b59c891e1d77d8db878280fe126374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->