### PR TITLE
fix(functional): scan all expressions in argument/array-element position

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -178,83 +178,25 @@ impl<'a> Scanner<'a> {
         element: &'a ArrayExpressionElement<'a>,
         context: FunctionContext,
     ) {
-        match element {
-            ArrayExpressionElement::SpreadElement(spread) => {
-                self.scan_expression(&spread.argument, context)
-            }
-            ArrayExpressionElement::CallExpression(call) => {
-                self.scan_call_expression(call, context)
-            }
-            ArrayExpressionElement::StaticMemberExpression(member) => {
-                self.scan_static_member_expression(member, context);
-            }
-            ArrayExpressionElement::ComputedMemberExpression(member) => {
-                self.scan_computed_member_expression(member, context);
-            }
-            ArrayExpressionElement::ArrowFunctionExpression(function) => {
-                self.scan_arrow_function(function, FunctionParamMeta::default());
-            }
-            ArrayExpressionElement::FunctionExpression(function) => {
-                self.scan_function(function, FunctionParamMeta::default());
-            }
-            ArrayExpressionElement::ArrayExpression(expression) => {
-                for element in &expression.elements {
-                    self.scan_array_element(element, context);
-                }
-            }
-            ArrayExpressionElement::ObjectExpression(expression) => {
-                for property in &expression.properties {
-                    if let ObjectPropertyKind::ObjectProperty(property) = property {
-                        self.scan_expression(&property.value, context);
-                    }
-                }
-            }
-            _ => {}
+        // Spread elements wrap an expression; an elision (hole) has none; every
+        // other element is an expression. Route expressions through
+        // `scan_expression` so no node type is skipped in array-element position.
+        if let ArrayExpressionElement::SpreadElement(spread) = element {
+            self.scan_expression(&spread.argument, context);
+        } else if let Some(expression) = element.as_expression() {
+            self.scan_expression(expression, context);
         }
     }
 
     pub(crate) fn scan_argument(&mut self, argument: &'a Argument<'a>, context: FunctionContext) {
-        match argument {
-            Argument::SpreadElement(spread) => self.scan_expression(&spread.argument, context),
-            Argument::Identifier(identifier) => {
-                let is_arguments = identifier.name == "arguments";
-                let allow_args = self.options.allow_arguments_keyword;
-                if is_arguments && !allow_args {
-                    self.report(
-                        "functional-parameters",
-                        "arguments",
-                        "Unexpected use of `arguments`. Use regular function arguments instead.",
-                        identifier.span,
-                    );
-                }
-            }
-            Argument::CallExpression(call) => self.scan_call_expression(call, context),
-            Argument::StaticMemberExpression(member) => {
-                self.scan_static_member_expression(member, context);
-            }
-            Argument::ComputedMemberExpression(member) => {
-                self.scan_computed_member_expression(member, context);
-            }
-            Argument::ArrowFunctionExpression(function) => {
-                self.scan_arrow_function(function, FunctionParamMeta::default());
-            }
-            Argument::FunctionExpression(function) => {
-                self.scan_function(function, FunctionParamMeta::default());
-            }
-            Argument::ClassExpression(class) => self.scan_class(class, context),
-            Argument::ArrayExpression(expression) => {
-                for element in &expression.elements {
-                    self.scan_array_element(element, context);
-                }
-            }
-            Argument::ObjectExpression(expression) => {
-                for property in &expression.properties {
-                    if let ObjectPropertyKind::ObjectProperty(property) = property {
-                        self.scan_expression(&property.value, context);
-                    }
-                }
-            }
-            _ => {}
+        // A call/new argument is either a spread element or any expression; route
+        // every expression through `scan_expression` so no node type (e.g.
+        // `this`, `new Promise(...)`, update/assignment expressions) is silently
+        // skipped in argument position.
+        if let Argument::SpreadElement(spread) = argument {
+            self.scan_expression(&spread.argument, context);
+        } else if let Some(expression) = argument.as_expression() {
+            self.scan_expression(expression, context);
         }
     }
 

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -413,7 +413,10 @@ fn reports_expressions_in_argument_position() {
         rule_names: ["no-this-expressions".into()].into_iter().collect(),
         ..FunctionalOptions::default()
     };
-    assert_eq!(scan_functional("foo(this);", "fixture.ts", &this_options).len(), 1);
+    assert_eq!(
+        scan_functional("foo(this);", "fixture.ts", &this_options).len(),
+        1
+    );
 
     // no-promise-reject fires for a rejecting `new Promise` in argument position.
     let reject_options = FunctionalOptions {
@@ -421,5 +424,8 @@ fn reports_expressions_in_argument_position() {
         ..FunctionalOptions::default()
     };
     let source = "foo(new Promise((resolve, reject) => reject('e')));";
-    assert_eq!(scan_functional(source, "fixture.ts", &reject_options).len(), 1);
+    assert_eq!(
+        scan_functional(source, "fixture.ts", &reject_options).len(),
+        1
+    );
 }

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -405,3 +405,21 @@ fn honors_core_options() {
         .is_empty()
     );
 }
+
+#[test]
+fn reports_expressions_in_argument_position() {
+    // no-this-expressions fires for `this` passed as a call argument.
+    let this_options = FunctionalOptions {
+        rule_names: ["no-this-expressions".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(scan_functional("foo(this);", "fixture.ts", &this_options).len(), 1);
+
+    // no-promise-reject fires for a rejecting `new Promise` in argument position.
+    let reject_options = FunctionalOptions {
+        rule_names: ["no-promise-reject".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let source = "foo(new Promise((resolve, reject) => reject('e')));";
+    assert_eq!(scan_functional(source, "fixture.ts", &reject_options).len(), 1);
+}

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -25,6 +25,11 @@ export type FunctionalScanOptions = {
   ignoreIfReadonlyWrapped?: boolean;
   ignoreIdentifierPattern?: string | string[];
   ignoreCodePattern?: string | string[];
+  enforceParameterCount?: 'off' | 'atLeastOne' | 'exactlyOne';
+  enforceCountIgnoreIife?: boolean;
+  enforceCountIgnoreGettersSetters?: boolean;
+  enforceCountIgnoreLambda?: boolean;
+  ignorePrefixSelectorNames?: string[];
 };
 
 export function implementedFunctionalRuleNames(): string[];


### PR DESCRIPTION
From the multi-dimensional review of the functional port.

`scan_argument` and `scan_array_element` enumerated a subset of node kinds and dropped the rest via `_ => {}`. Expressions such as `this`, `new Promise(...)`, and update/assignment expressions passed as a call argument or array element were never visited, so `no-this-expressions`, `no-promise-reject` and `immutable-data` missed them (untested by upstream fixtures, but a real divergence). Both now route every non-spread argument/element through `scan_expression` via `as_expression()`, which dispatches all expression kinds. Call-argument functions are still intercepted with lambda meta in `scan_call_expression` beforehand, so `functional-parameters` behavior is unchanged.

Also completes `api.d.ts` with the internal scan-option fields the wrapper produces. Adds a Rust unit test for reports in argument position. All existing full-parity fixtures continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783977354&installation_id=136613492&pr_number=161&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F161&signature=7a7f104bde44678595076c36e56002109bbac3539e959d5f15218b46a2490671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->