### PR TITLE
fix(regexp): use-ignore-case only fires when /i preserves pattern behavior

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -16,7 +16,8 @@ use crate::helpers::{
     first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
     first_unicode_escape_as_hex, first_uppercase_hex_escape, first_useless_escape,
     first_useless_one_quantifier, group_prefix, mention_char, pattern_ends_with_lazy_quantifier,
-    pattern_has_empty_string_literal, skip_escape, sorted_flags, string_literal_value_with_span,
+    pattern_has_empty_string_literal, pattern_is_safe_to_add_i_flag, skip_escape, sorted_flags,
+    string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -698,7 +699,10 @@ impl<'a> Scanner<'a> {
                 span,
             );
         }
-        if analysis.has_case_pair_class && !flags.contains('i') {
+        if analysis.has_case_pair_class
+            && !flags.contains('i')
+            && pattern_is_safe_to_add_i_flag(pattern, flags)
+        {
             self.report("use-ignore-case", "unexpected", span);
         }
         if analysis.has_useless_non_capturing_group {

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -1105,6 +1105,91 @@ pub(crate) fn class_has_case_pair(bytes: &[u8], open: usize) -> bool {
     (0..26).any(|i| has_lower[i] && has_upper[i])
 }
 
+/// Returns `true` when adding the `i` flag to the pattern would be
+/// equivalent — i.e. every ASCII letter in the pattern is already covered
+/// by a case-pair inside a character class, so flipping to case-insensitive
+/// mode changes nothing outside those classes.
+///
+/// The check is intentionally conservative (may return `false` when it could
+/// theoretically return `true`) so it never produces false positives:
+///
+/// - A bare ASCII letter outside a class makes the pattern case-variant
+///   (`/[aA]a/` → the bare `a` would also match `A` with `i`).
+/// - A `\b`/`\B` escape when the `u` or `v` flag is active is case-variant:
+///   Unicode word-boundary matching depends on the case of adjacent
+///   characters, so adding `i` can change whether `\b` fires.
+/// - A character class whose literal ASCII letters are not fully case-paired
+///   (e.g. `[aAb]` — `b` has no `B`) is case-variant.
+/// - Ranges, non-ASCII chars, escape sequences, and non-letter literals are
+///   conservatively treated as non-case-variant and are ignored.
+///
+/// Used by `use-ignore-case` to suppress the diagnostic when adding `/i`
+/// would change the set of strings matched by the rest of the pattern.
+pub(crate) fn pattern_is_safe_to_add_i_flag(pattern: &str, flags: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let unicode = flags.contains('u') || flags.contains('v');
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => {
+                // \b and \B (word boundaries) are case-variant in Unicode mode.
+                if unicode && matches!(bytes.get(index + 1).copied(), Some(b'b') | Some(b'B')) {
+                    return false;
+                }
+                index = skip_escape(bytes, index);
+            }
+            b'[' => {
+                let Some(end) = find_class_end(bytes, index) else {
+                    return false;
+                };
+                // Check that every literal ASCII letter inside the class has
+                // its opposite-case counterpart also present literally.
+                // Ranges and escape sequences are skipped (conservative).
+                let mut inner = index + 1;
+                if bytes.get(inner) == Some(&b'^') {
+                    inner += 1;
+                }
+                let mut has_lower = [false; 26];
+                let mut has_upper = [false; 26];
+                let mut i2 = inner;
+                while i2 < end {
+                    if bytes[i2] == b'\\' {
+                        i2 = skip_escape(bytes, i2).min(end);
+                        continue;
+                    }
+                    if i2 + 2 < end && bytes[i2 + 1] == b'-' {
+                        // range: skip all three bytes; don't record endpoints
+                        i2 += 3;
+                        continue;
+                    }
+                    let byte = bytes[i2];
+                    if byte.is_ascii_lowercase() {
+                        has_lower[(byte - b'a') as usize] = true;
+                    } else if byte.is_ascii_uppercase() {
+                        has_upper[(byte - b'A') as usize] = true;
+                    }
+                    i2 += 1;
+                }
+                // If any literal letter is unpaired, adding `i` changes the class.
+                for k in 0..26usize {
+                    if (has_lower[k] || has_upper[k]) && !(has_lower[k] && has_upper[k]) {
+                        return false;
+                    }
+                }
+                index = end + 1;
+            }
+            b => {
+                // Bare ASCII letter outside a class → case-variant.
+                if b.is_ascii_alphabetic() {
+                    return false;
+                }
+                index += 1;
+            }
+        }
+    }
+    true
+}
+
 /// Returns `Some(byte)` when the `[...]` class at `open` contains a `\q{X}`
 /// string literal whose body is exactly one ASCII char. Such literals are
 /// equivalent to the bare character in v-mode, so the `\q{}` wrapper is

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -658,6 +658,7 @@ mod use_ignore_case {
 
     #[test]
     fn reports_case_pair_classes_without_i_flag() {
+        // Bare case-pair class: every letter in the pattern is covered by a pair.
         assert_eq!(
             rule_ids_for("const a = /[aA]/u;", "use-ignore-case").as_slice(),
             &["unexpected"]
@@ -665,6 +666,16 @@ mod use_ignore_case {
         // Multi-pair class.
         assert_eq!(
             rule_ids_for("const a = /[aAbB]/u;", "use-ignore-case").as_slice(),
+            &["unexpected"]
+        );
+        // v-mode bare case-pair class.
+        assert_eq!(
+            rule_ids_for("const a = /[aA]/v;", "use-ignore-case").as_slice(),
+            &["unexpected"]
+        );
+        // Multiple case-pair classes, no bare letters.
+        assert_eq!(
+            rule_ids_for("const a = /[aA][aA][aA]/u;", "use-ignore-case").as_slice(),
             &["unexpected"]
         );
     }
@@ -678,6 +689,24 @@ mod use_ignore_case {
         // Ranges and escapes are intentionally skipped.
         assert!(rule_ids_for("const a = /[a-z]/u;", "use-ignore-case").is_empty());
         assert!(rule_ids_for("const a = /[\\w]/u;", "use-ignore-case").is_empty());
+    }
+
+    #[test]
+    fn regression_does_not_fire_when_adding_i_would_change_behavior() {
+        // Bare `a` outside the class: adding /i would also make the bare `a`
+        // match uppercase `A`, changing the set of strings matched.
+        assert!(rule_ids_for("const a = /[aA]a/u;", "use-ignore-case").is_empty());
+        assert!(rule_ids_for("const a = /[aA]a/v;", "use-ignore-case").is_empty());
+        assert!(rule_ids_for("const a = /[aA]a/;", "use-ignore-case").is_empty());
+        // Class with unpaired `b`: adding /i would make `b` match `B` too.
+        assert!(rule_ids_for("const a = /[aAb]/u;", "use-ignore-case").is_empty());
+        assert!(rule_ids_for("const a = /[aAb]/v;", "use-ignore-case").is_empty());
+        assert!(rule_ids_for("const a = /[aAb]/;", "use-ignore-case").is_empty());
+        // `\b` (word boundary) in Unicode mode is case-variant: its matching
+        // depends on whether adjacent characters are cased, so adding /i changes
+        // where the boundary fires.
+        assert!(rule_ids_for("const a = /\\b[aA]/u;", "use-ignore-case").is_empty());
+        assert!(rule_ids_for("const a = /\\b[aA]/v;", "use-ignore-case").is_empty());
     }
 }
 

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -8,10 +8,6 @@
     "no-lazy-ends": {
       "level": "off",
       "reason": "Flags lazy quantifiers like /a??/ and /a{3}?/ that upstream treats as valid."
-    },
-    "use-ignore-case": {
-      "level": "off",
-      "reason": "Flags case-pair classes like /[aA]a/ where adding the i flag would alter other literals in the pattern."
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Bug**: `use-ignore-case` was flagging patterns like `/[aA]a/` and `/[aAb]/` where adding the `/i` flag would change what the pattern matches (false positives).
- **Fix**: Added a `pattern_is_safe_to_add_i_flag(pattern, flags)` whole-pattern check in `helpers.rs`. The rule now only fires when the **entire pattern** is already case-insensitive-equivalent — i.e. every ASCII letter is inside a class that contains both cases of that letter.
- **Parity**: Removed `use-ignore-case` from `parity.json` quarantine; all upstream `valid[]` cases now produce zero diagnostics.

## Upstream's exact reporting condition

Upstream `isCaseVariant(patternAst, flags)` from `regexp-ast-analysis` checks the **full** pattern AST. It returns `true` (→ suppress the rule) when any part of the pattern would change behaviour with the `i` flag:
- A bare letter outside a class (e.g. the `a` in `/[aA]a/`)
- A class with an unpaired cased letter (e.g. the `b` in `/[aAb]/`)
- A `\b`/`\B` word-boundary in Unicode mode (`u`/`v`) — Unicode word boundaries are case-sensitive

## What the new whole-pattern check does

`pattern_is_safe_to_add_i_flag(pattern, flags)` returns `false` (→ suppress report) when:
1. Any bare ASCII letter appears outside a character class
2. Any character class contains a literal ASCII letter without its opposite case also present literally (skips ranges and escape sequences, being conservative)
3. `\b`/`\B` is present and the `u` or `v` flag is active

## Valid[] cases that were incorrectly firing — now fixed

| Pattern | Reason was suppressed |
|---|---|
| `/[aA]a/` | bare `a` outside class |
| `/[aAb]/` | `b` has no `B` in class |
| `/[aA]a/u` | bare `a` outside class |
| `/[aAb]/u` | `b` has no `B` in class |
| `/[aA]a/v` | bare `a` outside class |
| `/[aAb]/v` | `b` has no `B` in class |
| `/\b[aA]/u` | `\b` in unicode mode is case-variant |
| `/\b[aA]/v` | `\b` in unicode mode is case-variant |

## Invalid[] cases that still fire

| Pattern | Why it still fires |
|---|---|
| `/[aA]/u` | only fully-paired class, no bare letters |
| `/[aA]/v` | same |
| `/[aA][aA][aA][aA][aA]/` | all classes fully paired |
| `/\b0[xX][a-fA-F0-9]+\b/` | `[xX]` is fully paired; `\b` not in unicode mode |

## Known deferred gap (pre-existing, unchanged)

Range-based classes (`/[a-zA-Z]/`) and `\q{a|A}` string-disjunction patterns are still not detected by `class_has_case_pair` (ranges are skipped). This is the same pre-existing gap that existed before this fix — no regression.

## Test plan

- [x] `cargo check -p oxlint-plugins-regexp` → clean
- [x] `cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings` → clean
- [x] `cargo test -p oxlint-plugins-regexp` → 160 passed, 0 failed
- [x] Added regression test `regression_does_not_fire_when_adding_i_would_change_behavior` covering all 8 newly-fixed valid cases
- [x] Existing invalid-case tests (`/[aA]/u`, `/[aAbB]/u`, `/[aA]/v`, etc.) still pass
- [x] Removed `use-ignore-case` from `parity.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783977340&installation_id=136613492&pr_number=160&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F160&signature=008e8131d4c25af11e7a3fff909a2256bad72d2d738186a8ea18872585aa46e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->