### PR TITLE
port(sonarjs): port constructor-for-side-effects (S1848)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 14] = [
+pub const RULE_NAMES: [&str; 15] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -37,6 +37,7 @@ pub const RULE_NAMES: [&str; 14] = [
     "arguments-usage",
     "no-labels",
     "no-delete-var",
+    "constructor-for-side-effects",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -3,6 +3,7 @@
 
 mod arguments_usage;
 mod comma_or_logical_or_case;
+mod constructor_for_side_effects;
 mod no_all_duplicated_branches;
 mod no_collapsible_if;
 mod no_delete_var;

--- a/crates/sonarjs/src/rules/constructor_for_side_effects.rs
+++ b/crates/sonarjs/src/rules/constructor_for_side_effects.rs
@@ -1,0 +1,38 @@
+//! Rule `constructor-for-side-effects` (SonarJS key S1848).
+//!
+//! Clean-room port. Creating an object with `new` and immediately discarding
+//! the result (using the expression as a bare statement) is suspicious: either
+//! the constructor has side effects — which should instead live in a named
+//! function or method — or the result was meant to be assigned but the
+//! assignment was forgotten.
+//!
+//! **Flagged**: an `ExpressionStatement` whose `expression`, after stripping
+//! parentheses via `get_inner_expression()`, is a `NewExpression`
+//! (e.g. `new Foo();`, `new Bar`).
+//!
+//! **Not flagged**:
+//! - `const x = new Foo();` — the result is captured in a variable.
+//! - `new Foo().bar();` — the AST node is a `CallExpression` statement;
+//!   the `new` result is used as a receiver.
+//! - `foo();` — a plain call expression, not `new`.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Expression, ExpressionStatement};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "constructor-for-side-effects";
+
+impl Scanner<'_> {
+    pub(crate) fn check_constructor_for_side_effects(&mut self, stmt: &ExpressionStatement<'_>) {
+        if !matches!(
+            stmt.expression.get_inner_expression(),
+            Expression::NewExpression(_)
+        ) {
+            return;
+        }
+        self.report(RULE_NAME, "constructorForSideEffects", stmt.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,9 +3,9 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, IdentifierReference,
-    IfStatement, LabeledStatement, LogicalExpression, SwitchCase, SwitchStatement,
-    TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement,
+    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, SwitchCase,
+    SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -138,5 +138,10 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {
         self.check_no_labels(it);
         walk::walk_labeled_statement(self, it);
+    }
+
+    fn visit_expression_statement(&mut self, it: &ExpressionStatement<'a>) {
+        self.check_constructor_for_side_effects(it);
+        walk::walk_expression_statement(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -651,3 +651,41 @@ fn does_not_report_no_delete_var_for_plain_variable_declaration() {
     let diagnostics = scan("no-delete-var", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_constructor_for_side_effects_new_with_parens() {
+    let source = "new Foo();";
+    let diagnostics = scan("constructor-for-side-effects", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "constructor-for-side-effects");
+    assert_eq!(diagnostics[0].message_id, "constructorForSideEffects");
+}
+
+#[test]
+fn reports_constructor_for_side_effects_new_without_parens() {
+    let source = "new Foo;";
+    let diagnostics = scan("constructor-for-side-effects", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "constructorForSideEffects");
+}
+
+#[test]
+fn does_not_report_constructor_for_side_effects_when_result_assigned() {
+    let source = "const x = new Foo();";
+    let diagnostics = scan("constructor-for-side-effects", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_constructor_for_side_effects_when_result_used_as_receiver() {
+    let source = "new Foo().bar();";
+    let diagnostics = scan("constructor-for-side-effects", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_constructor_for_side_effects_for_plain_call_statement() {
+    let source = "foo();";
+    let diagnostics = scan("constructor-for-side-effects", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -65,6 +65,10 @@ const messages = Object.freeze({
     noDeleteVar:
       "Do not use 'delete' on a variable; it has no effect. Use 'delete' only to remove object properties.",
   },
+  'constructor-for-side-effects': {
+    constructorForSideEffects:
+      'Either use this object, assign it to a variable, or move the side effects into a named function instead of a constructor.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -88,6 +92,8 @@ const ruleDescriptions = Object.freeze({
   'no-labels': 'Disallow labeled statements; use structured control flow instead',
   'no-delete-var':
     "Disallow 'delete' applied to a plain variable; use it only on object properties",
+  'constructor-for-side-effects':
+    'Disallow using new solely for side effects without capturing or using the constructed object',
 });
 
 const ruleTypes = Object.freeze({
@@ -105,6 +111,7 @@ const ruleTypes = Object.freeze({
   'arguments-usage': 'suggestion',
   'no-labels': 'suggestion',
   'no-delete-var': 'problem',
+  'constructor-for-side-effects': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -122,6 +129,7 @@ const recommendedRuleConfig = Object.freeze({
   'arguments-usage': 'error',
   'no-labels': 'error',
   'no-delete-var': 'error',
+  'constructor-for-side-effects': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -17,6 +17,7 @@ const expectedRuleNames = [
   'arguments-usage',
   'no-labels',
   'no-delete-var',
+  'constructor-for-side-effects',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -510,6 +511,39 @@ describe('sonarjs native API', () => {
   it('does not report no-delete-var for a plain variable declaration', () => {
     const source = 'const z = 1;';
     const diagnostics = scan('no-delete-var', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports constructor-for-side-effects for new Foo() as a bare statement', () => {
+    const source = 'new Foo();';
+    const diagnostics = scan('constructor-for-side-effects', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('constructor-for-side-effects');
+    expect(diagnostics[0].messageId).toBe('constructorForSideEffects');
+  });
+
+  it('reports constructor-for-side-effects for new Foo (no parens) as a bare statement', () => {
+    const source = 'new Foo;';
+    const diagnostics = scan('constructor-for-side-effects', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('constructorForSideEffects');
+  });
+
+  it('does not report constructor-for-side-effects when result is assigned to a variable', () => {
+    const source = 'const x = new Foo();';
+    const diagnostics = scan('constructor-for-side-effects', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report constructor-for-side-effects when result is used as a call receiver', () => {
+    const source = 'new Foo().bar();';
+    const diagnostics = scan('constructor-for-side-effects', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report constructor-for-side-effects for a plain function call statement', () => {
+    const source = 'foo();';
+    const diagnostics = scan('constructor-for-side-effects', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -108,6 +108,7 @@ describe('sonarjs plugin shape', () => {
       'arguments-usage',
       'no-labels',
       'no-delete-var',
+      'constructor-for-side-effects',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -123,6 +124,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['arguments-usage']).toBe('object');
     expect(typeof plugin.rules['no-labels']).toBe('object');
     expect(typeof plugin.rules['no-delete-var']).toBe('object');
+    expect(typeof plugin.rules['constructor-for-side-effects']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -138,6 +140,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/arguments-usage']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-labels']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-delete-var']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/constructor-for-side-effects']).toBe('error');
   });
 });
 
@@ -241,6 +244,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-delete-var', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('noDeleteVar');
+  });
+
+  it('reports constructor-for-side-effects through the adapter', () => {
+    const source = 'new Foo();';
+    const reports = runRule('constructor-for-side-effects', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('constructorForSideEffects');
   });
 });
 
@@ -379,5 +389,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-delete-var)');
+  });
+
+  it('reports constructor-for-side-effects through the CLI', () => {
+    const source = 'new Foo();';
+    const result = runOxlint('constructor-for-side-effects', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(constructor-for-side-effects)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10718,19 +10718,19 @@
       },
       {
         "name": "constructor-for-side-effects",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule constructor-for-side-effects (Sonar key S1848). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1848). Reports a NewExpression used as a bare ExpressionStatement — the constructed object is immediately discarded. Implemented via visit_expression_statement + get_inner_expression(). No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "content-length",


### PR DESCRIPTION
## Summary
Clean-room port of **`constructor-for-side-effects`** (Sonar key S1848). Flags a `new` expression used as a bare statement (the object is created then discarded), e.g. `new Foo();` — side effects belong in a named function, or the result should be used. Not flagged: `const x = new Foo();`, `new Foo().bar();` (the `new` result is used as a receiver), and plain calls. Adds a `visit_expression_statement` hook.

## Tests
Rust unit tests (`new Foo();`, `new Foo;`, assigned, `new Foo().bar()` → 0, plain call → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(constructor-for-side-effects)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783976896&installation_id=136613492&pr_number=158&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F158&signature=54e18f01a6da003b59a02ade933f328ca939b0bc351cc77a0e796a7d0f0f4f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->