### PR TITLE
port(sonarjs): port generator-without-yield (S3531)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 16] = [
+pub const RULE_NAMES: [&str; 17] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -39,6 +39,7 @@ pub const RULE_NAMES: [&str; 16] = [
     "no-delete-var",
     "constructor-for-side-effects",
     "no-empty-character-class",
+    "generator-without-yield",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -71,6 +72,7 @@ pub fn scan_sonarjs(
         switch_depth: 0,
         conditional_depth: 0,
         if_chain_seen: SmallVec::new(),
+        generator_yield_stack: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -4,6 +4,7 @@
 mod arguments_usage;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
+mod generator_without_yield;
 mod no_all_duplicated_branches;
 mod no_collapsible_if;
 mod no_delete_var;

--- a/crates/sonarjs/src/rules/generator_without_yield.rs
+++ b/crates/sonarjs/src/rules/generator_without_yield.rs
@@ -1,0 +1,72 @@
+//! Rule `generator-without-yield` (SonarJS key S3531).
+//!
+//! Clean-room port. Reports a generator function (`function*`) whose own body
+//! contains no `yield` expression directly inside it, because such a generator
+//! behaves like a plain function that returns an iterator yielding nothing — almost
+//! always a mistake.
+//!
+//! ## Stack-based generator tracking
+//!
+//! A `yield` expression is syntactically valid **only** inside a generator function,
+//! and it always binds to the **nearest enclosing generator** — it can never cross
+//! a non-generator function boundary (that would be a SyntaxError). Therefore,
+//! maintaining a stack of boolean frames (one per open generator) and marking the
+//! **top** frame when a `yield` is encountered correctly attributes each yield to
+//! the right (innermost) generator.
+//!
+//! ### Nested-generator example
+//!
+//! ```js
+//! function* outer() {
+//!     function* inner() { yield 1; }   // inner has yield → only outer flagged
+//! }
+//! ```
+//!
+//! Walk order:
+//! 1. Enter `outer` → push `false` (stack: `[false]`)
+//! 2. Enter `inner` → push `false` (stack: `[false, false]`)
+//! 3. Visit `yield 1` → mark top: `[false, true]`
+//! 4. Leave `inner` → pop `true` → inner had yield → **no report for inner**
+//! 5. Leave `outer` → pop `false` → outer had no yield → **report outer**
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::Function;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "generator-without-yield";
+
+impl<'a> Scanner<'a> {
+    /// Called before walking a function node. Pushes a tracking frame onto the
+    /// generator stack if the function is a generator with a body. Returns
+    /// `true` when a frame was pushed (i.e., the caller must call
+    /// [`leave_generator`](Scanner::leave_generator) with `true`).
+    pub(crate) fn enter_generator(&mut self, func: &Function<'a>) -> bool {
+        let track = func.generator && func.body.is_some();
+        if track {
+            self.generator_yield_stack.push(false);
+        }
+        track
+    }
+
+    /// Called after walking a function node. Pops the frame and reports the
+    /// generator if it contained no `yield`.
+    pub(crate) fn leave_generator(&mut self, func: &Function<'a>, track: bool) {
+        if !track {
+            return;
+        }
+        let had_yield = self.generator_yield_stack.pop().unwrap_or(true);
+        if !had_yield {
+            self.report(RULE_NAME, "generatorWithoutYield", func.span);
+        }
+    }
+
+    /// Marks the innermost open generator frame as having seen a `yield`.
+    pub(crate) fn mark_generator_yield(&mut self) {
+        if let Some(top) = self.generator_yield_stack.last_mut() {
+            *top = true;
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,11 +4,13 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement,
-    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
+    Function, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
     SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
+use oxc_syntax::scope::ScopeFlags;
 use oxlint_plugins_carton::SmallVec;
 
 use crate::{Diagnostic, DiagnosticData, DiagnosticFix, LineIndex, SonarjsOptions};
@@ -28,6 +30,11 @@ pub(crate) struct Scanner<'a> {
     /// chain already processed by their head; used by `no-identical-conditions`
     /// to avoid double-processing a chain.
     pub(crate) if_chain_seen: SmallVec<[u32; 16]>,
+    /// Stack of boolean frames tracking whether each currently-open generator
+    /// function has seen at least one `yield` expression. A frame is pushed on
+    /// entry to a generator with a body and popped on exit; `generator-without-yield`
+    /// reports generators whose frame is still `false` when popped.
+    pub(crate) generator_yield_stack: SmallVec<[bool; 8]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -148,5 +155,16 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_expression_statement(&mut self, it: &ExpressionStatement<'a>) {
         self.check_constructor_for_side_effects(it);
         walk::walk_expression_statement(self, it);
+    }
+
+    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
+        let track = self.enter_generator(it);
+        walk::walk_function(self, it, flags);
+        self.leave_generator(it, track);
+    }
+
+    fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {
+        self.mark_generator_yield();
+        walk::walk_yield_expression(self, it);
     }
 }

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,8 +3,8 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement,
-    Function, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement, Function,
+    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
     SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
     YieldExpression,
 };

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -737,3 +737,57 @@ fn does_not_report_no_empty_character_class_for_literal_bracket_in_class() {
     let diagnostics = scan("no-empty-character-class", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_generator_without_yield_for_generator_that_only_returns() {
+    let source = "function* g() { return 1; }";
+    let diagnostics = scan("generator-without-yield", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "generator-without-yield");
+    assert_eq!(diagnostics[0].message_id, "generatorWithoutYield");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_generator_without_yield_for_empty_body_generator() {
+    let source = "function* g() {}";
+    let diagnostics = scan("generator-without-yield", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "generatorWithoutYield");
+}
+
+#[test]
+fn does_not_report_generator_without_yield_when_generator_yields() {
+    let source = "function* g() { yield 1; }";
+    let diagnostics = scan("generator-without-yield", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_generator_without_yield_for_regular_function() {
+    let source = "function g() { return 1; }";
+    let diagnostics = scan("generator-without-yield", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_generator_without_yield_for_outer_only_when_inner_yields() {
+    // outer has no direct yield; inner has yield 1 → only outer is flagged
+    let source = "function* outer() { function* inner() { yield 1; } }";
+    let diagnostics = scan("generator-without-yield", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "generatorWithoutYield");
+    // outer starts at column 0
+    assert_eq!(diagnostics[0].loc.start_column, 0);
+}
+
+#[test]
+fn reports_generator_without_yield_for_inner_only_when_outer_yields() {
+    // outer yields directly; inner has no yield → only inner is flagged
+    let source = "function* outer() { yield 1; function* inner() {} }";
+    let diagnostics = scan("generator-without-yield", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "generatorWithoutYield");
+    // inner starts at column > 0 (it is not at the start of the line)
+    assert!(diagnostics[0].loc.start_column > 0);
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -73,6 +73,10 @@ const messages = Object.freeze({
     emptyCharacterClass:
       'This empty character class [] can never match, so this regular expression will never match anything.',
   },
+  'generator-without-yield': {
+    generatorWithoutYield:
+      "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -100,6 +104,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow using new solely for side effects without capturing or using the constructed object',
   'no-empty-character-class':
     'Disallow empty character classes in regular expression literals, which can never match',
+  'generator-without-yield':
+    "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
 });
 
 const ruleTypes = Object.freeze({
@@ -119,6 +125,7 @@ const ruleTypes = Object.freeze({
   'no-delete-var': 'problem',
   'constructor-for-side-effects': 'problem',
   'no-empty-character-class': 'problem',
+  'generator-without-yield': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -138,6 +145,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-delete-var': 'error',
   'constructor-for-side-effects': 'error',
   'no-empty-character-class': 'error',
+  'generator-without-yield': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -19,6 +19,7 @@ const expectedRuleNames = [
   'no-delete-var',
   'constructor-for-side-effects',
   'no-empty-character-class',
+  'generator-without-yield',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -585,5 +586,49 @@ describe('sonarjs native API', () => {
     const source = 'const r = /[a[]/;';
     const diagnostics = scan('no-empty-character-class', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports generator-without-yield for a generator that only returns', () => {
+    const source = 'function* g() { return 1; }';
+    const diagnostics = scan('generator-without-yield', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('generator-without-yield');
+    expect(diagnostics[0].messageId).toBe('generatorWithoutYield');
+  });
+
+  it('reports generator-without-yield for a generator with an empty body', () => {
+    const source = 'function* g() {}';
+    const diagnostics = scan('generator-without-yield', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('generatorWithoutYield');
+  });
+
+  it('does not report generator-without-yield when the generator yields', () => {
+    const source = 'function* g() { yield 1; }';
+    const diagnostics = scan('generator-without-yield', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report generator-without-yield for a regular function', () => {
+    const source = 'function g() { return 1; }';
+    const diagnostics = scan('generator-without-yield', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports generator-without-yield for outer only when inner generator yields', () => {
+    const source = 'function* outer() { function* inner() { yield 1; } }';
+    const diagnostics = scan('generator-without-yield', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('generatorWithoutYield');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+    expect(diagnostics[0].loc.startColumn).toBe(0);
+  });
+
+  it('reports generator-without-yield for inner only when outer generator yields', () => {
+    const source = 'function* outer() { yield 1; function* inner() {} }';
+    const diagnostics = scan('generator-without-yield', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('generatorWithoutYield');
+    expect(diagnostics[0].loc.startColumn).toBeGreaterThan(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -110,6 +110,7 @@ describe('sonarjs plugin shape', () => {
       'no-delete-var',
       'constructor-for-side-effects',
       'no-empty-character-class',
+      'generator-without-yield',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -127,6 +128,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-delete-var']).toBe('object');
     expect(typeof plugin.rules['constructor-for-side-effects']).toBe('object');
     expect(typeof plugin.rules['no-empty-character-class']).toBe('object');
+    expect(typeof plugin.rules['generator-without-yield']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -144,6 +146,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-delete-var']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/constructor-for-side-effects']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-character-class']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/generator-without-yield']).toBe('error');
   });
 });
 
@@ -261,6 +264,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-empty-character-class', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('emptyCharacterClass');
+  });
+
+  it('reports generator-without-yield through the adapter', () => {
+    const source = 'function* g() { return 1; }';
+    const reports = runRule('generator-without-yield', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('generatorWithoutYield');
   });
 });
 
@@ -419,5 +429,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-empty-character-class)');
+  });
+
+  it('reports generator-without-yield through the CLI', () => {
+    const source = 'function* g() { return 1; }';
+    const result = runOxlint('generator-without-yield', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(generator-without-yield)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11310,19 +11310,19 @@
       },
       {
         "name": "generator-without-yield",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule generator-without-yield (Sonar key S3531). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S3531). Uses a SmallVec<[bool; 8]> generator frame stack in the Oxc visitor: a frame is pushed on entry to each generator function with a body and marked true if any yield is visited; the frame is popped on exit and the generator is reported when the frame is still false. Yield correctly attributes to the nearest enclosing generator because yield cannot cross a non-generator function boundary (SyntaxError). Async generators (async function*) are included. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "hardcoded-secret-signatures",


### PR DESCRIPTION
## Summary
Clean-room port of **`generator-without-yield`** (Sonar key S3531). Flags a generator function (`function*`) that has a body but no `yield` directly inside it. Uses a stack of generator frames — since a `yield` can never cross a function boundary, marking the top frame on each `yield` attributes it to the correct innermost generator, so nested generators are reported precisely. Adds `visit_function` (threading `ScopeFlags`) and `visit_yield_expression` hooks.

## Tests
Rust unit tests (no-yield, empty body, with yield → 0, plain function → 0, nested inner-has-yield → outer flagged, nested inner-empty → inner flagged), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(generator-without-yield)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783979105&installation_id=136613492&pr_number=166&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F166&signature=9aec3e6d4bd9b0181b1820100a9a3bae9fa5a99d11d0ce76cb90a8eb82b73237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->