### PR TITLE
port(sonarjs): port arguments-usage (S3513)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 11] = [
+pub const RULE_NAMES: [&str; 12] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -34,6 +34,7 @@ pub const RULE_NAMES: [&str; 11] = [
     "no-identical-conditions",
     "no-all-duplicated-branches",
     "no-identical-expressions",
+    "arguments-usage",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,6 +1,7 @@
 //! Clean-room rule implementations for the sonarjs port. Each module attaches
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
+mod arguments_usage;
 mod comma_or_logical_or_case;
 mod no_all_duplicated_branches;
 mod no_collapsible_if;

--- a/crates/sonarjs/src/rules/arguments_usage.rs
+++ b/crates/sonarjs/src/rules/arguments_usage.rs
@@ -1,0 +1,44 @@
+//! Rule `arguments-usage` (SonarJS key S3513).
+//!
+//! Clean-room port. Reports every use of the `arguments` object and suggests
+//! switching to rest parameters (`...args`), which are explicit, scoped to the
+//! function they are declared in, and work with arrow functions.
+//!
+//! ## Detection strategy
+//!
+//! The hook `visit_identifier_reference` is used because, in Oxc's AST, a
+//! *use* of a variable is represented as `Expression::Identifier(IdentifierReference)`.
+//! This means:
+//!
+//! - `obj.arguments` — the property name is an `IdentifierName` inside a static
+//!   member expression, **not** an `IdentifierReference`, so it is correctly skipped.
+//! - `function arguments() {}` — the function name is a `BindingIdentifier`, also
+//!   not flagged.
+//! - Arrow functions do not have their own `arguments` binding; any `arguments`
+//!   reference inside an arrow function refers to the enclosing function's object,
+//!   which is still the `arguments` object and is correctly flagged.
+//!
+//! ## Syntactic check
+//!
+//! This is a purely syntactic check. In the rare (and invalid in strict mode)
+//! case where a programmer declares a local binding literally named `arguments`,
+//! it will still be flagged. The trade-off is simplicity and zero false negatives
+//! for the common case.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::IdentifierReference;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "arguments-usage";
+
+impl Scanner<'_> {
+    pub(crate) fn check_arguments_usage(&mut self, ident: &IdentifierReference<'_>) {
+        if ident.name.as_str() != "arguments" {
+            return;
+        }
+        self.report(RULE_NAME, "argumentsUsage", ident.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,8 +3,9 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, IfStatement, LogicalExpression,
-    SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, IdentifierReference,
+    IfStatement, LogicalExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType,
+    TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -126,5 +127,10 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_ts_intersection_type(&mut self, it: &TSIntersectionType<'a>) {
         self.check_no_duplicate_in_composite(&it.types);
         walk::walk_ts_intersection_type(self, it);
+    }
+
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        self.check_arguments_usage(it);
+        walk::walk_identifier_reference(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -545,3 +545,41 @@ fn does_not_report_identical_expressions_different_member_access() {
     let diagnostics = scan("no-identical-expressions", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_arguments_usage_inside_function() {
+    let source = "function f() { return arguments[0]; }";
+    let diagnostics = scan("arguments-usage", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "arguments-usage");
+    assert_eq!(diagnostics[0].message_id, "argumentsUsage");
+}
+
+#[test]
+fn reports_arguments_usage_for_arguments_length() {
+    let source = "function f() { console.log(arguments.length); }";
+    let diagnostics = scan("arguments-usage", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "argumentsUsage");
+}
+
+#[test]
+fn does_not_report_arguments_usage_with_rest_params() {
+    let source = "function f(...args) { return args[0]; }";
+    let diagnostics = scan("arguments-usage", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_arguments_usage_for_property_name() {
+    let source = "const o = { arguments: 1 }; o.arguments;";
+    let diagnostics = scan("arguments-usage", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_arguments_usage_for_plain_function() {
+    let source = "function f() { return 1; }";
+    let diagnostics = scan("arguments-usage", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -55,6 +55,9 @@ const messages = Object.freeze({
     identicalExpressions:
       'Identical sub-expressions on both sides of this operator make the result constant or redundant.',
   },
+  'arguments-usage': {
+    argumentsUsage: "Use the rest parameter syntax (...args) instead of the 'arguments' object.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -74,6 +77,7 @@ const ruleDescriptions = Object.freeze({
     'Disallow conditional structures where every branch has the same implementation',
   'no-identical-expressions':
     'Disallow identical sub-expressions on both sides of binary or logical operators where the result is constant or redundant',
+  'arguments-usage': "Disallow use of the 'arguments' object; use rest parameters instead",
 });
 
 const ruleTypes = Object.freeze({
@@ -88,6 +92,7 @@ const ruleTypes = Object.freeze({
   'no-identical-conditions': 'problem',
   'no-all-duplicated-branches': 'problem',
   'no-identical-expressions': 'problem',
+  'arguments-usage': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -102,6 +107,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-identical-conditions': 'error',
   'no-all-duplicated-branches': 'error',
   'no-identical-expressions': 'error',
+  'arguments-usage': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -14,6 +14,7 @@ const expectedRuleNames = [
   'no-identical-conditions',
   'no-all-duplicated-branches',
   'no-identical-expressions',
+  'arguments-usage',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -415,6 +416,39 @@ describe('sonarjs native API', () => {
   it('does not report no-identical-expressions for a.b === a.c (different member access)', () => {
     const source = 'a.b === a.c';
     const diagnostics = scan('no-identical-expressions', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports arguments-usage when arguments is used inside a function', () => {
+    const source = 'function f() { return arguments[0]; }';
+    const diagnostics = scan('arguments-usage', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('arguments-usage');
+    expect(diagnostics[0].messageId).toBe('argumentsUsage');
+  });
+
+  it('reports arguments-usage when arguments.length is accessed', () => {
+    const source = 'function f() { console.log(arguments.length); }';
+    const diagnostics = scan('arguments-usage', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('argumentsUsage');
+  });
+
+  it('does not report arguments-usage when rest parameters are used', () => {
+    const source = 'function f(...args) { return args[0]; }';
+    const diagnostics = scan('arguments-usage', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report arguments-usage for object property named arguments', () => {
+    const source = 'const o = { arguments: 1 }; o.arguments;';
+    const diagnostics = scan('arguments-usage', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report arguments-usage for a function that does not use arguments', () => {
+    const source = 'function f() { return 1; }';
+    const diagnostics = scan('arguments-usage', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -105,6 +105,7 @@ describe('sonarjs plugin shape', () => {
       'no-identical-conditions',
       'no-all-duplicated-branches',
       'no-identical-expressions',
+      'arguments-usage',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -117,6 +118,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-identical-conditions']).toBe('object');
     expect(typeof plugin.rules['no-all-duplicated-branches']).toBe('object');
     expect(typeof plugin.rules['no-identical-expressions']).toBe('object');
+    expect(typeof plugin.rules['arguments-usage']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -129,6 +131,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-identical-conditions']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-all-duplicated-branches']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-identical-expressions']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/arguments-usage']).toBe('error');
   });
 });
 
@@ -211,6 +214,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-identical-expressions', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('identicalExpressions');
+  });
+
+  it('reports arguments-usage through the adapter', () => {
+    const source = 'function f() { return arguments[0]; }';
+    const reports = runRule('arguments-usage', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('argumentsUsage');
   });
 });
 
@@ -319,5 +329,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-identical-expressions)');
+  });
+
+  it('reports arguments-usage through the CLI', () => {
+    const source = 'function f() { return arguments[0]; }';
+    const result = runOxlint('arguments-usage', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(arguments-usage)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10094,19 +10094,19 @@
       },
       {
         "name": "arguments-usage",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule arguments-usage (Sonar key S3513). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S3513). Reports every IdentifierReference named 'arguments'; suggests rest parameters instead. Syntactic check only; no upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "array-callback-without-return",


### PR DESCRIPTION
## Summary
Clean-room port of **`arguments-usage`** (Sonar key S3513). Reports every use of the `arguments` object (an `IdentifierReference` named `arguments`), suggesting rest parameters (`...args`). Member property names (`obj.arguments`) and binding declarations are correctly not flagged (they are `IdentifierName`/`BindingIdentifier`, not references). `arguments` inside an arrow function refers to the enclosing function's object and is correctly flagged. Adds a `visit_identifier_reference` hook.

## Tests
Rust unit tests (`arguments[0]`, `arguments.length`, rest params → 0, property name → 0, no-arguments → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(arguments-usage)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783974784&installation_id=136613492&pr_number=148&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F148&signature=2892982e54caf476a6760732f75e11bf8bf437ef487057cb8d866c1eab081fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->