### PR TITLE
port(sonarjs): port no-exclusive-tests (S6426)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 17] = [
+pub const RULE_NAMES: [&str; 18] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -40,6 +40,7 @@ pub const RULE_NAMES: [&str; 17] = [
     "constructor-for-side-effects",
     "no-empty-character-class",
     "generator-without-yield",
+    "no-exclusive-tests",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -10,6 +10,7 @@ mod no_collapsible_if;
 mod no_delete_var;
 mod no_duplicate_in_composite;
 mod no_empty_character_class;
+mod no_exclusive_tests;
 mod no_identical_conditions;
 mod no_identical_expressions;
 mod no_labels;

--- a/crates/sonarjs/src/rules/no_exclusive_tests.rs
+++ b/crates/sonarjs/src/rules/no_exclusive_tests.rs
@@ -1,0 +1,45 @@
+//! Rule `no-exclusive-tests` (SonarJS key S6426).
+//!
+//! Clean-room port. Reports a `.only` member access on a known test-runner
+//! function identifier. Calling `describe.only(...)`, `it.only(...)`, or
+//! similar silently disables every other test in the suite — acceptable during
+//! local debugging but disastrous if committed, because CI will only run the
+//! focused test(s) and give a false green.
+//!
+//! **Covered forms**: `describe.only`, `it.only`, `test.only`, `context.only`,
+//! `suite.only`, and `specify.only` where the object is a bare identifier
+//! reference to one of those six known test-runner names. Chained or
+//! namespaced forms (`myFramework.describe.only`) are not flagged because the
+//! object after stripping parentheses is not a bare identifier.
+//!
+//! **Out of scope / follow-up**: Jasmine `fdescribe` / `fit` and other
+//! framework-specific focused-test prefixes are not covered by this rule. They
+//! can be added as a follow-up once the `.only` member-expression form is
+//! stable in CI.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S6426) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{Expression, StaticMemberExpression};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-exclusive-tests";
+
+const TEST_RUNNERS: [&str; 6] = ["describe", "it", "test", "context", "suite", "specify"];
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_exclusive_tests(&mut self, member: &StaticMemberExpression<'_>) {
+        if member.property.name.as_str() != "only" {
+            return;
+        }
+        let Expression::Identifier(object) = member.object.get_inner_expression() else {
+            return;
+        };
+        if !TEST_RUNNERS.contains(&object.name.as_str()) {
+            return;
+        }
+        self.report(RULE_NAME, "noExclusiveTests", member.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,8 +3,8 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, Expression, ExpressionStatement,
-    Function, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement, Function,
+    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
     StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType,
     TemplateLiteral, UnaryExpression, YieldExpression,
 };

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,10 +3,10 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement, Function,
-    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
-    SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
-    YieldExpression,
+    AssignmentExpression, BinaryExpression, ConditionalExpression, Expression, ExpressionStatement,
+    Function, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
+    StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType,
+    TemplateLiteral, UnaryExpression, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -145,6 +145,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
         self.check_no_empty_character_class(it);
         walk::walk_reg_exp_literal(self, it);
+    }
+
+    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+        self.check_no_exclusive_tests(it);
+        walk::walk_static_member_expression(self, it);
     }
 
     fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -791,3 +791,50 @@ fn reports_generator_without_yield_for_inner_only_when_outer_yields() {
     // inner starts at column > 0 (it is not at the start of the line)
     assert!(diagnostics[0].loc.start_column > 0);
 }
+
+#[test]
+fn reports_no_exclusive_tests_for_describe_only() {
+    let source = "describe.only('x', () => {});";
+    let diagnostics = scan("no-exclusive-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-exclusive-tests");
+    assert_eq!(diagnostics[0].message_id, "noExclusiveTests");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_no_exclusive_tests_for_it_only() {
+    let source = "it.only('x', () => {});";
+    let diagnostics = scan("no-exclusive-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noExclusiveTests");
+}
+
+#[test]
+fn reports_no_exclusive_tests_for_test_only() {
+    let source = "test.only('x', () => {});";
+    let diagnostics = scan("no-exclusive-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noExclusiveTests");
+}
+
+#[test]
+fn does_not_report_no_exclusive_tests_for_it_without_only() {
+    let source = "it('x', () => {});";
+    let diagnostics = scan("no-exclusive-tests", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_exclusive_tests_for_unknown_function_with_only() {
+    let source = "foo.only();";
+    let diagnostics = scan("no-exclusive-tests", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_exclusive_tests_for_describe_without_only() {
+    let source = "describe('x', () => {});";
+    let diagnostics = scan("no-exclusive-tests", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -77,6 +77,9 @@ const messages = Object.freeze({
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
   },
+  'no-exclusive-tests': {
+    noExclusiveTests: "Remove '.only' so the whole test suite runs, not just this test.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -106,6 +109,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow empty character classes in regular expression literals, which can never match',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
+  'no-exclusive-tests':
+    'Disallow .only on test-runner functions (describe, it, test, etc.) that would disable all other tests',
 });
 
 const ruleTypes = Object.freeze({
@@ -126,6 +131,7 @@ const ruleTypes = Object.freeze({
   'constructor-for-side-effects': 'problem',
   'no-empty-character-class': 'problem',
   'generator-without-yield': 'problem',
+  'no-exclusive-tests': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -146,6 +152,7 @@ const recommendedRuleConfig = Object.freeze({
   'constructor-for-side-effects': 'error',
   'no-empty-character-class': 'error',
   'generator-without-yield': 'error',
+  'no-exclusive-tests': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -20,6 +20,7 @@ const expectedRuleNames = [
   'constructor-for-side-effects',
   'no-empty-character-class',
   'generator-without-yield',
+  'no-exclusive-tests',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -630,5 +631,45 @@ describe('sonarjs native API', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].messageId).toBe('generatorWithoutYield');
     expect(diagnostics[0].loc.startColumn).toBeGreaterThan(0);
+  });
+
+  it('reports no-exclusive-tests for describe.only(...)', () => {
+    const source = "describe.only('x', () => {});";
+    const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-exclusive-tests');
+    expect(diagnostics[0].messageId).toBe('noExclusiveTests');
+  });
+
+  it('reports no-exclusive-tests for it.only(...)', () => {
+    const source = "it.only('x', () => {});";
+    const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noExclusiveTests');
+  });
+
+  it('reports no-exclusive-tests for test.only(...)', () => {
+    const source = "test.only('x', () => {});";
+    const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noExclusiveTests');
+  });
+
+  it('does not report no-exclusive-tests for it without .only', () => {
+    const source = "it('x', () => {});";
+    const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-exclusive-tests for foo.only (unknown function)', () => {
+    const source = 'foo.only();';
+    const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-exclusive-tests for describe without .only', () => {
+    const source = "describe('x', () => {});";
+    const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -111,6 +111,7 @@ describe('sonarjs plugin shape', () => {
       'constructor-for-side-effects',
       'no-empty-character-class',
       'generator-without-yield',
+      'no-exclusive-tests',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -129,6 +130,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['constructor-for-side-effects']).toBe('object');
     expect(typeof plugin.rules['no-empty-character-class']).toBe('object');
     expect(typeof plugin.rules['generator-without-yield']).toBe('object');
+    expect(typeof plugin.rules['no-exclusive-tests']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -147,6 +149,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/constructor-for-side-effects']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-character-class']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/generator-without-yield']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-exclusive-tests']).toBe('error');
   });
 });
 
@@ -271,6 +274,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('generator-without-yield', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('generatorWithoutYield');
+  });
+
+  it('reports no-exclusive-tests for describe.only through the adapter', () => {
+    const source = "describe.only('x', () => {});";
+    const reports = runRule('no-exclusive-tests', source, { filename: 'sample.js' });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noExclusiveTests');
   });
 });
 
@@ -439,5 +449,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(generator-without-yield)');
+  });
+
+  it('reports no-exclusive-tests through the CLI', () => {
+    const source = "describe.only('x', () => {});";
+    const result = runOxlint('no-exclusive-tests', source, 'sample.js');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-exclusive-tests)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12062,19 +12062,19 @@
       },
       {
         "name": "no-exclusive-tests",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-exclusive-tests (Sonar key S6426). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S6426). Covers the .only member-expression form on the six known test-runner identifiers: describe, it, test, context, suite, specify. Jasmine fdescribe/fit and other focused-test prefix forms are out of scope and noted as a follow-up."
       },
       {
         "name": "no-extra-arguments",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-exclusive-tests`** (Sonar key S6426). Flags a `.only` member access on a known test-runner identifier (`describe`/`it`/`test`/`context`/`suite`/`specify`) — e.g. `it.only(...)` — which silently disables every other test in the suite if committed (CI shows a false green). Adds a `visit_static_member_expression` hook.

**Scope:** the `.only` member form on those bare identifiers. Jasmine `fdescribe`/`fit` focused prefixes are a documented follow-up.

## Tests
Rust unit tests (`describe.only`, `it.only`, `test.only`, plain `it` → 0, non-runner `.only` → 0, plain `describe` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-exclusive-tests)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783980144&installation_id=136613492&pr_number=169&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F169&signature=ed0974c6e42f58b9ba213d1688412b6fdd7f49647bbf6b306a3dc61fb704b81a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->