### PR TITLE
fix(regexp): no-lazy-ends — add usage-context guard and fix {n}? false positive

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -501,7 +501,20 @@ impl<'a> Scanner<'a> {
             .as_ref()
             .and_then(|raw| raw.as_str().rsplit_once('/').map(|(_, flags)| flags))
             .unwrap_or("");
-        self.check_regexp(pattern, flags, literal.span, false, None, None, false);
+        // Determine whether this regex literal is used as a complete (whole)
+        // pattern — i.e. actually matched against a string.  The pre-pass in
+        // `usage.rs` collected the span-starts of all such literals.
+        let used_as_whole = self.whole_pattern_regex_spans.contains(&literal.span.start);
+        self.check_regexp(
+            pattern,
+            flags,
+            literal.span,
+            false,
+            None,
+            None,
+            false,
+            used_as_whole,
+        );
     }
 
     fn check_regexp_constructor(
@@ -533,6 +546,9 @@ impl<'a> Scanner<'a> {
             Some(pattern_span),
             flags.map(|(_, span)| span),
             flags_is_non_literal,
+            // RegExp constructor calls produce patterns that are typically used
+            // as building blocks (partial), so `no-lazy-ends` is not fired.
+            false,
         );
     }
 
@@ -551,6 +567,10 @@ impl<'a> Scanner<'a> {
         // `require-unicode-regexp` and `require-unicode-sets-regexp` checks
         // are skipped to avoid false positives.
         flags_is_non_literal: bool,
+        // `true` when the regex is provably used as a complete (whole) pattern —
+        // directly called via `.test()` / `.exec()` / etc., or via a variable
+        // that is used that way and is not exported.  Controls `no-lazy-ends`.
+        used_as_whole: bool,
     ) {
         if let Some(flag) = duplicate_flag(flags) {
             self.report_with_data(
@@ -601,7 +621,7 @@ impl<'a> Scanner<'a> {
         }
 
         self.check_flag_style(flags, span, flags_is_non_literal);
-        self.check_pattern_rules(pattern, flags, span, is_constructor);
+        self.check_pattern_rules(pattern, flags, span, is_constructor, used_as_whole);
     }
 
     #[allow(
@@ -664,6 +684,7 @@ impl<'a> Scanner<'a> {
         flags: &str,
         span: Span,
         is_constructor: bool,
+        used_as_whole: bool,
     ) {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern);
@@ -1091,7 +1112,11 @@ impl<'a> Scanner<'a> {
                 span,
             );
         }
-        if pattern_ends_with_lazy_quantifier(pattern) {
+        // `no-lazy-ends`: only fire when the regex is provably used as a
+        // whole (complete) pattern, matching upstream `ignorePartial: true`
+        // (the default).  A bare literal or an exported binding is "unknown /
+        // partial" and should not be flagged.
+        if used_as_whole && pattern_ends_with_lazy_quantifier(pattern) {
             self.report("no-lazy-ends", "unexpected", span);
         }
         if let Some(text) = first_useless_one_quantifier(pattern) {

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -958,12 +958,18 @@ pub(crate) fn pattern_ends_with_lazy_quantifier(pattern: &str) -> bool {
         while idx > 0 && bytes[idx] != b'{' && bytes[idx] != b']' {
             idx -= 1;
         }
+        let content = &bytes[idx + 1..len - 2];
         if bytes.get(idx) == Some(&b'{')
             && (idx == 0 || bytes[idx - 1] != b'\\')
-            && bytes[idx + 1..len - 2]
-                .iter()
-                .all(|&b| b.is_ascii_digit() || b == b',')
+            && content.iter().all(|&b| b.is_ascii_digit() || b == b',')
         {
+            // `{n}` (no comma) means min == max — the lazy modifier `?` is
+            // "uselessly lazy" in a different sense but upstream's
+            // `extractLazyEndQuantifiers` only yields quantifiers where
+            // `min !== max`, so fixed-count braced quantifiers must be skipped.
+            if !content.contains(&b',') {
+                return false;
+            }
             return true;
         }
     }

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -7,6 +7,7 @@ mod pattern;
 mod scanner;
 mod traversal;
 mod types;
+mod usage;
 
 #[cfg(test)]
 mod tests;
@@ -19,6 +20,7 @@ use oxlint_plugins_carton::SmallVec;
 
 use crate::scanner::Scanner;
 use crate::types::LineIndex;
+use crate::usage::collect_whole_pattern_regex_spans;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
@@ -112,12 +114,18 @@ pub fn scan_regexp(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 1
     let scoping = semantic.scoping();
     let nodes = semantic.nodes();
 
+    // Pre-pass: determine which regex literals are "used as a whole pattern"
+    // so that `no-lazy-ends` can apply `ignorePartial: true` semantics.
+    let whole_pattern_regex_spans =
+        collect_whole_pattern_regex_spans(&parser_return.program, scoping, nodes, source_text);
+
     let mut scanner = Scanner {
         source_text,
         line_index: LineIndex::new(source_text),
         diagnostics: SmallVec::new(),
         scoping,
         nodes,
+        whole_pattern_regex_spans,
     };
     scanner.scan_program(&parser_return.program.body);
     scanner.diagnostics

--- a/crates/regexp/src/scanner.rs
+++ b/crates/regexp/src/scanner.rs
@@ -5,7 +5,7 @@ use oxc_ast::AstKind;
 use oxc_ast::ast::Expression;
 use oxc_semantic::{AstNodes, Scoping};
 use oxc_span::Span;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{FastHashSet, SmallVec};
 
 use crate::types::{Diagnostic, DiagnosticData, LineIndex};
 
@@ -21,6 +21,12 @@ pub(crate) struct Scanner<'a> {
     /// (e.g. to check whether a variable is initialised with a string
     /// literal).
     pub(crate) nodes: &'a AstNodes<'a>,
+    /// Span-starts of `RegExpLiteral` nodes that are "used as a whole pattern"
+    /// (i.e. directly applied via `.test()` / `.exec()` / etc., or assigned to
+    /// a non-exported variable that is then used that way).  Only these regexps
+    /// are eligible for `no-lazy-ends` diagnostics; bare / exported / partial
+    /// usages are excluded, matching upstream `ignorePartial: true` semantics.
+    pub(crate) whole_pattern_regex_spans: FastHashSet<u32>,
 }
 
 impl<'a> Scanner<'a> {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -862,34 +862,100 @@ mod no_useless_dollar_replacements {
 mod no_lazy_ends {
     use super::*;
 
+    // ── used-as-whole-pattern cases (should fire) ─────────────────────────
+
     #[test]
-    fn reports_lazy_quantifiers_at_end_of_pattern() {
+    fn reports_direct_lazy_quantifiers_at_end_of_pattern() {
+        // Direct usage: regex literal is the receiver of a regexp method call.
         assert_eq!(
-            rule_ids_for("const a = /a*?/u;", "no-lazy-ends").as_slice(),
+            rule_ids_for("/a*?/u.test(str)", "no-lazy-ends").as_slice(),
             &["unexpected"]
         );
         assert_eq!(
-            rule_ids_for("const a = /a+?/u;", "no-lazy-ends").as_slice(),
+            rule_ids_for("/a+?/u.test(str)", "no-lazy-ends").as_slice(),
             &["unexpected"]
         );
         assert_eq!(
-            rule_ids_for("const a = /a??/u;", "no-lazy-ends").as_slice(),
+            rule_ids_for("/a??/u.test(str)", "no-lazy-ends").as_slice(),
             &["unexpected"]
         );
         assert_eq!(
-            rule_ids_for("const a = /a{2,}?/u;", "no-lazy-ends").as_slice(),
+            rule_ids_for("/a{2,}?/u.test(str)", "no-lazy-ends").as_slice(),
             &["unexpected"]
         );
     }
 
     #[test]
+    fn reports_variable_based_lazy_quantifiers() {
+        // Variable usage: regex assigned to a non-exported variable that is
+        // later used as a regexp object.
+        assert_eq!(
+            rule_ids_for("const foo = /a*?/u;\nfoo.exec(str)", "no-lazy-ends").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    // ── not-used-as-whole-pattern cases (must NOT fire) ───────────────────
+
+    #[test]
+    fn ignores_bare_literal_without_usage() {
+        // `/a??/` — unknown usage, must not fire (upstream valid case).
+        assert!(rule_ids_for("/a??/u", "no-lazy-ends").is_empty());
+        assert!(rule_ids_for("const a = /a??/u;", "no-lazy-ends").is_empty());
+        assert!(rule_ids_for("const a = /a*?/u;", "no-lazy-ends").is_empty());
+    }
+
+    #[test]
+    fn ignores_fixed_braced_quantifier() {
+        // `/a{3}?/.test(str)` — upstream treats `{n}?` (min == max) as
+        // "uselessly lazy" but NOT as a `no-lazy-ends` violation.
+        assert!(rule_ids_for("/a{3}?/u.test(str)", "no-lazy-ends").is_empty());
+    }
+
+    #[test]
     fn ignores_lazy_quantifiers_followed_by_something() {
-        assert!(rule_ids_for("const a = /a*?b/u;", "no-lazy-ends").is_empty());
-        assert!(rule_ids_for("const a = /a*?$/u;", "no-lazy-ends").is_empty());
+        // Lazy quantifier not at the end — not a lazy-end.
+        assert!(rule_ids_for("/a*?b/u.test(str)", "no-lazy-ends").is_empty());
+        // Anchored: `$` follows the lazy quantifier.
+        assert!(rule_ids_for("/a*?$/u.test(str)", "no-lazy-ends").is_empty());
         // Greedy quantifier at the end is fine.
-        assert!(rule_ids_for("const a = /a*/u;", "no-lazy-ends").is_empty());
+        assert!(rule_ids_for("/a*/u.test(str)", "no-lazy-ends").is_empty());
         // Plain greedy braced quantifier.
-        assert!(rule_ids_for("const a = /a{2,}/u;", "no-lazy-ends").is_empty());
+        assert!(rule_ids_for("/a{2,}/u.test(str)", "no-lazy-ends").is_empty());
+    }
+
+    #[test]
+    fn regression_bare_vs_direct_usage() {
+        // The key regression: same pattern `/a??/` must NOT fire when bare,
+        // but MUST fire when used via `.test()`.
+        assert!(rule_ids_for("/a??/u", "no-lazy-ends").is_empty());
+        assert_eq!(
+            rule_ids_for("/a??/u.test(str)", "no-lazy-ends").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_exported_variable_upstream_valid_cases() {
+        // Upstream valid case: `/* exported a */` makes the binding exported;
+        // even though `a.test(str)` is a whole-pattern usage, the regex should
+        // not be flagged because it may be used externally as a partial pattern.
+        assert!(
+            rule_ids_for(
+                "\n/* exported a */\nconst a = /a??/\na.test(str)",
+                "no-lazy-ends"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn upstream_valid_lazy_not_at_end() {
+        // From upstream fixture valid[]: lazy quantifier is NOT the last element.
+        assert!(rule_ids_for("/a+?b*/.test(str)", "no-lazy-ends").is_empty());
+        assert!(rule_ids_for("/a??(?:ba+?|c)*/.test(str)", "no-lazy-ends").is_empty());
+        // `$` follows the lazy quantifier — not at effective end.
+        assert!(rule_ids_for("/ba*?$/.test(str)", "no-lazy-ends").is_empty());
     }
 }
 

--- a/crates/regexp/src/usage.rs
+++ b/crates/regexp/src/usage.rs
@@ -1,0 +1,433 @@
+//! Pre-pass analysis: determine which `RegExpLiteral` nodes in a program are
+//! used as *whole* patterns (i.e. the regex is fully applied, not merely
+//! accessed via `.source`).  The result is consumed by the `no-lazy-ends`
+//! check, which only fires when `ignorePartial: true` (the upstream default).
+//!
+//! A regex is considered a "whole pattern usage" when:
+//!
+//! 1. **Direct call object**: `/re/.test(str)` — the literal is the object of
+//!    a member-call to a recognised regexp or string method.
+//! 2. **Variable forwarding**: `const x = /re/; x.exec(str)` — the literal is
+//!    the initialiser of a `const`/`let`/`var` binding that is *not* exported,
+//!    and at least one read reference to that binding is the object of such a
+//!    call.
+//!
+//! Recognised methods (regex as **object**): `test`, `exec`.
+//! Recognised methods (regex as first **argument**): `match`, `matchAll`,
+//! `search`, `split`, `replace`, `replaceAll`.
+//!
+//! Bare literals, `.source` accesses, and exported bindings are excluded,
+//! matching upstream `ignorePartial: true` semantics.
+
+use oxc_ast::AstKind;
+use oxc_ast::ast::{
+    Argument, BindingPattern, ChainElement, Expression, ForStatementInit, ForStatementLeft,
+    ObjectPropertyKind, Program, Statement,
+};
+use oxc_semantic::{AstNodes, NodeId, Scoping};
+use oxlint_plugins_carton::{CompactString, FastHashSet};
+
+/// Methods where the **regex is the receiver** (object position).
+fn is_regexp_object_method(name: &str) -> bool {
+    matches!(name, "test" | "exec")
+}
+
+/// Methods where the **regex is the first argument** (string-method pattern).
+fn is_string_regexp_method(name: &str) -> bool {
+    matches!(
+        name,
+        "match" | "matchAll" | "search" | "split" | "replace" | "replaceAll"
+    )
+}
+
+/// Walk the program AST, collecting the `span.start` of every `RegExpLiteral`
+/// that is provably used as a whole pattern.  Returns the set; the main
+/// scanner stores it and guards `no-lazy-ends` on membership.
+pub(crate) fn collect_whole_pattern_regex_spans<'a>(
+    program: &'a Program<'a>,
+    scoping: &'a Scoping,
+    nodes: &'a AstNodes<'a>,
+    source_text: &'a str,
+) -> FastHashSet<u32> {
+    let mut ctx = UsageCtx {
+        scoping,
+        nodes,
+        spans: FastHashSet::default(),
+        exported_names: FastHashSet::default(),
+    };
+    // Collect `/* exported name */` style exports from the program comments.
+    // These appear in script-mode files processed by tools such as jshint/
+    // eslint globals, and mean the binding is consumed outside this file.
+    for comment in &program.comments {
+        let span = comment.content_span();
+        let text = span.source_text(source_text).trim();
+        // The canonical form is `/* exported a, b, c */`.
+        if let Some(rest) = text.strip_prefix("exported") {
+            let rest = rest.trim();
+            for name in rest.split(',') {
+                let name = name.trim();
+                if !name.is_empty() {
+                    ctx.exported_names.insert(CompactString::from(name));
+                }
+            }
+        }
+    }
+    ctx.walk_statements(&program.body);
+    ctx.spans
+}
+
+struct UsageCtx<'a> {
+    scoping: &'a Scoping,
+    nodes: &'a AstNodes<'a>,
+    /// Span-starts accumulated so far.
+    spans: FastHashSet<u32>,
+    /// Names exported via `/* exported name */` comment (script-mode).
+    exported_names: FastHashSet<CompactString>,
+}
+
+impl<'a> UsageCtx<'a> {
+    fn walk_statements(&mut self, stmts: &'a [Statement<'a>]) {
+        for stmt in stmts {
+            self.walk_statement(stmt);
+        }
+    }
+
+    fn walk_statement(&mut self, stmt: &'a Statement<'a>) {
+        match stmt {
+            Statement::BlockStatement(block) => self.walk_statements(&block.body),
+            Statement::ExpressionStatement(s) => self.walk_expr(&s.expression),
+            Statement::IfStatement(s) => {
+                self.walk_expr(&s.test);
+                self.walk_statement(&s.consequent);
+                if let Some(alt) = &s.alternate {
+                    self.walk_statement(alt);
+                }
+            }
+            Statement::ReturnStatement(s) => {
+                if let Some(arg) = &s.argument {
+                    self.walk_expr(arg);
+                }
+            }
+            Statement::ThrowStatement(s) => self.walk_expr(&s.argument),
+            Statement::WhileStatement(s) => {
+                self.walk_expr(&s.test);
+                self.walk_statement(&s.body);
+            }
+            Statement::DoWhileStatement(s) => {
+                self.walk_statement(&s.body);
+                self.walk_expr(&s.test);
+            }
+            Statement::ForStatement(s) => {
+                if let Some(init) = &s.init {
+                    match init {
+                        ForStatementInit::VariableDeclaration(decl) => {
+                            for declarator in &decl.declarations {
+                                if let Some(init) = &declarator.init {
+                                    self.walk_expr(init);
+                                }
+                            }
+                        }
+                        _ => {
+                            if let Some(expr) = init.as_expression() {
+                                self.walk_expr(expr);
+                            }
+                        }
+                    }
+                }
+                if let Some(test) = &s.test {
+                    self.walk_expr(test);
+                }
+                if let Some(update) = &s.update {
+                    self.walk_expr(update);
+                }
+                self.walk_statement(&s.body);
+            }
+            Statement::ForInStatement(s) => {
+                if let ForStatementLeft::VariableDeclaration(decl) = &s.left {
+                    for declarator in &decl.declarations {
+                        if let Some(init) = &declarator.init {
+                            self.walk_expr(init);
+                        }
+                    }
+                }
+                self.walk_expr(&s.right);
+                self.walk_statement(&s.body);
+            }
+            Statement::ForOfStatement(s) => {
+                if let ForStatementLeft::VariableDeclaration(decl) = &s.left {
+                    for declarator in &decl.declarations {
+                        if let Some(init) = &declarator.init {
+                            self.walk_expr(init);
+                        }
+                    }
+                }
+                self.walk_expr(&s.right);
+                self.walk_statement(&s.body);
+            }
+            Statement::SwitchStatement(s) => {
+                self.walk_expr(&s.discriminant);
+                for case in &s.cases {
+                    if let Some(test) = &case.test {
+                        self.walk_expr(test);
+                    }
+                    self.walk_statements(&case.consequent);
+                }
+            }
+            Statement::TryStatement(s) => {
+                self.walk_statements(&s.block.body);
+                if let Some(handler) = &s.handler {
+                    self.walk_statements(&handler.body.body);
+                }
+                if let Some(finalizer) = &s.finalizer {
+                    self.walk_statements(&finalizer.body);
+                }
+            }
+            Statement::LabeledStatement(s) => self.walk_statement(&s.body),
+            Statement::VariableDeclaration(decl) => {
+                for declarator in &decl.declarations {
+                    if let Some(init) = &declarator.init {
+                        self.walk_expr(init);
+                    }
+                }
+            }
+            Statement::FunctionDeclaration(f) => {
+                if let Some(body) = &f.body {
+                    self.walk_statements(&body.statements);
+                }
+            }
+            Statement::ClassDeclaration(_) => {}
+            // Exported declarations: scan the inner declaration the same way,
+            // but mark identifiers as exported — their regex initialisers are
+            // not whole-pattern usages even if the variable is called elsewhere.
+            Statement::ExportNamedDeclaration(export) => {
+                if let Some(decl) = &export.declaration {
+                    match decl {
+                        oxc_ast::ast::Declaration::VariableDeclaration(var) => {
+                            // Mark all declared names as ES-module-exported.
+                            for declarator in &var.declarations {
+                                self.mark_binding_exported(&declarator.id);
+                                if let Some(init) = &declarator.init {
+                                    self.walk_expr(init);
+                                }
+                            }
+                        }
+                        oxc_ast::ast::Declaration::FunctionDeclaration(f) => {
+                            if let Some(body) = &f.body {
+                                self.walk_statements(&body.statements);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Statement::ExportDefaultDeclaration(export) => {
+                if let Some(expr) = export.declaration.as_expression() {
+                    self.walk_expr(expr);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn mark_binding_exported(&mut self, binding: &BindingPattern) {
+        if let BindingPattern::BindingIdentifier(id) = binding {
+            self.exported_names
+                .insert(CompactString::from(id.name.as_str()));
+        }
+    }
+
+    fn walk_expr(&mut self, expr: &'a Expression<'a>) {
+        match expr.get_inner_expression() {
+            Expression::CallExpression(call) => {
+                self.check_call(call);
+                // Also recurse into callee and arguments.
+                self.walk_expr(&call.callee);
+                for arg in &call.arguments {
+                    self.walk_argument(arg);
+                }
+            }
+            Expression::StaticMemberExpression(member) => {
+                self.walk_expr(&member.object);
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.walk_expr(&member.object);
+                self.walk_expr(&member.expression);
+            }
+            Expression::BinaryExpression(bin) => {
+                self.walk_expr(&bin.left);
+                self.walk_expr(&bin.right);
+            }
+            Expression::LogicalExpression(log) => {
+                self.walk_expr(&log.left);
+                self.walk_expr(&log.right);
+            }
+            Expression::ConditionalExpression(cond) => {
+                self.walk_expr(&cond.test);
+                self.walk_expr(&cond.consequent);
+                self.walk_expr(&cond.alternate);
+            }
+            Expression::ArrayExpression(arr) => {
+                for el in &arr.elements {
+                    if let Some(e) = el.as_expression() {
+                        self.walk_expr(e);
+                    }
+                }
+            }
+            Expression::ObjectExpression(obj) => {
+                for prop in &obj.properties {
+                    match prop {
+                        ObjectPropertyKind::ObjectProperty(p) => {
+                            self.walk_expr(&p.value);
+                        }
+                        ObjectPropertyKind::SpreadProperty(s) => {
+                            self.walk_expr(&s.argument);
+                        }
+                    }
+                }
+            }
+            Expression::AssignmentExpression(assign) => {
+                self.walk_expr(&assign.right);
+            }
+            Expression::SequenceExpression(seq) => {
+                for e in &seq.expressions {
+                    self.walk_expr(e);
+                }
+            }
+            Expression::AwaitExpression(aw) => self.walk_expr(&aw.argument),
+            Expression::UnaryExpression(un) => self.walk_expr(&un.argument),
+            Expression::YieldExpression(y) => {
+                if let Some(arg) = &y.argument {
+                    self.walk_expr(arg);
+                }
+            }
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::CallExpression(call) => {
+                    self.check_call(call);
+                    self.walk_expr(&call.callee);
+                    for arg in &call.arguments {
+                        self.walk_argument(arg);
+                    }
+                }
+                ChainElement::StaticMemberExpression(member) => {
+                    self.walk_expr(&member.object);
+                }
+                ChainElement::ComputedMemberExpression(member) => {
+                    self.walk_expr(&member.object);
+                    self.walk_expr(&member.expression);
+                }
+                _ => {}
+            },
+            Expression::FunctionExpression(f) => {
+                if let Some(body) = &f.body {
+                    self.walk_statements(&body.statements);
+                }
+            }
+            Expression::ArrowFunctionExpression(f) => {
+                self.walk_statements(&f.body.statements);
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_argument(&mut self, arg: &'a Argument<'a>) {
+        if let Some(expr) = arg.as_expression() {
+            self.walk_expr(expr);
+        } else if let Argument::SpreadElement(spread) = arg {
+            self.walk_expr(&spread.argument);
+        }
+    }
+
+    /// Inspects one `CallExpression` node for "whole-pattern usage" and records
+    /// the relevant `RegExpLiteral` spans.
+    fn check_call(&mut self, call: &'a oxc_ast::ast::CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = call.callee.get_inner_expression() else {
+            return;
+        };
+        let method = member.property.name.as_str();
+
+        // Case A: regex is the object of `.test()` / `.exec()`.
+        if is_regexp_object_method(method) {
+            let obj = member.object.get_inner_expression();
+            self.record_if_regex(obj);
+            return;
+        }
+
+        // Case B: regex is the first argument to a string method.
+        if is_string_regexp_method(method) {
+            let Some(first_arg) = call.arguments.first().and_then(Argument::as_expression) else {
+                return;
+            };
+            let first_arg = first_arg.get_inner_expression();
+            self.record_if_regex(first_arg);
+        }
+    }
+
+    /// Records `expr` as a whole-pattern regex if it is:
+    /// - a `RegExpLiteral` directly, or
+    /// - an `IdentifierReference` that resolves to a non-exported `const`/
+    ///   `let`/`var` binding whose initialiser is a `RegExpLiteral`.
+    fn record_if_regex(&mut self, expr: &'a Expression<'a>) {
+        match expr {
+            Expression::RegExpLiteral(lit) => {
+                self.spans.insert(lit.span.start);
+            }
+            Expression::Identifier(ident) => {
+                // Resolve the reference to its declaration symbol.
+                let Some(ref_id) = ident.reference_id.get() else {
+                    return;
+                };
+                let Some(symbol_id) = self.scoping.get_reference(ref_id).symbol_id() else {
+                    // Free/global reference — not a local binding.
+                    return;
+                };
+                // Check that the binding is not script-exported via comment.
+                let sym_name = self.scoping.symbol_name(symbol_id);
+                if self.exported_names.contains(sym_name) {
+                    return;
+                }
+                // Walk up from the declaration to see if it's inside an ES-module
+                // `export` statement.
+                let decl_node_id = self.scoping.symbol_declaration(symbol_id);
+                if self.is_node_in_export(decl_node_id) {
+                    return;
+                }
+                // Check the initialiser.
+                let decl_kind = self.nodes.get_node(decl_node_id).kind();
+                let AstKind::VariableDeclarator(declarator) = decl_kind else {
+                    return;
+                };
+                let Some(init) = &declarator.init else {
+                    return;
+                };
+                let Expression::RegExpLiteral(lit) = init.get_inner_expression() else {
+                    return;
+                };
+                self.spans.insert(lit.span.start);
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns `true` when the AST node at `node_id` (or one of its ancestors
+    /// up to the program root) is an `ExportNamedDeclaration` or
+    /// `ExportDefaultDeclaration` — meaning the binding is an ES-module export.
+    fn is_node_in_export(&self, node_id: NodeId) -> bool {
+        let mut current = node_id;
+        // Walk up to the root (NodeId 0 is the Program node).
+        loop {
+            match self.nodes.get_node(current).kind() {
+                AstKind::ExportNamedDeclaration(_) | AstKind::ExportDefaultDeclaration(_) => {
+                    return true;
+                }
+                AstKind::Program(_) => return false,
+                _ => {}
+            }
+            let parent = self.nodes.parent_id(current);
+            if parent == current {
+                // Reached the root without cycling.
+                return false;
+            }
+            current = parent;
+        }
+    }
+}

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -4,10 +4,6 @@
     "no-dupe-characters-character-class": {
       "level": "off",
       "reason": "False duplicate in nested v-mode classes / set operations, e.g. /[\\q{a}\\q{ab}\\q{abc}[\\w--[ab]][\\w&&b]]/v. The \\q{...} body is now skipped (so simple cases pass), but nested [...] operands still need set-aware handling."
-    },
-    "no-lazy-ends": {
-      "level": "off",
-      "reason": "Flags lazy quantifiers like /a??/ and /a{3}?/ that upstream treats as valid."
     }
   }
 }

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -310,10 +310,10 @@ const invalidCases = [
   // no-useless-flag
   ['no-useless-flag', 's without dot', "const re = new RegExp('abc', 's');\n", ['unexpected']],
   ['no-useless-flag', 'm without anchor', "const re = new RegExp('abc', 'm');\n", ['unexpected']],
-  // no-lazy-ends
-  ['no-lazy-ends', 'star lazy at end', 'const re = /a*?/u;\n', ['unexpected']],
-  ['no-lazy-ends', 'plus lazy at end', 'const re = /a+?/u;\n', ['unexpected']],
-  ['no-lazy-ends', 'braced lazy at end', 'const re = /a{2,}?/u;\n', ['unexpected']],
+  // no-lazy-ends (only fires when the regex is used as a whole pattern)
+  ['no-lazy-ends', 'star lazy at end', '/a*?/u.test(str)\n', ['unexpected']],
+  ['no-lazy-ends', 'plus lazy at end', '/a+?/u.test(str)\n', ['unexpected']],
+  ['no-lazy-ends', 'braced lazy at end', '/a{2,}?/u.test(str)\n', ['unexpected']],
   // no-useless-dollar-replacements
   [
     'no-useless-dollar-replacements',


### PR DESCRIPTION
## Summary

- Introduce a pre-pass (`usage.rs`) that walks the AST and collects the span-starts of `RegExpLiteral` nodes that are provably used as **whole patterns** (direct `.test()`/`.exec()` calls, string-method arguments like `.match()`, and non-exported variable bindings forwarded to those same methods). Only these span-starts are eligible for `no-lazy-ends` diagnostics, matching upstream's `ignorePartial: true` default.
- Guard the `no-lazy-ends` check in `check_pattern_rules()` behind `used_as_whole`, so bare regex literals (`/a??/`) and exported bindings (`/* exported a */ const a = /a??/; a.test(str)`) are no longer flagged.
- Fix `pattern_ends_with_lazy_quantifier()` to return `false` for `{n}?` (fixed quantifier, no comma ⇒ `min == max`), matching upstream `extractLazyEndQuantifiers` which only yields lazy quantifiers where `min !== max`.
- Remove `no-lazy-ends` from the `"off"` quarantine list in `npm/regexp/test/parity.json`.

## Test plan

- [ ] `cargo test -p oxlint-plugins-regexp` — all 172 tests pass
- [ ] `cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings` — clean
- [ ] Upstream fixture valid cases: `/a??/`, `/a{3}?/.test(str)` (fixed quantifier), exported binding all produce zero diagnostics
- [ ] Upstream fixture invalid cases: `/a*?/.test(str)`, `const foo = /[\s\S]*?/; foo.exec(str)` each produce exactly one diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783979187&installation_id=136613492&pr_number=167&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F167&signature=66e07192c4303084c390f2223ecda2f3ae761e2ea6a88b1ede569af89aad3bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->