### PR TITLE
port(sonarjs): port no-all-duplicated-branches (S3923)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 9] = [
+pub const RULE_NAMES: [&str; 10] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -32,6 +32,7 @@ pub const RULE_NAMES: [&str; 9] = [
     "no-duplicate-in-composite",
     "non-existent-operator",
     "no-identical-conditions",
+    "no-all-duplicated-branches",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -2,6 +2,7 @@
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
 mod comma_or_logical_or_case;
+mod no_all_duplicated_branches;
 mod no_collapsible_if;
 mod no_duplicate_in_composite;
 mod no_identical_conditions;

--- a/crates/sonarjs/src/rules/no_all_duplicated_branches.rs
+++ b/crates/sonarjs/src/rules/no_all_duplicated_branches.rs
@@ -1,0 +1,133 @@
+//! Rule `no-all-duplicated-branches` (SonarJS key S3923).
+//!
+//! Clean-room port. A conditional structure whose every branch has the exact
+//! same implementation is pointless: the condition has no effect on the
+//! program's output, and the duplication most likely signals a mistake.
+//!
+//! Two structures are covered:
+//!
+//! ## A. if / else-if / else chains
+//!
+//! The head `if` is reported when ALL of the following hold:
+//! - The chain has a terminal `else` (the last `alternate` is a non-`if`
+//!   `Statement`, e.g. a block or a bare statement — NOT `None` and NOT
+//!   another `IfStatement`).
+//! - The chain has at least 2 branches total (head consequent + at least one
+//!   else-if consequent or the final else body).
+//! - Every branch body (head consequent, each else-if consequent, and the
+//!   terminal else body) has identical source text, compared via
+//!   `Scanner::text(stmt.span())`.
+//!
+//! Head detection reuses the shared `if_chain_seen` set (same one used by
+//! `no-identical-conditions`): at entry each check function skips nodes whose
+//! `span.start` is already in the set, then pushes each else-if's `span.start`
+//! so it is skipped on the visitor's subsequent visit. Sharing is intentional
+//! and safe: both rules skip else-if members, and duplicate pushes are harmless.
+//!
+//! ## B. switch statements
+//!
+//! The `switch` is reported when ALL of the following hold:
+//! - The switch has a `default` case (a `SwitchCase` with `test: None`).
+//! - It has at least 2 cases total (including `default`).
+//! - Every case's body has identical source text. A case body is defined as the
+//!   source spanning `first_consequent.span().start .. last_consequent.span().end`
+//!   when the case has ≥1 consequent statement; empty-string `""` when the case
+//!   has 0 consequent statements (fall-through case).
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{IfStatement, Statement, SwitchStatement};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-all-duplicated-branches";
+
+/// Returns `true` iff `texts` has at least two elements and every element
+/// equals the first.
+fn all_equal(texts: &[&str]) -> bool {
+    texts.len() >= 2 && texts.iter().all(|t| *t == texts[0])
+}
+
+impl<'a> Scanner<'a> {
+    /// Check rule A: if / else-if / else chains.
+    pub(crate) fn check_no_all_duplicated_branches_if(&mut self, if_stmt: &IfStatement<'a>) {
+        // Skip else-if nodes already processed as part of their chain head.
+        if self.if_chain_seen.contains(&if_stmt.span.start) {
+            return;
+        }
+
+        // Phase 1 — immutable pass: walk the chain, collecting branch-body
+        // texts and the span.start of each else-if node.
+        let mut bodies: SmallVec<[&'a str; 8]> = SmallVec::new();
+        let mut else_if_starts: SmallVec<[u32; 8]> = SmallVec::new();
+
+        bodies.push(self.text(if_stmt.consequent.span()));
+
+        let mut alternate = if_stmt.alternate.as_ref();
+        let mut has_terminal_else = false;
+
+        while let Some(stmt) = alternate {
+            match stmt {
+                Statement::IfStatement(next) => {
+                    else_if_starts.push(next.span.start);
+                    bodies.push(self.text(next.consequent.span()));
+                    alternate = next.alternate.as_ref();
+                }
+                other => {
+                    // Terminal else: collect its text and mark the flag.
+                    bodies.push(self.text(other.span()));
+                    has_terminal_else = true;
+                    break;
+                }
+            }
+        }
+
+        // Phase 2 — mutable pass: record else-if starts so the visitor skips
+        // them later (shared with no-identical-conditions; harmless duplicates).
+        for start in else_if_starts {
+            self.if_chain_seen.push(start);
+        }
+
+        // Report only when there is a terminal else and every body is identical.
+        if has_terminal_else && all_equal(&bodies) {
+            self.report(RULE_NAME, "allDuplicatedBranches", if_stmt.span);
+        }
+    }
+
+    /// Check rule B: switch statements.
+    pub(crate) fn check_no_all_duplicated_branches_switch(
+        &mut self,
+        switch_stmt: &SwitchStatement<'a>,
+    ) {
+        let cases = &switch_stmt.cases;
+
+        // Need at least 2 cases and a default.
+        if cases.len() < 2 {
+            return;
+        }
+        let has_default = cases.iter().any(|c| c.test.is_none());
+        if !has_default {
+            return;
+        }
+
+        // Phase 1 — immutable pass: collect case body texts.
+        let mut bodies: SmallVec<[&'a str; 8]> = SmallVec::new();
+        for case in cases {
+            let text = match (case.consequent.first(), case.consequent.last()) {
+                (Some(first), Some(last)) => {
+                    self.text(Span::new(first.span().start, last.span().end))
+                }
+                _ => "",
+            };
+            bodies.push(text);
+        }
+
+        // Phase 2 — report if all bodies are identical.
+        if all_equal(&bodies) {
+            self.report(RULE_NAME, "allDuplicatedBranches", switch_stmt.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -71,6 +71,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
         self.check_no_nested_switch(it);
+        self.check_no_all_duplicated_branches_switch(it);
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;
@@ -102,6 +103,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
         self.check_no_collapsible_if(it);
         self.check_no_identical_conditions(it);
+        self.check_no_all_duplicated_branches_if(it);
         walk::walk_if_statement(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -385,3 +385,56 @@ fn does_not_report_identical_condition_in_nested_separate_chain() {
     let diagnostics = scan("no-identical-conditions", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_all_duplicated_branches_if_else_identical() {
+    let source = "if (a) { f(); } else { f(); }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-all-duplicated-branches");
+    assert_eq!(diagnostics[0].message_id, "allDuplicatedBranches");
+}
+
+#[test]
+fn reports_all_duplicated_branches_if_else_if_else_identical() {
+    let source = "if (a) { f(); } else if (b) { f(); } else { f(); }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "allDuplicatedBranches");
+}
+
+#[test]
+fn does_not_report_all_duplicated_branches_if_else_differ() {
+    let source = "if (a) { f(); } else { g(); }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_all_duplicated_branches_no_terminal_else() {
+    let source = "if (a) { f(); } else if (b) { f(); }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_all_duplicated_branches_switch_all_identical() {
+    let source = "switch (x) { case 1: f(); break; default: f(); break; }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "allDuplicatedBranches");
+}
+
+#[test]
+fn does_not_report_all_duplicated_branches_switch_cases_differ() {
+    let source = "switch (x) { case 1: f(); break; default: g(); break; }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_all_duplicated_branches_switch_no_default() {
+    let source = "switch (x) { case 1: f(); break; case 2: f(); break; }";
+    let diagnostics = scan("no-all-duplicated-branches", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -47,6 +47,10 @@ const messages = Object.freeze({
     identicalConditions:
       "This branch's condition duplicates an earlier one in the same if/else-if chain, so it can never be reached.",
   },
+  'no-all-duplicated-branches': {
+    allDuplicatedBranches:
+      'Remove this conditional structure or edit its code blocks so that they are not all the same.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -62,6 +66,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow the suspicious '=-', '=+', or '=!' operator typos adjacent to a plain assignment",
   'no-identical-conditions':
     'Disallow duplicate conditions in the same if/else-if chain (dead branch)',
+  'no-all-duplicated-branches':
+    'Disallow conditional structures where every branch has the same implementation',
 });
 
 const ruleTypes = Object.freeze({
@@ -74,6 +80,7 @@ const ruleTypes = Object.freeze({
   'no-duplicate-in-composite': 'suggestion',
   'non-existent-operator': 'problem',
   'no-identical-conditions': 'problem',
+  'no-all-duplicated-branches': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -86,6 +93,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-duplicate-in-composite': 'error',
   'non-existent-operator': 'error',
   'no-identical-conditions': 'error',
+  'no-all-duplicated-branches': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -12,6 +12,7 @@ const expectedRuleNames = [
   'no-duplicate-in-composite',
   'non-existent-operator',
   'no-identical-conditions',
+  'no-all-duplicated-branches',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -275,5 +276,51 @@ describe('sonarjs native API', () => {
     const diagnostics = scan('no-identical-conditions', source);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].messageId).toBe('identicalConditions');
+  });
+
+  it('reports no-all-duplicated-branches for an if/else where both branches are identical', () => {
+    const source = 'if (a) { f(); } else { f(); }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-all-duplicated-branches');
+    expect(diagnostics[0].messageId).toBe('allDuplicatedBranches');
+  });
+
+  it('reports no-all-duplicated-branches for an if/else-if/else chain where all branches are identical', () => {
+    const source = 'if (a) { f(); } else if (b) { f(); } else { f(); }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('allDuplicatedBranches');
+  });
+
+  it('does not report no-all-duplicated-branches when branches differ', () => {
+    const source = 'if (a) { f(); } else { g(); }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-all-duplicated-branches when there is no terminal else', () => {
+    const source = 'if (a) { f(); } else if (b) { f(); }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-all-duplicated-branches for a switch where all cases are identical', () => {
+    const source = 'switch (x) { case 1: f(); break; default: f(); break; }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('allDuplicatedBranches');
+  });
+
+  it('does not report no-all-duplicated-branches for a switch where cases differ', () => {
+    const source = 'switch (x) { case 1: f(); break; default: g(); break; }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-all-duplicated-branches for a switch without a default case', () => {
+    const source = 'switch (x) { case 1: f(); break; case 2: f(); break; }';
+    const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -103,6 +103,7 @@ describe('sonarjs plugin shape', () => {
       'no-duplicate-in-composite',
       'non-existent-operator',
       'no-identical-conditions',
+      'no-all-duplicated-branches',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -113,6 +114,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-duplicate-in-composite']).toBe('object');
     expect(typeof plugin.rules['non-existent-operator']).toBe('object');
     expect(typeof plugin.rules['no-identical-conditions']).toBe('object');
+    expect(typeof plugin.rules['no-all-duplicated-branches']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -123,6 +125,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-in-composite']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/non-existent-operator']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-identical-conditions']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-all-duplicated-branches']).toBe('error');
   });
 });
 
@@ -191,6 +194,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-identical-conditions', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('identicalConditions');
+  });
+
+  it('reports no-all-duplicated-branches through the adapter', () => {
+    const source = 'if (a) { f(); } else { f(); }';
+    const reports = runRule('no-all-duplicated-branches', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('allDuplicatedBranches');
   });
 });
 
@@ -279,5 +289,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-identical-conditions)');
+  });
+
+  it('reports no-all-duplicated-branches through the CLI', () => {
+    const source = 'if (a) { f(); } else { f(); }';
+    const result = runOxlint('no-all-duplicated-branches', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-all-duplicated-branches)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11630,19 +11630,19 @@
       },
       {
         "name": "no-all-duplicated-branches",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-all-duplicated-branches (Sonar key S3923). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S3923. Rust core checks if/else-if/else chains (must have terminal else; all branch bodies compared by source text) and switch statements (must have default; all case bodies compared by source text). Head detection for if-chains reuses the shared if_chain_seen set alongside no-identical-conditions. No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "no-alphabetical-sort",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-all-duplicated-branches`** (Sonar key S3923). Reports a conditional structure whose branches are all identical (the condition has no effect):
- **if/else-if chains** with a terminal `else` where every branch body has identical source text;
- **switch** statements with a `default` where every case body is identical.

Reuses the shared `if_chain_seen` chain-head detection introduced for `no-identical-conditions`. Bodies compared by source text.

## Tests
Rust unit tests (if all-equal with else, else-if all-equal, differing bodies, no-terminal-else, switch all-equal with default, differing case, no-default), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-all-duplicated-branches)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783973108&installation_id=136613492&pr_number=145&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F145&signature=bd2536df4f072459be044b2f34babf86e09559ff0f23f989c58d0ef648be5329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->