### PR TITLE
port(functional): bring no-mixed-types to full upstream parity

### DIFF
--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -95,6 +95,10 @@ pub struct FunctionalOptions {
     /// Extracted method names from `ignorePrefixSelector` patterns of the form
     /// `CallExpression[callee.property.name='NAME']`.
     pub ignore_prefix_selector_names: SmallVec<[CompactString; 4]>,
+    /// no-mixed-types: check `interface` declarations (default: true).
+    pub check_interfaces: bool,
+    /// no-mixed-types: check object type literals (default: true).
+    pub check_type_literals: bool,
 }
 
 impl Default for FunctionalOptions {
@@ -120,6 +124,8 @@ impl Default for FunctionalOptions {
             enforce_count_ignore_getters_setters: true,
             enforce_count_ignore_lambda: false,
             ignore_prefix_selector_names: SmallVec::new(),
+            check_interfaces: true,
+            check_type_literals: true,
         }
     }
 }

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -429,3 +429,37 @@ fn reports_expressions_in_argument_position() {
         1
     );
 }
+
+#[test]
+fn no_mixed_types_reports_once_and_honors_options() {
+    let options = FunctionalOptions {
+        rule_names: ["no-mixed-types".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
+
+    // A type alias mixing a property and a method is reported exactly once
+    // (not double-counted by both the alias and the type-literal visitor).
+    let alias = count("type Foo = { bar: string; baz(): number };", &options);
+    assert_eq!(alias, 1);
+    let iface = count("interface Foo { bar: string; baz(): number }", &options);
+    assert_eq!(iface, 1);
+    // Same-kind members are not reported.
+    let same = count("type Foo = { bar: string; baz: number };", &options);
+    assert_eq!(same, 0);
+
+    // checkTypeLiterals / checkInterfaces: false skip their declaration kind.
+    let no_literals = FunctionalOptions {
+        rule_names: ["no-mixed-types".into()].into_iter().collect(),
+        check_type_literals: false,
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("type Foo = { bar: string; baz(): number };", &no_literals), 0);
+    let no_ifaces = FunctionalOptions {
+        rule_names: ["no-mixed-types".into()].into_iter().collect(),
+        check_interfaces: false,
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("interface Foo { bar: string; baz(): number }", &no_ifaces), 0);
+}

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -455,11 +455,17 @@ fn no_mixed_types_reports_once_and_honors_options() {
         check_type_literals: false,
         ..FunctionalOptions::default()
     };
-    assert_eq!(count("type Foo = { bar: string; baz(): number };", &no_literals), 0);
+    assert_eq!(
+        count("type Foo = { bar: string; baz(): number };", &no_literals),
+        0
+    );
     let no_ifaces = FunctionalOptions {
         rule_names: ["no-mixed-types".into()].into_iter().collect(),
         check_interfaces: false,
         ..FunctionalOptions::default()
     };
-    assert_eq!(count("interface Foo { bar: string; baz(): number }", &no_ifaces), 0);
+    assert_eq!(
+        count("interface Foo { bar: string; baz(): number }", &no_ifaces),
+        0
+    );
 }

--- a/crates/functional/src/types.rs
+++ b/crates/functional/src/types.rs
@@ -31,16 +31,8 @@ impl<'a> Scanner<'a> {
         &mut self,
         declaration: &'a TSTypeAliasDeclaration<'a>,
     ) {
-        if let TSType::TSTypeLiteral(type_literal) = &declaration.type_annotation
-            && has_mixed_signatures(&type_literal.members)
-        {
-            self.report(
-                "no-mixed-types",
-                "generic",
-                "Only the same kind of members allowed in types.",
-                declaration.span,
-            );
-        }
+        // no-mixed-types for the aliased type literal is reported by `scan_type`
+        // (a type alias is a type literal); reporting here too would double-count.
         if is_mutable_type(&declaration.type_annotation) {
             self.report(
                 "type-declaration-immutability",
@@ -56,7 +48,7 @@ impl<'a> Scanner<'a> {
         &mut self,
         declaration: &'a TSInterfaceDeclaration<'a>,
     ) {
-        if has_mixed_signatures(&declaration.body.body) {
+        if self.options.check_interfaces && has_mixed_signatures(&declaration.body.body) {
             self.report(
                 "no-mixed-types",
                 "generic",
@@ -194,7 +186,7 @@ impl<'a> Scanner<'a> {
                 self.scan_type_operator(operator);
             }
             TSType::TSTypeLiteral(literal) => {
-                if has_mixed_signatures(&literal.members) {
+                if self.options.check_type_literals && has_mixed_signatures(&literal.members) {
                     self.report(
                         "no-mixed-types",
                         "generic",

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -30,6 +30,8 @@ export type FunctionalScanOptions = {
   enforceCountIgnoreGettersSetters?: boolean;
   enforceCountIgnoreLambda?: boolean;
   ignorePrefixSelectorNames?: string[];
+  checkInterfaces?: boolean;
+  checkTypeLiterals?: boolean;
 };
 
 export function implementedFunctionalRuleNames(): string[];

--- a/npm/functional/api.js
+++ b/npm/functional/api.js
@@ -45,6 +45,9 @@ function normalizeOptions(options) {
     enforceCountIgnoreLambda:
       typeof raw.enforceCountIgnoreLambda === 'boolean' ? raw.enforceCountIgnoreLambda : undefined,
     ignorePrefixSelectorNames: normalizeStringList(raw.ignorePrefixSelectorNames),
+    checkInterfaces: typeof raw.checkInterfaces === 'boolean' ? raw.checkInterfaces : undefined,
+    checkTypeLiterals:
+      typeof raw.checkTypeLiterals === 'boolean' ? raw.checkTypeLiterals : undefined,
   };
 }
 

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -281,6 +281,18 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'no-mixed-types') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          checkInterfaces: { type: 'boolean' },
+          checkTypeLiterals: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
   return [];
 }
 
@@ -429,6 +441,9 @@ function scanOptionsForRule(context, ruleName) {
     enforceCountIgnoreGettersSetters,
     enforceCountIgnoreLambda,
     ignorePrefixSelectorNames,
+    checkInterfaces: ruleName === 'no-mixed-types' ? options.checkInterfaces !== false : undefined,
+    checkTypeLiterals:
+      ruleName === 'no-mixed-types' ? options.checkTypeLiterals !== false : undefined,
   };
 }
 

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -40,6 +40,10 @@ mod napi_abi {
         pub enforce_count_ignore_lambda: Option<bool>,
         /// Extracted method-name strings from ignorePrefixSelector patterns.
         pub ignore_prefix_selector_names: Option<Vec<String>>,
+        /// no-mixed-types: check interfaces (default: true).
+        pub check_interfaces: Option<bool>,
+        /// no-mixed-types: check object type literals (default: true).
+        pub check_type_literals: Option<bool>,
     }
 
     #[napi(object)]
@@ -128,6 +132,12 @@ mod napi_abi {
             ignore_prefix_selector_names: compact_pattern_list(
                 options.ignore_prefix_selector_names,
             ),
+            check_interfaces: options
+                .check_interfaces
+                .unwrap_or(default_options.check_interfaces),
+            check_type_literals: options
+                .check_type_literals
+                .unwrap_or(default_options.check_type_literals),
         };
 
         core::scan_functional(&source_text, &filename, &core_options)

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -35,6 +35,7 @@ const FULL_PARITY = new Set([
   'no-classes',
   'no-let',
   'no-loop-statements',
+  'no-mixed-types',
   'no-promise-reject',
   'no-this-expressions',
   'no-try-statements',


### PR DESCRIPTION
Fixes a double-report (a mixed `type Foo = {...}` was counted by both the type-alias and the type-literal visitor) and implements the `checkInterfaces` / `checkTypeLiterals` options (default true). no-mixed-types joins FULL_PARITY (all upstream cases asserted). Rust unit test added. The rule is fully syntactic — no type information is needed for any upstream case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783978235&installation_id=136613492&pr_number=165&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F165&signature=9cfb2b3887666ec2e49fd85e6d4fd362680427eff1886f2bc28520d55002f715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->