### PR TITLE
port(functional): bring functional-parameters to full upstream parity

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -6,6 +6,7 @@ use crate::FunctionContext;
 use crate::FunctionParamMeta;
 use crate::helpers::{
     assignment_target_is_member, is_identifier_expression, is_mutating_call, is_static_call,
+    property_key_name,
 };
 use crate::scanner::Scanner;
 
@@ -66,8 +67,7 @@ impl<'a> Scanner<'a> {
                 self.scan_arrow_function(function, FunctionParamMeta::default());
             }
             Expression::FunctionExpression(function) => {
-                let fn_name: Option<&'a str> =
-                    function.id.as_ref().map(|id| id.name.as_str());
+                let fn_name: Option<&'a str> = function.id.as_ref().map(|id| id.name.as_str());
                 let meta = FunctionParamMeta {
                     name: fn_name,
                     ..FunctionParamMeta::default()
@@ -85,25 +85,14 @@ impl<'a> Scanner<'a> {
                             // For function/arrow values in an object literal, thread the
                             // property name and getter/setter flag into the meta so that
                             // `ignoreIdentifierPattern` and `ignoreGettersAndSetters` work.
-                            let prop_name: Option<&'a str> =
-                                if let PropertyKey::StaticIdentifier(id) = &property.key {
-                                    Some(id.name.as_str())
-                                } else if let PropertyKey::StringLiteral(lit) = &property.key {
-                                    Some(lit.value.as_str())
-                                } else {
-                                    None
-                                };
-                            let is_getter_setter = matches!(
-                                property.kind,
-                                PropertyKind::Get | PropertyKind::Set
-                            );
+                            let prop_name = property_key_name(&property.key);
+                            let is_getter_setter =
+                                matches!(property.kind, PropertyKind::Get | PropertyKind::Set);
                             match property.value.get_inner_expression() {
                                 Expression::FunctionExpression(func) => {
-                                    let name_from_id: Option<&'a str> =
-                                        func.id.as_ref().map(|id| id.name.as_str());
-                                    let effective_name = name_from_id.or(prop_name);
+                                    let from_id = func.id.as_ref().map(|id| id.name.as_str());
                                     let meta = FunctionParamMeta {
-                                        name: effective_name,
+                                        name: from_id.or(prop_name),
                                         is_getter_setter,
                                         ..FunctionParamMeta::default()
                                     };
@@ -378,8 +367,7 @@ impl<'a> Scanner<'a> {
         if callee_is_iife_fn {
             match callee_inner {
                 Expression::FunctionExpression(func) => {
-                    let fn_name: Option<&'a str> =
-                        func.id.as_ref().map(|id| id.name.as_str());
+                    let fn_name: Option<&'a str> = func.id.as_ref().map(|id| id.name.as_str());
                     let meta = FunctionParamMeta {
                         name: fn_name,
                         is_iife: true,
@@ -401,12 +389,10 @@ impl<'a> Scanner<'a> {
         }
 
         // Determine the callee property name for ignorePrefixSelector.
-        let callee_prop_name: Option<&'a str> =
-            if let Expression::StaticMemberExpression(member) = callee_inner {
-                Some(member.property.name.as_str())
-            } else {
-                None
-            };
+        let callee_prop_name = match callee_inner {
+            Expression::StaticMemberExpression(member) => Some(member.property.name.as_str()),
+            _ => None,
+        };
 
         for argument in &call.arguments {
             // For function/arrow arguments, scan them as lambda args with the
@@ -414,8 +400,7 @@ impl<'a> Scanner<'a> {
             // double-scanning via the generic scan_argument path.
             match argument {
                 Argument::FunctionExpression(func) => {
-                    let fn_name: Option<&'a str> =
-                        func.id.as_ref().map(|id| id.name.as_str());
+                    let fn_name: Option<&'a str> = func.id.as_ref().map(|id| id.name.as_str());
                     let meta = FunctionParamMeta {
                         name: fn_name,
                         is_lambda_arg: true,

--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -3,6 +3,7 @@
 use oxc_ast::ast::*;
 
 use crate::FunctionContext;
+use crate::FunctionParamMeta;
 use crate::helpers::{
     assignment_target_is_member, is_identifier_expression, is_mutating_call, is_static_call,
 };
@@ -16,7 +17,9 @@ impl<'a> Scanner<'a> {
     ) {
         match expression.get_inner_expression() {
             Expression::Identifier(identifier) => {
-                if identifier.name == "arguments" && !self.options.allow_arguments_keyword {
+                let is_arguments = identifier.name == "arguments";
+                let allow_args = self.options.allow_arguments_keyword;
+                if is_arguments && !allow_args {
                     self.report(
                         "functional-parameters",
                         "arguments",
@@ -59,8 +62,18 @@ impl<'a> Scanner<'a> {
                     expression.span,
                 );
             }
-            Expression::ArrowFunctionExpression(function) => self.scan_arrow_function(function),
-            Expression::FunctionExpression(function) => self.scan_function(function),
+            Expression::ArrowFunctionExpression(function) => {
+                self.scan_arrow_function(function, FunctionParamMeta::default());
+            }
+            Expression::FunctionExpression(function) => {
+                let fn_name: Option<&'a str> =
+                    function.id.as_ref().map(|id| id.name.as_str());
+                let meta = FunctionParamMeta {
+                    name: fn_name,
+                    ..FunctionParamMeta::default()
+                };
+                self.scan_function(function, meta);
+            }
             Expression::ClassExpression(class) => self.scan_class(class, context),
             Expression::ObjectExpression(expression) => {
                 for property in &expression.properties {
@@ -69,7 +82,45 @@ impl<'a> Scanner<'a> {
                             if property.computed {
                                 self.scan_property_key(&property.key, context);
                             }
-                            self.scan_expression(&property.value, context);
+                            // For function/arrow values in an object literal, thread the
+                            // property name and getter/setter flag into the meta so that
+                            // `ignoreIdentifierPattern` and `ignoreGettersAndSetters` work.
+                            let prop_name: Option<&'a str> =
+                                if let PropertyKey::StaticIdentifier(id) = &property.key {
+                                    Some(id.name.as_str())
+                                } else if let PropertyKey::StringLiteral(lit) = &property.key {
+                                    Some(lit.value.as_str())
+                                } else {
+                                    None
+                                };
+                            let is_getter_setter = matches!(
+                                property.kind,
+                                PropertyKind::Get | PropertyKind::Set
+                            );
+                            match property.value.get_inner_expression() {
+                                Expression::FunctionExpression(func) => {
+                                    let name_from_id: Option<&'a str> =
+                                        func.id.as_ref().map(|id| id.name.as_str());
+                                    let effective_name = name_from_id.or(prop_name);
+                                    let meta = FunctionParamMeta {
+                                        name: effective_name,
+                                        is_getter_setter,
+                                        ..FunctionParamMeta::default()
+                                    };
+                                    self.scan_function(func, meta);
+                                }
+                                Expression::ArrowFunctionExpression(func) => {
+                                    let meta = FunctionParamMeta {
+                                        name: prop_name,
+                                        is_getter_setter,
+                                        ..FunctionParamMeta::default()
+                                    };
+                                    self.scan_arrow_function(func, meta);
+                                }
+                                _ => {
+                                    self.scan_expression(&property.value, context);
+                                }
+                            }
                         }
                         ObjectPropertyKind::SpreadProperty(spread) => {
                             self.scan_expression(&spread.argument, context);
@@ -152,9 +203,11 @@ impl<'a> Scanner<'a> {
                 self.scan_computed_member_expression(member, context);
             }
             ArrayExpressionElement::ArrowFunctionExpression(function) => {
-                self.scan_arrow_function(function)
+                self.scan_arrow_function(function, FunctionParamMeta::default());
             }
-            ArrayExpressionElement::FunctionExpression(function) => self.scan_function(function),
+            ArrayExpressionElement::FunctionExpression(function) => {
+                self.scan_function(function, FunctionParamMeta::default());
+            }
             ArrayExpressionElement::ArrayExpression(expression) => {
                 for element in &expression.elements {
                     self.scan_array_element(element, context);
@@ -174,6 +227,18 @@ impl<'a> Scanner<'a> {
     pub(crate) fn scan_argument(&mut self, argument: &'a Argument<'a>, context: FunctionContext) {
         match argument {
             Argument::SpreadElement(spread) => self.scan_expression(&spread.argument, context),
+            Argument::Identifier(identifier) => {
+                let is_arguments = identifier.name == "arguments";
+                let allow_args = self.options.allow_arguments_keyword;
+                if is_arguments && !allow_args {
+                    self.report(
+                        "functional-parameters",
+                        "arguments",
+                        "Unexpected use of `arguments`. Use regular function arguments instead.",
+                        identifier.span,
+                    );
+                }
+            }
             Argument::CallExpression(call) => self.scan_call_expression(call, context),
             Argument::StaticMemberExpression(member) => {
                 self.scan_static_member_expression(member, context);
@@ -181,8 +246,12 @@ impl<'a> Scanner<'a> {
             Argument::ComputedMemberExpression(member) => {
                 self.scan_computed_member_expression(member, context);
             }
-            Argument::ArrowFunctionExpression(function) => self.scan_arrow_function(function),
-            Argument::FunctionExpression(function) => self.scan_function(function),
+            Argument::ArrowFunctionExpression(function) => {
+                self.scan_arrow_function(function, FunctionParamMeta::default());
+            }
+            Argument::FunctionExpression(function) => {
+                self.scan_function(function, FunctionParamMeta::default());
+            }
             Argument::ClassExpression(class) => self.scan_class(class, context),
             Argument::ArrayExpression(expression) => {
                 for element in &expression.elements {
@@ -299,9 +368,74 @@ impl<'a> Scanner<'a> {
                 call.span,
             );
         }
-        self.scan_expression(&call.callee, context);
+
+        // Determine if the callee itself is a function (IIFE).
+        let callee_inner = call.callee.get_inner_expression();
+        let callee_is_iife_fn = matches!(
+            callee_inner,
+            Expression::FunctionExpression(_) | Expression::ArrowFunctionExpression(_)
+        );
+        if callee_is_iife_fn {
+            match callee_inner {
+                Expression::FunctionExpression(func) => {
+                    let fn_name: Option<&'a str> =
+                        func.id.as_ref().map(|id| id.name.as_str());
+                    let meta = FunctionParamMeta {
+                        name: fn_name,
+                        is_iife: true,
+                        ..FunctionParamMeta::default()
+                    };
+                    self.scan_function(func, meta);
+                }
+                Expression::ArrowFunctionExpression(func) => {
+                    let meta = FunctionParamMeta {
+                        is_iife: true,
+                        ..FunctionParamMeta::default()
+                    };
+                    self.scan_arrow_function(func, meta);
+                }
+                _ => {}
+            }
+        } else {
+            self.scan_expression(&call.callee, context);
+        }
+
+        // Determine the callee property name for ignorePrefixSelector.
+        let callee_prop_name: Option<&'a str> =
+            if let Expression::StaticMemberExpression(member) = callee_inner {
+                Some(member.property.name.as_str())
+            } else {
+                None
+            };
+
         for argument in &call.arguments {
-            self.scan_argument(argument, context);
+            // For function/arrow arguments, scan them as lambda args with the
+            // enclosing call property set (for ignorePrefixSelector). This avoids
+            // double-scanning via the generic scan_argument path.
+            match argument {
+                Argument::FunctionExpression(func) => {
+                    let fn_name: Option<&'a str> =
+                        func.id.as_ref().map(|id| id.name.as_str());
+                    let meta = FunctionParamMeta {
+                        name: fn_name,
+                        is_lambda_arg: true,
+                        enclosing_call_property: callee_prop_name,
+                        ..FunctionParamMeta::default()
+                    };
+                    self.scan_function(func, meta);
+                }
+                Argument::ArrowFunctionExpression(func) => {
+                    let meta = FunctionParamMeta {
+                        is_lambda_arg: true,
+                        enclosing_call_property: callee_prop_name,
+                        ..FunctionParamMeta::default()
+                    };
+                    self.scan_arrow_function(func, meta);
+                }
+                _ => {
+                    self.scan_argument(argument, context);
+                }
+            }
         }
     }
 

--- a/crates/functional/src/helpers.rs
+++ b/crates/functional/src/helpers.rs
@@ -7,6 +7,16 @@
 
 use oxc_ast::ast::*;
 
+/// The static name of a property/method key (identifier or string literal),
+/// used for `ignoreIdentifierPattern` matching on object/class members.
+pub(crate) fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
 pub(crate) fn assignment_target_is_member(target: &AssignmentTarget<'_>) -> bool {
     matches!(
         target,

--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -58,6 +58,18 @@ pub struct Diagnostic {
     pub loc: DiagnosticLoc,
 }
 
+/// Whether and how to enforce parameter counts for functional-parameters.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+pub enum EnforceParameterCount {
+    /// Do not enforce parameter count.
+    Off,
+    /// Every function must have at least one parameter.
+    #[default]
+    AtLeastOne,
+    /// Every function must have exactly one parameter.
+    ExactlyOne,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FunctionalOptions {
     pub rule_names: SmallVec<[CompactString; 20]>,
@@ -72,6 +84,17 @@ pub struct FunctionalOptions {
     pub ignore_if_readonly_wrapped: bool,
     pub ignore_identifier_pattern: SmallVec<[CompactString; 4]>,
     pub ignore_code_pattern: SmallVec<[CompactString; 4]>,
+    /// Whether/how to enforce parameter counts (default: AtLeastOne).
+    pub enforce_parameter_count: EnforceParameterCount,
+    /// When true, IIFEs are exempt from the parameter count check (default: true).
+    pub enforce_count_ignore_iife: bool,
+    /// When true, getters and setters are exempt from the parameter count check (default: true).
+    pub enforce_count_ignore_getters_setters: bool,
+    /// When true, lambda expressions (functions passed as arguments) are exempt (default: false).
+    pub enforce_count_ignore_lambda: bool,
+    /// Extracted method names from `ignorePrefixSelector` patterns of the form
+    /// `CallExpression[callee.property.name='NAME']`.
+    pub ignore_prefix_selector_names: SmallVec<[CompactString; 4]>,
 }
 
 impl Default for FunctionalOptions {
@@ -92,6 +115,11 @@ impl Default for FunctionalOptions {
             ignore_if_readonly_wrapped: false,
             ignore_identifier_pattern: SmallVec::new(),
             ignore_code_pattern: SmallVec::new(),
+            enforce_parameter_count: EnforceParameterCount::AtLeastOne,
+            enforce_count_ignore_iife: true,
+            enforce_count_ignore_getters_setters: true,
+            enforce_count_ignore_lambda: false,
+            ignore_prefix_selector_names: SmallVec::new(),
         }
     }
 }
@@ -142,7 +170,24 @@ impl LineIndex {
     }
 }
 
-#[derive(Clone, Copy)]
+/// Metadata threaded into `scan_function`/`scan_arrow_function` so that
+/// `scan_function_parameters` can apply the correct `functional-parameters`
+/// ignore/count logic without a second traversal pass.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct FunctionParamMeta<'a> {
+    /// The declared name of the function, if any (for `ignoreIdentifierPattern`).
+    pub name: Option<&'a str>,
+    /// True when this function is the callee of a call expression (IIFE).
+    pub is_iife: bool,
+    /// True when this function is a getter or setter.
+    pub is_getter_setter: bool,
+    /// True when this function is passed directly as a call argument (lambda).
+    pub is_lambda_arg: bool,
+    /// The `callee.property.name` of the enclosing call when the function is a
+    /// lambda arg, used for `ignorePrefixSelector` matching.
+    pub enclosing_call_property: Option<&'a str>,
+}
+
 pub(crate) struct FunctionContext {
     pub(crate) in_async_function: bool,
     /// True when the current statement is inside the `try` block of a

--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -188,6 +188,7 @@ pub(crate) struct FunctionParamMeta<'a> {
     pub enclosing_call_property: Option<&'a str>,
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct FunctionContext {
     pub(crate) in_async_function: bool,
     /// True when the current statement is inside the `try` block of a

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -150,8 +150,8 @@ impl<'a> Scanner<'a> {
 
                 if !skip_count {
                     // Upstream counts node.params.length which includes the rest element.
-                    let param_count = params.items.len()
-                        + if params.rest.is_some() { 1 } else { 0 };
+                    let param_count =
+                        params.items.len() + if params.rest.is_some() { 1 } else { 0 };
                     if enforce == EnforceParameterCount::AtLeastOne && param_count == 0 {
                         self.report(
                             "functional-parameters",

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -11,7 +11,7 @@ use oxc_ast::ast::*;
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
 
-use crate::helpers::is_mutable_type;
+use crate::helpers::{is_mutable_type, property_key_name};
 use crate::{
     Diagnostic, EnforceParameterCount, FunctionContext, FunctionParamMeta, FunctionalOptions,
     LineIndex,
@@ -305,18 +305,8 @@ impl<'a> Scanner<'a> {
                         method.kind,
                         MethodDefinitionKind::Get | MethodDefinitionKind::Set
                     );
-                    // Extract the static identifier name from the method key so that
-                    // `ignoreIdentifierPattern` can match it.
-                    let method_name: Option<&'a str> =
-                        if let PropertyKey::StaticIdentifier(id) = &method.key {
-                            Some(id.name.as_str())
-                        } else if let PropertyKey::StringLiteral(lit) = &method.key {
-                            Some(lit.value.as_str())
-                        } else {
-                            None
-                        };
                     let meta = FunctionParamMeta {
-                        name: method_name,
+                        name: property_key_name(&method.key),
                         is_getter_setter,
                         ..FunctionParamMeta::default()
                     };

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -12,7 +12,10 @@ use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
 
 use crate::helpers::is_mutable_type;
-use crate::{Diagnostic, FunctionContext, FunctionalOptions, LineIndex};
+use crate::{
+    Diagnostic, EnforceParameterCount, FunctionContext, FunctionParamMeta, FunctionalOptions,
+    LineIndex,
+};
 
 pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,
@@ -54,8 +57,12 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    pub(crate) fn scan_function(&mut self, function: &'a Function<'a>) {
-        self.scan_function_parameters(&function.params, function.span);
+    pub(crate) fn scan_function(
+        &mut self,
+        function: &'a Function<'a>,
+        meta: FunctionParamMeta<'a>,
+    ) {
+        self.scan_function_parameters(&function.params, function.span, meta);
         if let Some(return_type) = &function.return_type {
             self.scan_return_type(return_type);
         }
@@ -69,8 +76,12 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    pub(crate) fn scan_arrow_function(&mut self, function: &'a ArrowFunctionExpression<'a>) {
-        self.scan_function_parameters(&function.params, function.span);
+    pub(crate) fn scan_arrow_function(
+        &mut self,
+        function: &'a ArrowFunctionExpression<'a>,
+        meta: FunctionParamMeta<'a>,
+    ) {
+        self.scan_function_parameters(&function.params, function.span, meta);
         self.check_prefer_tacit(function);
         if let Some(return_type) = &function.return_type {
             self.scan_return_type(return_type);
@@ -83,25 +94,83 @@ impl<'a> Scanner<'a> {
         self.scan_function_body(&function.body, context);
     }
 
-    fn scan_function_parameters(&mut self, params: &'a FormalParameters<'a>, span: Span) {
-        if params.items.is_empty() && params.rest.is_none() {
-            self.report(
-                "functional-parameters",
-                "paramCountAtLeastOne",
-                "Functions must have at least one parameter.",
-                span,
-            );
+    fn function_is_ignored_by_prefix_selector(&self, meta: &FunctionParamMeta<'a>) -> bool {
+        if self.options.ignore_prefix_selector_names.is_empty() {
+            return false;
         }
-        if let Some(rest) = &params.rest
-            && !self.options.allow_rest_parameter
-        {
-            self.report(
-                "functional-parameters",
-                "restParam",
-                "Unexpected rest parameter. Use a regular parameter of type array instead.",
-                rest.span,
-            );
+        let prop = match meta.enclosing_call_property {
+            Some(p) => p,
+            None => return false,
+        };
+        for name in &self.options.ignore_prefix_selector_names {
+            if name == prop {
+                return true;
+            }
         }
+        false
+    }
+
+    fn scan_function_parameters(
+        &mut self,
+        params: &'a FormalParameters<'a>,
+        span: Span,
+        meta: FunctionParamMeta<'a>,
+    ) {
+        // Check ignoreIdentifierPattern — if the function name matches, skip all
+        // functional-parameters checks for this function.
+        let name_is_ignored = match meta.name {
+            Some(name) => self.matches_ignore_identifier(name),
+            None => false,
+        };
+        let prefix_selector_ignored = self.function_is_ignored_by_prefix_selector(&meta);
+        let is_ignored = name_is_ignored || prefix_selector_ignored;
+
+        if !is_ignored {
+            if let Some(rest) = &params.rest {
+                let allow_rest = self.options.allow_rest_parameter;
+                if !allow_rest {
+                    self.report(
+                        "functional-parameters",
+                        "restParam",
+                        "Unexpected rest parameter. Use a regular parameter of type array instead.",
+                        rest.span,
+                    );
+                }
+            }
+
+            // Parameter count enforcement.
+            let enforce = self.options.enforce_parameter_count;
+            if enforce != EnforceParameterCount::Off {
+                // Determine whether to skip the count check.
+                let skip_iife = meta.is_iife && self.options.enforce_count_ignore_iife;
+                let skip_getter_setter =
+                    meta.is_getter_setter && self.options.enforce_count_ignore_getters_setters;
+                let skip_lambda = meta.is_lambda_arg && self.options.enforce_count_ignore_lambda;
+                let skip_count = skip_iife || skip_getter_setter || skip_lambda;
+
+                if !skip_count {
+                    // Upstream counts node.params.length which includes the rest element.
+                    let param_count = params.items.len()
+                        + if params.rest.is_some() { 1 } else { 0 };
+                    if enforce == EnforceParameterCount::AtLeastOne && param_count == 0 {
+                        self.report(
+                            "functional-parameters",
+                            "paramCountAtLeastOne",
+                            "Functions must have at least one parameter.",
+                            span,
+                        );
+                    } else if enforce == EnforceParameterCount::ExactlyOne && param_count != 1 {
+                        self.report(
+                            "functional-parameters",
+                            "paramCountExactlyOne",
+                            "Functions must have exactly one parameter.",
+                            span,
+                        );
+                    }
+                }
+            }
+        }
+
         for param in &params.items {
             if let Some(type_annotation) = &param.type_annotation {
                 self.scan_type(&type_annotation.type_annotation);
@@ -231,7 +300,28 @@ impl<'a> Scanner<'a> {
         for element in &class.body.body {
             match element {
                 ClassElement::StaticBlock(block) => self.scan_statement_list(&block.body, context),
-                ClassElement::MethodDefinition(method) => self.scan_function(&method.value),
+                ClassElement::MethodDefinition(method) => {
+                    let is_getter_setter = matches!(
+                        method.kind,
+                        MethodDefinitionKind::Get | MethodDefinitionKind::Set
+                    );
+                    // Extract the static identifier name from the method key so that
+                    // `ignoreIdentifierPattern` can match it.
+                    let method_name: Option<&'a str> =
+                        if let PropertyKey::StaticIdentifier(id) = &method.key {
+                            Some(id.name.as_str())
+                        } else if let PropertyKey::StringLiteral(lit) = &method.key {
+                            Some(lit.value.as_str())
+                        } else {
+                            None
+                        };
+                    let meta = FunctionParamMeta {
+                        name: method_name,
+                        is_getter_setter,
+                        ..FunctionParamMeta::default()
+                    };
+                    self.scan_function(&method.value, meta);
+                }
                 ClassElement::PropertyDefinition(property) => {
                     if let Some(type_annotation) = &property.type_annotation {
                         self.scan_type(&type_annotation.type_annotation);

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -3,6 +3,7 @@
 use oxc_ast::ast::*;
 
 use crate::FunctionContext;
+use crate::FunctionParamMeta;
 use crate::helpers::is_mutable_type;
 use crate::scanner::Scanner;
 
@@ -175,7 +176,14 @@ impl<'a> Scanner<'a> {
             Statement::VariableDeclaration(declaration) => {
                 self.scan_variable_declaration(declaration, context, false);
             }
-            Statement::FunctionDeclaration(function) => self.scan_function(function),
+            Statement::FunctionDeclaration(function) => {
+                let fn_name: Option<&'a str> = function.id.as_ref().map(|id| id.name.as_str());
+                let meta = FunctionParamMeta {
+                    name: fn_name,
+                    ..FunctionParamMeta::default()
+                };
+                self.scan_function(function, meta);
+            }
             Statement::ClassDeclaration(class) => self.scan_class(class, context),
             Statement::TSTypeAliasDeclaration(declaration) => {
                 self.scan_type_alias_declaration(declaration);
@@ -190,7 +198,13 @@ impl<'a> Scanner<'a> {
             }
             Statement::ExportDefaultDeclaration(declaration) => match &declaration.declaration {
                 ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
-                    self.scan_function(function)
+                    let fn_name: Option<&'a str> =
+                        function.id.as_ref().map(|id| id.name.as_str());
+                    let meta = FunctionParamMeta {
+                        name: fn_name,
+                        ..FunctionParamMeta::default()
+                    };
+                    self.scan_function(function, meta);
                 }
                 ExportDefaultDeclarationKind::ClassDeclaration(class) => {
                     self.scan_class(class, context)
@@ -210,7 +224,14 @@ impl<'a> Scanner<'a> {
             Declaration::VariableDeclaration(declaration) => {
                 self.scan_variable_declaration(declaration, context, false);
             }
-            Declaration::FunctionDeclaration(function) => self.scan_function(function),
+            Declaration::FunctionDeclaration(function) => {
+                let fn_name: Option<&'a str> = function.id.as_ref().map(|id| id.name.as_str());
+                let meta = FunctionParamMeta {
+                    name: fn_name,
+                    ..FunctionParamMeta::default()
+                };
+                self.scan_function(function, meta);
+            }
             Declaration::ClassDeclaration(class) => self.scan_class(class, context),
             Declaration::TSTypeAliasDeclaration(declaration) => {
                 self.scan_type_alias_declaration(declaration);

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -198,8 +198,7 @@ impl<'a> Scanner<'a> {
             }
             Statement::ExportDefaultDeclaration(declaration) => match &declaration.declaration {
                 ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
-                    let fn_name: Option<&'a str> =
-                        function.id.as_ref().map(|id| id.name.as_str());
+                    let fn_name: Option<&'a str> = function.id.as_ref().map(|id| id.name.as_str());
                     let meta = FunctionParamMeta {
                         name: fn_name,
                         ..FunctionParamMeta::default()

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -1,4 +1,122 @@
-use super::{FunctionalOptions, implemented_functional_rule_names, scan_functional};
+use super::{
+    EnforceParameterCount, FunctionalOptions, implemented_functional_rule_names, scan_functional,
+};
+
+#[test]
+fn functional_parameters_rest_param() {
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        enforce_parameter_count: EnforceParameterCount::Off,
+        ..FunctionalOptions::default()
+    };
+    let count = |source: &str, opts: &FunctionalOptions| {
+        scan_functional(source, "fixture.ts", opts).len()
+    };
+
+    // Rest parameter is reported by default.
+    assert_eq!(count("function f(...args) {}", &options), 1);
+
+    // allowRestParameter suppresses the report.
+    let allow_rest = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        allow_rest_parameter: true,
+        enforce_parameter_count: EnforceParameterCount::Off,
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("function f(...args) {}", &allow_rest), 0);
+}
+
+#[test]
+fn functional_parameters_arguments_keyword() {
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        enforce_parameter_count: EnforceParameterCount::Off,
+        ..FunctionalOptions::default()
+    };
+    let count = |source: &str, opts: &FunctionalOptions| {
+        scan_functional(source, "fixture.ts", opts).len()
+    };
+
+    // `arguments` reference is reported.
+    assert_eq!(count("function f(x) { return arguments; }", &options), 1);
+
+    // allowArgumentsKeyword suppresses it.
+    let allow_args = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        allow_arguments_keyword: true,
+        enforce_parameter_count: EnforceParameterCount::Off,
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("function f(x) { return arguments; }", &allow_args), 0);
+}
+
+#[test]
+fn functional_parameters_count_at_least_one_default() {
+    // Default options: atLeastOne, ignoreIIFE=true, ignoreGettersAndSetters=true.
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let diagnostics = scan_functional("function f() {}", "fixture.ts", &options);
+    let ids: Vec<&str> = diagnostics.iter().map(|d| d.message_id).collect();
+    assert!(ids.contains(&"paramCountAtLeastOne"));
+}
+
+#[test]
+fn functional_parameters_iife_ignored_by_default() {
+    // By default ignoreIIFE=true, so an IIFE with no params should NOT be reported.
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let diagnostics = scan_functional("(function() {})()", "fixture.ts", &options);
+    let ids: Vec<&str> = diagnostics.iter().map(|d| d.message_id).collect();
+    assert!(!ids.contains(&"paramCountAtLeastOne"));
+}
+
+#[test]
+fn functional_parameters_iife_reported_when_ignore_iife_false() {
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        enforce_count_ignore_iife: false,
+        ..FunctionalOptions::default()
+    };
+    let diagnostics = scan_functional("(function() {})()", "fixture.ts", &options);
+    let ids: Vec<&str> = diagnostics.iter().map(|d| d.message_id).collect();
+    assert!(ids.contains(&"paramCountAtLeastOne"));
+}
+
+#[test]
+fn functional_parameters_exactly_one_two_params() {
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        enforce_parameter_count: EnforceParameterCount::ExactlyOne,
+        ..FunctionalOptions::default()
+    };
+    let diagnostics =
+        scan_functional("function f(a, b) {}", "fixture.ts", &options);
+    let ids: Vec<&str> = diagnostics.iter().map(|d| d.message_id).collect();
+    assert!(ids.contains(&"paramCountExactlyOne"));
+}
+
+#[test]
+fn functional_parameters_ignore_identifier_pattern_suppresses() {
+    let options = FunctionalOptions {
+        rule_names: ["functional-parameters".into()].into_iter().collect(),
+        ignore_identifier_pattern: ["^foo$".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    // `foo` matches the ignore pattern — rest param and count should not be reported.
+    let diagnostics =
+        scan_functional("function foo(...args) {}", "fixture.ts", &options);
+    assert!(diagnostics.is_empty());
+
+    // `bar` does NOT match — rest param is reported.
+    let diagnostics2 =
+        scan_functional("function bar(...args) {}", "fixture.ts", &options);
+    let ids: Vec<&str> = diagnostics2.iter().map(|d| d.message_id).collect();
+    assert!(ids.contains(&"restParam"));
+}
 
 #[test]
 fn no_let_honors_options() {

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -9,9 +9,8 @@ fn functional_parameters_rest_param() {
         enforce_parameter_count: EnforceParameterCount::Off,
         ..FunctionalOptions::default()
     };
-    let count = |source: &str, opts: &FunctionalOptions| {
-        scan_functional(source, "fixture.ts", opts).len()
-    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
 
     // Rest parameter is reported by default.
     assert_eq!(count("function f(...args) {}", &options), 1);
@@ -33,9 +32,8 @@ fn functional_parameters_arguments_keyword() {
         enforce_parameter_count: EnforceParameterCount::Off,
         ..FunctionalOptions::default()
     };
-    let count = |source: &str, opts: &FunctionalOptions| {
-        scan_functional(source, "fixture.ts", opts).len()
-    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
 
     // `arguments` reference is reported.
     assert_eq!(count("function f(x) { return arguments; }", &options), 1);
@@ -93,8 +91,7 @@ fn functional_parameters_exactly_one_two_params() {
         enforce_parameter_count: EnforceParameterCount::ExactlyOne,
         ..FunctionalOptions::default()
     };
-    let diagnostics =
-        scan_functional("function f(a, b) {}", "fixture.ts", &options);
+    let diagnostics = scan_functional("function f(a, b) {}", "fixture.ts", &options);
     let ids: Vec<&str> = diagnostics.iter().map(|d| d.message_id).collect();
     assert!(ids.contains(&"paramCountExactlyOne"));
 }
@@ -107,13 +104,11 @@ fn functional_parameters_ignore_identifier_pattern_suppresses() {
         ..FunctionalOptions::default()
     };
     // `foo` matches the ignore pattern — rest param and count should not be reported.
-    let diagnostics =
-        scan_functional("function foo(...args) {}", "fixture.ts", &options);
+    let diagnostics = scan_functional("function foo(...args) {}", "fixture.ts", &options);
     assert!(diagnostics.is_empty());
 
     // `bar` does NOT match — rest param is reported.
-    let diagnostics2 =
-        scan_functional("function bar(...args) {}", "fixture.ts", &options);
+    let diagnostics2 = scan_functional("function bar(...args) {}", "fixture.ts", &options);
     let ids: Vec<&str> = diagnostics2.iter().map(|d| d.message_id).collect();
     assert!(ids.contains(&"restParam"));
 }

--- a/npm/functional/api.js
+++ b/npm/functional/api.js
@@ -34,6 +34,17 @@ function normalizeOptions(options) {
     ignoreIfReadonlyWrapped: raw.ignoreIfReadonlyWrapped === true,
     ignoreIdentifierPattern: normalizeStringList(raw.ignoreIdentifierPattern),
     ignoreCodePattern: normalizeStringList(raw.ignoreCodePattern),
+    enforceParameterCount:
+      typeof raw.enforceParameterCount === 'string' ? raw.enforceParameterCount : undefined,
+    enforceCountIgnoreIife:
+      typeof raw.enforceCountIgnoreIife === 'boolean' ? raw.enforceCountIgnoreIife : undefined,
+    enforceCountIgnoreGettersSetters:
+      typeof raw.enforceCountIgnoreGettersSetters === 'boolean'
+        ? raw.enforceCountIgnoreGettersSetters
+        : undefined,
+    enforceCountIgnoreLambda:
+      typeof raw.enforceCountIgnoreLambda === 'boolean' ? raw.enforceCountIgnoreLambda : undefined,
+    ignorePrefixSelectorNames: normalizeStringList(raw.ignorePrefixSelectorNames),
   };
 }
 

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -208,6 +208,24 @@ function schemaForRule(ruleName) {
         properties: {
           allowRestParameter: { type: 'boolean' },
           allowArgumentsKeyword: { type: 'boolean' },
+          enforceParameterCount: {
+            oneOf: [
+              { type: 'boolean', enum: [false] },
+              { type: 'string', enum: ['atLeastOne', 'exactlyOne'] },
+              {
+                type: 'object',
+                properties: {
+                  count: { type: 'string', enum: ['atLeastOne', 'exactlyOne'] },
+                  ignoreIIFE: { type: 'boolean' },
+                  ignoreLambdaExpression: { type: 'boolean' },
+                  ignoreGettersAndSetters: { type: 'boolean' },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          ignoreIdentifierPattern: stringOrStringArraySchema(),
+          ignorePrefixSelector: stringOrStringArraySchema(),
         },
         additionalProperties: true,
       },
@@ -298,9 +316,90 @@ function classRuleUsesIgnorePatterns(ruleName) {
   return ruleName === 'no-classes' || ruleName === 'no-class-inheritance';
 }
 
+function normalizeEnforceParameterCount(enforceOpt) {
+  // enforceOpt can be: false | "atLeastOne" | "exactlyOne" | { count, ignoreIIFE, ... }
+  if (enforceOpt === false) {
+    return {
+      enforceParameterCount: 'off',
+      enforceCountIgnoreIife: true,
+      enforceCountIgnoreGettersSetters: true,
+      enforceCountIgnoreLambda: false,
+    };
+  }
+  if (typeof enforceOpt === 'string') {
+    return {
+      enforceParameterCount: enforceOpt,
+      enforceCountIgnoreIife: true,
+      enforceCountIgnoreGettersSetters: true,
+      enforceCountIgnoreLambda: false,
+    };
+  }
+  if (enforceOpt && typeof enforceOpt === 'object') {
+    const count = typeof enforceOpt.count === 'string' ? enforceOpt.count : 'atLeastOne';
+    const ignoreIife = typeof enforceOpt.ignoreIIFE === 'boolean' ? enforceOpt.ignoreIIFE : true;
+    const ignoreGettersSetter =
+      typeof enforceOpt.ignoreGettersAndSetters === 'boolean'
+        ? enforceOpt.ignoreGettersAndSetters
+        : true;
+    const ignoreLambda =
+      typeof enforceOpt.ignoreLambdaExpression === 'boolean'
+        ? enforceOpt.ignoreLambdaExpression
+        : false;
+    return {
+      enforceParameterCount: count,
+      enforceCountIgnoreIife: ignoreIife,
+      enforceCountIgnoreGettersSetters: ignoreGettersSetter,
+      enforceCountIgnoreLambda: ignoreLambda,
+    };
+  }
+  // Default: atLeastOne, ignoreIIFE=true, ignoreGettersAndSetters=true
+  return {
+    enforceParameterCount: 'atLeastOne',
+    enforceCountIgnoreIife: true,
+    enforceCountIgnoreGettersSetters: true,
+    enforceCountIgnoreLambda: false,
+  };
+}
+
+// Parse an ignorePrefixSelector string/string[] into an array of method-name
+// strings extracted from the narrow pattern
+// `CallExpression[callee.property.name='NAME']`.
+const PREFIX_SELECTOR_RE = /^CallExpression\[callee\.property\.name='([^']+)'\]$/;
+
+function parsePrefixSelectorNames(selectorOpt) {
+  if (!selectorOpt) return undefined;
+  const selectors = Array.isArray(selectorOpt) ? selectorOpt : [selectorOpt];
+  const names = [];
+  for (const sel of selectors) {
+    const match = typeof sel === 'string' ? PREFIX_SELECTOR_RE.exec(sel) : null;
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+  return names.length > 0 ? names : undefined;
+}
+
 function scanOptionsForRule(context, ruleName) {
   const raw = context.options?.[0];
   const options = raw && typeof raw === 'object' ? raw : {};
+
+  let enforceParameterCount;
+  let enforceCountIgnoreIife;
+  let enforceCountIgnoreGettersSetters;
+  let enforceCountIgnoreLambda;
+  let ignoreIdentifierPatternForFunctional;
+  let ignorePrefixSelectorNames;
+
+  if (ruleName === 'functional-parameters') {
+    const normalized = normalizeEnforceParameterCount(options.enforceParameterCount);
+    enforceParameterCount = normalized.enforceParameterCount;
+    enforceCountIgnoreIife = normalized.enforceCountIgnoreIife;
+    enforceCountIgnoreGettersSetters = normalized.enforceCountIgnoreGettersSetters;
+    enforceCountIgnoreLambda = normalized.enforceCountIgnoreLambda;
+    ignoreIdentifierPatternForFunctional = options.ignoreIdentifierPattern;
+    ignorePrefixSelectorNames = parsePrefixSelectorNames(options.ignorePrefixSelector);
+  }
+
   return {
     ruleNames: [ruleName],
     allowRestParameter: ruleName === 'functional-parameters' && options.allowRestParameter === true,
@@ -319,10 +418,17 @@ function scanOptionsForRule(context, ruleName) {
     ignoreIdentifierPattern:
       classRuleUsesIgnorePatterns(ruleName) || ruleName === 'no-let'
         ? options.ignoreIdentifierPattern
-        : undefined,
+        : ruleName === 'functional-parameters'
+          ? ignoreIdentifierPatternForFunctional
+          : undefined,
     ignoreCodePattern: classRuleUsesIgnorePatterns(ruleName)
       ? options.ignoreCodePattern
       : undefined,
+    enforceParameterCount,
+    enforceCountIgnoreIife,
+    enforceCountIgnoreGettersSetters,
+    enforceCountIgnoreLambda,
+    ignorePrefixSelectorNames,
   };
 }
 

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -30,6 +30,16 @@ mod napi_abi {
         pub ignore_if_readonly_wrapped: Option<bool>,
         pub ignore_identifier_pattern: Option<Vec<String>>,
         pub ignore_code_pattern: Option<Vec<String>>,
+        /// "off" | "atLeastOne" | "exactlyOne" (default: "atLeastOne")
+        pub enforce_parameter_count: Option<String>,
+        /// default: true
+        pub enforce_count_ignore_iife: Option<bool>,
+        /// default: true
+        pub enforce_count_ignore_getters_setters: Option<bool>,
+        /// default: false
+        pub enforce_count_ignore_lambda: Option<bool>,
+        /// Extracted method-name strings from ignorePrefixSelector patterns.
+        pub ignore_prefix_selector_names: Option<Vec<String>>,
     }
 
     #[napi(object)]
@@ -66,6 +76,13 @@ mod napi_abi {
     ) -> Vec<Diagnostic> {
         let options = options.unwrap_or_default();
         let default_options = core::FunctionalOptions::default();
+        let enforce_parameter_count =
+            match options.enforce_parameter_count.as_deref() {
+                Some("off") => core::EnforceParameterCount::Off,
+                Some("exactlyOne") => core::EnforceParameterCount::ExactlyOne,
+                Some("atLeastOne") | None => core::EnforceParameterCount::AtLeastOne,
+                Some(_) => default_options.enforce_parameter_count,
+            };
         let core_options = core::FunctionalOptions {
             rule_names: compact_rule_names(options.rule_names),
             allow_rest_parameter: options
@@ -99,6 +116,19 @@ mod napi_abi {
                 .unwrap_or(default_options.ignore_if_readonly_wrapped),
             ignore_identifier_pattern: compact_pattern_list(options.ignore_identifier_pattern),
             ignore_code_pattern: compact_pattern_list(options.ignore_code_pattern),
+            enforce_parameter_count,
+            enforce_count_ignore_iife: options
+                .enforce_count_ignore_iife
+                .unwrap_or(default_options.enforce_count_ignore_iife),
+            enforce_count_ignore_getters_setters: options
+                .enforce_count_ignore_getters_setters
+                .unwrap_or(default_options.enforce_count_ignore_getters_setters),
+            enforce_count_ignore_lambda: options
+                .enforce_count_ignore_lambda
+                .unwrap_or(default_options.enforce_count_ignore_lambda),
+            ignore_prefix_selector_names: compact_pattern_list(
+                options.ignore_prefix_selector_names,
+            ),
         };
 
         core::scan_functional(&source_text, &filename, &core_options)

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -76,13 +76,12 @@ mod napi_abi {
     ) -> Vec<Diagnostic> {
         let options = options.unwrap_or_default();
         let default_options = core::FunctionalOptions::default();
-        let enforce_parameter_count =
-            match options.enforce_parameter_count.as_deref() {
-                Some("off") => core::EnforceParameterCount::Off,
-                Some("exactlyOne") => core::EnforceParameterCount::ExactlyOne,
-                Some("atLeastOne") | None => core::EnforceParameterCount::AtLeastOne,
-                Some(_) => default_options.enforce_parameter_count,
-            };
+        let enforce_parameter_count = match options.enforce_parameter_count.as_deref() {
+            Some("off") => core::EnforceParameterCount::Off,
+            Some("exactlyOne") => core::EnforceParameterCount::ExactlyOne,
+            Some("atLeastOne") | None => core::EnforceParameterCount::AtLeastOne,
+            Some(_) => default_options.enforce_parameter_count,
+        };
         let core_options = core::FunctionalOptions {
             rule_names: compact_rule_names(options.rule_names),
             allow_rest_parameter: options

--- a/npm/functional/test/fixtures/functional-parameters.json
+++ b/npm/functional/test/fixtures/functional-parameters.json
@@ -217,22 +217,6 @@
           ]
         }
       ]
-    },
-    {
-      "code": "function foo(...bar: string[]) {\n  console.log(bar);\n}",
-      "typeAware": true
-    },
-    {
-      "code": "function foo(bar: string[]) {\n  console.log(arguments);\n}",
-      "typeAware": true
-    },
-    {
-      "code": "function foo(...bar: string[]) {\n  console.log(bar);\n}",
-      "typeAware": true
-    },
-    {
-      "code": "function foo(bar: string[]) {\n  console.log(arguments);\n}",
-      "typeAware": true
     }
   ],
   "invalid": [

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -30,6 +30,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
 const FULL_PARITY = new Set([
+  'functional-parameters',
   'no-class-inheritance',
   'no-classes',
   'no-let',

--- a/tools/tasks/sync-functional-tests.ts
+++ b/tools/tasks/sync-functional-tests.ts
@@ -273,6 +273,15 @@ function normalizeCase(raw: CapturedCase, isInvalid: boolean): CapturedCase | nu
     return null;
   }
 
+  // The eslint-plugin-functional "overrides" meta-feature passes options as a
+  // non-array object (`{ ...opts, overrides: [...] }`) that applies different
+  // options per file/type specifier. The syntax-only port cannot model it, so
+  // such cases are dropped (counted as dropped — not silently truncated).
+  const rawOptions: unknown = raw.options;
+  if (rawOptions !== undefined && !Array.isArray(rawOptions)) {
+    return null;
+  }
+
   const out: CapturedCase = { code: raw.code, typeAware: raw.typeAware };
 
   if (Array.isArray(raw.options) && raw.options.length > 0) {


### PR DESCRIPTION
Implements functional-parameters' full option surface: `enforceParameterCount` (false/"atLeastOne"/"exactlyOne"/object with ignoreIIFE+ignoreGettersAndSetters+ignoreLambdaExpression), `ignoreIdentifierPattern`, and `ignorePrefixSelector` (narrow `CallExpression[callee.property.name='X']` form). A `FunctionParamMeta` is threaded into scan_function/scan_arrow from each call site so the parameter checks know each function's role (IIFE / getter-setter / lambda arg / name / enclosing call) without a second pass.

Also fixes the sync tool to drop the non-array `overrides` meta-feature cases (file/type-specifier based; not modelable syntax-only) — counted, not silently truncated.

functional-parameters joins FULL_PARITY (22 valid + 8 invalid asserted); Rust unit test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783972803&installation_id=136613492&pr_number=144&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F144&signature=4f933bdf6f428c3fc2848ca99c6e22869683172477e2152017f5f62fa3d75c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->