### PR TITLE
fix(functional): correctness fixes from final review

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -44,7 +44,15 @@ impl<'a> Scanner<'a> {
                 ChainElement::StaticMemberExpression(member) => {
                     self.scan_static_member_expression(member, context);
                 }
-                _ => {}
+                ChainElement::ComputedMemberExpression(member) => {
+                    self.scan_computed_member_expression(member, context);
+                }
+                ChainElement::PrivateFieldExpression(member) => {
+                    self.scan_expression(&member.object, context);
+                }
+                ChainElement::TSNonNullExpression(expression) => {
+                    self.scan_expression(&expression.expression, context);
+                }
             },
             Expression::StaticMemberExpression(member) => {
                 self.scan_static_member_expression(member, context);

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -191,7 +191,7 @@ impl<'a> Scanner<'a> {
                     );
                 }
             }
-            if param.readonly {
+            if param.readonly && self.options.readonly_type_mode == "generic" {
                 self.report(
                     "readonly-type",
                     "generic",
@@ -270,7 +270,10 @@ impl<'a> Scanner<'a> {
         }
         if !self.ignore_code_regexes.is_empty() {
             let span = class.span;
-            let code = &self.source_text[span.start as usize..span.end as usize];
+            let code = self
+                .source_text
+                .get(span.start as usize..span.end as usize)
+                .unwrap_or("");
             if self.ignore_code_regexes.iter().any(|re| re.is_match(code)) {
                 return true;
             }

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -118,6 +118,9 @@ impl<'a> Scanner<'a> {
                 self.scan_expression(&statement.test, context);
             }
             Statement::TryStatement(statement) => {
+                // Upstream checks the catch handler and the finalizer
+                // independently, so a `try/catch/finally` with both disallowed
+                // reports both (not just the first).
                 if statement.handler.is_some() && !self.options.allow_try_catch {
                     self.report(
                         "no-try-statements",
@@ -125,7 +128,8 @@ impl<'a> Scanner<'a> {
                         "Unexpected try-catch, this pattern is not functional.",
                         statement.span,
                     );
-                } else if statement.finalizer.is_some() && !self.options.allow_try_finally {
+                }
+                if statement.finalizer.is_some() && !self.options.allow_try_finally {
                     self.report(
                         "no-try-statements",
                         "finally",

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -512,3 +512,37 @@ fn no_throw_statements_honors_allow_to_reject_promises() {
     let nested = count("async function f() { function g() { throw e; } }", &allow);
     assert_eq!(nested, 1);
 }
+
+#[test]
+fn no_try_statements_reports_catch_and_finally_independently() {
+    let both = FunctionalOptions {
+        rule_names: ["no-try-statements".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let allow_catch = FunctionalOptions {
+        rule_names: ["no-try-statements".into()].into_iter().collect(),
+        allow_try_catch: true,
+        ..FunctionalOptions::default()
+    };
+    let allow_finally = FunctionalOptions {
+        rule_names: ["no-try-statements".into()].into_iter().collect(),
+        allow_try_finally: true,
+        ..FunctionalOptions::default()
+    };
+    let src = "try { f(); } catch (e) { g(); } finally { h(); }";
+    let ids = |opts: &FunctionalOptions| {
+        let mut ids: Vec<&str> = scan_functional(src, "fixture.ts", opts)
+            .iter()
+            .map(|d| d.message_id)
+            .collect();
+        ids.sort_unstable();
+        ids
+    };
+
+    // Both disallowed: a try/catch/finally reports catch AND finally.
+    assert_eq!(ids(&both), ["catch", "finally"]);
+    // allowCatch leaves only the finally diagnostic.
+    assert_eq!(ids(&allow_catch), ["finally"]);
+    // allowFinally leaves only the catch diagnostic.
+    assert_eq!(ids(&allow_finally), ["catch"]);
+}


### PR DESCRIPTION
Follow-up correctness fixes surfaced by the final multi-dimensional review of the `functional` crate. Each was verified against the captured upstream fixtures before changing.

## Changes

- **no-try-statements — independent catch/finally reporting.** The handler and finalizer checks were chained with `else if`, so a `try { } catch { } finally { }` with both disallowed reported only `catch` and silently dropped `finally`. Upstream checks them independently. Switched to two `if`s. The upstream fixtures only cover single-disable cases (one of catch/finally allowed), so the dual-disable path was untested — added a Rust unit test asserting `["catch", "finally"]`, `["finally"]`, and `["catch"]` for the three option combinations. All existing fixtures stay green.
- **Optional-chain traversal completeness.** `ChainExpression` only matched `CallExpression` and `StaticMemberExpression`, dropping the computed-member, private-field, and non-null chain elements. Nested expressions inside `obj?.[expr]`, `obj?.#field`, and `expr?.x!` were never scanned (so e.g. `this`/`arguments`/throws inside them were missed). Now handles all `ChainElement` variants.
- **readonly-type respects `readonly_type_mode`.** The parameter-property path reported unconditionally; the property-signature path already guards on `readonly_type_mode == "generic"`. Mirrored the guard so `keyword` mode no longer false-positives.
- **Defensive source slice.** `class_is_ignored` sliced `source_text[start..end]` directly; switched to `get(..).unwrap_or("")`. OXC guarantees char-boundary spans so this is defensive only.

## Verification

Behavior cross-checked against `npm/functional/test/fixtures/*.json`. The reviewer also flagged adding a promise-handler branch to `no-promise-reject`, but the fixtures prove upstream does **not** flag a throw inside a `.then`/`.catch` handler, so that was intentionally not changed (it would over-report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)