### PR TITLE
port(sonarjs): port max-switch-cases (S1479)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 20] = [
+pub const RULE_NAMES: [&str; 21] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -43,6 +43,7 @@ pub const RULE_NAMES: [&str; 20] = [
     "no-exclusive-tests",
     "no-built-in-override",
     "class-prototype",
+    "max-switch-cases",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -6,6 +6,7 @@ mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
 mod generator_without_yield;
+mod max_switch_cases;
 mod no_all_duplicated_branches;
 mod no_built_in_override;
 mod no_collapsible_if;

--- a/crates/sonarjs/src/rules/max_switch_cases.rs
+++ b/crates/sonarjs/src/rules/max_switch_cases.rs
@@ -1,0 +1,44 @@
+//! Rule `max-switch-cases` (SonarJS key S1479).
+//!
+//! Clean-room port. Reports a `switch` statement whose number of `case` (and
+//! `default`) clauses exceeds the threshold, because a switch with too many
+//! branches is hard to read and is usually better expressed as a lookup table
+//! or through polymorphism.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! ## Threshold
+//!
+//! The threshold is fixed at **30** (`MAX_CASES`). SonarJS exposes a
+//! configurable `maximum` option, but this port has no per-rule options
+//! infrastructure yet. Configurability is a follow-up task; for now the
+//! default of 30 is hardcoded.
+//!
+//! ## Counting
+//!
+//! All entries in `SwitchStatement.cases` are counted, including both `case`
+//! clauses and the optional `default` clause. A diagnostic is emitted when the
+//! count is **strictly greater than** `MAX_CASES`.
+
+use oxc_ast::ast::SwitchStatement;
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "max-switch-cases";
+
+/// Maximum number of `case`/`default` clauses allowed in a single `switch`.
+/// A switch with more than this many clauses is flagged.
+const MAX_CASES: usize = 30;
+
+impl Scanner<'_> {
+    pub(crate) fn check_max_switch_cases(&mut self, switch: &SwitchStatement<'_>) {
+        if switch.cases.len() <= MAX_CASES {
+            return;
+        }
+        let start = switch.span.start;
+        let keyword = Span::new(start, start + 6);
+        self.report(RULE_NAME, "maxSwitchCases", keyword);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -80,6 +80,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
         self.check_no_nested_switch(it);
         self.check_no_all_duplicated_branches_switch(it);
+        self.check_max_switch_cases(it);
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -932,3 +932,29 @@ fn does_not_report_class_prototype_for_read_expression() {
     let diagnostics = scan("class-prototype", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_max_switch_cases_for_switch_with_31_cases() {
+    // 31 case clauses (indices 0..=30) — strictly greater than MAX_CASES (30) → 1 diagnostic
+    let source = "switch (x) {case 0: break;case 1: break;case 2: break;case 3: break;case 4: break;case 5: break;case 6: break;case 7: break;case 8: break;case 9: break;case 10: break;case 11: break;case 12: break;case 13: break;case 14: break;case 15: break;case 16: break;case 17: break;case 18: break;case 19: break;case 20: break;case 21: break;case 22: break;case 23: break;case 24: break;case 25: break;case 26: break;case 27: break;case 28: break;case 29: break;case 30: break;}";
+    let diagnostics = scan("max-switch-cases", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "max-switch-cases");
+    assert_eq!(diagnostics[0].message_id, "maxSwitchCases");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn does_not_report_max_switch_cases_for_small_switch() {
+    let source = "switch (x) { case 1: break; default: break; }";
+    let diagnostics = scan("max-switch-cases", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_max_switch_cases_for_exactly_30_cases() {
+    // 30 cases (indices 0..=29) — equal to MAX_CASES, not strictly greater → 0 diagnostics
+    let source = "switch (x) {case 0: break;case 1: break;case 2: break;case 3: break;case 4: break;case 5: break;case 6: break;case 7: break;case 8: break;case 9: break;case 10: break;case 11: break;case 12: break;case 13: break;case 14: break;case 15: break;case 16: break;case 17: break;case 18: break;case 19: break;case 20: break;case 21: break;case 22: break;case 23: break;case 24: break;case 25: break;case 26: break;case 27: break;case 28: break;case 29: break;}";
+    let diagnostics = scan("max-switch-cases", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -87,6 +87,9 @@ const messages = Object.freeze({
     classPrototype:
       'Define this on a class using method syntax instead of assigning to the prototype.',
   },
+  'max-switch-cases': {
+    maxSwitchCases: 'This switch has too many cases; consider a lookup table or polymorphism.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -122,6 +125,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow overriding or shadowing standard ECMAScript built-in global objects and functions',
   'class-prototype':
     'Disallow assigning methods or properties to a constructor prototype; use class syntax instead',
+  'max-switch-cases':
+    'Disallow switch statements with more than 30 case/default clauses (threshold fixed at default 30; configurability is a follow-up)',
 });
 
 const ruleTypes = Object.freeze({
@@ -145,6 +150,7 @@ const ruleTypes = Object.freeze({
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
   'class-prototype': 'suggestion',
+  'max-switch-cases': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -168,6 +174,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',
   'class-prototype': 'error',
+  'max-switch-cases': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -23,6 +23,7 @@ const expectedRuleNames = [
   'no-exclusive-tests',
   'no-built-in-override',
   'class-prototype',
+  'max-switch-cases',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -745,6 +746,21 @@ describe('sonarjs native API', () => {
   it('does not report class-prototype for obj.prototype (read, not assignment)', () => {
     const source = 'obj.prototype;';
     const diagnostics = scan('class-prototype', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports max-switch-cases for a switch with 31 cases (exceeds 30)', () => {
+    const big =
+      'switch (x) {' + Array.from({ length: 31 }, (_, i) => `case ${i}: break;`).join('') + '}';
+    const diagnostics = scan('max-switch-cases', big);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('max-switch-cases');
+    expect(diagnostics[0].messageId).toBe('maxSwitchCases');
+  });
+
+  it('does not report max-switch-cases for a small switch with 3 cases', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; default: break; }';
+    const diagnostics = scan('max-switch-cases', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -114,6 +114,7 @@ describe('sonarjs plugin shape', () => {
       'no-exclusive-tests',
       'no-built-in-override',
       'class-prototype',
+      'max-switch-cases',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -135,6 +136,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-exclusive-tests']).toBe('object');
     expect(typeof plugin.rules['no-built-in-override']).toBe('object');
     expect(typeof plugin.rules['class-prototype']).toBe('object');
+    expect(typeof plugin.rules['max-switch-cases']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -156,6 +158,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-exclusive-tests']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-built-in-override']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/class-prototype']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/max-switch-cases']).toBe('error');
   });
 });
 
@@ -301,6 +304,14 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('class-prototype', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('classPrototype');
+  });
+
+  it('reports max-switch-cases for a switch with 31 cases through the adapter', () => {
+    const big =
+      'switch (x) {' + Array.from({ length: 31 }, (_, i) => `case ${i}: break;`).join('') + '}';
+    const reports = runRule('max-switch-cases', big);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('maxSwitchCases');
   });
 });
 
@@ -499,5 +510,16 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(class-prototype)');
+  });
+
+  it('reports max-switch-cases through the CLI', () => {
+    const big =
+      'switch (x) {' + Array.from({ length: 31 }, (_, i) => `case ${i}: break;`).join('') + '}';
+    const result = runOxlint('max-switch-cases', big);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(max-switch-cases)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11550,19 +11550,19 @@
       },
       {
         "name": "max-switch-cases",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule max-switch-cases (Sonar key S1479). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1479). Reports a switch statement whose case/default clause count exceeds 30. Threshold is fixed at the SonarJS default of 30 (MAX_CASES); per-rule options infrastructure for configurability is a follow-up task. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "max-union-size",


### PR DESCRIPTION
## Summary
Clean-room port of **`max-switch-cases`** (Sonar key S1479). Reports a `switch` with more than **30** case/default clauses. The threshold is fixed at the SonarJS default of 30 — per-rule **options** infrastructure for configurability is a documented follow-up (this port has no options layer yet). Reports the `switch` keyword. Adds a third check to the existing `visit_switch_statement` hook.

## Tests
Rust unit tests (31 cases → 1, exactly 30 → 0 boundary, small switch → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(max-switch-cases)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783982533&installation_id=136613492&pr_number=175&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F175&signature=060ee779b2c0160f5896d49f76185514dd4458650cc304b808ac1f69d924472a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->