### PR TITLE
port(sonarjs): port class-prototype (S3525)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 19] = [
+pub const RULE_NAMES: [&str; 20] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -42,6 +42,7 @@ pub const RULE_NAMES: [&str; 19] = [
     "generator-without-yield",
     "no-exclusive-tests",
     "no-built-in-override",
+    "class-prototype",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -2,6 +2,7 @@
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
 mod arguments_usage;
+mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
 mod generator_without_yield;

--- a/crates/sonarjs/src/rules/class_prototype.rs
+++ b/crates/sonarjs/src/rules/class_prototype.rs
@@ -1,0 +1,59 @@
+//! Rule `class-prototype` (SonarJS key S3525).
+//!
+//! Clean-room port. Assigning methods or properties directly to a constructor's
+//! `.prototype` is the old-style way to define class behaviour. Modern JavaScript
+//! provides `class` syntax that is easier to read, refactor, and tool-analyse.
+//!
+//! ## Flagged forms
+//!
+//! Any `AssignmentExpression` whose left-hand side is a static member expression
+//! of the form `<X>.prototype.<member>`. Examples:
+//!
+//! ```js
+//! Foo.prototype.bar = function () {};   // flagged
+//! Foo.prototype.baz = 1;               // flagged
+//! a.b.prototype.c = x;                 // flagged (outer.object is a.b.prototype)
+//! ```
+//!
+//! ## Not flagged
+//!
+//! - `Foo.prototype = {}` — the LHS property IS `prototype` itself; there is no
+//!   `.member` after it. The outer member's `object` is plain `Foo`, not a
+//!   `.prototype` expression.
+//! - `foo.bar = 1` — no `.prototype` in the chain.
+//! - `Foo.prototype` read without assignment.
+//! - Computed access: `Foo.prototype["bar"] = x` — out of scope for this PR
+//!   (only the static-member `.prototype.name` form is covered; computed-member
+//!   support can be added as a follow-up).
+//!
+//! ## Detection strategy
+//!
+//! `visit_assignment_expression` checks whether `assign.left` is
+//! `AssignmentTarget::StaticMemberExpression(outer)` and whether
+//! `outer.object.get_inner_expression()` resolves to a
+//! `Expression::StaticMemberExpression(inner)` whose `inner.property.name` is
+//! `"prototype"`. Reports the full assignment expression's span.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{AssignmentExpression, AssignmentTarget, Expression};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "class-prototype";
+
+impl Scanner<'_> {
+    pub(crate) fn check_class_prototype(&mut self, assign: &AssignmentExpression<'_>) {
+        let AssignmentTarget::StaticMemberExpression(outer) = &assign.left else {
+            return;
+        };
+        let Expression::StaticMemberExpression(inner) = outer.object.get_inner_expression() else {
+            return;
+        };
+        if inner.property.name.as_str() != "prototype" {
+            return;
+        }
+        self.report(RULE_NAME, "classPrototype", assign.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -130,6 +130,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
         self.check_non_existent_operator(it);
         self.check_no_built_in_override_assignment(it);
+        self.check_class_prototype(it);
         walk::walk_assignment_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -884,3 +884,51 @@ fn does_not_report_no_built_in_override_for_member_assignment_foo_object() {
     let diagnostics = scan("no-built-in-override", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_class_prototype_for_method_assignment() {
+    let source = "Foo.prototype.bar = function () {};";
+    let diagnostics = scan("class-prototype", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "class-prototype");
+    assert_eq!(diagnostics[0].message_id, "classPrototype");
+}
+
+#[test]
+fn reports_class_prototype_for_property_assignment() {
+    let source = "Foo.prototype.baz = 1;";
+    let diagnostics = scan("class-prototype", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "classPrototype");
+}
+
+#[test]
+fn reports_class_prototype_for_chained_prototype_assignment() {
+    let source = "a.b.prototype.c = x;";
+    let diagnostics = scan("class-prototype", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "classPrototype");
+}
+
+#[test]
+fn does_not_report_class_prototype_for_prototype_itself_assignment() {
+    // LHS is Foo.prototype — the property IS prototype; no .member after it
+    let source = "Foo.prototype = {};";
+    let diagnostics = scan("class-prototype", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_class_prototype_for_plain_member_assignment() {
+    let source = "foo.bar = 1;";
+    let diagnostics = scan("class-prototype", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_class_prototype_for_read_expression() {
+    // Reading Foo.prototype (not an assignment) — no AssignmentExpression
+    let source = "obj.prototype;";
+    let diagnostics = scan("class-prototype", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -83,6 +83,10 @@ const messages = Object.freeze({
   'no-built-in-override': {
     noBuiltInOverride: 'Do not override or shadow a built-in object or function.',
   },
+  'class-prototype': {
+    classPrototype:
+      'Define this on a class using method syntax instead of assigning to the prototype.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -116,6 +120,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow .only on test-runner functions (describe, it, test, etc.) that would disable all other tests',
   'no-built-in-override':
     'Disallow overriding or shadowing standard ECMAScript built-in global objects and functions',
+  'class-prototype':
+    'Disallow assigning methods or properties to a constructor prototype; use class syntax instead',
 });
 
 const ruleTypes = Object.freeze({
@@ -138,6 +144,7 @@ const ruleTypes = Object.freeze({
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
+  'class-prototype': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -160,6 +167,7 @@ const recommendedRuleConfig = Object.freeze({
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',
+  'class-prototype': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -22,6 +22,7 @@ const expectedRuleNames = [
   'generator-without-yield',
   'no-exclusive-tests',
   'no-built-in-override',
+  'class-prototype',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -711,6 +712,39 @@ describe('sonarjs native API', () => {
   it('does not report no-built-in-override for a member assignment to foo.Object', () => {
     const source = 'foo.Object = 1;';
     const diagnostics = scan('no-built-in-override', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports class-prototype for Foo.prototype.bar = function () {}', () => {
+    const source = 'Foo.prototype.bar = function () {};';
+    const diagnostics = scan('class-prototype', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('class-prototype');
+    expect(diagnostics[0].messageId).toBe('classPrototype');
+  });
+
+  it('reports class-prototype for Foo.prototype.baz = 1', () => {
+    const source = 'Foo.prototype.baz = 1;';
+    const diagnostics = scan('class-prototype', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('classPrototype');
+  });
+
+  it('does not report class-prototype for Foo.prototype = {} (no member after prototype)', () => {
+    const source = 'Foo.prototype = {};';
+    const diagnostics = scan('class-prototype', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report class-prototype for foo.bar = 1 (no prototype in chain)', () => {
+    const source = 'foo.bar = 1;';
+    const diagnostics = scan('class-prototype', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report class-prototype for obj.prototype (read, not assignment)', () => {
+    const source = 'obj.prototype;';
+    const diagnostics = scan('class-prototype', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -113,6 +113,7 @@ describe('sonarjs plugin shape', () => {
       'generator-without-yield',
       'no-exclusive-tests',
       'no-built-in-override',
+      'class-prototype',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -133,6 +134,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['generator-without-yield']).toBe('object');
     expect(typeof plugin.rules['no-exclusive-tests']).toBe('object');
     expect(typeof plugin.rules['no-built-in-override']).toBe('object');
+    expect(typeof plugin.rules['class-prototype']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -153,6 +155,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/generator-without-yield']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-exclusive-tests']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-built-in-override']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/class-prototype']).toBe('error');
   });
 });
 
@@ -291,6 +294,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-built-in-override', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('noBuiltInOverride');
+  });
+
+  it('reports class-prototype for Foo.prototype.bar = function () {} through the adapter', () => {
+    const source = 'Foo.prototype.bar = function () {};';
+    const reports = runRule('class-prototype', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('classPrototype');
   });
 });
 
@@ -479,5 +489,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-built-in-override)');
+  });
+
+  it('reports class-prototype through the CLI', () => {
+    const source = 'Foo.prototype.bar = function () {};';
+    const result = runOxlint('class-prototype', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(class-prototype)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10590,19 +10590,19 @@
       },
       {
         "name": "class-prototype",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule class-prototype (Sonar key S3525). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S3525). Flags AssignmentExpression whose LHS is a StaticMemberExpression where the object (after get_inner_expression) is itself a StaticMemberExpression with property name 'prototype'. Covers the static-member form only (X.prototype.member = ...); computed-member (X.prototype['member'] = ...) is a follow-up."
       },
       {
         "name": "code-eval",


### PR DESCRIPTION
## Summary
Clean-room port of **`class-prototype`** (Sonar key S3525). Flags assigning to a constructor prototype member (`Foo.prototype.bar = …`) — modern code should use `class` method syntax. `Foo.prototype = {}` and plain member assignments are not flagged. Computed `Foo.prototype["x"] = …` is a documented follow-up. Adds a third check to the existing `visit_assignment_expression` hook.

## Tests
Rust unit tests (`prototype.method = fn`, `prototype.prop = 1`, `prototype = {}` → 0, plain member → 0, prototype read → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(class-prototype)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783981912&installation_id=136613492&pr_number=173&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F173&signature=8e6273d9e1cb3bdf7601af7ac36774413b20f3c18d5c63c2fd261c33eab89a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->