### PR TITLE
port(sonarjs): port no-labels (S1119)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 12] = [
+pub const RULE_NAMES: [&str; 13] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -35,6 +35,7 @@ pub const RULE_NAMES: [&str; 12] = [
     "no-all-duplicated-branches",
     "no-identical-expressions",
     "arguments-usage",
+    "no-labels",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -8,6 +8,7 @@ mod no_collapsible_if;
 mod no_duplicate_in_composite;
 mod no_identical_conditions;
 mod no_identical_expressions;
+mod no_labels;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_labels.rs
+++ b/crates/sonarjs/src/rules/no_labels.rs
@@ -1,0 +1,34 @@
+//! Rule `no-labels` (SonarJS key S1119).
+//!
+//! Clean-room port. Labels provide goto-like control flow and hurt readability.
+//! This rule flags every `LabeledStatement` unconditionally — including labels
+//! placed on loops or switch statements — because SonarJS discourages labels
+//! entirely and encourages refactoring to structured control flow instead.
+//!
+//! ## Detection strategy
+//!
+//! The hook `visit_labeled_statement` fires for every labeled statement node in
+//! the AST. The diagnostic is anchored on `stmt.label.span`, which covers only
+//! the identifier part of the label (before the colon), keeping the reported
+//! location concise and pointing directly at the label name.
+//!
+//! ## Syntactic check
+//!
+//! This is a purely syntactic, unconditional check. All labeled statements are
+//! flagged regardless of whether the label is actually referenced by a `break`
+//! or `continue` inside the body.
+//!
+//! Behaviour is reproduced from the public RSPEC S1119 description only; no
+//! upstream source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::LabeledStatement;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-labels";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_labels(&mut self, stmt: &LabeledStatement<'_>) {
+        self.report(RULE_NAME, "noLabels", stmt.label.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,8 +4,8 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, ConditionalExpression, IdentifierReference,
-    IfStatement, LogicalExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType,
-    TemplateLiteral, UnaryExpression,
+    IfStatement, LabeledStatement, LogicalExpression, SwitchCase, SwitchStatement,
+    TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -132,5 +132,10 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
         self.check_arguments_usage(it);
         walk::walk_identifier_reference(self, it);
+    }
+
+    fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {
+        self.check_no_labels(it);
+        walk::walk_labeled_statement(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -583,3 +583,33 @@ fn does_not_report_arguments_usage_for_plain_function() {
     let diagnostics = scan("arguments-usage", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_labels_for_labeled_loop() {
+    let source = "loop: for (;;) { break loop; }";
+    let diagnostics = scan("no-labels", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-labels");
+    assert_eq!(diagnostics[0].message_id, "noLabels");
+}
+
+#[test]
+fn reports_no_labels_for_two_nested_labeled_loops() {
+    let source = "outer: for (;;) { inner: for (;;) { break outer; } }";
+    let diagnostics = scan("no-labels", source);
+    assert_eq!(diagnostics.len(), 2);
+}
+
+#[test]
+fn does_not_report_no_labels_for_unlabeled_loop() {
+    let source = "for (;;) { break; }";
+    let diagnostics = scan("no-labels", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_labels_for_plain_variable_declaration() {
+    let source = "const x = 1;";
+    let diagnostics = scan("no-labels", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -58,6 +58,9 @@ const messages = Object.freeze({
   'arguments-usage': {
     argumentsUsage: "Use the rest parameter syntax (...args) instead of the 'arguments' object.",
   },
+  'no-labels': {
+    noLabels: 'Remove this label and refactor the code to use structured control flow instead.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -78,6 +81,7 @@ const ruleDescriptions = Object.freeze({
   'no-identical-expressions':
     'Disallow identical sub-expressions on both sides of binary or logical operators where the result is constant or redundant',
   'arguments-usage': "Disallow use of the 'arguments' object; use rest parameters instead",
+  'no-labels': 'Disallow labeled statements; use structured control flow instead',
 });
 
 const ruleTypes = Object.freeze({
@@ -93,6 +97,7 @@ const ruleTypes = Object.freeze({
   'no-all-duplicated-branches': 'problem',
   'no-identical-expressions': 'problem',
   'arguments-usage': 'suggestion',
+  'no-labels': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -108,6 +113,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-all-duplicated-branches': 'error',
   'no-identical-expressions': 'error',
   'arguments-usage': 'error',
+  'no-labels': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -15,6 +15,7 @@ const expectedRuleNames = [
   'no-all-duplicated-branches',
   'no-identical-expressions',
   'arguments-usage',
+  'no-labels',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -449,6 +450,32 @@ describe('sonarjs native API', () => {
   it('does not report arguments-usage for a function that does not use arguments', () => {
     const source = 'function f() { return 1; }';
     const diagnostics = scan('arguments-usage', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-labels for a labeled loop', () => {
+    const source = 'loop: for (;;) { break loop; }';
+    const diagnostics = scan('no-labels', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-labels');
+    expect(diagnostics[0].messageId).toBe('noLabels');
+  });
+
+  it('reports no-labels for two nested labeled loops (one diagnostic per label)', () => {
+    const source = 'outer: for (;;) { inner: for (;;) { break outer; } }';
+    const diagnostics = scan('no-labels', source);
+    expect(diagnostics).toHaveLength(2);
+  });
+
+  it('does not report no-labels for an unlabeled loop', () => {
+    const source = 'for (;;) { break; }';
+    const diagnostics = scan('no-labels', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-labels for a plain variable declaration', () => {
+    const source = 'const x = 1;';
+    const diagnostics = scan('no-labels', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -106,6 +106,7 @@ describe('sonarjs plugin shape', () => {
       'no-all-duplicated-branches',
       'no-identical-expressions',
       'arguments-usage',
+      'no-labels',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -119,6 +120,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-all-duplicated-branches']).toBe('object');
     expect(typeof plugin.rules['no-identical-expressions']).toBe('object');
     expect(typeof plugin.rules['arguments-usage']).toBe('object');
+    expect(typeof plugin.rules['no-labels']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -132,6 +134,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-all-duplicated-branches']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-identical-expressions']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/arguments-usage']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-labels']).toBe('error');
   });
 });
 
@@ -221,6 +224,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('arguments-usage', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('argumentsUsage');
+  });
+
+  it('reports no-labels through the adapter', () => {
+    const source = 'loop: for (;;) { break loop; }';
+    const reports = runRule('no-labels', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noLabels');
   });
 });
 
@@ -339,5 +349,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(arguments-usage)');
+  });
+
+  it('reports no-labels through the CLI', () => {
+    const source = 'loop: for (;;) { break loop; }';
+    const result = runOxlint('no-labels', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-labels)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12526,19 +12526,19 @@
       },
       {
         "name": "no-labels",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-labels (Sonar key S1119). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of no-labels (Sonar key S1119). Flags every LabeledStatement unconditionally via visit_labeled_statement; reports stmt.label.span. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-literal-call",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-labels`** (Sonar key S1119). Flags every labeled statement (labels enable goto-like control flow); reports the label identifier span. All labeled statements are flagged unconditionally (Sonar discourages labels entirely). Adds a `visit_labeled_statement` hook.

## Tests
Rust unit tests (single label, nested labels → 2, unlabeled loop → 0, plain code → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-labels)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783975508&installation_id=136613492&pr_number=153&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F153&signature=1db94825a4f25f4c12cb5a7604d83907bf349598c83342d72ee0b28b647726d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->