### PR TITLE
fix(regexp): invert hexadecimal-escape to flag unicode escapes ≤ 0xFF

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -12,9 +12,9 @@ use oxlint_plugins_carton::CompactString;
 
 use crate::helpers::{
     duplicate_flag, find_class_end, first_control_character, first_fixed_unicode_escape,
-    first_hex_x_escape, first_invisible_character, first_literal_control_character,
-    first_non_standard_flag, first_numbered_backreference_with_named_group, first_octal_escape,
-    first_surrogate_pair_escape, first_uppercase_hex_escape, first_useless_escape,
+    first_invisible_character, first_literal_control_character, first_non_standard_flag,
+    first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
+    first_unicode_escape_as_hex, first_uppercase_hex_escape, first_useless_escape,
     first_useless_one_quantifier, group_prefix, mention_char, pattern_ends_with_lazy_quantifier,
     pattern_has_empty_string_literal, skip_escape, sorted_flags, string_literal_value_with_span,
 };
@@ -874,7 +874,7 @@ impl<'a> Scanner<'a> {
                 span,
             );
         }
-        if let Some((escape, replacement)) = first_hex_x_escape(pattern) {
+        if let Some((escape, replacement)) = first_unicode_escape_as_hex(pattern) {
             self.report_with_data(
                 "hexadecimal-escape",
                 "unexpected",

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -570,20 +570,23 @@ fn is_invisible_character(ch: char) -> bool {
     )
 }
 
+/// Builds the lower-case `\xHH` escape for a code point in `0..=0xFF`. The
+/// nibble masks keep both indices within `HEX`, so no fallible conversion is
+/// needed.
+fn hex_escape_for(code_point: u32) -> CompactString {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = CompactString::new("\\x");
+    out.push(HEX[((code_point >> 4) & 0xF) as usize] as char);
+    out.push(HEX[(code_point & 0xF) as usize] as char);
+    out
+}
+
 /// Returns the first `\uHHHH` or `\u{H+}` escape sequence in `pattern` whose
 /// decoded code point is ≤ 0xFF, together with its `\xHH` replacement. Used by
 /// `hexadecimal-escape` (default `"always"` config: flag unicode escapes that
 /// can be written as `\xHH` and suggest the hexadecimal form). Code points
 /// above 0xFF are not representable as `\xHH` and are silently skipped.
 /// `\xHH` escapes (already in the correct form) are also skipped.
-/// Builds the lower-case `\xHH` escape for a code point in `0..=0xFF`.
-fn hex_escape_for(code_point: u32) -> CompactString {
-    let mut out = CompactString::new("\\x");
-    out.push(char::from_digit((code_point >> 4) & 0xF, 16).unwrap());
-    out.push(char::from_digit(code_point & 0xF, 16).unwrap());
-    out
-}
-
 pub(crate) fn first_unicode_escape_as_hex(pattern: &str) -> Option<(&str, CompactString)> {
     let bytes = pattern.as_bytes();
     let mut index = 0;

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -570,11 +570,13 @@ fn is_invisible_character(ch: char) -> bool {
     )
 }
 
-/// Returns the first `\xHH` escape sequence in `pattern` together with its
-/// `\u{HH}` replacement. Used by `hexadecimal-escape` (default config: flag
-/// hex escapes and prefer unicode-style replacements). Other escapes such as
-/// `\uHHHH`, `\u{H+}`, and `\d` are skipped via `skip_escape`.
-pub(crate) fn first_hex_x_escape(pattern: &str) -> Option<(&str, CompactString)> {
+/// Returns the first `\uHHHH` or `\u{H+}` escape sequence in `pattern` whose
+/// decoded code point is ≤ 0xFF, together with its `\xHH` replacement. Used by
+/// `hexadecimal-escape` (default `"always"` config: flag unicode escapes that
+/// can be written as `\xHH` and suggest the hexadecimal form). Code points
+/// above 0xFF are not representable as `\xHH` and are silently skipped.
+/// `\xHH` escapes (already in the correct form) are also skipped.
+pub(crate) fn first_unicode_escape_as_hex(pattern: &str) -> Option<(&str, CompactString)> {
     let bytes = pattern.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -582,17 +584,44 @@ pub(crate) fn first_hex_x_escape(pattern: &str) -> Option<(&str, CompactString)>
             index += 1;
             continue;
         }
-        if bytes.get(index + 1) == Some(&b'x')
-            && index + 4 <= bytes.len()
-            && bytes[index + 2].is_ascii_hexdigit()
-            && bytes[index + 3].is_ascii_hexdigit()
-        {
-            let original = &pattern[index..index + 4];
-            let mut replacement = CompactString::new("\\u{");
-            replacement.push(bytes[index + 2].to_ascii_lowercase() as char);
-            replacement.push(bytes[index + 3].to_ascii_lowercase() as char);
-            replacement.push('}');
-            return Some((original, replacement));
+        if bytes.get(index + 1) == Some(&b'u') {
+            if bytes.get(index + 2) == Some(&b'{') {
+                // \u{H+} form
+                let mut cursor = index + 3;
+                while cursor < bytes.len() && bytes[cursor] != b'}' {
+                    cursor += 1;
+                }
+                if cursor < bytes.len() {
+                    let hex_str = &pattern[index + 3..cursor];
+                    if let Ok(code_point) = u32::from_str_radix(hex_str, 16) {
+                        if code_point <= 0xFF {
+                            let original = &pattern[index..cursor + 1];
+                            let replacement = format!("\\x{:02x}", code_point);
+                            return Some((original, CompactString::from(replacement.as_str())));
+                        }
+                    }
+                    index = cursor + 1;
+                    continue;
+                }
+                index = cursor.saturating_add(1).min(bytes.len());
+                continue;
+            }
+            // \uHHHH form (fixed 4 hex digits)
+            if index + 6 <= bytes.len()
+                && bytes[index + 2].is_ascii_hexdigit()
+                && bytes[index + 3].is_ascii_hexdigit()
+                && bytes[index + 4].is_ascii_hexdigit()
+                && bytes[index + 5].is_ascii_hexdigit()
+            {
+                let hex_str = &pattern[index + 2..index + 6];
+                if let Ok(code_point) = u32::from_str_radix(hex_str, 16) {
+                    if code_point <= 0xFF {
+                        let original = &pattern[index..index + 6];
+                        let replacement = format!("\\x{:02x}", code_point);
+                        return Some((original, CompactString::from(replacement.as_str())));
+                    }
+                }
+            }
         }
         index = skip_escape(bytes, index);
     }

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -576,6 +576,14 @@ fn is_invisible_character(ch: char) -> bool {
 /// can be written as `\xHH` and suggest the hexadecimal form). Code points
 /// above 0xFF are not representable as `\xHH` and are silently skipped.
 /// `\xHH` escapes (already in the correct form) are also skipped.
+/// Builds the lower-case `\xHH` escape for a code point in `0..=0xFF`.
+fn hex_escape_for(code_point: u32) -> CompactString {
+    let mut out = CompactString::new("\\x");
+    out.push(char::from_digit((code_point >> 4) & 0xF, 16).unwrap());
+    out.push(char::from_digit(code_point & 0xF, 16).unwrap());
+    out
+}
+
 pub(crate) fn first_unicode_escape_as_hex(pattern: &str) -> Option<(&str, CompactString)> {
     let bytes = pattern.as_bytes();
     let mut index = 0;
@@ -593,12 +601,11 @@ pub(crate) fn first_unicode_escape_as_hex(pattern: &str) -> Option<(&str, Compac
                 }
                 if cursor < bytes.len() {
                     let hex_str = &pattern[index + 3..cursor];
-                    if let Ok(code_point) = u32::from_str_radix(hex_str, 16) {
-                        if code_point <= 0xFF {
-                            let original = &pattern[index..cursor + 1];
-                            let replacement = format!("\\x{:02x}", code_point);
-                            return Some((original, CompactString::from(replacement.as_str())));
-                        }
+                    if let Ok(code_point) = u32::from_str_radix(hex_str, 16)
+                        && code_point <= 0xFF
+                    {
+                        let original = &pattern[index..cursor + 1];
+                        return Some((original, hex_escape_for(code_point)));
                     }
                     index = cursor + 1;
                     continue;
@@ -614,12 +621,11 @@ pub(crate) fn first_unicode_escape_as_hex(pattern: &str) -> Option<(&str, Compac
                 && bytes[index + 5].is_ascii_hexdigit()
             {
                 let hex_str = &pattern[index + 2..index + 6];
-                if let Ok(code_point) = u32::from_str_radix(hex_str, 16) {
-                    if code_point <= 0xFF {
-                        let original = &pattern[index..index + 6];
-                        let replacement = format!("\\x{:02x}", code_point);
-                        return Some((original, CompactString::from(replacement.as_str())));
-                    }
+                if let Ok(code_point) = u32::from_str_radix(hex_str, 16)
+                    && code_point <= 0xFF
+                {
+                    let original = &pattern[index..index + 6];
+                    return Some((original, hex_escape_for(code_point)));
                 }
             }
         }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1810,38 +1810,68 @@ mod hexadecimal_escape {
     use super::*;
 
     #[test]
-    fn reports_hex_x_escapes_with_unicode_replacement() {
-        let data = first_data(
-            "const a = new RegExp('\\\\xab', 'u');",
-            "hexadecimal-escape",
-        );
-        assert_eq!(data.expr.as_ref().map(CompactString::as_str), Some("\\xab"));
+    fn reports_unicode_escapes_with_hex_replacement() {
+        // \uHHHH form whose code point is ≤ 0xFF is flagged and suggests \xHH.
+        let data = first_data("const a = /\\u000a/u;", "hexadecimal-escape");
         assert_eq!(
-            data.replacement.as_ref().map(CompactString::as_str),
-            Some("\\u{ab}")
-        );
-        // Uppercase digits are normalised in the replacement.
-        let data = first_data(
-            "const a = new RegExp('\\\\xAB', 'u');",
-            "hexadecimal-escape",
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\u000a")
         );
         assert_eq!(
             data.replacement.as_ref().map(CompactString::as_str),
-            Some("\\u{ab}")
+            Some("\\x0a")
+        );
+
+        // \u{H+} form with code point ≤ 0xFF is also flagged.
+        let data = first_data(
+            "const a = new RegExp('\\\\u{00000a}', 'u');",
+            "hexadecimal-escape",
+        );
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\u{00000a}")
+        );
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\x0a")
+        );
+
+        // «» (U+00AB, ≤ 0xFF) represented as \uHHHH is flagged → \xab.
+        let data = first_data("const a = /\\u00ab/u;", "hexadecimal-escape");
+        assert_eq!(
+            data.expr.as_ref().map(CompactString::as_str),
+            Some("\\u00ab")
+        );
+        assert_eq!(
+            data.replacement.as_ref().map(CompactString::as_str),
+            Some("\\xab")
         );
     }
 
     #[test]
-    fn ignores_unicode_escapes_and_unrelated_escapes() {
+    fn ignores_hex_x_escapes_and_high_code_points_and_unrelated_escapes() {
+        // \xHH is already in the correct form — not flagged.
+        assert!(rule_ids_for("const a = /\\xab/u;", "hexadecimal-escape").is_empty());
+        // \uHHHH with code point > 0xFF — not representable as \xHH, not flagged.
         assert!(rule_ids_for("const a = /\\uabcd/u;", "hexadecimal-escape").is_empty());
+        // \u{100} is code point 256 > 0xFF — not flagged.
         assert!(
             rule_ids_for(
-                "const a = new RegExp('\\\\u{ab}', 'u');",
+                "const a = new RegExp('\\\\u{100}', 'u');",
                 "hexadecimal-escape"
             )
             .is_empty()
         );
+        // Non-escape characters are never flagged.
         assert!(rule_ids_for("const a = /\\d/u;", "hexadecimal-escape").is_empty());
+        // \xHH pattern from the upstream valid fixture — no diagnostic.
+        assert!(
+            rule_ids_for(
+                "const a = /a \\x0a \\cM \\0 \u{0100} \\u{100}/u;",
+                "hexadecimal-escape"
+            )
+            .is_empty()
+        );
     }
 }
 

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -94,7 +94,8 @@ const messages = Object.freeze({
     unexpected: 'Unexpected invisible character {{ char }}.',
   },
   'hexadecimal-escape': {
-    unexpected: "Unexpected hexadecimal escape '{{expr}}'. Use '{{replacement}}' instead.",
+    unexpected:
+      "Unexpected unicode escape '{{expr}}'. Use the hexadecimal escape '{{replacement}}' instead.",
   },
   'unicode-escape': {
     unexpected: "Unexpected fixed-width unicode escape '{{expr}}'. Use '{{replacement}}' instead.",

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -99,7 +99,7 @@ describe('regexp native API', () => {
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[6].data.charText).toBe('U+0001');
+    expect(diagnostics[7].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -89,17 +89,17 @@ describe('regexp native API', () => {
       // new RegExp('[', 'u') — constructor parse error short-circuits the flag-style checks.
       ['no-invalid-regexp', 'error'],
       // new RegExp('\\x01', 'u') — u is present so require-unicode-sets-regexp fires
-      // alongside the control-character diagnostic and `hexadecimal-escape` (the
-      // `\xHH` escape is independently flagged regardless of the character value).
+      // alongside the control-character diagnostic. `hexadecimal-escape` does NOT fire
+      // because `\x01` is already in the correct hexadecimal form; only unicode escapes
+      // (e.g. `` or `\u{1}`) whose code point is ≤ 0xFF would be flagged.
       ['require-unicode-sets-regexp', 'require'],
       ['no-control-character', 'unexpected'],
-      ['hexadecimal-escape', 'unexpected'],
     ]);
     expect(diagnostics[0].data).toMatchObject({
       flags: 'mi',
       sortedFlags: 'im',
     });
-    expect(diagnostics[7].data.charText).toBe('U+0001');
+    expect(diagnostics[6].data.charText).toBe('U+0001');
   });
 
   it('returns LSP-shaped locations from Rust', () => {

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -1,10 +1,6 @@
 {
   "_doc": "Per-rule upstream-parity enforcement level for the synced eslint-plugin-regexp fixtures (see test/upstream.test.mjs). Levels: 'off' = quarantined; the rule's behavior diverges from upstream defaults, so its valid and invalid cases are skipped until the port is fixed (the reason is the parity-debt backlog entry). 'valid' (the default for any rule not listed here) = every upstream VALID case must emit zero diagnostics for the rule (soundness). 'full' = 'valid' plus invalid-case COUNT parity (same number of diagnostics per case as upstream). Diagnostic message text and span are intentionally NOT asserted: the port rewords messages and may flag a different span (e.g. the whole literal) than upstream by design; the recorded fixture locations are reference data for a future strict-location pass.",
   "rules": {
-    "hexadecimal-escape": {
-      "level": "off",
-      "reason": "Diverges on mixed escape forms under the u flag (e.g. /a \\x0a \\cM \\0 \\u0100 \\u{100}/u)."
-    },
     "no-dupe-characters-character-class": {
       "level": "off",
       "reason": "False duplicate in nested v-mode classes / set operations, e.g. /[\\q{a}\\q{ab}\\q{abc}[\\w--[ab]][\\w&&b]]/v. The \\q{...} body is now skipped (so simple cases pass), but nested [...] operands still need set-aware handling."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -175,14 +175,14 @@ const invalidCases = [
   // hexadecimal-escape
   [
     'hexadecimal-escape',
-    'lowercase \\xHH',
-    "const re = new RegExp('\\\\xab', 'u');\n",
+    '\\uHHHH with code point ≤ 0xFF',
+    "const re = new RegExp('\\\\u000a', 'u');\n",
     ['unexpected'],
   ],
   [
     'hexadecimal-escape',
-    'uppercase \\xHH still flagged',
-    "const re = new RegExp('\\\\xAB', 'u');\n",
+    '\\u{H+} with code point ≤ 0xFF',
+    "const re = new RegExp('\\\\u{ab}', 'u');\n",
     ['unexpected'],
   ],
   // unicode-escape


### PR DESCRIPTION
## Summary

- **Bug**: `hexadecimal-escape` was inverted — it flagged `\xHH` escapes and suggested `\u{hh}`, the opposite of upstream behavior.
- **Fix**: Replace `first_hex_x_escape` with `first_unicode_escape_as_hex` in `helpers.rs` — finds the first `\uHHHH` or `\u{H+}` escape whose decoded code point is ≤ 0xFF and suggests `\xHH` form.
- **Parity**: Remove `hexadecimal-escape` from `parity.json` quarantine (was `"off"`); defaults to `"valid"` level so upstream valid cases are now tested.

## Upstream behavior (from `upstream/eslint-plugin-regexp/lib/rules/hexadecimal-escape.ts`)

Default option is `"always"`. It flags any `\uHHHH` or `\u{H...}` escape
whose code point is ≤ 0xFF, and suggests the `\xHH` form. Code points > 0xFF
cannot be represented as `\xHH` and are not flagged. Message: `"Expected hexadecimal escape ('{{hexEscape}}'), but {{unexpectedKind}} escape ('{{rejectEscape}}') is used."` (we use a simplified `"Unexpected unicode escape '{{expr}}'. Use the hexadecimal escape '{{replacement}}' instead."`).

## Files changed

- `crates/regexp/src/helpers.rs` — replaced `first_hex_x_escape` with `first_unicode_escape_as_hex`
- `crates/regexp/src/checks.rs` — updated import and call site
- `crates/regexp/src/tests.rs` — rewrote `mod hexadecimal_escape` for the corrected direction
- `npm/regexp/index.js` — updated message to describe flagging unicode escapes, not hex ones
- `npm/regexp/test/plugin.test.mjs` — updated invalid cases to unicode-escape inputs
- `npm/regexp/test/api.test.mjs` — removed `hexadecimal-escape` from `\x01` test (hex form no longer flagged)
- `npm/regexp/test/parity.json` — removed quarantined entry

## Fixture validity check

| Case | Expected | Result |
|------|----------|--------|
| `/a \x0a \cM \0 Ā \u{100}/u` (valid) | 0 diagnostics | `\x0a` is hex form ✓, `Ā`/`\u{100}` are > 0xFF ✓ |
| `/\7/` (valid) | 0 diagnostics | No unicode escape ✓ |
| `/\cA \cB \cM/` (valid) | 0 diagnostics | No unicode escape ✓ |
| `/
 \u{00000a}/u` (invalid) | ≥1 diagnostic | `
` (U+000A ≤ 0xFF) flagged → `\x0a` ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783973666&installation_id=136613492&pr_number=146&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F146&signature=29d63509d920e24dc2fba652342702bae0c9da882ff7887e3b26ff46a76d44c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->