### PR TITLE
port(sonarjs): port no-empty-character-class (S2639)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 15] = [
+pub const RULE_NAMES: [&str; 16] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -38,6 +38,7 @@ pub const RULE_NAMES: [&str; 15] = [
     "no-labels",
     "no-delete-var",
     "constructor-for-side-effects",
+    "no-empty-character-class",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -8,6 +8,7 @@ mod no_all_duplicated_branches;
 mod no_collapsible_if;
 mod no_delete_var;
 mod no_duplicate_in_composite;
+mod no_empty_character_class;
 mod no_identical_conditions;
 mod no_identical_expressions;
 mod no_labels;

--- a/crates/sonarjs/src/rules/no_empty_character_class.rs
+++ b/crates/sonarjs/src/rules/no_empty_character_class.rs
@@ -1,0 +1,94 @@
+//! Rule `no-empty-character-class` (SonarJS key S2639).
+//!
+//! Clean-room port. A character class `[]` in a regular expression is empty:
+//! it can never match any character, which means the whole regex can never
+//! match anything. This is almost always a programmer mistake — a missing
+//! character range, a forgotten escape, or an accidental transposition.
+//!
+//! ## What is flagged
+//!
+//! Any **regex literal** that contains a syntactic empty character class `[]`
+//! (two square brackets with nothing between them):
+//!
+//! ```js
+//! /a[]b/   // flagged — empty class, can never match
+//! /[]/     // flagged — the entire pattern is an empty class
+//! ```
+//!
+//! ## What is NOT flagged
+//!
+//! - `[^]` — a negated empty class. In JavaScript this *does* match any
+//!   single character (it is equivalent to `[\s\S]`), so it is NOT empty
+//!   and is intentionally left alone.
+//! - `[abc]` — a non-empty class.
+//! - `/a\[\]b/` — escaped brackets; these are literal bracket characters
+//!   in the input, not a class syntax pair.
+//! - `[a[]` — a class whose content is `a[`; the first `]` closes the class
+//!   and there is no empty class.
+//!
+//! ## Scope: regex literals only
+//!
+//! This rule detects empty character classes in **regex literals** (e.g.
+//! `/a[]b/`) only. The `new RegExp("[]")` string-argument form is out of
+//! scope for this PR; a correct implementation would require string-value
+//! tracking and is left as a follow-up.
+//!
+//! ## Detection strategy
+//!
+//! The visitor hook `visit_reg_exp_literal` is overridden. The raw pattern
+//! string is obtained via `lit.regex.pattern.text.as_str()`, which is the
+//! `text` field of `oxc_ast::ast::RegExpPattern` — a `Str<'a>` that holds
+//! the pattern exactly as it appears in source between the slashes, without
+//! the flags.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-empty-character-class";
+
+/// Returns `true` when the regex pattern string contains a syntactic empty
+/// character class `[]`. The algorithm is byte-level and handles:
+/// - backslash escapes: `\x` skips the next byte entirely
+/// - negated empty classes `[^]`: the `^` makes the class non-empty, skip
+/// - nested `[` inside an open class: treated as a literal character
+fn has_empty_character_class(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut i = 0usize;
+    let mut in_class = false;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                i += 2; // skip the escaped char
+                continue;
+            }
+            b'[' if !in_class => {
+                // empty class is `[]` exactly (NOT `[^]`, which matches any char)
+                if bytes.get(i + 1) == Some(&b']') {
+                    return true;
+                }
+                in_class = true;
+            }
+            b']' if in_class => {
+                in_class = false;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_empty_character_class(&mut self, lit: &RegExpLiteral<'_>) {
+        // `lit.regex.pattern.text` is `Str<'a>` — the raw pattern between
+        // the slashes, without flags, as it appears in source.
+        let pattern = lit.regex.pattern.text.as_str();
+        if has_empty_character_class(pattern) {
+            self.report(RULE_NAME, "emptyCharacterClass", lit.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,8 +4,8 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement,
-    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, SwitchCase,
-    SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
+    SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -133,6 +133,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
         self.check_arguments_usage(it);
         walk::walk_identifier_reference(self, it);
+    }
+
+    fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
+        self.check_no_empty_character_class(it);
+        walk::walk_reg_exp_literal(self, it);
     }
 
     fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -689,3 +689,51 @@ fn does_not_report_constructor_for_side_effects_for_plain_call_statement() {
     let diagnostics = scan("constructor-for-side-effects", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_empty_character_class_between_other_chars() {
+    let source = "const r = /a[]b/;";
+    let diagnostics = scan("no-empty-character-class", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-empty-character-class");
+    assert_eq!(diagnostics[0].message_id, "emptyCharacterClass");
+}
+
+#[test]
+fn reports_no_empty_character_class_whole_pattern() {
+    let source = "const r = /[]/;";
+    let diagnostics = scan("no-empty-character-class", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "emptyCharacterClass");
+}
+
+#[test]
+fn does_not_report_no_empty_character_class_for_non_empty_class() {
+    let source = "const r = /[abc]/;";
+    let diagnostics = scan("no-empty-character-class", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_empty_character_class_for_negated_empty_class() {
+    // [^] is a valid JS regex that matches any single character — NOT empty
+    let source = "const r = /[^]/;";
+    let diagnostics = scan("no-empty-character-class", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_empty_character_class_for_escaped_brackets() {
+    // /a\[\]b/ in source: the pattern is a\[\]b — escaped brackets, no class
+    let source = "const r = /a\\[\\]b/;";
+    let diagnostics = scan("no-empty-character-class", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_empty_character_class_for_literal_bracket_in_class() {
+    // /[a[]/ — class content is `a[`, closed by the first `]`; no empty class
+    let source = "const r = /[a[]/;";
+    let diagnostics = scan("no-empty-character-class", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -69,6 +69,10 @@ const messages = Object.freeze({
     constructorForSideEffects:
       'Either use this object, assign it to a variable, or move the side effects into a named function instead of a constructor.',
   },
+  'no-empty-character-class': {
+    emptyCharacterClass:
+      'This empty character class [] can never match, so this regular expression will never match anything.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -94,6 +98,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow 'delete' applied to a plain variable; use it only on object properties",
   'constructor-for-side-effects':
     'Disallow using new solely for side effects without capturing or using the constructed object',
+  'no-empty-character-class':
+    'Disallow empty character classes in regular expression literals, which can never match',
 });
 
 const ruleTypes = Object.freeze({
@@ -112,6 +118,7 @@ const ruleTypes = Object.freeze({
   'no-labels': 'suggestion',
   'no-delete-var': 'problem',
   'constructor-for-side-effects': 'problem',
+  'no-empty-character-class': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -130,6 +137,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-labels': 'error',
   'no-delete-var': 'error',
   'constructor-for-side-effects': 'error',
+  'no-empty-character-class': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -18,6 +18,7 @@ const expectedRuleNames = [
   'no-labels',
   'no-delete-var',
   'constructor-for-side-effects',
+  'no-empty-character-class',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -544,6 +545,45 @@ describe('sonarjs native API', () => {
   it('does not report constructor-for-side-effects for a plain function call statement', () => {
     const source = 'foo();';
     const diagnostics = scan('constructor-for-side-effects', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-empty-character-class for a regex with an empty class between other chars', () => {
+    const source = 'const r = /a[]b/;';
+    const diagnostics = scan('no-empty-character-class', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-empty-character-class');
+    expect(diagnostics[0].messageId).toBe('emptyCharacterClass');
+  });
+
+  it('reports no-empty-character-class for a regex that is only an empty class', () => {
+    const source = 'const r = /[]/;';
+    const diagnostics = scan('no-empty-character-class', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('emptyCharacterClass');
+  });
+
+  it('does not report no-empty-character-class for a regex with a non-empty class', () => {
+    const source = 'const r = /[abc]/;';
+    const diagnostics = scan('no-empty-character-class', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-empty-character-class for a negated empty class [^]', () => {
+    const source = 'const r = /[^]/;';
+    const diagnostics = scan('no-empty-character-class', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-empty-character-class for escaped brackets that are not a class', () => {
+    const source = 'const r = /a\\[\\]b/;';
+    const diagnostics = scan('no-empty-character-class', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-empty-character-class when the class content is a literal open bracket', () => {
+    const source = 'const r = /[a[]/;';
+    const diagnostics = scan('no-empty-character-class', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -109,6 +109,7 @@ describe('sonarjs plugin shape', () => {
       'no-labels',
       'no-delete-var',
       'constructor-for-side-effects',
+      'no-empty-character-class',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -125,6 +126,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-labels']).toBe('object');
     expect(typeof plugin.rules['no-delete-var']).toBe('object');
     expect(typeof plugin.rules['constructor-for-side-effects']).toBe('object');
+    expect(typeof plugin.rules['no-empty-character-class']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -141,6 +143,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-labels']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-delete-var']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/constructor-for-side-effects']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-empty-character-class']).toBe('error');
   });
 });
 
@@ -251,6 +254,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('constructor-for-side-effects', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('constructorForSideEffects');
+  });
+
+  it('reports no-empty-character-class through the adapter', () => {
+    const source = 'const r = /a[]b/;';
+    const reports = runRule('no-empty-character-class', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('emptyCharacterClass');
   });
 });
 
@@ -399,5 +409,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(constructor-for-side-effects)');
+  });
+
+  it('reports no-empty-character-class through the CLI', () => {
+    const source = 'const r = /a[]b/;';
+    const result = runOxlint('no-empty-character-class', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-empty-character-class)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11982,19 +11982,19 @@
       },
       {
         "name": "no-empty-character-class",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-empty-character-class (Sonar key S2639). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S2639). Detects regex literals containing an empty character class [] that can never match. Scope: regex literals only; new RegExp(\"[]\") string-argument form is out of scope (follow-up). Uses visit_reg_exp_literal hook; pattern text via lit.regex.pattern.text.as_str()."
       },
       {
         "name": "no-empty-collection",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-empty-character-class`** (Sonar key S2639). Flags a regex literal containing an empty character class `[]` (which can never match, so the whole regex never matches). An escape/class-aware byte scan correctly excludes `[^]` (matches any char), escaped `\[\]`, and an inner literal `[` inside a class (`[a[]`).

**Scope:** regex literals only. The `new RegExp("[]")` string-argument form is a documented follow-up (noted in the rule and status.json). Reads the pattern via `lit.regex.pattern.text`.

## Tests
Rust unit tests (`/a[]b/`, `/[]/`, `/[abc]/` → 0, `/[^]/` → 0, `/a\[\]b/` → 0, `/[a[]/` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-empty-character-class)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)