### PR TITLE
fix(functional): honor no-conditional-statements allowReturningBranches

### DIFF
--- a/crates/functional/src/lib.rs
+++ b/crates/functional/src/lib.rs
@@ -99,6 +99,11 @@ pub struct FunctionalOptions {
     pub check_interfaces: bool,
     /// no-mixed-types: check object type literals (default: true).
     pub check_type_literals: bool,
+    /// no-conditional-statements: when true (the `allowReturningBranches: true`
+    /// option), an `if`/`switch` is allowed when every branch ends in an abrupt
+    /// completion (return/throw/break/continue). The `"ifExhaustive"` mode needs
+    /// type information and is not modeled here. Default: false.
+    pub allow_returning_branches: bool,
 }
 
 impl Default for FunctionalOptions {
@@ -126,6 +131,7 @@ impl Default for FunctionalOptions {
             ignore_prefix_selector_names: SmallVec::new(),
             check_interfaces: true,
             check_type_literals: true,
+            allow_returning_branches: false,
         }
     }
 }

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -30,8 +30,8 @@ impl<'a> Scanner<'a> {
             }
             Statement::BlockStatement(block) => self.scan_statement_list(&block.body, context),
             Statement::IfStatement(statement) => {
-                let allowed = self.options.allow_returning_branches
-                    && self.if_all_branches_return(statement);
+                let allowed =
+                    self.options.allow_returning_branches && self.if_all_branches_return(statement);
                 if !allowed {
                     self.report(
                         "no-conditional-statements",

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -30,12 +30,16 @@ impl<'a> Scanner<'a> {
             }
             Statement::BlockStatement(block) => self.scan_statement_list(&block.body, context),
             Statement::IfStatement(statement) => {
-                self.report(
-                    "no-conditional-statements",
-                    "unexpectedIf",
-                    "Unexpected if, use a conditional expression (ternary operator) instead.",
-                    statement.span,
-                );
+                let allowed = self.options.allow_returning_branches
+                    && self.if_all_branches_return(statement);
+                if !allowed {
+                    self.report(
+                        "no-conditional-statements",
+                        "unexpectedIf",
+                        "Unexpected if, use a conditional expression (ternary operator) instead.",
+                        statement.span,
+                    );
+                }
                 self.scan_expression(&statement.test, context);
                 self.scan_statement(&statement.consequent, context);
                 if let Some(alternate) = &statement.alternate {
@@ -43,12 +47,16 @@ impl<'a> Scanner<'a> {
                 }
             }
             Statement::SwitchStatement(statement) => {
-                self.report(
-                    "no-conditional-statements",
-                    "unexpectedSwitch",
-                    "Unexpected switch, use a conditional expression instead.",
-                    statement.span,
-                );
+                let allowed = self.options.allow_returning_branches
+                    && self.switch_all_cases_return(&statement.cases);
+                if !allowed {
+                    self.report(
+                        "no-conditional-statements",
+                        "unexpectedSwitch",
+                        "Unexpected switch, use a conditional expression instead.",
+                        statement.span,
+                    );
+                }
                 self.scan_expression(&statement.discriminant, context);
                 for case in &statement.cases {
                     if let Some(test) = &case.test {
@@ -278,6 +286,61 @@ impl<'a> Scanner<'a> {
             }
             None => {}
         }
+    }
+
+    /// Whether a branch statement guarantees an abrupt completion (return,
+    /// throw, break, or continue) — the syntactic basis of `no-conditional-
+    /// statements`' `allowReturningBranches: true`. A `never`-returning call
+    /// would also count upstream, but that needs type information.
+    fn branch_is_returning(&self, statement: &Statement<'a>) -> bool {
+        match statement {
+            Statement::ReturnStatement(_)
+            | Statement::ThrowStatement(_)
+            | Statement::BreakStatement(_)
+            | Statement::ContinueStatement(_) => true,
+            Statement::BlockStatement(block) => block
+                .body
+                .last()
+                .is_some_and(|last| self.branch_is_returning(last)),
+            Statement::IfStatement(inner) => inner.alternate.as_ref().is_some_and(|alternate| {
+                self.branch_is_returning(&inner.consequent) && self.branch_is_returning(alternate)
+            }),
+            _ => false,
+        }
+    }
+
+    /// An `if` is "returning" when its consequent is returning and, if present,
+    /// its alternate is too (an `if` without `else` only needs the consequent).
+    fn if_all_branches_return(&self, statement: &IfStatement<'a>) -> bool {
+        if !self.branch_is_returning(&statement.consequent) {
+            return false;
+        }
+        match &statement.alternate {
+            Some(alternate) => self.branch_is_returning(alternate),
+            None => true,
+        }
+    }
+
+    /// A `switch` is "returning" when every case is returning. Empty
+    /// (fall-through) cases inherit the returning status of the case they fall
+    /// into, so cases are walked bottom-up.
+    fn switch_all_cases_return(&self, cases: &[SwitchCase<'a>]) -> bool {
+        if cases.is_empty() {
+            return false;
+        }
+        let mut following_returns = false;
+        for case in cases.iter().rev() {
+            if !case.consequent.is_empty() {
+                following_returns = case
+                    .consequent
+                    .last()
+                    .is_some_and(|last| self.branch_is_returning(last));
+            }
+            if !following_returns {
+                return false;
+            }
+        }
+        following_returns
     }
 
     fn scan_for_init(&mut self, init: &'a ForStatementInit<'a>, context: FunctionContext) {

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -584,3 +584,41 @@ fn traverses_nested_scopes_for_this_and_let() {
     assert_eq!(count("namespace N { let x = 1; }", &let_opts), 1);
     assert_eq!(count("outer: { let y = 1; }", &let_opts), 1);
 }
+
+#[test]
+fn no_conditional_statements_allow_returning_branches() {
+    let base = FunctionalOptions {
+        rule_names: ["no-conditional-statements".into()].into_iter().collect(),
+        ..FunctionalOptions::default()
+    };
+    let allow = FunctionalOptions {
+        rule_names: ["no-conditional-statements".into()].into_iter().collect(),
+        allow_returning_branches: true,
+        ..FunctionalOptions::default()
+    };
+    let count =
+        |source: &str, opts: &FunctionalOptions| scan_functional(source, "fixture.ts", opts).len();
+
+    let if_returns = "function f(i) { if (i) { return 1; } }";
+    let if_throws = "function f(i) { if (i) { throw e; } }";
+    let if_not_returning = "function f(i) { if (i) { g(); } }";
+    let if_else_returns = "function f(i) { if (i) { return 1; } else { return 0; } }";
+    let if_else_partial = "function f(i) { if (i) { return 1; } else { g(); } }";
+    let switch_returns = "function f(i) { switch (i) { case 1: return 1; default: return 2; } }";
+    let switch_partial = "function f(i) { switch (i) { case 1: g(); default: return 2; } }";
+
+    // Default: every if/switch is reported.
+    assert_eq!(count(if_returns, &base), 1);
+
+    // allowReturningBranches: an if whose branches all end in return/throw is
+    // allowed; one with a non-returning branch is still reported.
+    assert_eq!(count(if_returns, &allow), 0);
+    assert_eq!(count(if_throws, &allow), 0);
+    assert_eq!(count(if_not_returning, &allow), 1);
+    assert_eq!(count(if_else_returns, &allow), 0);
+    assert_eq!(count(if_else_partial, &allow), 1);
+
+    // switch: allowed only when every case is returning (fall-through inherits).
+    assert_eq!(count(switch_returns, &allow), 0);
+    assert_eq!(count(switch_partial, &allow), 1);
+}

--- a/npm/functional/api.d.ts
+++ b/npm/functional/api.d.ts
@@ -32,6 +32,7 @@ export type FunctionalScanOptions = {
   ignorePrefixSelectorNames?: string[];
   checkInterfaces?: boolean;
   checkTypeLiterals?: boolean;
+  allowReturningBranches?: boolean;
 };
 
 export function implementedFunctionalRuleNames(): string[];

--- a/npm/functional/api.js
+++ b/npm/functional/api.js
@@ -48,6 +48,7 @@ function normalizeOptions(options) {
     checkInterfaces: typeof raw.checkInterfaces === 'boolean' ? raw.checkInterfaces : undefined,
     checkTypeLiterals:
       typeof raw.checkTypeLiterals === 'boolean' ? raw.checkTypeLiterals : undefined,
+    allowReturningBranches: raw.allowReturningBranches === true,
   };
 }
 

--- a/npm/functional/index.js
+++ b/npm/functional/index.js
@@ -255,6 +255,22 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'no-conditional-statements') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          // `true` is honored syntactically; `"ifExhaustive"` is accepted but
+          // needs type information, so it falls back to flagging conditionals.
+          allowReturningBranches: {
+            oneOf: [{ type: 'boolean' }, { type: 'string', enum: ['ifExhaustive'] }],
+          },
+          ignoreCodePattern: stringOrStringArraySchema(),
+        },
+        additionalProperties: true,
+      },
+    ];
+  }
   if (ruleName === 'no-try-statements') {
     return [
       {
@@ -423,6 +439,9 @@ function scanOptionsForRule(context, ruleName) {
       ruleName === 'no-throw-statements' && options.allowToRejectPromises === true,
     allowTryCatch: ruleName === 'no-try-statements' && options.allowCatch === true,
     allowTryFinally: ruleName === 'no-try-statements' && options.allowFinally === true,
+    // Only the boolean `true` form is modeled; `"ifExhaustive"` needs types.
+    allowReturningBranches:
+      ruleName === 'no-conditional-statements' && options.allowReturningBranches === true,
     readonlyTypeMode:
       ruleName === 'readonly-type' && (raw === 'keyword' || raw === 'generic') ? raw : undefined,
     ignoreIfReadonlyWrapped:

--- a/npm/functional/src/lib.rs
+++ b/npm/functional/src/lib.rs
@@ -44,6 +44,8 @@ mod napi_abi {
         pub check_interfaces: Option<bool>,
         /// no-mixed-types: check object type literals (default: true).
         pub check_type_literals: Option<bool>,
+        /// no-conditional-statements: allowReturningBranches: true (default: false).
+        pub allow_returning_branches: Option<bool>,
     }
 
     #[napi(object)]
@@ -138,6 +140,9 @@ mod napi_abi {
             check_type_literals: options
                 .check_type_literals
                 .unwrap_or(default_options.check_type_literals),
+            allow_returning_branches: options
+                .allow_returning_branches
+                .unwrap_or(default_options.allow_returning_branches),
         };
 
         core::scan_functional(&source_text, &filename, &core_options)


### PR DESCRIPTION
From the final multi-dimensional review. The plugin's **recommended** config ships `'no-conditional-statements': ['error', { allowReturningBranches: true }]`, but:

1. `schemaForRule('no-conditional-statements')` returned `[]` (no options allowed) → enabling the recommended preset would **fail ESLint schema validation**.
2. The option was never plumbed to the scanner → every `if`/`switch` was flagged regardless, so the recommended preset was unusable noise.

## Fix
- Add `allowReturningBranches` (`true` | `"ifExhaustive"`) to the rule schema.
- Plumb it through `index.js` → `api.js`/`api.d.ts` → the NAPI boundary → Rust `FunctionalOptions`.
- When `true`, an `if`/`switch` is allowed when **every branch ends in an abrupt completion** (`return`/`throw`/`break`/`continue`); empty fall-through `switch` cases inherit the next case's status. Implemented purely syntactically.
- `"ifExhaustive"` (exhaustiveness) and `never`-returning calls require type information and remain a documented limitation — the rule stays "syntactic core". `"ifExhaustive"` is accepted by the schema but falls back to flagging conditionals.

Default behavior is unchanged (`allow_returning_branches: false` → flag all `if`/`switch`).

## Tests
Rust unit tests cover: default flags `if`; `true` allows returning `if`/`if-else`/`throw`, still flags non-returning branches; `switch` allowed only when all cases return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783983150&installation_id=136613492&pr_number=178&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F178&signature=f453d2972a0a4d63166e20526f788346838b8d7b8ab430be66295dd6411c1fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->