### PR TITLE
fix(functional): close AST traversal gaps + concise-arrow false positive

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -71,6 +71,11 @@ impl<'a> Scanner<'a> {
                     expression.span,
                 );
             }
+            Expression::YieldExpression(expression) => {
+                if let Some(argument) = &expression.argument {
+                    self.scan_expression(argument, context);
+                }
+            }
             Expression::ArrowFunctionExpression(function) => {
                 self.scan_arrow_function(function, FunctionParamMeta::default());
             }
@@ -209,15 +214,11 @@ impl<'a> Scanner<'a> {
     }
 
     pub(crate) fn scan_property_key(&mut self, key: &'a PropertyKey<'a>, context: FunctionContext) {
-        match key {
-            PropertyKey::StaticMemberExpression(member) => {
-                self.scan_static_member_expression(member, context);
-            }
-            PropertyKey::ComputedMemberExpression(member) => {
-                self.scan_computed_member_expression(member, context);
-            }
-            PropertyKey::CallExpression(call) => self.scan_call_expression(call, context),
-            _ => {}
+        // A computed key can be any expression (`{ [this.k]: v }`, `[fn()]() {}`);
+        // route every expression-kind key through `scan_expression` so nested
+        // `this`/calls/etc. are not missed. Identifier keys carry no expression.
+        if let Some(expression) = key.as_expression() {
+            self.scan_expression(expression, context);
         }
     }
 

--- a/crates/functional/src/scanner.rs
+++ b/crates/functional/src/scanner.rs
@@ -99,7 +99,18 @@ impl<'a> Scanner<'a> {
             in_function: true,
             in_promise_handler: meta_is_promise_handler(&meta),
         };
-        self.scan_function_body(&function.body, context);
+        if function.expression {
+            // A concise arrow body `() => expr` is stored by oxc as a single
+            // synthetic `ExpressionStatement`; scanning it as a statement would
+            // wrongly fire `no-expression-statements` (upstream's ESTree model
+            // represents the body as a bare expression, never a statement).
+            // Scan the expression directly instead.
+            if let Some(expression) = function.get_expression() {
+                self.scan_expression(expression, context);
+            }
+        } else {
+            self.scan_function_body(&function.body, context);
+        }
     }
 
     fn function_is_ignored_by_prefix_selector(&self, meta: &FunctionParamMeta<'a>) -> bool {
@@ -313,6 +324,9 @@ impl<'a> Scanner<'a> {
             match element {
                 ClassElement::StaticBlock(block) => self.scan_statement_list(&block.body, context),
                 ClassElement::MethodDefinition(method) => {
+                    if method.computed {
+                        self.scan_property_key(&method.key, context);
+                    }
                     let is_getter_setter = matches!(
                         method.kind,
                         MethodDefinitionKind::Get | MethodDefinitionKind::Set
@@ -325,6 +339,9 @@ impl<'a> Scanner<'a> {
                     self.scan_function(&method.value, meta);
                 }
                 ClassElement::PropertyDefinition(property) => {
+                    if property.computed {
+                        self.scan_property_key(&property.key, context);
+                    }
                     if let Some(type_annotation) = &property.type_annotation {
                         self.scan_type(&type_annotation.type_annotation);
                         if is_mutable_type(&type_annotation.type_annotation) && !property.readonly {

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -196,6 +196,12 @@ impl<'a> Scanner<'a> {
                 self.scan_function(function, meta);
             }
             Statement::ClassDeclaration(class) => self.scan_class(class, context),
+            Statement::LabeledStatement(labeled) => {
+                self.scan_statement(&labeled.body, context);
+            }
+            Statement::TSModuleDeclaration(module) => {
+                self.scan_ts_module_declaration(module, context);
+            }
             Statement::TSTypeAliasDeclaration(declaration) => {
                 self.scan_type_alias_declaration(declaration);
             }
@@ -243,6 +249,9 @@ impl<'a> Scanner<'a> {
                 self.scan_function(function, meta);
             }
             Declaration::ClassDeclaration(class) => self.scan_class(class, context),
+            Declaration::TSModuleDeclaration(module) => {
+                self.scan_ts_module_declaration(module, context);
+            }
             Declaration::TSTypeAliasDeclaration(declaration) => {
                 self.scan_type_alias_declaration(declaration);
             }
@@ -250,6 +259,24 @@ impl<'a> Scanner<'a> {
                 self.scan_interface_declaration(declaration);
             }
             _ => {}
+        }
+    }
+
+    /// Traverse the body of a `namespace`/`module` declaration so rules still
+    /// fire on its nested statements (the body is otherwise skipped).
+    fn scan_ts_module_declaration(
+        &mut self,
+        module: &'a TSModuleDeclaration<'a>,
+        context: FunctionContext,
+    ) {
+        match &module.body {
+            Some(TSModuleDeclarationBody::TSModuleBlock(block)) => {
+                self.scan_statement_list(&block.body, context);
+            }
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(inner)) => {
+                self.scan_ts_module_declaration(inner, context);
+            }
+            None => {}
         }
     }
 

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -546,3 +546,41 @@ fn no_try_statements_reports_catch_and_finally_independently() {
     // allowFinally leaves only the catch diagnostic.
     assert_eq!(ids(&allow_finally), ["catch"]);
 }
+
+#[test]
+fn concise_arrow_body_is_not_an_expression_statement() {
+    let options = FunctionalOptions {
+        rule_names: ["no-expression-statements".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
+
+    // A concise arrow body is a bare expression, not a statement: upstream does
+    // not flag it (oxc stores it as a synthetic ExpressionStatement).
+    assert_eq!(count("const f = () => effect();", &options), 0);
+    // A block-body arrow whose body is a real expression statement is flagged.
+    assert_eq!(count("const g = () => { effect(); };", &options), 1);
+}
+
+#[test]
+fn traverses_nested_scopes_for_this_and_let() {
+    // no-this-expressions inside a yield argument and a computed class key.
+    let this_opts = FunctionalOptions {
+        rule_names: ["no-this-expressions".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
+
+    assert_eq!(count("function* g() { yield this.value; }", &this_opts), 1);
+    assert_eq!(count("class C { [this.k]() {} }", &this_opts), 1);
+
+    // no-let inside a namespace body and a labeled statement.
+    let let_opts = FunctionalOptions {
+        rule_names: ["no-let".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    assert_eq!(count("namespace N { let x = 1; }", &let_opts), 1);
+    assert_eq!(count("outer: { let y = 1; }", &let_opts), 1);
+}


### PR DESCRIPTION
Correctness fixes from the final multi-dimensional review (each verified against the captured upstream fixtures and OXC AST representation before changing).

## Findings fixed

- **MAJOR — concise arrow false positive.** OXC stores `() => expr` as `body.statements[0] = ExpressionStatement` (`expression: true`). `scan_arrow_function` walked it as a statement, so `no-expression-statements` fired on every concise arrow — the most common functional form. Upstream's ESTree model represents the body as a bare expression and never reports it. Now scans the concise body via `get_expression()` directly. Hidden until now because `no-expression-statements` is smoke-run only (not asserted).
- **Traversal gaps (missed diagnostics).** `yield` arguments, `LabeledStatement` bodies, and `TSModuleDeclaration` (`namespace`/`module`) bodies were never recursed into, so every rule produced false negatives inside them. Added arms in `scan_statement`/`scan_declaration` + a `scan_ts_module_declaration` helper.
- **Computed keys.** Computed class-member keys (`[this.k]() {}`, `[expr]: v`) were not scanned; `scan_property_key` now routes any expression-kind key through `scan_expression` (covers `this`, templates, calls, etc.).

## Tests

Added Rust unit tests: concise arrow emits no `no-expression-statements` (block-body arrow still does); `this` inside `yield`/computed key reports `no-this-expressions`; `let` inside `namespace`/labeled block reports `no-let`.

## Not changed (with reason)
- The reviewer's `no-promise-reject` promise-handler suggestion: fixtures prove upstream does not flag a `.then` throw — would over-report.
- `no-let` "errors: undefined" cases: `no-let` emits a single messageId, so count-only assertion cannot mask a wrong id; matches upstream's own assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783982442&installation_id=136613492&pr_number=174&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F174&signature=1c67f64670186a5c9e176d0490a87190c98964f701d79ea62a6e15206cdf5ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->