### PR TITLE
port(sonarjs): port no-case-label-in-switch (S1219)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 23] = [
+pub const RULE_NAMES: [&str; 24] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -46,6 +46,7 @@ pub const RULE_NAMES: [&str; 23] = [
     "max-switch-cases",
     "max-union-size",
     "elseif-without-else",
+    "no-case-label-in-switch",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -11,6 +11,7 @@ mod max_switch_cases;
 mod max_union_size;
 mod no_all_duplicated_branches;
 mod no_built_in_override;
+mod no_case_label_in_switch;
 mod no_collapsible_if;
 mod no_delete_var;
 mod no_duplicate_in_composite;

--- a/crates/sonarjs/src/rules/no_case_label_in_switch.rs
+++ b/crates/sonarjs/src/rules/no_case_label_in_switch.rs
@@ -1,0 +1,51 @@
+//! Rule `no-case-label-in-switch` (SonarJS key S1219).
+//!
+//! Clean-room port. A labeled statement that appears directly among the
+//! consequent statements of a switch case is almost certainly a typo — the
+//! programmer likely intended a `case` clause (e.g. wrote `foo:` when they
+//! meant `case foo:`, or misspelled `default:`).
+//!
+//! ## Detection strategy
+//!
+//! Only **direct** children of a `SwitchCase.consequent` array are inspected.
+//! If the labeled statement is nested inside a block (`{ foo: bar(); }`) that
+//! itself lives inside a case, it is **not** flagged — it is a deliberate block
+//! label and falls outside the documented scope of this rule. The `no-labels`
+//! rule covers that usage if desired.
+//!
+//! Overlap with `no-labels` is intentional: both rules may fire for the same
+//! node when both are enabled. `no-labels` is unconditional (any labeled
+//! statement); this rule is focused exclusively on the misleading switch-case
+//! context.
+//!
+//! The diagnostic is anchored on `label.label.span`, which covers only the
+//! identifier part of the label before the colon, keeping the report concise
+//! and pointing directly at the label name.
+//!
+//! Behaviour is reproduced from the public RSPEC S1219 description only; no
+//! upstream source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Statement, SwitchStatement};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-case-label-in-switch";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_case_label_in_switch(&mut self, switch: &SwitchStatement<'_>) {
+        // Collect spans first (immutable borrow of switch param), then report.
+        let mut spans: SmallVec<[Span; 4]> = SmallVec::new();
+        for case in &switch.cases {
+            for stmt in &case.consequent {
+                if let Statement::LabeledStatement(label) = stmt {
+                    spans.push(label.label.span);
+                }
+            }
+        }
+        for span in spans {
+            self.report(RULE_NAME, "caseLabelInSwitch", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -81,6 +81,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_nested_switch(it);
         self.check_no_all_duplicated_branches_switch(it);
         self.check_max_switch_cases(it);
+        self.check_no_case_label_in_switch(it);
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1044,3 +1044,34 @@ fn reports_elseif_without_else_exactly_once_for_inner_chain() {
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].message_id, "elseifWithoutElse");
 }
+
+#[test]
+fn reports_no_case_label_in_switch_for_label_directly_in_case() {
+    let source = "switch (x) { case 1: foo(); lbl: bar(); break; }";
+    let diagnostics = scan("no-case-label-in-switch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-case-label-in-switch");
+    assert_eq!(diagnostics[0].message_id, "caseLabelInSwitch");
+}
+
+#[test]
+fn does_not_report_no_case_label_in_switch_for_switch_without_labels() {
+    let source = "switch (x) { case 1: break; default: break; }";
+    let diagnostics = scan("no-case-label-in-switch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_case_label_in_switch_for_label_nested_in_block() {
+    // The label is inside a block statement, not a direct child of the case consequent.
+    let source = "switch (x) { case 1: { lbl: bar(); } break; }";
+    let diagnostics = scan("no-case-label-in-switch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_case_label_in_switch_for_label_outside_switch() {
+    let source = "lbl: for (;;) {}";
+    let diagnostics = scan("no-case-label-in-switch", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -98,6 +98,10 @@ const messages = Object.freeze({
     elseifWithoutElse:
       "Add a final 'else' clause to this 'if … else if' chain to handle the remaining cases explicitly.",
   },
+  'no-case-label-in-switch': {
+    caseLabelInSwitch:
+      "Remove this misleading label; it looks like a 'case' clause but is a labeled statement.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -139,6 +143,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow union types with more than 3 members (threshold fixed at default 3; configurability is a follow-up; each TSUnionType node is counted per-node)',
   'elseif-without-else':
     "Require a final 'else' clause when an 'if … else if' chain is present, to explicitly handle the remaining case",
+  'no-case-label-in-switch':
+    "Disallow labeled statements appearing directly in a switch case's consequent list, where they are likely mistaken 'case' clauses",
 });
 
 const ruleTypes = Object.freeze({
@@ -165,6 +171,7 @@ const ruleTypes = Object.freeze({
   'max-switch-cases': 'suggestion',
   'max-union-size': 'suggestion',
   'elseif-without-else': 'suggestion',
+  'no-case-label-in-switch': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -191,6 +198,7 @@ const recommendedRuleConfig = Object.freeze({
   'max-switch-cases': 'error',
   'max-union-size': 'error',
   'elseif-without-else': 'error',
+  'no-case-label-in-switch': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -26,6 +26,7 @@ const expectedRuleNames = [
   'max-switch-cases',
   'max-union-size',
   'elseif-without-else',
+  'no-case-label-in-switch',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -838,5 +839,32 @@ describe('sonarjs native API', () => {
     const diagnostics = scan('elseif-without-else', source);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].messageId).toBe('elseifWithoutElse');
+  });
+
+  it('reports no-case-label-in-switch for a label directly in a case consequent', () => {
+    const source = 'switch (x) { case 1: foo(); lbl: bar(); break; }';
+    const diagnostics = scan('no-case-label-in-switch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-case-label-in-switch');
+    expect(diagnostics[0].messageId).toBe('caseLabelInSwitch');
+  });
+
+  it('does not report no-case-label-in-switch for a switch with no labels', () => {
+    const source = 'switch (x) { case 1: break; default: break; }';
+    const diagnostics = scan('no-case-label-in-switch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-case-label-in-switch for a label nested inside a block within a case', () => {
+    // Label is inside a block statement, not a direct child of the case consequent.
+    const source = 'switch (x) { case 1: { lbl: bar(); } break; }';
+    const diagnostics = scan('no-case-label-in-switch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-case-label-in-switch for a label outside any switch', () => {
+    const source = 'lbl: for (;;) {}';
+    const diagnostics = scan('no-case-label-in-switch', source);
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -117,6 +117,7 @@ describe('sonarjs plugin shape', () => {
       'max-switch-cases',
       'max-union-size',
       'elseif-without-else',
+      'no-case-label-in-switch',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -141,6 +142,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['max-switch-cases']).toBe('object');
     expect(typeof plugin.rules['max-union-size']).toBe('object');
     expect(typeof plugin.rules['elseif-without-else']).toBe('object');
+    expect(typeof plugin.rules['no-case-label-in-switch']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -165,6 +167,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/max-switch-cases']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-union-size']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/elseif-without-else']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-case-label-in-switch']).toBe('error');
   });
 });
 
@@ -561,5 +564,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(elseif-without-else)');
+  });
+
+  it('reports no-case-label-in-switch through the adapter', () => {
+    const source = 'switch (x) { case 1: foo(); lbl: bar(); break; }';
+    const reports = runRule('no-case-label-in-switch', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('caseLabelInSwitch');
+  });
+
+  it('reports no-case-label-in-switch through the CLI', () => {
+    const source = 'switch (x) { case 1: foo(); lbl: bar(); break; }';
+    const result = runOxlint('no-case-label-in-switch', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-case-label-in-switch)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11742,19 +11742,19 @@
       },
       {
         "name": "no-case-label-in-switch",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-case-label-in-switch (Sonar key S1219). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1219). Detects labeled statements appearing directly in the consequent list of a switch case, where they almost certainly represent a mistyped 'case' clause. Only direct children of SwitchCase.consequent are flagged; labels nested inside a block within a case are intentionally out of scope. Overlap with no-labels is intentional — both rules may fire when both are enabled. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-clear-text-protocols",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-case-label-in-switch`** (Sonar key S1219). Flags a labeled statement appearing directly among a switch case's consequent statements (`switch (x) { case 1: foo(); lbl: bar(); }`) — almost always a typo for a `case` clause. Push-down scan over the switch's cases. Labels nested inside a block within a case are out of scope (documented). Adds a fourth check to the existing `visit_switch_statement` hook.

## Tests
Rust unit tests (label among cases → 1, plain switch → 0, label in nested block → 0, label outside switch → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-case-label-in-switch)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783984140&installation_id=136613492&pr_number=180&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F180&signature=f3c5410a298583e5941287218dbc7cb54f2a7a8a7c81359450a2b58c33d2c6cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->