### PR TITLE
port(sonarjs): port no-built-in-override (S2424)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 18] = [
+pub const RULE_NAMES: [&str; 19] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -41,6 +41,7 @@ pub const RULE_NAMES: [&str; 18] = [
     "no-empty-character-class",
     "generator-without-yield",
     "no-exclusive-tests",
+    "no-built-in-override",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -6,6 +6,7 @@ mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
 mod generator_without_yield;
 mod no_all_duplicated_branches;
+mod no_built_in_override;
 mod no_collapsible_if;
 mod no_delete_var;
 mod no_duplicate_in_composite;

--- a/crates/sonarjs/src/rules/no_built_in_override.rs
+++ b/crates/sonarjs/src/rules/no_built_in_override.rs
@@ -1,0 +1,112 @@
+//! Rule `no-built-in-override` (SonarJS key S2424).
+//!
+//! Clean-room port. Overriding or shadowing a standard ECMAScript built-in
+//! global object or function is dangerous and confusing. Code that relies on a
+//! built-in being available (e.g. `Array.isArray`, `Object.keys`) will break
+//! silently if an outer scope has rebound the name to something else.
+//!
+//! ## Standard built-in globals
+//!
+//! The rule targets the following standard ECMAScript built-in global names:
+//!
+//! `Object`, `Function`, `Boolean`, `Symbol`, `Error`, `EvalError`,
+//! `RangeError`, `ReferenceError`, `SyntaxError`, `TypeError`, `URIError`,
+//! `Number`, `BigInt`, `Math`, `Date`, `String`, `RegExp`, `Array`, `Map`,
+//! `Set`, `WeakMap`, `WeakSet`, `Promise`, `Proxy`, `Reflect`, `JSON`,
+//! `ArrayBuffer`, `DataView`, `Infinity`, `NaN`, `undefined`, `globalThis`,
+//! `parseInt`, `parseFloat`, `isNaN`, `isFinite`, `decodeURI`,
+//! `decodeURIComponent`, `encodeURI`, `encodeURIComponent`.
+//!
+//! ## Detection strategy
+//!
+//! Two paths are covered:
+//!
+//! 1. **Binding declarations** (`visit_binding_identifier`): catches `let`,
+//!    `const`, `var`, function declarations, class declarations, function
+//!    parameters, and destructuring bindings whose name matches a built-in.
+//!    E.g. `let Object = 1`, `function Array() {}`, `class Map {}`,
+//!    `function f(Promise) {}`.
+//!
+//! 2. **Simple assignments** (`visit_assignment_expression`): catches bare
+//!    assignments whose left-hand side is a plain identifier that matches a
+//!    built-in.  E.g. `Array = 2`. Member-expression targets such as
+//!    `Math.PI = 3` are intentionally **not** reported — only bare identifier
+//!    targets are flagged.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{AssignmentExpression, AssignmentTarget, BindingIdentifier};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-built-in-override";
+
+const BUILTINS: [&str; 40] = [
+    "Array",
+    "ArrayBuffer",
+    "BigInt",
+    "Boolean",
+    "DataView",
+    "Date",
+    "Error",
+    "EvalError",
+    "Function",
+    "Infinity",
+    "JSON",
+    "Map",
+    "Math",
+    "NaN",
+    "Number",
+    "Object",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "ReferenceError",
+    "Reflect",
+    "RegExp",
+    "Set",
+    "String",
+    "Symbol",
+    "SyntaxError",
+    "TypeError",
+    "URIError",
+    "WeakMap",
+    "WeakSet",
+    "decodeURI",
+    "decodeURIComponent",
+    "encodeURI",
+    "encodeURIComponent",
+    "globalThis",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "undefined",
+];
+
+fn is_builtin(name: &str) -> bool {
+    BUILTINS.contains(&name)
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_built_in_override_binding(&mut self, id: &BindingIdentifier<'_>) {
+        if !is_builtin(id.name.as_str()) {
+            return;
+        }
+        self.report(RULE_NAME, "noBuiltInOverride", id.span);
+    }
+
+    pub(crate) fn check_no_built_in_override_assignment(
+        &mut self,
+        assign: &AssignmentExpression<'_>,
+    ) {
+        let AssignmentTarget::AssignmentTargetIdentifier(id) = &assign.left else {
+            return;
+        };
+        if !is_builtin(id.name.as_str()) {
+            return;
+        }
+        self.report(RULE_NAME, "noBuiltInOverride", id.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,10 +3,10 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, ConditionalExpression, ExpressionStatement, Function,
-    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
-    StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSUnionType,
-    TemplateLiteral, UnaryExpression, YieldExpression,
+    AssignmentExpression, BinaryExpression, BindingIdentifier, ConditionalExpression,
+    ExpressionStatement, Function, IdentifierReference, IfStatement, LabeledStatement,
+    LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase, SwitchStatement,
+    TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -122,8 +122,14 @@ impl<'a> Visit<'a> for Scanner<'a> {
         walk::walk_if_statement(self, it);
     }
 
+    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
+        self.check_no_built_in_override_binding(it);
+        walk::walk_binding_identifier(self, it);
+    }
+
     fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
         self.check_non_existent_operator(it);
+        self.check_no_built_in_override_assignment(it);
         walk::walk_assignment_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -838,3 +838,49 @@ fn does_not_report_no_exclusive_tests_for_describe_without_only() {
     let diagnostics = scan("no-exclusive-tests", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_built_in_override_for_let_declaration_shadowing_object() {
+    let source = "let Object = 1;";
+    let diagnostics = scan("no-built-in-override", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-built-in-override");
+    assert_eq!(diagnostics[0].message_id, "noBuiltInOverride");
+}
+
+#[test]
+fn reports_no_built_in_override_for_simple_assignment_to_array() {
+    let source = "Array = 2;";
+    let diagnostics = scan("no-built-in-override", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noBuiltInOverride");
+}
+
+#[test]
+fn reports_no_built_in_override_for_function_declaration_named_map() {
+    let source = "function Map() {}";
+    let diagnostics = scan("no-built-in-override", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noBuiltInOverride");
+}
+
+#[test]
+fn does_not_report_no_built_in_override_for_member_expression_assignment() {
+    let source = "Math.PI = 3;";
+    let diagnostics = scan("no-built-in-override", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_built_in_override_for_non_builtin_variable() {
+    let source = "let obj = 1;";
+    let diagnostics = scan("no-built-in-override", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_built_in_override_for_member_assignment_foo_object() {
+    let source = "foo.Object = 1;";
+    let diagnostics = scan("no-built-in-override", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -80,6 +80,9 @@ const messages = Object.freeze({
   'no-exclusive-tests': {
     noExclusiveTests: "Remove '.only' so the whole test suite runs, not just this test.",
   },
+  'no-built-in-override': {
+    noBuiltInOverride: 'Do not override or shadow a built-in object or function.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -111,6 +114,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
     'Disallow .only on test-runner functions (describe, it, test, etc.) that would disable all other tests',
+  'no-built-in-override':
+    'Disallow overriding or shadowing standard ECMAScript built-in global objects and functions',
 });
 
 const ruleTypes = Object.freeze({
@@ -132,6 +137,7 @@ const ruleTypes = Object.freeze({
   'no-empty-character-class': 'problem',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
+  'no-built-in-override': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -153,6 +159,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-empty-character-class': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
+  'no-built-in-override': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -21,6 +21,7 @@ const expectedRuleNames = [
   'no-empty-character-class',
   'generator-without-yield',
   'no-exclusive-tests',
+  'no-built-in-override',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -670,6 +671,46 @@ describe('sonarjs native API', () => {
   it('does not report no-exclusive-tests for describe without .only', () => {
     const source = "describe('x', () => {});";
     const diagnostics = scan('no-exclusive-tests', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-built-in-override for a let declaration that shadows Object', () => {
+    const source = 'let Object = 1;';
+    const diagnostics = scan('no-built-in-override', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-built-in-override');
+    expect(diagnostics[0].messageId).toBe('noBuiltInOverride');
+  });
+
+  it('reports no-built-in-override for a simple assignment to Array', () => {
+    const source = 'Array = 2;';
+    const diagnostics = scan('no-built-in-override', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noBuiltInOverride');
+  });
+
+  it('reports no-built-in-override for a function declaration named Map', () => {
+    const source = 'function Map() {}';
+    const diagnostics = scan('no-built-in-override', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noBuiltInOverride');
+  });
+
+  it('does not report no-built-in-override for a member-expression assignment to Math.PI', () => {
+    const source = 'Math.PI = 3;';
+    const diagnostics = scan('no-built-in-override', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-built-in-override for a non-builtin variable declaration', () => {
+    const source = 'let obj = 1;';
+    const diagnostics = scan('no-built-in-override', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-built-in-override for a member assignment to foo.Object', () => {
+    const source = 'foo.Object = 1;';
+    const diagnostics = scan('no-built-in-override', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -112,6 +112,7 @@ describe('sonarjs plugin shape', () => {
       'no-empty-character-class',
       'generator-without-yield',
       'no-exclusive-tests',
+      'no-built-in-override',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -131,6 +132,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-empty-character-class']).toBe('object');
     expect(typeof plugin.rules['generator-without-yield']).toBe('object');
     expect(typeof plugin.rules['no-exclusive-tests']).toBe('object');
+    expect(typeof plugin.rules['no-built-in-override']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -150,6 +152,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-character-class']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/generator-without-yield']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-exclusive-tests']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-built-in-override']).toBe('error');
   });
 });
 
@@ -281,6 +284,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-exclusive-tests', source, { filename: 'sample.js' });
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('noExclusiveTests');
+  });
+
+  it('reports no-built-in-override for a let declaration that shadows Object through the adapter', () => {
+    const source = 'let Object = 1;';
+    const reports = runRule('no-built-in-override', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noBuiltInOverride');
   });
 });
 
@@ -459,5 +469,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-exclusive-tests)');
+  });
+
+  it('reports no-built-in-override through the CLI', () => {
+    const source = 'let Object = 1;';
+    const result = runOxlint('no-built-in-override', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-built-in-override)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11726,19 +11726,19 @@
       },
       {
         "name": "no-built-in-override",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-built-in-override (Sonar key S2424). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S2424). Detects binding declarations and simple assignments that override or shadow standard ECMAScript built-in globals (Object, Array, Math, etc. — a fixed set of 40 names documented in the rule source). Member-expression targets such as Math.PI = 3 are intentionally excluded. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-case-label-in-switch",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-built-in-override`** (Sonar key S2424). Flags overriding/shadowing a standard ECMAScript built-in global: a binding declaration named like a built-in (`let Object`, `function Array(){}`, `class Map{}`, a param), or a bare assignment to one (`Array = 2`). Member-expression targets (`Math.PI = 3`) are not flagged. Targets a documented set of 40 standard globals. Adds a `visit_binding_identifier` hook plus a second check on the existing `visit_assignment_expression`.

## Tests
Rust unit tests (`let Object`, `Array =`, `function Map`, `Math.PI =` → 0, non-builtin decl → 0, `foo.Object =` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-built-in-override)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783981334&installation_id=136613492&pr_number=172&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F172&signature=dd802c318ba51c7d81069bad4c91435dd75be6e983ce4dc6ee49d59144822d75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->