### PR TITLE
fix(regexp): prefer-named-replacement only flags named groups on known-string receivers

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -135,11 +135,55 @@ fn replacement_has_useless_dollar_zero_ref(replacement: &str, capture_count: u32
     false
 }
 
-/// Returns `true` when `replacement` contains a `$N` backreference (where `N`
-/// is a single ASCII digit 1-9). Used by `prefer-named-replacement` to decide
-/// whether a string replacement is using numbered backreferences. `$$` (escaped
-/// dollar) and `$&` (whole match) are intentionally skipped.
-fn contains_numeric_backreference(replacement: &str) -> bool {
+/// Builds a bitmask of capture-group indices (1-based, bits 1-9) that are
+/// named groups in `pattern`.  The bitmask is zero when there are no named
+/// groups.  Uses the same scanning approach as
+/// `first_numbered_backreference_with_named_group` in `helpers.rs`.
+fn named_group_mask(pattern: &str) -> u32 {
+    if !pattern.contains("(?<") {
+        return 0;
+    }
+    let bytes = pattern.as_bytes();
+    let mut mask: u32 = 0;
+    let mut group_counter: u32 = 0;
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'[' {
+            if let Some(close) = find_class_end(bytes, index) {
+                index = close + 1;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if bytes[index] == b'\\' {
+            index = skip_escape(bytes, index).max(index + 1);
+            continue;
+        }
+        if bytes[index] == b'(' {
+            let gp = group_prefix(bytes, index);
+            if gp.capturing {
+                group_counter += 1;
+                if gp.named && group_counter <= 9 {
+                    mask |= 1 << group_counter;
+                }
+            }
+            index = gp.next;
+            continue;
+        }
+        index += 1;
+    }
+    mask
+}
+
+/// Returns `true` when `replacement` contains a `$N` backreference (N = 1-9)
+/// where capture group N is a *named* group according to `named_mask`.
+/// `$$` (escaped dollar) is intentionally skipped.  Groups beyond 9 and the
+/// `$0` form are out of scope for this rule.
+fn replacement_has_named_group_numeric_ref(replacement: &str, named_mask: u32) -> bool {
+    if named_mask == 0 {
+        return false;
+    }
     let bytes = replacement.as_bytes();
     let mut index = 0;
     while index + 1 < bytes.len() {
@@ -149,8 +193,11 @@ fn contains_numeric_backreference(replacement: &str) -> bool {
                 index += 2;
                 continue;
             }
-            if next.is_ascii_digit() && next != b'0' {
-                return true;
+            if matches!(next, b'1'..=b'9') {
+                let group_num = (next - b'0') as u32;
+                if named_mask & (1 << group_num) != 0 {
+                    return true;
+                }
             }
         }
         index += 1;
@@ -299,9 +346,19 @@ impl<'a> Scanner<'a> {
         self.report("no-useless-dollar-replacements", "unexpected", call.span);
     }
 
-    /// `prefer-named-replacement`: when `<expr>.replace(<regexp with named
-    /// captures>, "...$N...")` mixes numbered backreferences with a regex that
-    /// has at least one named capture, the named form `$<name>` is clearer.
+    /// `prefer-named-replacement`: when `<string>.replace(<regexp with named
+    /// captures>, "...$N...")` uses a numbered backreference `$N` where group N
+    /// is itself a named capture, the named form `$<name>` is clearer.
+    ///
+    /// Two conditions must both hold before we report:
+    /// 1. The receiver is a statically-known string (string literal, no-expr
+    ///    template, or a `const`/`let`/`var` initialised with one). An unknown
+    ///    receiver (free variable, call result, …) might not be a `String` at
+    ///    all and is left unreported.
+    /// 2. The `$N` in the replacement refers to a group index that is itself a
+    ///    *named* group in the regex literal. A `$N` that points at an unnamed
+    ///    group has no named alternative and must not be flagged.
+    ///
     /// We only attempt the literal-regexp + literal-replacement case; dynamic
     /// arguments are deferred.
     fn check_prefer_named_replacement(&mut self, call: &'a CallExpression<'a>) {
@@ -310,6 +367,10 @@ impl<'a> Scanner<'a> {
         };
         let method = member.property.name.as_str();
         if method != "replace" && method != "replaceAll" {
+            return;
+        }
+        // Condition 1: receiver must be a statically-known string.
+        if !self.receiver_is_known_string(&member.object) {
             return;
         }
         if call.arguments.len() < 2 {
@@ -321,7 +382,10 @@ impl<'a> Scanner<'a> {
         let Expression::RegExpLiteral(literal) = arg0.get_inner_expression() else {
             return;
         };
-        if !literal.regex.pattern.text.as_str().contains("(?<") {
+        let pattern = literal.regex.pattern.text.as_str();
+        // Condition 2: build named-group mask; bail early when there are none.
+        let mask = named_group_mask(pattern);
+        if mask == 0 {
             return;
         }
         let Some(arg1) = call.arguments.get(1).and_then(Argument::as_expression) else {
@@ -330,7 +394,7 @@ impl<'a> Scanner<'a> {
         let Expression::StringLiteral(replacement) = arg1.get_inner_expression() else {
             return;
         };
-        if !contains_numeric_backreference(replacement.value.as_str()) {
+        if !replacement_has_named_group_numeric_ref(replacement.value.as_str(), mask) {
             return;
         }
         self.report("prefer-named-replacement", "unexpected", call.span);

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -2268,9 +2268,10 @@ mod prefer_named_replacement {
 
     #[test]
     fn reports_numbered_backreference_with_named_capture_pattern() {
+        // String-literal receiver + $N referring to a named group → fires.
         assert_eq!(
             rule_ids_for(
-                "str.replace(/(?<year>\\d{4})/u, '$1');",
+                "\"s\".replace(/(?<year>\\d{4})/u, '$1');",
                 "prefer-named-replacement"
             )
             .as_slice(),
@@ -2279,7 +2280,7 @@ mod prefer_named_replacement {
         // `replaceAll` shares the same shape.
         assert_eq!(
             rule_ids_for(
-                "str.replaceAll(/(?<year>\\d{4})/gu, 'year: $1');",
+                "\"s\".replaceAll(/(?<year>\\d{4})/gu, 'year: $1');",
                 "prefer-named-replacement"
             )
             .as_slice(),
@@ -2292,7 +2293,7 @@ mod prefer_named_replacement {
         // Named replacement form — no diagnostic.
         assert!(
             rule_ids_for(
-                "str.replace(/(?<year>\\d{4})/u, '$<year>');",
+                "\"s\".replace(/(?<year>\\d{4})/u, '$<year>');",
                 "prefer-named-replacement"
             )
             .is_empty()
@@ -2300,7 +2301,7 @@ mod prefer_named_replacement {
         // Regex has no named capture, so `$1` is the only way to refer back.
         assert!(
             rule_ids_for(
-                "str.replace(/(\\d{4})/u, '$1');",
+                "\"s\".replace(/(\\d{4})/u, '$1');",
                 "prefer-named-replacement"
             )
             .is_empty()
@@ -2308,14 +2309,54 @@ mod prefer_named_replacement {
         // Escaped dollar must not count as a numeric backreference.
         assert!(
             rule_ids_for(
-                "str.replace(/(?<year>\\d{4})/u, '$$1');",
+                "\"s\".replace(/(?<year>\\d{4})/u, '$$1');",
                 "prefer-named-replacement"
             )
             .is_empty()
         );
         // Unrelated method.
         assert!(
-            rule_ids_for("str.match(/(?<year>\\d{4})/u);", "prefer-named-replacement").is_empty()
+            rule_ids_for(
+                "\"s\".match(/(?<year>\\d{4})/u);",
+                "prefer-named-replacement"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn regression_unnamed_group_not_flagged() {
+        // $1 refers to group 1 = (a) which is UNNAMED → must NOT fire.
+        assert!(
+            rule_ids_for(
+                "\"str\".replace(/(a)(?<foo>b)c/, '_$1_');",
+                "prefer-named-replacement"
+            )
+            .is_empty()
+        );
+        // Free/unknown receiver → must NOT fire regardless of group type.
+        assert!(
+            rule_ids_for(
+                "unknown.replace(/a(?<foo>b)c/, '_$1_');",
+                "prefer-named-replacement"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "unknown.replaceAll(/a(?<foo>b)c/, '_$1_');",
+                "prefer-named-replacement"
+            )
+            .is_empty()
+        );
+        // String-literal receiver + $N pointing at a NAMED group → fires.
+        assert_eq!(
+            rule_ids_for(
+                "\"s\".replace(/(?<foo>b)/, '$1');",
+                "prefer-named-replacement"
+            )
+            .as_slice(),
+            &["unexpected"]
         );
     }
 }

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -9,10 +9,6 @@
       "level": "off",
       "reason": "Flags lazy quantifiers like /a??/ and /a{3}?/ that upstream treats as valid."
     },
-    "prefer-named-replacement": {
-      "level": "off",
-      "reason": "Flags $1 referring to an unnamed group, which has no named-replacement alternative."
-    },
     "use-ignore-case": {
       "level": "off",
       "reason": "Flags case-pair classes like /[aA]a/ where adding the i flag would alter other literals in the pattern."

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -247,13 +247,13 @@ const invalidCases = [
   [
     'prefer-named-replacement',
     'numbered backref with named regex',
-    "str.replace(/(?<year>\\d{4})/u, '$1');\n",
+    "'s'.replace(/(?<year>\\d{4})/u, '$1');\n",
     ['unexpected'],
   ],
   [
     'prefer-named-replacement',
     'replaceAll variant',
-    "str.replaceAll(/(?<year>\\d{4})/gu, 'year: $1');\n",
+    "'s'.replaceAll(/(?<year>\\d{4})/gu, 'year: $1');\n",
     ['unexpected'],
   ],
   // no-obscure-range


### PR DESCRIPTION
## Summary

- **Receiver guard**: `check_prefer_named_replacement` now calls `self.receiver_is_known_string(&member.object)` (the helper merged in #156) and bails out early when the receiver is not a statically-known string (string literal, no-expr template, or a `const`/`let`/`var` initialised with one). Free-variable receivers (`unknown.replace(…)`) are no longer flagged.
- **Named-group mask**: A new `named_group_mask(pattern) -> u32` helper walks the regex pattern (reusing `group_prefix` / `skip_escape` / `find_class_end` exactly as `first_numbered_backreference_with_named_group` in `helpers.rs` does) and builds a bitmask of capture-group indices (bits 1–9) that are *named* groups. `$N` in the replacement is only reported when bit N is set in that mask — i.e. group N is itself a named capture.
- **`parity.json`**: The `prefer-named-replacement` quarantine entry (level `"off"`) is removed; the rule now passes all upstream `valid[]` cases.
- **Tests converted**: The existing Rust tests in `mod prefer_named_replacement` and the two `plugin.test.mjs` cases that used a free-variable receiver `str.replace(…)` / `str.replaceAll(…)` are updated to use string-literal receivers (`"s".replace(…)`). A new `regression_unnamed_group_not_flagged` test covers all three regression scenarios explicitly.

## Test plan

- [ ] `cargo check -p oxlint-plugins-regexp` — clean
- [ ] `cargo test -p oxlint-plugins-regexp` — 157 passed, 0 failed
- [ ] `cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings` — clean
- [ ] All 10 `valid[]` cases in `fixtures/prefer-named-replacement.json` produce zero diagnostics
- [ ] All 4 `invalid[]` cases still fire (only `$N` where group N is named, on string-literal receivers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783976680&installation_id=136613492&pr_number=157&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F157&signature=76fd052bfca413608b3c54d22f95f5da3ae215e28881ab1c630dca02b6976ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->