### PR TITLE
DIAGNOSTIC (do not merge): assert all functional rules

### DIFF
--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -30,14 +30,26 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 // Rules whose syntax-only port has reached full upstream parity. Populated one
 // entry per porting PR. See the file header for what "full parity" asserts.
 const FULL_PARITY = new Set([
+  'functional-parameters',
+  'immutable-data',
   'no-class-inheritance',
   'no-classes',
+  'no-conditional-statements',
+  'no-expression-statements',
   'no-let',
   'no-loop-statements',
+  'no-mixed-types',
   'no-promise-reject',
+  'no-return-void',
   'no-this-expressions',
+  'no-throw-statements',
   'no-try-statements',
+  'prefer-immutable-types',
   'prefer-property-signatures',
+  'prefer-readonly-type',
+  'prefer-tacit',
+  'readonly-type',
+  'type-declaration-immutability',
 ]);
 
 function runRule(ruleName, testCase) {


### PR DESCRIPTION
Throwaway diagnostic to see which functional rules' syntax-only ports already pass their upstream fixtures. Will be closed without merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783975100&installation_id=136613492&pr_number=151&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F151&signature=b847a691f0a73c1e22cdffe768ee297271adb9c9ca2cc4e32ee8d57eab3cf597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->