### PR TITLE
port(regexp): add semantic-analysis foundation; fix require-unicode-regexp shadowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_regular_expression",
+ "oxc_semantic",
  "oxc_span",
  "oxlint-plugins-_carton",
 ]

--- a/crates/regexp/Cargo.toml
+++ b/crates/regexp/Cargo.toml
@@ -13,6 +13,7 @@ oxc_allocator.workspace = true
 oxc_ast.workspace = true
 oxc_parser.workspace = true
 oxc_regular_expression.workspace = true
+oxc_semantic.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true
 

--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -206,7 +206,7 @@ impl<'a> Scanner<'a> {
     }
 
     pub(crate) fn check_call_expression(&mut self, call: &'a CallExpression<'a>) {
-        if call.callee.is_specific_id("RegExp") {
+        if self.is_global_regexp_callee(&call.callee) {
             self.check_regexp_constructor(call.span, &call.arguments);
         }
         self.check_prefer_regexp_exec(call);
@@ -412,7 +412,7 @@ impl<'a> Scanner<'a> {
     }
 
     pub(crate) fn check_new_expression(&mut self, new_expression: &'a NewExpression<'a>) {
-        if new_expression.callee.is_specific_id("RegExp") {
+        if self.is_global_regexp_callee(&new_expression.callee) {
             self.check_regexp_constructor(new_expression.span, &new_expression.arguments);
         }
     }

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -13,6 +13,7 @@ mod tests;
 
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxlint_plugins_carton::SmallVec;
 
@@ -99,10 +100,18 @@ pub fn scan_regexp(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 1
         return SmallVec::new();
     }
 
+    let semantic_return = SemanticBuilder::new().build(&parser_return.program);
+    if !semantic_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+    let semantic = semantic_return.semantic;
+    let scoping = semantic.scoping();
+
     let mut scanner = Scanner {
         source_text,
         line_index: LineIndex::new(source_text),
         diagnostics: SmallVec::new(),
+        scoping,
     };
     scanner.scan_program(&parser_return.program.body);
     scanner.diagnostics

--- a/crates/regexp/src/scanner.rs
+++ b/crates/regexp/src/scanner.rs
@@ -1,6 +1,8 @@
 //! Core scanner state for the regexp port. AST traversal lives in
 //! `traversal.rs`; regexp-specific checks live in `checks.rs`.
 
+use oxc_ast::ast::Expression;
+use oxc_semantic::Scoping;
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
 
@@ -10,6 +12,10 @@ pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,
     pub(crate) line_index: LineIndex,
     pub(crate) diagnostics: SmallVec<[Diagnostic; 16]>,
+    /// Scoping information from semantic analysis. Used for reference
+    /// resolution (e.g. to detect whether a `RegExp` identifier is the
+    /// global constructor or a shadowed local binding).
+    pub(crate) scoping: &'a Scoping,
 }
 
 impl<'a> Scanner<'a> {
@@ -30,5 +36,36 @@ impl<'a> Scanner<'a> {
             data,
             loc: self.line_index.loc_for_span(self.source_text, span),
         });
+    }
+
+    /// Returns `true` when `callee` is the global `RegExp` constructor (an
+    /// unqualified `RegExp` identifier that is not shadowed by a local
+    /// binding). A shadowed `RegExp` (e.g. a function parameter) resolves to
+    /// a local symbol and should not be treated as the global constructor.
+    ///
+    /// The check relies on the `reference_id` that the semantic analyser
+    /// attaches to every [`IdentifierReference`]: if the reference resolves to
+    /// a local symbol, `symbol_id()` will be `Some(…)`; if it is unresolved
+    /// (i.e. a free/global reference), `symbol_id()` will be `None`.
+    pub(crate) fn is_global_regexp_callee(&self, callee: &Expression) -> bool {
+        let Expression::Identifier(ident) = callee else {
+            return false;
+        };
+        if ident.name != "RegExp" {
+            return false;
+        }
+        // After semantic analysis the `reference_id` cell is always `Some`.
+        // If for any reason it is still `None` (e.g. in a test that bypasses
+        // semantic), treat the identifier conservatively as global so existing
+        // behaviour is preserved.
+        let Some(reference_id) = ident.reference_id.get() else {
+            return true;
+        };
+        // A resolved reference has a `symbol_id`; an unresolved (global)
+        // reference does not.
+        self.scoping
+            .get_reference(reference_id)
+            .symbol_id()
+            .is_none()
     }
 }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -1372,6 +1372,39 @@ mod require_unicode_regexp {
             "call expression with non-literal flags should not be flagged"
         );
     }
+
+    #[test]
+    fn ignores_shadowed_regexp_identifier() {
+        // When `RegExp` is shadowed by a local binding (e.g. a function
+        // parameter), the constructor call no longer refers to the global
+        // `RegExp` and must NOT trigger require-unicode-regexp or
+        // require-unicode-sets-regexp.
+        assert!(
+            rule_ids_for(
+                "function f(RegExp) { return new RegExp('foo') }",
+                "require-unicode-regexp"
+            )
+            .is_empty(),
+            "shadowed RegExp parameter must not fire require-unicode-regexp"
+        );
+        assert!(
+            rule_ids_for(
+                "function f(RegExp) { return new RegExp('foo') }",
+                "require-unicode-sets-regexp"
+            )
+            .is_empty(),
+            "shadowed RegExp parameter must not fire require-unicode-sets-regexp"
+        );
+        // But the global RegExp (no shadowing) still fires.
+        assert!(
+            !rule_ids_for("new RegExp('foo')", "require-unicode-regexp").is_empty(),
+            "global RegExp without flags must still fire require-unicode-regexp"
+        );
+        assert!(
+            !rule_ids_for("new RegExp('foo')", "require-unicode-sets-regexp").is_empty(),
+            "global RegExp without flags must still fire require-unicode-sets-regexp"
+        );
+    }
 }
 
 mod no_escape_backspace {

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -17,10 +17,6 @@
       "level": "off",
       "reason": "Flags $1 referring to an unnamed group, which has no named-replacement alternative."
     },
-    "require-unicode-regexp": {
-      "level": "off",
-      "reason": "Non-literal constructor flags are now skipped, but the shadowed-global case (e.g. function f(RegExp) { return new RegExp('foo') }) still false-positives — needs scope analysis to know RegExp is not the global."
-    },
     "use-ignore-case": {
       "level": "off",
       "reason": "Flags case-pair classes like /[aA]a/ where adding the i flag would alter other literals in the pattern."


### PR DESCRIPTION
## Summary

- **Foundation**: wires `oxc_semantic::SemanticBuilder` into `scan_regexp` in `lib.rs`. After the parser succeeds, semantic analysis is run and the resulting `Scoping` is passed into the `Scanner` as a new `scoping: &'a Scoping` field. This gives all check methods access to fully-resolved scope and reference information.

- **First consumer — `is_global_regexp_callee`**: a new `Scanner` method that returns `true` only when a callee is an unqualified `RegExp` identifier that is **not** shadowed by a local binding. It works by reading the `reference_id: Cell<Option<ReferenceId>>` that the semantic analyser attaches to every `IdentifierReference`, then calling `scoping.get_reference(ref_id).symbol_id()` — `None` means global/unresolved, `Some(_)` means a local symbol shadows it.

- **`require-unicode-regexp` fix**: `check_call_expression` and `check_new_expression` in `checks.rs` previously used `is_specific_id("RegExp")` (name-only). Both now call `self.is_global_regexp_callee(&callee)` instead, so a shadowed `RegExp` (e.g. a function parameter) suppresses all constructor-based rules.

## Key API used (oxc_semantic 0.135)

```rust
// In SemanticBuilder / Semantic:
let semantic_return = SemanticBuilder::new().build(&parser_return.program);
let scoping = semantic_return.semantic.scoping();  // returns &Scoping

// On IdentifierReference (oxc_ast 0.135):
// pub reference_id: Cell<Option<ReferenceId>>
let Some(reference_id) = ident.reference_id.get() else { … };

// On Scoping:
scoping.get_reference(reference_id).symbol_id()
// → None  = unresolved/global reference
// → Some(_) = resolved to a local symbol
```

## Scanner field shape

```rust
pub(crate) struct Scanner<'a> {
    pub(crate) source_text: &'a str,
    pub(crate) line_index: LineIndex,
    pub(crate) diagnostics: SmallVec<[Diagnostic; 16]>,
    pub(crate) scoping: &'a Scoping,  // NEW — borrows the Scoping owned by Semantic
}
```

The `Semantic` object is owned in `scan_regexp`'s stack frame; `scoping` is a shared borrow of it. `scan_program` is called with an immutable borrow of `parser_return.program.body`, which is also fine (multiple immutable borrows).

## Files changed

- `crates/regexp/Cargo.toml` — add `oxc_semantic.workspace = true`
- `crates/regexp/src/lib.rs` — build semantic after parse, pass `scoping` into Scanner
- `crates/regexp/src/scanner.rs` — add `scoping` field + `is_global_regexp_callee` method
- `crates/regexp/src/checks.rs` — gate constructor handlers on `is_global_regexp_callee`
- `crates/regexp/src/tests.rs` — add `ignores_shadowed_regexp_identifier` regression test
- `npm/regexp/test/parity.json` — promote `require-unicode-regexp` (remove from quarantine)

## Test results

```
cargo check -p oxlint-plugins-regexp     → Finished (no errors)
cargo test -p oxlint-plugins-regexp      → 154 passed; 0 failed
cargo clippy -p ... -- -D warnings       → Finished (no warnings)
```

All upstream `require-unicode-regexp` `valid[]` fixture cases (including `function f(RegExp) { return new RegExp('foo') }`) emit zero diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783975458&installation_id=136613492&pr_number=152&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F152&signature=5400522fb1b775f6e8a770d0bbb36c934b5b12366dfda6163a7212c20d50726e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->