### PR TITLE
port(functional): bring no-throw-statements to full upstream parity

### DIFF
--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -203,6 +203,9 @@ pub(crate) struct FunctionContext {
     pub(crate) in_try_with_catch: bool,
     /// True when inside any function/arrow/method body; used by no-let allowInFunctions.
     pub(crate) in_function: bool,
+    /// True when the enclosing function is a `.then`/`.catch` promise handler; an
+    /// async-style throw there rejects the promise (no-throw allowToRejectPromises).
+    pub(crate) in_promise_handler: bool,
 }
 
 pub fn implemented_functional_rule_names() -> &'static [&'static str] {
@@ -245,6 +248,7 @@ pub fn scan_functional(
             in_async_function: false,
             in_try_with_catch: false,
             in_function: false,
+            in_promise_handler: false,
         },
     );
     scanner.diagnostics

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -29,6 +29,12 @@ pub(crate) struct Scanner<'a> {
     pub(crate) ignore_code_regexes: SmallVec<[regex::Regex; 4]>,
 }
 
+/// A function passed to `.then(...)`/`.catch(...)` is a promise handler: a throw
+/// inside it rejects the surrounding promise (no-throw `allowToRejectPromises`).
+fn meta_is_promise_handler(meta: &FunctionParamMeta<'_>) -> bool {
+    meta.is_lambda_arg && matches!(meta.enclosing_call_property, Some("then") | Some("catch"))
+}
+
 impl<'a> Scanner<'a> {
     pub(crate) fn report(
         &mut self,
@@ -70,6 +76,7 @@ impl<'a> Scanner<'a> {
             in_async_function: function.r#async,
             in_try_with_catch: false,
             in_function: true,
+            in_promise_handler: meta_is_promise_handler(&meta),
         };
         if let Some(body) = &function.body {
             self.scan_function_body(body, context);
@@ -90,6 +97,7 @@ impl<'a> Scanner<'a> {
             in_async_function: function.r#async,
             in_try_with_catch: false,
             in_function: true,
+            in_promise_handler: meta_is_promise_handler(&meta),
         };
         self.scan_function_body(&function.body, context);
     }
@@ -198,6 +206,7 @@ impl<'a> Scanner<'a> {
                         in_async_function: false,
                         in_try_with_catch: false,
                         in_function: false,
+                        in_promise_handler: false,
                     },
                 );
             }

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -150,7 +150,14 @@ impl<'a> Scanner<'a> {
                 }
             }
             Statement::ThrowStatement(statement) => {
-                if !(self.options.allow_throw_to_reject_promises && context.in_async_function) {
+                // allowToRejectPromises permits a throw that rejects the enclosing
+                // promise: one in a `.then`/`.catch` handler, or an async throw that
+                // escapes (not caught by a try/catch in the same function).
+                let rejects_via_handler = context.in_promise_handler;
+                let rejects_via_async = context.in_async_function && !context.in_try_with_catch;
+                let allowed_as_rejection = self.options.allow_throw_to_reject_promises
+                    && (rejects_via_handler || rejects_via_async);
+                if !allowed_as_rejection {
                     self.report(
                         "no-throw-statements",
                         "generic",

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -469,3 +469,37 @@ fn no_mixed_types_reports_once_and_honors_options() {
         0
     );
 }
+
+#[test]
+fn no_throw_statements_honors_allow_to_reject_promises() {
+    let base = FunctionalOptions {
+        rule_names: ["no-throw-statements".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let allow = FunctionalOptions {
+        rule_names: ["no-throw-statements".into()].into_iter().collect(),
+        allow_throw_to_reject_promises: true,
+        ..FunctionalOptions::default()
+    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
+
+    // Default: every throw is reported.
+    let basic = count("function f() { throw new Error(); }", &base);
+    assert_eq!(basic, 1);
+
+    // allowToRejectPromises: an async escape, a `.then` handler, and a
+    // try/finally (no catch) all reject the promise and are allowed.
+    let async_escape = count("async function f() { throw new Error(); }", &allow);
+    assert_eq!(async_escape, 0);
+    let handler = count("function f() { p.then(() => { throw new Error(); }); }", &allow);
+    assert_eq!(handler, 0);
+    let finally_throw = count("async function f() { try { throw e; } finally { g(); } }", &allow);
+    assert_eq!(finally_throw, 0);
+
+    // A caught throw and a nested non-async throw still report.
+    let caught = count("async function f() { try { throw e; } catch (x) { g(); } }", &allow);
+    assert_eq!(caught, 1);
+    let nested = count("async function f() { function g() { throw e; } }", &allow);
+    assert_eq!(nested, 1);
+}

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -498,7 +498,10 @@ fn no_throw_statements_honors_allow_to_reject_promises() {
     assert_eq!(finally_throw, 0);
 
     // A caught throw and a nested non-async throw still report.
-    let caught = count("async function f() { try { throw e; } catch (x) { g(); } }", &allow);
+    let caught = count(
+        "async function f() { try { throw e; } catch (x) { g(); } }",
+        &allow,
+    );
     assert_eq!(caught, 1);
     let nested = count("async function f() { function g() { throw e; } }", &allow);
     assert_eq!(nested, 1);

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -492,9 +492,15 @@ fn no_throw_statements_honors_allow_to_reject_promises() {
     // try/finally (no catch) all reject the promise and are allowed.
     let async_escape = count("async function f() { throw new Error(); }", &allow);
     assert_eq!(async_escape, 0);
-    let handler = count("function f() { p.then(() => { throw new Error(); }); }", &allow);
+    let handler = count(
+        "function f() { p.then(() => { throw new Error(); }); }",
+        &allow,
+    );
     assert_eq!(handler, 0);
-    let finally_throw = count("async function f() { try { throw e; } finally { g(); } }", &allow);
+    let finally_throw = count(
+        "async function f() { try { throw e; } finally { g(); } }",
+        &allow,
+    );
     assert_eq!(finally_throw, 0);
 
     // A caught throw and a nested non-async throw still report.

--- a/npm/functional/README.md
+++ b/npm/functional/README.md
@@ -28,15 +28,15 @@ counted in the parity ledger — never silently dropped.
 | `no-classes`                    | ✅ Full parity                                                                   |
 | `no-let`                        | ✅ Full parity                                                                   |
 | `no-loop-statements`            | ✅ Full parity                                                                   |
+| `no-mixed-types`                | ✅ Full parity                                                                   |
 | `no-promise-reject`             | ✅ Full parity                                                                   |
 | `no-this-expressions`           | ✅ Full parity                                                                   |
+| `no-throw-statements`           | ✅ Full parity                                                                   |
 | `no-try-statements`             | ✅ Full parity                                                                   |
 | `prefer-property-signatures`    | ✅ Full parity                                                                   |
 | `readonly-type`                 | ✅ AST-only (no upstream test suite)                                             |
 | `no-conditional-statements`     | 🟡 Syntactic core; `allowReturningBranches: "ifExhaustive"` needs types          |
 | `no-expression-statements`      | 🟡 Syntactic core; `ignoreVoid` / `ignoreSelfReturning` need types               |
-| `no-mixed-types`                | 🟡 Syntactic core; resolving a property typed as a function needs types          |
-| `no-throw-statements`           | 🟡 Syntactic core; `allowToRejectPromises` promise-handler detection needs types |
 | `prefer-readonly-type`          | 🟡 Syntactic core; `checkImplicit` needs types                                   |
 | `immutable-data`                | 🔵 Needs type information (array/map/set detection)                              |
 | `no-return-void`                | 🔵 Needs type information (inferred return types)                                |

--- a/npm/functional/README.md
+++ b/npm/functional/README.md
@@ -21,28 +21,28 @@ counted in the parity ledger — never silently dropped.
 
 ### Rule status
 
-| Rule                            | Status                                                                           |
-| ------------------------------- | -------------------------------------------------------------------------------- |
-| `functional-parameters`         | ✅ Full parity                                                                   |
-| `no-class-inheritance`          | ✅ Full parity                                                                   |
-| `no-classes`                    | ✅ Full parity                                                                   |
-| `no-let`                        | ✅ Full parity                                                                   |
-| `no-loop-statements`            | ✅ Full parity                                                                   |
-| `no-mixed-types`                | ✅ Full parity                                                                   |
-| `no-promise-reject`             | ✅ Full parity                                                                   |
-| `no-this-expressions`           | ✅ Full parity                                                                   |
-| `no-throw-statements`           | ✅ Full parity                                                                   |
-| `no-try-statements`             | ✅ Full parity                                                                   |
-| `prefer-property-signatures`    | ✅ Full parity                                                                   |
-| `readonly-type`                 | ✅ AST-only (no upstream test suite)                                             |
-| `no-conditional-statements`     | 🟡 Syntactic core; `allowReturningBranches: "ifExhaustive"` needs types          |
-| `no-expression-statements`      | 🟡 Syntactic core; `ignoreVoid` / `ignoreSelfReturning` need types               |
-| `prefer-readonly-type`          | 🟡 Syntactic core; `checkImplicit` needs types                                   |
-| `immutable-data`                | 🔵 Needs type information (array/map/set detection)                              |
-| `no-return-void`                | 🔵 Needs type information (inferred return types)                                |
-| `prefer-immutable-types`        | 🔵 Needs type information (`is-immutable-type`)                                  |
-| `prefer-tacit`                  | 🔵 Needs type information (call-signature arity)                                 |
-| `type-declaration-immutability` | 🔵 Needs type information (`is-immutable-type`)                                  |
+| Rule                            | Status                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `functional-parameters`         | ✅ Full parity                                                          |
+| `no-class-inheritance`          | ✅ Full parity                                                          |
+| `no-classes`                    | ✅ Full parity                                                          |
+| `no-let`                        | ✅ Full parity                                                          |
+| `no-loop-statements`            | ✅ Full parity                                                          |
+| `no-mixed-types`                | ✅ Full parity                                                          |
+| `no-promise-reject`             | ✅ Full parity                                                          |
+| `no-this-expressions`           | ✅ Full parity                                                          |
+| `no-throw-statements`           | ✅ Full parity                                                          |
+| `no-try-statements`             | ✅ Full parity                                                          |
+| `prefer-property-signatures`    | ✅ Full parity                                                          |
+| `readonly-type`                 | ✅ AST-only (no upstream test suite)                                    |
+| `no-conditional-statements`     | 🟡 Syntactic core; `allowReturningBranches: "ifExhaustive"` needs types |
+| `no-expression-statements`      | 🟡 Syntactic core; `ignoreVoid` / `ignoreSelfReturning` need types      |
+| `prefer-readonly-type`          | 🟡 Syntactic core; `checkImplicit` needs types                          |
+| `immutable-data`                | 🔵 Needs type information (array/map/set detection)                     |
+| `no-return-void`                | 🔵 Needs type information (inferred return types)                       |
+| `prefer-immutable-types`        | 🔵 Needs type information (`is-immutable-type`)                         |
+| `prefer-tacit`                  | 🔵 Needs type information (call-signature arity)                        |
+| `type-declaration-immutability` | 🔵 Needs type information (`is-immutable-type`)                         |
 
 - ✅ Full parity — every upstream test case is asserted.
 - 🟡 Syntactic core — the rule's syntax-only behavior is implemented and the

--- a/npm/functional/test/upstream.test.mjs
+++ b/npm/functional/test/upstream.test.mjs
@@ -38,6 +38,7 @@ const FULL_PARITY = new Set([
   'no-mixed-types',
   'no-promise-reject',
   'no-this-expressions',
+  'no-throw-statements',
   'no-try-statements',
   'prefer-property-signatures',
 ]);


### PR DESCRIPTION
Implements `allowToRejectPromises` faithfully to upstream: a throw is permitted only when it rejects the enclosing promise — inside a `.then`/`.catch` handler, or an async throw that escapes (not caught by a try/catch in the same function). A caught throw, or a throw in a nested non-async function, still reports. FunctionContext gains `in_promise_handler` (derived from the function-role meta). no-throw-statements joins FULL_PARITY (all upstream cases asserted). Rust unit test added; no JS changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783979188&installation_id=136613492&pr_number=168&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F168&signature=f42ecb67ee26550d5ac65427e0840d2d008c69b947e0dc8184e17095b9529efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->