### PR TITLE
port(sonarjs): port max-union-size (S4622)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 21] = [
+pub const RULE_NAMES: [&str; 22] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -44,6 +44,7 @@ pub const RULE_NAMES: [&str; 21] = [
     "no-built-in-override",
     "class-prototype",
     "max-switch-cases",
+    "max-union-size",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -7,6 +7,7 @@ mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
 mod generator_without_yield;
 mod max_switch_cases;
+mod max_union_size;
 mod no_all_duplicated_branches;
 mod no_built_in_override;
 mod no_collapsible_if;

--- a/crates/sonarjs/src/rules/max_union_size.rs
+++ b/crates/sonarjs/src/rules/max_union_size.rs
@@ -1,0 +1,42 @@
+//! Rule `max-union-size` (SonarJS key S4622).
+//!
+//! Clean-room port. Reports a TypeScript union type (`A | B | C | D`) whose
+//! number of direct member types exceeds the threshold, because a union with
+//! too many members is hard to read and often signals a missing abstraction
+//! that should be expressed as a named type alias or interface.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! ## Threshold
+//!
+//! The threshold is fixed at **3** (`MAX_UNION_SIZE`). SonarJS exposes a
+//! configurable `threshold` option, but this port has no per-rule options
+//! infrastructure yet. Configurability is a follow-up task; for now the
+//! default of 3 is hardcoded.
+//!
+//! ## Counting
+//!
+//! Each `TSUnionType` node is checked independently. `union.types.len()`
+//! counts the direct members of that union node. Nested parenthesized unions
+//! are counted per-node (i.e. each `TSUnionType` node is evaluated on its own
+//! direct children, without flattening through parentheses).
+
+use oxc_ast::ast::TSUnionType;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "max-union-size";
+
+/// Maximum number of members allowed in a single union type.
+/// A union with more than this many members is flagged.
+const MAX_UNION_SIZE: usize = 3;
+
+impl Scanner<'_> {
+    pub(crate) fn check_max_union_size(&mut self, union: &TSUnionType<'_>) {
+        if union.types.len() <= MAX_UNION_SIZE {
+            return;
+        }
+        self.report(RULE_NAME, "maxUnionSize", union.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -137,6 +137,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_ts_union_type(&mut self, it: &TSUnionType<'a>) {
         self.check_no_duplicate_in_composite(&it.types);
+        self.check_max_union_size(it);
         walk::walk_ts_union_type(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -958,3 +958,42 @@ fn does_not_report_max_switch_cases_for_exactly_30_cases() {
     let diagnostics = scan("max-switch-cases", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_max_union_size_for_four_member_union() {
+    let source = "type T = A | B | C | D;";
+    let diagnostics = scan("max-union-size", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "max-union-size");
+    assert_eq!(diagnostics[0].message_id, "maxUnionSize");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn does_not_report_max_union_size_for_three_member_union_at_threshold() {
+    let source = "type T = A | B | C;";
+    let diagnostics = scan("max-union-size", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_max_union_size_for_two_member_union() {
+    let source = "type T = A | B;";
+    let diagnostics = scan("max-union-size", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_max_union_size_for_single_type_alias() {
+    let source = "type T = A;";
+    let diagnostics = scan("max-union-size", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_max_union_size_for_union_in_variable_annotation() {
+    let source = "let x: A | B | C | D | E;";
+    let diagnostics = scan("max-union-size", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "maxUnionSize");
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -90,6 +90,10 @@ const messages = Object.freeze({
   'max-switch-cases': {
     maxSwitchCases: 'This switch has too many cases; consider a lookup table or polymorphism.',
   },
+  'max-union-size': {
+    maxUnionSize:
+      'This union type has too many members; consider refactoring into a named type or interface.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -127,6 +131,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow assigning methods or properties to a constructor prototype; use class syntax instead',
   'max-switch-cases':
     'Disallow switch statements with more than 30 case/default clauses (threshold fixed at default 30; configurability is a follow-up)',
+  'max-union-size':
+    'Disallow union types with more than 3 members (threshold fixed at default 3; configurability is a follow-up; each TSUnionType node is counted per-node)',
 });
 
 const ruleTypes = Object.freeze({
@@ -151,6 +157,7 @@ const ruleTypes = Object.freeze({
   'no-built-in-override': 'problem',
   'class-prototype': 'suggestion',
   'max-switch-cases': 'suggestion',
+  'max-union-size': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -175,6 +182,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-built-in-override': 'error',
   'class-prototype': 'error',
   'max-switch-cases': 'error',
+  'max-union-size': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -24,6 +24,7 @@ const expectedRuleNames = [
   'no-built-in-override',
   'class-prototype',
   'max-switch-cases',
+  'max-union-size',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -762,5 +763,38 @@ describe('sonarjs native API', () => {
     const source = 'switch (x) { case 1: break; case 2: break; default: break; }';
     const diagnostics = scan('max-switch-cases', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports max-union-size for a union type with 4 members', () => {
+    const source = 'type T = A | B | C | D;';
+    const diagnostics = scan('max-union-size', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('max-union-size');
+    expect(diagnostics[0].messageId).toBe('maxUnionSize');
+  });
+
+  it('does not report max-union-size for a union type with exactly 3 members (at threshold)', () => {
+    const source = 'type T = A | B | C;';
+    const diagnostics = scan('max-union-size', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report max-union-size for a union type with 2 members', () => {
+    const source = 'type T = A | B;';
+    const diagnostics = scan('max-union-size', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report max-union-size for a single type alias (not a union)', () => {
+    const source = 'type T = A;';
+    const diagnostics = scan('max-union-size', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports max-union-size for a union in a variable type annotation with 5 members', () => {
+    const source = 'let x: A | B | C | D | E;';
+    const diagnostics = scan('max-union-size', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('maxUnionSize');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -115,6 +115,7 @@ describe('sonarjs plugin shape', () => {
       'no-built-in-override',
       'class-prototype',
       'max-switch-cases',
+      'max-union-size',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -137,6 +138,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-built-in-override']).toBe('object');
     expect(typeof plugin.rules['class-prototype']).toBe('object');
     expect(typeof plugin.rules['max-switch-cases']).toBe('object');
+    expect(typeof plugin.rules['max-union-size']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -159,6 +161,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-built-in-override']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/class-prototype']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-switch-cases']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/max-union-size']).toBe('error');
   });
 });
 
@@ -312,6 +315,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('max-switch-cases', big);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('maxSwitchCases');
+  });
+
+  it('reports max-union-size for a union type with 4 members through the adapter', () => {
+    const source = 'type T = A | B | C | D;';
+    const reports = runRule('max-union-size', source, { filename: 'sample.ts' });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('maxUnionSize');
   });
 });
 
@@ -521,5 +531,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(max-switch-cases)');
+  });
+
+  it('reports max-union-size through the CLI', () => {
+    const source = 'type T = A | B | C | D;';
+    const result = runOxlint('max-union-size', source, 'sample.ts');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(max-union-size)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11566,19 +11566,19 @@
       },
       {
         "name": "max-union-size",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule max-union-size (Sonar key S4622). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S4622). Reports a TypeScript union type whose direct member count exceeds 3. Threshold is fixed at the SonarJS default of 3 (MAX_UNION_SIZE); per-rule options infrastructure for configurability is a follow-up task. Each TSUnionType node is counted per-node — nested parenthesized unions are not flattened. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "misplaced-loop-counter",


### PR DESCRIPTION
## Summary
Clean-room port of **`max-union-size`** (Sonar key S4622). Reports a TypeScript union type with more than **3** direct members. Threshold fixed at the SonarJS default of 3 — configurability is a documented options follow-up. Per-node counting. Reuses the existing `visit_ts_union_type` hook.

## Tests
Rust unit tests (4 members → 1, exactly 3 → 0 boundary, 2 → 0, non-union → 0, 5-member annotation → 1), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(max-union-size)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783983021&installation_id=136613492&pr_number=176&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F176&signature=e7f77a42fc4c62f76d65a915fef27f2a8d6e16f3c4bf6df376ae47bdc75a1b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->