### PR TITLE
port(sonarjs): port no-identical-expressions (S1764)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 10] = [
+pub const RULE_NAMES: [&str; 11] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -33,6 +33,7 @@ pub const RULE_NAMES: [&str; 10] = [
     "non-existent-operator",
     "no-identical-conditions",
     "no-all-duplicated-branches",
+    "no-identical-expressions",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -6,6 +6,7 @@ mod no_all_duplicated_branches;
 mod no_collapsible_if;
 mod no_duplicate_in_composite;
 mod no_identical_conditions;
+mod no_identical_expressions;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_identical_expressions.rs
+++ b/crates/sonarjs/src/rules/no_identical_expressions.rs
@@ -1,0 +1,87 @@
+//! Rule `no-identical-expressions` (SonarJS key S1764).
+//!
+//! Clean-room port. Reports a binary or logical expression where the left and
+//! right operands are textually identical AND the operator belongs to a targeted
+//! set where having the same sub-expression on both sides is almost certainly a
+//! bug (the result would be constant or redundant).
+//!
+//! ## Targeted operators
+//!
+//! ### Binary (`BinaryExpression`)
+//! - Comparisons: `<` (`LessThan`), `<=` (`LessEqualThan`), `>` (`GreaterThan`),
+//!   `>=` (`GreaterEqualThan`), `==` (`Equality`), `===` (`StrictEquality`),
+//!   `!=` (`Inequality`), `!==` (`StrictInequality`)
+//! - Bitwise: `&` (`BitwiseAnd`), `|` (`BitwiseOR`), `^` (`BitwiseXOR`)
+//! - Arithmetic: `-` (`Subtraction`), `/` (`Division`), `%` (`Remainder`)
+//!
+//! ### Logical (`LogicalExpression`)
+//! - `&&` (`LogicalOperator::And`), `||` (`LogicalOperator::Or`)
+//!
+//! ## Explicitly excluded operators (not a bug with identical operands)
+//! - `+` — `a + a` is legitimate doubling.
+//! - `*` — `a * a` is legitimate squaring.
+//! - `**` — exponentiation; `a ** a` is intentional.
+//! - `<<`, `>>`, `>>>` — bit-shifts with identical operands are unusual but
+//!   not clearly bugs.
+//! - `??` — nullish-coalescing with identical operands may be intentional.
+//! - `instanceof`, `in` — not meaningful to flag with identical operands.
+//!
+//! ## Operand identity
+//! Two operands are "identical" iff `self.text(left.span()) == self.text(right.span())`.
+//! This is a **syntactic** (source-text) comparison; it does not account for
+//! semantic equivalence or aliasing.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{BinaryExpression, LogicalExpression};
+use oxc_span::GetSpan;
+use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-identical-expressions";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_identical_expressions_binary(&mut self, expr: &BinaryExpression<'_>) {
+        let is_targeted = matches!(
+            expr.operator,
+            BinaryOperator::LessThan
+                | BinaryOperator::LessEqualThan
+                | BinaryOperator::GreaterThan
+                | BinaryOperator::GreaterEqualThan
+                | BinaryOperator::Equality
+                | BinaryOperator::StrictEquality
+                | BinaryOperator::Inequality
+                | BinaryOperator::StrictInequality
+                | BinaryOperator::BitwiseAnd
+                | BinaryOperator::BitwiseOR
+                | BinaryOperator::BitwiseXOR
+                | BinaryOperator::Subtraction
+                | BinaryOperator::Division
+                | BinaryOperator::Remainder
+        );
+        if !is_targeted {
+            return;
+        }
+        let left = self.text(expr.left.span());
+        let right = self.text(expr.right.span());
+        if left == right {
+            self.report(RULE_NAME, "identicalExpressions", expr.span);
+        }
+    }
+
+    pub(crate) fn check_no_identical_expressions_logical(
+        &mut self,
+        expr: &LogicalExpression<'_>,
+    ) {
+        if !matches!(expr.operator, LogicalOperator::And | LogicalOperator::Or) {
+            return;
+        }
+        let left = self.text(expr.left.span());
+        let right = self.text(expr.right.span());
+        if left == right {
+            self.report(RULE_NAME, "identicalExpressions", expr.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/rules/no_identical_expressions.rs
+++ b/crates/sonarjs/src/rules/no_identical_expressions.rs
@@ -71,10 +71,7 @@ impl Scanner<'_> {
         }
     }
 
-    pub(crate) fn check_no_identical_expressions_logical(
-        &mut self,
-        expr: &LogicalExpression<'_>,
-    ) {
+    pub(crate) fn check_no_identical_expressions_logical(&mut self, expr: &LogicalExpression<'_>) {
         if !matches!(expr.operator, LogicalOperator::And | LogicalOperator::Or) {
             return;
         }

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,8 +3,8 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, IfStatement, SwitchCase,
-    SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, IfStatement, LogicalExpression,
+    SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -84,7 +84,13 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {
         self.check_no_redundant_boolean_binary(it);
+        self.check_no_identical_expressions_binary(it);
         walk::walk_binary_expression(self, it);
+    }
+
+    fn visit_logical_expression(&mut self, it: &LogicalExpression<'a>) {
+        self.check_no_identical_expressions_logical(it);
+        walk::walk_logical_expression(self, it);
     }
 
     fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -438,3 +438,110 @@ fn does_not_report_all_duplicated_branches_switch_no_default() {
     let diagnostics = scan("no-all-duplicated-branches", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_identical_expressions_strict_equality() {
+    let source = "a === a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-identical-expressions");
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_strict_inequality() {
+    let source = "b !== b";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_less_than() {
+    let source = "x < x";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_logical_and() {
+    let source = "a && a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_logical_or() {
+    let source = "a || a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_bitwise_and() {
+    let source = "a & a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_subtraction() {
+    let source = "a - a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn reports_identical_expressions_division() {
+    let source = "a / a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "identicalExpressions");
+}
+
+#[test]
+fn does_not_report_identical_expressions_different_operands() {
+    let source = "a === b";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_identical_expressions_addition_excluded() {
+    let source = "a + a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_identical_expressions_multiplication_excluded() {
+    let source = "a * a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_identical_expressions_left_shift_excluded() {
+    let source = "a << a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_identical_expressions_nullish_coalescing_excluded() {
+    let source = "a ?? a";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_identical_expressions_different_member_access() {
+    let source = "a.b === a.c";
+    let diagnostics = scan("no-identical-expressions", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -51,6 +51,10 @@ const messages = Object.freeze({
     allDuplicatedBranches:
       'Remove this conditional structure or edit its code blocks so that they are not all the same.',
   },
+  'no-identical-expressions': {
+    identicalExpressions:
+      'Identical sub-expressions on both sides of this operator make the result constant or redundant.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -68,6 +72,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow duplicate conditions in the same if/else-if chain (dead branch)',
   'no-all-duplicated-branches':
     'Disallow conditional structures where every branch has the same implementation',
+  'no-identical-expressions':
+    'Disallow identical sub-expressions on both sides of binary or logical operators where the result is constant or redundant',
 });
 
 const ruleTypes = Object.freeze({
@@ -81,6 +87,7 @@ const ruleTypes = Object.freeze({
   'non-existent-operator': 'problem',
   'no-identical-conditions': 'problem',
   'no-all-duplicated-branches': 'problem',
+  'no-identical-expressions': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -94,6 +101,7 @@ const recommendedRuleConfig = Object.freeze({
   'non-existent-operator': 'error',
   'no-identical-conditions': 'error',
   'no-all-duplicated-branches': 'error',
+  'no-identical-expressions': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -13,6 +13,7 @@ const expectedRuleNames = [
   'non-existent-operator',
   'no-identical-conditions',
   'no-all-duplicated-branches',
+  'no-identical-expressions',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -321,6 +322,99 @@ describe('sonarjs native API', () => {
   it('does not report no-all-duplicated-branches for a switch without a default case', () => {
     const source = 'switch (x) { case 1: f(); break; case 2: f(); break; }';
     const diagnostics = scan('no-all-duplicated-branches', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-identical-expressions for a === a', () => {
+    const source = 'a === a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-identical-expressions');
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for b !== b', () => {
+    const source = 'b !== b';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for x < x', () => {
+    const source = 'x < x';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for a && a', () => {
+    const source = 'a && a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for a || a', () => {
+    const source = 'a || a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for a & a (bitwise AND)', () => {
+    const source = 'a & a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for a - a (subtraction)', () => {
+    const source = 'a - a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports no-identical-expressions for a / a (division)', () => {
+    const source = 'a / a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('does not report no-identical-expressions for a === b (different operands)', () => {
+    const source = 'a === b';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-identical-expressions for a + a (addition is excluded)', () => {
+    const source = 'a + a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-identical-expressions for a * a (multiplication is excluded)', () => {
+    const source = 'a * a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-identical-expressions for a << a (left-shift is excluded)', () => {
+    const source = 'a << a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-identical-expressions for a ?? a (nullish coalescing is excluded)', () => {
+    const source = 'a ?? a';
+    const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-identical-expressions for a.b === a.c (different member access)', () => {
+    const source = 'a.b === a.c';
+    const diagnostics = scan('no-identical-expressions', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -104,6 +104,7 @@ describe('sonarjs plugin shape', () => {
       'non-existent-operator',
       'no-identical-conditions',
       'no-all-duplicated-branches',
+      'no-identical-expressions',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -115,6 +116,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['non-existent-operator']).toBe('object');
     expect(typeof plugin.rules['no-identical-conditions']).toBe('object');
     expect(typeof plugin.rules['no-all-duplicated-branches']).toBe('object');
+    expect(typeof plugin.rules['no-identical-expressions']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -126,6 +128,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/non-existent-operator']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-identical-conditions']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-all-duplicated-branches']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-identical-expressions']).toBe('error');
   });
 });
 
@@ -201,6 +204,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-all-duplicated-branches', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('allDuplicatedBranches');
+  });
+
+  it('reports no-identical-expressions through the adapter', () => {
+    const source = 'a === a';
+    const reports = runRule('no-identical-expressions', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('identicalExpressions');
   });
 });
 
@@ -299,5 +309,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-all-duplicated-branches)');
+  });
+
+  it('reports no-identical-expressions through the CLI', () => {
+    const source = 'a === a';
+    const result = runOxlint('no-identical-expressions', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-identical-expressions)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12270,19 +12270,19 @@
       },
       {
         "name": "no-identical-expressions",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-identical-expressions (Sonar key S1764). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S1764. Rust core checks BinaryExpression (comparison, bitwise, arithmetic operators) and LogicalExpression (&&, ||) for textually identical left/right operands; excluded operators (+, *, **, <<, >>, >>>, ??, instanceof, in) are documented in the rule. No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "no-identical-functions",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-identical-expressions`** (Sonar key S1764). Reports a binary/logical expression whose left and right operands are textually identical, for a targeted operator set: comparisons (`< <= > >= == === != !==`), bitwise (`& | ^`), arithmetic (`- / %`), and logical (`&& ||`). **Explicitly excludes** `+ * ** << >> >>> ?? instanceof in` (identical operands there are legitimate — doubling/squaring — or not clearly bugs); this exclusion set is documented in the rule. Adds a `visit_logical_expression` hook plus a second check on the existing `visit_binary_expression`. Operand identity = source-text equality.

## Tests
Rust unit tests (8 positives across the operator families, 6 negatives incl. `+`, `*`, `<<`, `??`, and distinct members), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-identical-expressions)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783973696&installation_id=136613492&pr_number=147&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F147&signature=e8e1c88739c0aa101393b6db7eb54a3fe42154439034f1bfb03e41e62721a9bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->