### PR TITLE
port(sonarjs): port elseif-without-else (S126)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 22] = [
+pub const RULE_NAMES: [&str; 23] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -45,6 +45,7 @@ pub const RULE_NAMES: [&str; 22] = [
     "class-prototype",
     "max-switch-cases",
     "max-union-size",
+    "elseif-without-else",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -5,6 +5,7 @@ mod arguments_usage;
 mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
+mod elseif_without_else;
 mod generator_without_yield;
 mod max_switch_cases;
 mod max_union_size;

--- a/crates/sonarjs/src/rules/elseif_without_else.rs
+++ b/crates/sonarjs/src/rules/elseif_without_else.rs
@@ -1,0 +1,78 @@
+//! Rule `elseif-without-else` (SonarJS key S126).
+//!
+//! Clean-room port. An `if … else if …` chain that contains at least one
+//! `else if` branch should always end with a final `else` clause. Without a
+//! terminal `else`, the developer has not documented (or guarded) the remaining
+//! case, which can hide unintentional fall-through behaviour.
+//!
+//! Only the **head** `if` is reported, and only when:
+//! - The chain has at least one `else if` branch (i.e., an `alternate` that is
+//!   itself an `IfStatement`), AND
+//! - The chain has no terminal `else` (i.e., the last `alternate` is `None`,
+//!   not a non-`IfStatement` statement).
+//!
+//! ## Flagged
+//! ```js
+//! if (a) {} else if (b) {}
+//! if (a) {} else if (b) {} else if (c) {}
+//! ```
+//!
+//! ## Not flagged
+//! ```js
+//! if (a) {}                          // no else-if at all
+//! if (a) {} else {}                  // else but no else-if
+//! if (a) {} else if (b) {} else {}   // has terminal else
+//! ```
+//!
+//! Chain-head detection reuses the shared `if_chain_seen` field on
+//! `Scanner` (same mechanism used by `no-identical-conditions` and
+//! `no-all-duplicated-branches`). Else-if span starts are pushed into the set
+//! so the visitor skips them later; duplicate pushes from the other chain rules
+//! are harmless because head detection uses `.contains()`.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{IfStatement, Statement};
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "elseif-without-else";
+
+impl<'a> Scanner<'a> {
+    pub(crate) fn check_elseif_without_else(&mut self, if_stmt: &IfStatement<'a>) {
+        // Only process from the chain head (skip else-if members already covered).
+        if self.if_chain_seen.contains(&if_stmt.span.start) {
+            return;
+        }
+
+        // Walk the chain: collect else-if span.starts; track else-if count + terminal else.
+        let mut else_if_starts: SmallVec<[u32; 8]> = SmallVec::new();
+        let mut else_if_count = 0usize;
+        let mut has_terminal_else = false;
+        let mut alternate = if_stmt.alternate.as_ref();
+
+        while let Some(stmt) = alternate {
+            match stmt {
+                Statement::IfStatement(next) => {
+                    else_if_count += 1;
+                    else_if_starts.push(next.span.start);
+                    alternate = next.alternate.as_ref();
+                }
+                _ => {
+                    has_terminal_else = true;
+                    break;
+                }
+            }
+        }
+
+        for start in else_if_starts {
+            self.if_chain_seen.push(start);
+        }
+
+        if else_if_count >= 1 && !has_terminal_else {
+            self.report(RULE_NAME, "elseifWithoutElse", if_stmt.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -120,6 +120,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_collapsible_if(it);
         self.check_no_identical_conditions(it);
         self.check_no_all_duplicated_branches_if(it);
+        self.check_elseif_without_else(it);
         walk::walk_if_statement(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -997,3 +997,50 @@ fn reports_max_union_size_for_union_in_variable_annotation() {
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].message_id, "maxUnionSize");
 }
+
+#[test]
+fn reports_elseif_without_else_for_chain_with_one_else_if() {
+    let source = "if (a) {} else if (b) {}";
+    let diagnostics = scan("elseif-without-else", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "elseif-without-else");
+    assert_eq!(diagnostics[0].message_id, "elseifWithoutElse");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_elseif_without_else_for_chain_with_two_else_ifs() {
+    let source = "if (a) {} else if (b) {} else if (c) {}";
+    let diagnostics = scan("elseif-without-else", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "elseifWithoutElse");
+}
+
+#[test]
+fn does_not_report_elseif_without_else_when_chain_ends_with_else() {
+    let source = "if (a) {} else if (b) {} else {}";
+    let diagnostics = scan("elseif-without-else", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_elseif_without_else_for_lone_if() {
+    let source = "if (a) {}";
+    let diagnostics = scan("elseif-without-else", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_elseif_without_else_for_if_with_only_else() {
+    let source = "if (a) {} else {}";
+    let diagnostics = scan("elseif-without-else", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_elseif_without_else_exactly_once_for_inner_chain() {
+    let source = "if (a) { if (x) {} else if (y) {} }";
+    let diagnostics = scan("elseif-without-else", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "elseifWithoutElse");
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -94,6 +94,10 @@ const messages = Object.freeze({
     maxUnionSize:
       'This union type has too many members; consider refactoring into a named type or interface.',
   },
+  'elseif-without-else': {
+    elseifWithoutElse:
+      "Add a final 'else' clause to this 'if … else if' chain to handle the remaining cases explicitly.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -133,6 +137,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow switch statements with more than 30 case/default clauses (threshold fixed at default 30; configurability is a follow-up)',
   'max-union-size':
     'Disallow union types with more than 3 members (threshold fixed at default 3; configurability is a follow-up; each TSUnionType node is counted per-node)',
+  'elseif-without-else':
+    "Require a final 'else' clause when an 'if … else if' chain is present, to explicitly handle the remaining case",
 });
 
 const ruleTypes = Object.freeze({
@@ -158,6 +164,7 @@ const ruleTypes = Object.freeze({
   'class-prototype': 'suggestion',
   'max-switch-cases': 'suggestion',
   'max-union-size': 'suggestion',
+  'elseif-without-else': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -183,6 +190,7 @@ const recommendedRuleConfig = Object.freeze({
   'class-prototype': 'error',
   'max-switch-cases': 'error',
   'max-union-size': 'error',
+  'elseif-without-else': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -25,6 +25,7 @@ const expectedRuleNames = [
   'class-prototype',
   'max-switch-cases',
   'max-union-size',
+  'elseif-without-else',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -796,5 +797,46 @@ describe('sonarjs native API', () => {
     const diagnostics = scan('max-union-size', source);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].messageId).toBe('maxUnionSize');
+  });
+
+  it('reports elseif-without-else for a chain with one else-if and no else', () => {
+    const source = 'if (a) {} else if (b) {}';
+    const diagnostics = scan('elseif-without-else', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('elseif-without-else');
+    expect(diagnostics[0].messageId).toBe('elseifWithoutElse');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('reports elseif-without-else for a chain with two else-ifs and no else', () => {
+    const source = 'if (a) {} else if (b) {} else if (c) {}';
+    const diagnostics = scan('elseif-without-else', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('elseifWithoutElse');
+  });
+
+  it('does not report elseif-without-else when the chain ends with else', () => {
+    const source = 'if (a) {} else if (b) {} else {}';
+    const diagnostics = scan('elseif-without-else', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report elseif-without-else for a lone if with no else-if', () => {
+    const source = 'if (a) {}';
+    const diagnostics = scan('elseif-without-else', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report elseif-without-else for an if with only an else (no else-if)', () => {
+    const source = 'if (a) {} else {}';
+    const diagnostics = scan('elseif-without-else', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports elseif-without-else exactly once for an inner chain with else-if but no else', () => {
+    const source = 'if (a) { if (x) {} else if (y) {} }';
+    const diagnostics = scan('elseif-without-else', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('elseifWithoutElse');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -116,6 +116,7 @@ describe('sonarjs plugin shape', () => {
       'class-prototype',
       'max-switch-cases',
       'max-union-size',
+      'elseif-without-else',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -139,6 +140,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['class-prototype']).toBe('object');
     expect(typeof plugin.rules['max-switch-cases']).toBe('object');
     expect(typeof plugin.rules['max-union-size']).toBe('object');
+    expect(typeof plugin.rules['elseif-without-else']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -162,6 +164,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/class-prototype']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-switch-cases']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-union-size']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/elseif-without-else']).toBe('error');
   });
 });
 
@@ -541,5 +544,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(max-union-size)');
+  });
+
+  it('reports elseif-without-else through the adapter', () => {
+    const source = 'if (a) {} else if (b) {}';
+    const reports = runRule('elseif-without-else', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('elseifWithoutElse');
+  });
+
+  it('reports elseif-without-else through the CLI', () => {
+    const source = 'if (a) {} else if (b) {}';
+    const result = runOxlint('elseif-without-else', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(elseif-without-else)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11022,19 +11022,19 @@
       },
       {
         "name": "elseif-without-else",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule elseif-without-else (Sonar key S126). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S126). Reports the head if of an else-if chain that has no terminal else. Reuses the shared if_chain_seen chain-head mechanism. No upstream source, tests, fixtures, or messages were consulted."
       },
       {
         "name": "empty-string-repetition",


### PR DESCRIPTION
## Summary
Clean-room port of **`elseif-without-else`** (Sonar key S126). Flags an `if … else if …` chain that has at least one `else if` but no terminal `else` clause. Reuses the shared `if_chain_seen` chain-head detection (from `no-identical-conditions`/`no-all-duplicated-branches`) so each chain is processed once and inner chains are handled independently.

## Tests
Rust unit tests (else-if no else → 1, multi else-if no else → 1, with else → 0, lone if → 0, if/else without else-if → 0, inner chain → 1), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(elseif-without-else)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783983597&installation_id=136613492&pr_number=179&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F179&signature=6eb0fe4e23f3a4c82ce99d303756982bd1af81aac004208c0c303a22cad6af53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->