### PR TITLE
port(sonarjs): port no-delete-var (S3001)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 13] = [
+pub const RULE_NAMES: [&str; 14] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -36,6 +36,7 @@ pub const RULE_NAMES: [&str; 13] = [
     "no-identical-expressions",
     "arguments-usage",
     "no-labels",
+    "no-delete-var",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -5,6 +5,7 @@ mod arguments_usage;
 mod comma_or_logical_or_case;
 mod no_all_duplicated_branches;
 mod no_collapsible_if;
+mod no_delete_var;
 mod no_duplicate_in_composite;
 mod no_identical_conditions;
 mod no_identical_expressions;

--- a/crates/sonarjs/src/rules/no_delete_var.rs
+++ b/crates/sonarjs/src/rules/no_delete_var.rs
@@ -1,0 +1,35 @@
+//! Rule `no-delete-var` (SonarJS key S3001).
+//!
+//! Clean-room port. The `delete` operator is designed for removing properties
+//! from objects. Applying `delete` to a plain variable identifier (`delete x`)
+//! is a no-op in sloppy mode and a `SyntaxError` in strict mode, so it is
+//! almost always a programmer mistake.
+//!
+//! **Flagged**: a `UnaryExpression` with operator `delete` whose argument,
+//! after stripping parentheses via `get_inner_expression()`, is a bare
+//! `IdentifierReference` (e.g. `delete x`, `delete (y)`).
+//!
+//! **Not flagged**: `delete obj.prop` or `delete obj[key]` — those are member
+//! expressions and are the legitimate use of the operator.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Expression, UnaryExpression};
+use oxc_syntax::operator::UnaryOperator;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-delete-var";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_delete_var(&mut self, expr: &UnaryExpression<'_>) {
+        if expr.operator != UnaryOperator::Delete {
+            return;
+        }
+        if !matches!(expr.argument.get_inner_expression(), Expression::Identifier(_)) {
+            return;
+        }
+        self.report(RULE_NAME, "noDeleteVar", expr.span);
+    }
+}

--- a/crates/sonarjs/src/rules/no_delete_var.rs
+++ b/crates/sonarjs/src/rules/no_delete_var.rs
@@ -27,7 +27,10 @@ impl Scanner<'_> {
         if expr.operator != UnaryOperator::Delete {
             return;
         }
-        if !matches!(expr.argument.get_inner_expression(), Expression::Identifier(_)) {
+        if !matches!(
+            expr.argument.get_inner_expression(),
+            Expression::Identifier(_)
+        ) {
             return;
         }
         self.report(RULE_NAME, "noDeleteVar", expr.span);

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -96,6 +96,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
         self.check_no_redundant_boolean_unary(it);
+        self.check_no_delete_var(it);
         walk::walk_unary_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -613,3 +613,41 @@ fn does_not_report_no_labels_for_plain_variable_declaration() {
     let diagnostics = scan("no-labels", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_delete_var_for_bare_variable() {
+    let source = "delete x;";
+    let diagnostics = scan("no-delete-var", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-delete-var");
+    assert_eq!(diagnostics[0].message_id, "noDeleteVar");
+}
+
+#[test]
+fn reports_no_delete_var_for_parenthesised_variable() {
+    let source = "delete (y);";
+    let diagnostics = scan("no-delete-var", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noDeleteVar");
+}
+
+#[test]
+fn does_not_report_no_delete_var_for_member_expression_dot() {
+    let source = "delete obj.prop;";
+    let diagnostics = scan("no-delete-var", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_delete_var_for_member_expression_bracket() {
+    let source = "delete obj[key];";
+    let diagnostics = scan("no-delete-var", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_delete_var_for_plain_variable_declaration() {
+    let source = "const z = 1;";
+    let diagnostics = scan("no-delete-var", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -61,6 +61,10 @@ const messages = Object.freeze({
   'no-labels': {
     noLabels: 'Remove this label and refactor the code to use structured control flow instead.',
   },
+  'no-delete-var': {
+    noDeleteVar:
+      "Do not use 'delete' on a variable; it has no effect. Use 'delete' only to remove object properties.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -82,6 +86,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow identical sub-expressions on both sides of binary or logical operators where the result is constant or redundant',
   'arguments-usage': "Disallow use of the 'arguments' object; use rest parameters instead",
   'no-labels': 'Disallow labeled statements; use structured control flow instead',
+  'no-delete-var':
+    "Disallow 'delete' applied to a plain variable; use it only on object properties",
 });
 
 const ruleTypes = Object.freeze({
@@ -98,6 +104,7 @@ const ruleTypes = Object.freeze({
   'no-identical-expressions': 'problem',
   'arguments-usage': 'suggestion',
   'no-labels': 'suggestion',
+  'no-delete-var': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -114,6 +121,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-identical-expressions': 'error',
   'arguments-usage': 'error',
   'no-labels': 'error',
+  'no-delete-var': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -16,6 +16,7 @@ const expectedRuleNames = [
   'no-identical-expressions',
   'arguments-usage',
   'no-labels',
+  'no-delete-var',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -476,6 +477,39 @@ describe('sonarjs native API', () => {
   it('does not report no-labels for a plain variable declaration', () => {
     const source = 'const x = 1;';
     const diagnostics = scan('no-labels', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-delete-var for delete applied to a bare variable', () => {
+    const source = 'delete x;';
+    const diagnostics = scan('no-delete-var', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-delete-var');
+    expect(diagnostics[0].messageId).toBe('noDeleteVar');
+  });
+
+  it('reports no-delete-var for delete applied to a parenthesised variable', () => {
+    const source = 'delete (y);';
+    const diagnostics = scan('no-delete-var', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noDeleteVar');
+  });
+
+  it('does not report no-delete-var for delete on a member expression (dot)', () => {
+    const source = 'delete obj.prop;';
+    const diagnostics = scan('no-delete-var', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-delete-var for delete on a member expression (bracket)', () => {
+    const source = 'delete obj[key];';
+    const diagnostics = scan('no-delete-var', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-delete-var for a plain variable declaration', () => {
+    const source = 'const z = 1;';
+    const diagnostics = scan('no-delete-var', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -107,6 +107,7 @@ describe('sonarjs plugin shape', () => {
       'no-identical-expressions',
       'arguments-usage',
       'no-labels',
+      'no-delete-var',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -121,6 +122,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-identical-expressions']).toBe('object');
     expect(typeof plugin.rules['arguments-usage']).toBe('object');
     expect(typeof plugin.rules['no-labels']).toBe('object');
+    expect(typeof plugin.rules['no-delete-var']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -135,6 +137,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-identical-expressions']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/arguments-usage']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-labels']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-delete-var']).toBe('error');
   });
 });
 
@@ -231,6 +234,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-labels', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('noLabels');
+  });
+
+  it('reports no-delete-var through the adapter', () => {
+    const source = 'delete x;';
+    const reports = runRule('no-delete-var', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noDeleteVar');
   });
 });
 
@@ -359,5 +369,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-labels)');
+  });
+
+  it('reports no-delete-var through the CLI', () => {
+    const source = 'delete x;';
+    const result = runOxlint('no-delete-var', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-delete-var)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11870,19 +11870,19 @@
       },
       {
         "name": "no-delete-var",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-delete-var (Sonar key S3001). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S3001. Reports delete applied to a bare variable identifier (delete x), which is a no-op in sloppy mode and a SyntaxError in strict mode. Member-expression operands (delete obj.prop, delete obj[key]) are not flagged. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-duplicate-in-composite",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-delete-var`** (Sonar key S3001). Flags `delete` applied to a bare variable identifier (`delete x`) — a no-op in sloppy mode and a `SyntaxError` in strict mode. Member expressions (`delete obj.prop`, `delete obj[key]`), the legitimate use of `delete`, are not flagged. Reuses the existing `visit_unary_expression` hook.

## Tests
Rust unit tests (`delete x`, `delete (y)`, `delete obj.prop` → 0, `delete obj[key]` → 0, plain decl → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-delete-var)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783976002&installation_id=136613492&pr_number=155&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F155&signature=54197b31b05ff0a302684fb941a7d99021d7a7998b0f2b6f207052d2e83a4edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->