### PR TITLE
docs(functional): document per-rule upstream parity status

### DIFF
--- a/npm/functional/README.md
+++ b/npm/functional/README.md
@@ -1,5 +1,54 @@
 # @oxlint-plugins/oxlint-plugin-functional
 
-Rust-backed Oxlint plugin port of `eslint-plugin-functional`.
+Rust-backed Oxlint plugin port of [`eslint-plugin-functional`](https://github.com/eslint-functional/eslint-plugin-functional).
 
-The native scanner uses Oxc and reports all upstream rule ids. Rules that need TypeScript's checker are implemented as AST-safe checks for the violations that can be proven from syntax alone.
+The native scanner uses Oxc and reports every upstream rule id. Rules whose
+behavior can be decided from syntax alone are ported to full upstream parity;
+rules that depend on TypeScript's type checker are implemented as AST-safe checks
+for the violations that can be proven from syntax, with the type-dependent cases
+documented below.
+
+## Upstream test parity
+
+The upstream test suite is captured verbatim from the vendored submodule
+(`eslint-plugin-functional` v10.0.0) into committed JSON fixtures by
+`pnpm run port:tests:functional` and replayed against this plugin by
+`npm/functional/test/upstream.test.mjs`, so behavior tracks upstream as the
+submodule is bumped. For full-parity rules every upstream case is asserted
+(reported messageIds and counts must match). For the remaining rules every case
+is still captured, and the cases that require type information are skipped and
+counted in the parity ledger — never silently dropped.
+
+### Rule status
+
+| Rule                            | Status                                                                           |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| `functional-parameters`         | ✅ Full parity                                                                   |
+| `no-class-inheritance`          | ✅ Full parity                                                                   |
+| `no-classes`                    | ✅ Full parity                                                                   |
+| `no-let`                        | ✅ Full parity                                                                   |
+| `no-loop-statements`            | ✅ Full parity                                                                   |
+| `no-promise-reject`             | ✅ Full parity                                                                   |
+| `no-this-expressions`           | ✅ Full parity                                                                   |
+| `no-try-statements`             | ✅ Full parity                                                                   |
+| `prefer-property-signatures`    | ✅ Full parity                                                                   |
+| `readonly-type`                 | ✅ AST-only (no upstream test suite)                                             |
+| `no-conditional-statements`     | 🟡 Syntactic core; `allowReturningBranches: "ifExhaustive"` needs types          |
+| `no-expression-statements`      | 🟡 Syntactic core; `ignoreVoid` / `ignoreSelfReturning` need types               |
+| `no-mixed-types`                | 🟡 Syntactic core; resolving a property typed as a function needs types          |
+| `no-throw-statements`           | 🟡 Syntactic core; `allowToRejectPromises` promise-handler detection needs types |
+| `prefer-readonly-type`          | 🟡 Syntactic core; `checkImplicit` needs types                                   |
+| `immutable-data`                | 🔵 Needs type information (array/map/set detection)                              |
+| `no-return-void`                | 🔵 Needs type information (inferred return types)                                |
+| `prefer-immutable-types`        | 🔵 Needs type information (`is-immutable-type`)                                  |
+| `prefer-tacit`                  | 🔵 Needs type information (call-signature arity)                                 |
+| `type-declaration-immutability` | 🔵 Needs type information (`is-immutable-type`)                                  |
+
+- ✅ Full parity — every upstream test case is asserted.
+- 🟡 Syntactic core — the rule's syntax-only behavior is implemented and the
+  syntactic cases pass; specific options/cases that require the TypeScript
+  checker are captured and skipped (counted in the ledger).
+- 🔵 Needs type information — the rule's core requires TypeScript types. The
+  scanner emits AST-level approximations, but full parity requires the
+  type-aware pipeline (`@oxlint-plugins/oxlint-plugin-type-aware`); all upstream
+  cases are captured and skipped until then.


### PR DESCRIPTION
Documents, for all 20 eslint-plugin-functional rules, the parity status: full parity (9 + readonly-type which has no upstream tests), syntactic-core-with-type-dependent-options (5), and type-information-dependent (5). Also explains the captured-and-replayed upstream test suite and the skip+count of type-dependent cases (no silent truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783975861&installation_id=136613492&pr_number=154&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F154&signature=bb4a53dd4adedcef18a7ae614f098015deb376d4aa2a2eb0121b650f0bada668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->