### PR TITLE
port(regexp): port no-standalone-backslash (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -15,9 +15,9 @@ use crate::helpers::{
     first_invisible_character, first_literal_control_character, first_non_standard_flag,
     first_numbered_backreference_with_named_group, first_octal_escape, first_surrogate_pair_escape,
     first_unicode_escape_as_hex, first_uppercase_hex_escape, first_useless_escape,
-    first_useless_one_quantifier, group_prefix, mention_char, pattern_ends_with_lazy_quantifier,
-    pattern_has_empty_string_literal, pattern_is_safe_to_add_i_flag, skip_escape, sorted_flags,
-    string_literal_value_with_span,
+    first_useless_one_quantifier, group_prefix, has_standalone_backslash, mention_char,
+    pattern_ends_with_lazy_quantifier, pattern_has_empty_string_literal,
+    pattern_is_safe_to_add_i_flag, skip_escape, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -1244,6 +1244,15 @@ impl<'a> Scanner<'a> {
                 },
                 span,
             );
+        }
+        // `no-standalone-backslash`: in non-`u`/non-`v` mode the engine
+        // silently accepts `\c[non-letter]` as a literal backslash. This is
+        // almost certainly unintentional — the author probably intended a
+        // control-character escape `\cX` (which requires a letter after `\c`).
+        // Narrow form: only flag when `u`/`v` are absent (with those flags the
+        // pattern is a parse error that `no-invalid-regexp` already catches).
+        if !flags.contains('u') && !flags.contains('v') && has_standalone_backslash(pattern) {
+            self.report("no-standalone-backslash", "unexpected", span);
         }
     }
 }

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -1763,6 +1763,67 @@ pub(crate) fn class_contains_zwj(bytes: &[u8], open: usize) -> bool {
     body.windows(3).any(|w| w == [0xE2, 0x80, 0x8D])
 }
 
+/// Returns `true` when the pattern contains a standalone backslash — a `\c`
+/// sequence where `c` is NOT an ASCII letter (so `\cX` would be a control
+/// character escape only when `X ∈ [A-Za-z]`).  In non-`u`/non-`v` mode the
+/// engine silently treats `\cX` (non-letter X) as a literal backslash, which
+/// is almost certainly unintentional.  The check covers both top-level patterns
+/// and the inside of character classes.  Used by `no-standalone-backslash`.
+pub(crate) fn has_standalone_backslash(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'[' => {
+                // Walk inside the character class. We still need to detect
+                // `\c[non-letter]` here (e.g. `/[\c]/` is invalid). Use the
+                // simple (non-nested) class scanner; v-mode nested classes will
+                // be handled conservatively — the outer `[` is processed here
+                // and any inner `[...]` content is also scanned via the
+                // recursive character loop.
+                index += 1;
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b'\\' => {
+                            if let Some(&next) = bytes.get(index + 1) {
+                                if next == b'c' {
+                                    let after = bytes.get(index + 2).copied();
+                                    if !after.is_some_and(|b| b.is_ascii_alphabetic()) {
+                                        return true;
+                                    }
+                                }
+                                index = skip_escape(bytes, index);
+                            } else {
+                                index += 1;
+                            }
+                        }
+                        b']' => {
+                            index += 1;
+                            break;
+                        }
+                        _ => index += 1,
+                    }
+                }
+            }
+            b'\\' => {
+                if let Some(&next) = bytes.get(index + 1) {
+                    if next == b'c' {
+                        let after = bytes.get(index + 2).copied();
+                        if !after.is_some_and(|b| b.is_ascii_alphabetic()) {
+                            return true;
+                        }
+                    }
+                    index = skip_escape(bytes, index);
+                } else {
+                    index += 1;
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    false
+}
+
 pub(crate) fn mention_char(ch: char) -> CompactString {
     let mut text = CompactString::new("U+");
     let code = ch as u32;

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -24,7 +24,7 @@ use crate::usage::collect_whole_pattern_regex_spans;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 66] = [
+pub const RULE_NAMES: [&str; 67] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -91,6 +91,7 @@ pub const RULE_NAMES: [&str; 66] = [
     "negation",
     "no-useless-lazy",
     "no-misleading-unicode-character",
+    "no-standalone-backslash",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -107,8 +107,49 @@ fn exposes_initial_regexp_rule_names() {
             "negation",
             "no-useless-lazy",
             "no-misleading-unicode-character",
+            "no-standalone-backslash",
         ]
     );
+}
+
+mod no_standalone_backslash {
+    use super::*;
+
+    #[test]
+    fn reports_standalone_backslash() {
+        // `\c` at end of pattern — no control letter follows
+        assert_eq!(
+            rule_ids_for(r"const a = /\c/;", "no-standalone-backslash").as_slice(),
+            &["unexpected"]
+        );
+        // `\c` followed by a digit — not a valid control-char escape
+        assert_eq!(
+            rule_ids_for(r"const a = /\c1/;", "no-standalone-backslash").as_slice(),
+            &["unexpected"]
+        );
+        // `\c` followed by `-` — not a letter
+        assert_eq!(
+            rule_ids_for(r"const a = /\c-/;", "no-standalone-backslash").as_slice(),
+            &["unexpected"]
+        );
+        // `\c` inside a character class before `]`
+        assert_eq!(
+            rule_ids_for(r"const a = /[\c]/;", "no-standalone-backslash").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_valid_control_char_escapes() {
+        // `\cX` where X is an uppercase letter — valid control-char escape
+        assert!(rule_ids_for(r"const a = /\cX/;", "no-standalone-backslash").is_empty());
+        // `\cA` through `\cZ` in a v-mode class
+        assert!(
+            rule_ids_for(r"const a = /[[\cA-\cZ]--\cX]/v;", "no-standalone-backslash").is_empty()
+        );
+        // Lowercase control letters are also valid
+        assert!(rule_ids_for(r"const a = /\ca/;", "no-standalone-backslash").is_empty());
+    }
 }
 
 mod no_useless_backreference {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -357,7 +357,7 @@ const ruleDescriptions = Object.freeze({
   'no-useless-lazy': 'disallow lazy modifiers on fixed-count brace quantifiers (`{n}?`, `{n,n}?`)',
   'no-misleading-unicode-character':
     'disallow character classes that contain a ZWJ (U+200D) and match it as a separate atom',
-  'no-standalone-backslash': "disallow standalone backslashes (`\\`)",
+  'no-standalone-backslash': 'disallow standalone backslashes (`\\`)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -251,6 +251,10 @@ const messages = Object.freeze({
     unexpected:
       'Character class contains a ZWJ (U+200D) and matches it as a separate atom; ZWJ-joined sequences cannot be matched as a single grapheme this way.',
   },
+  'no-standalone-backslash': {
+    unexpected:
+      "Unexpected standalone backslash (`\\`). It looks like an escape sequence, but it's a single `\\` character pattern.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -351,6 +355,9 @@ const ruleDescriptions = Object.freeze({
   negation:
     'enforce use of equivalent shorthand for negated character classes containing a single predefined shorthand',
   'no-useless-lazy': 'disallow lazy modifiers on fixed-count brace quantifiers (`{n}?`, `{n,n}?`)',
+  'no-misleading-unicode-character':
+    'disallow character classes that contain a ZWJ (U+200D) and match it as a separate atom',
+  'no-standalone-backslash': "disallow standalone backslashes (`\\`)",
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -419,6 +426,7 @@ const ruleTypes = Object.freeze({
   negation: 'suggestion',
   'no-useless-lazy': 'suggestion',
   'no-misleading-unicode-character': 'problem',
+  'no-standalone-backslash': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -71,6 +71,7 @@ describe('regexp native API', () => {
       'negation',
       'no-useless-lazy',
       'no-misleading-unicode-character',
+      'no-standalone-backslash',
     ]);
   });
 

--- a/npm/regexp/test/fixtures/no-standalone-backslash.json
+++ b/npm/regexp/test/fixtures/no-standalone-backslash.json
@@ -1,0 +1,72 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-regexp",
+    "version": "3.1.0",
+    "sourceFile": "tests/lib/rules/no-standalone-backslash.ts",
+    "snapshotFile": "tests/lib/rules/__snapshots__/no-standalone-backslash.ts.eslintsnap",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-regexp-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "/\\cX/"
+    },
+    {
+      "code": "/[[\\cA-\\cZ]--\\cX]/v"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "/\\c/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Unexpected standalone backslash (`\\`). It looks like an escape sequence, but it's a single `\\` character pattern.",
+          "line": 1,
+          "column": 2,
+          "endColumn": 3
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/\\c-/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Unexpected standalone backslash (`\\`). It looks like an escape sequence, but it's a single `\\` character pattern.",
+          "line": 1,
+          "column": 2,
+          "endColumn": 3
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/\\c1/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Unexpected standalone backslash (`\\`). It looks like an escape sequence, but it's a single `\\` character pattern.",
+          "line": 1,
+          "column": 2,
+          "endColumn": 3
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/[\\c]/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Unexpected standalone backslash (`\\`). It looks like an escape sequence, but it's a single `\\` character pattern.",
+          "line": 1,
+          "column": 3,
+          "endColumn": 4
+        }
+      ],
+      "output": null
+    }
+  ]
+}

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -182,7 +182,11 @@ const validCases = [
   ],
   // no-standalone-backslash
   ['no-standalone-backslash', 'valid control escape \\cX', 'const re = /\\cX/;\n'],
-  ['no-standalone-backslash', 'v-mode valid control escapes', 'const re = /[[\\cA-\\cZ]--\\cX]/v;\n'],
+  [
+    'no-standalone-backslash',
+    'v-mode valid control escapes',
+    'const re = /[[\\cA-\\cZ]--\\cX]/v;\n',
+  ],
 ];
 
 const invalidCases = [

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -180,6 +180,9 @@ const validCases = [
     'surrogate half \\uHHHH',
     "const re = new RegExp('\\\\ud83d\\\\ude00', 'u');\n",
   ],
+  // no-standalone-backslash
+  ['no-standalone-backslash', 'valid control escape \\cX', 'const re = /\\cX/;\n'],
+  ['no-standalone-backslash', 'v-mode valid control escapes', 'const re = /[[\\cA-\\cZ]--\\cX]/v;\n'],
 ];
 
 const invalidCases = [
@@ -493,6 +496,10 @@ const invalidCases = [
     ['unexpected'],
   ],
   ['no-misleading-unicode-character', 'bare zwj in class', 'const re = /[‍]/u;\n', ['unexpected']],
+  // no-standalone-backslash
+  ['no-standalone-backslash', '\\c at end of pattern', 'const re = /\\c/;\n', ['unexpected']],
+  ['no-standalone-backslash', '\\c followed by digit', 'const re = /\\c1/;\n', ['unexpected']],
+  ['no-standalone-backslash', '\\c inside class', 'const re = /[\\c]/;\n', ['unexpected']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8971,19 +8971,19 @@
       },
       {
         "name": "no-standalone-backslash",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-standalone-backslash."
+        "notes": "Narrow form: scans for `\\c[non-letter]` sequences (the control-character escape `\\cX` requires an ASCII letter after `\\c`; any other character, or end-of-pattern, is a standalone backslash). Only fires without the `u`/`v` flag (with those flags the pattern is already a parse error caught by no-invalid-regexp)."
       },
       {
         "name": "no-super-linear-backtracking",


### PR DESCRIPTION
## Summary

- Ports `regexp/no-standalone-backslash` from `eslint-plugin-regexp` in narrow form
- Detects `\c[non-letter]` sequences where the control-character escape `\cX` requires an ASCII letter after `\c`; any other byte or end-of-pattern is a standalone backslash
- Only fires when the regex has neither `u` nor `v` flag (with those flags, the pattern is already a parse error caught by `no-invalid-regexp`)
- Covers both top-level patterns and inside character classes (e.g., `/[\c]/`)

## Files changed

- `crates/regexp/src/helpers.rs`: added `has_standalone_backslash(pattern)` scanner
- `crates/regexp/src/checks.rs`: wired the check in `check_pattern_rules`; added import
- `crates/regexp/src/lib.rs`: bumped `RULE_NAMES` from 66 → 67, appended `"no-standalone-backslash"`
- `crates/regexp/src/tests.rs`: added `no_standalone_backslash` module with pass/fail tests; updated `exposes_initial_regexp_rule_names`
- `npm/regexp/index.js`: added messages, description, type entries
- `npm/regexp/test/api.test.mjs`: appended rule to expected array
- `npm/regexp/test/plugin.test.mjs`: added 2 valid + 3 invalid cases
- `npm/regexp/test/fixtures/no-standalone-backslash.json`: generated fixture (2 valid, 4 invalid)
- `status.json`: flipped `"pending"` → `"ported"`

## Soundness reasoning

Valid cases (fixture): `/\cX/` (letter after `\c`) and `/[[\cA-\cZ]--\cX]/v` (v-flag → rule skips entirely). Both produce zero diagnostics. All 4 invalid upstream cases fire correctly. No false positives possible because the check is strictly `\c` followed by a non-letter (or nothing), and the v/u guard prevents interference with parse-error territory.

`cargo test -p oxlint-plugins-regexp`: 187 passed, 0 failed
`cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783984155&installation_id=136613492&pr_number=181&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F181&signature=f3977503c5848fd8006e4f6c28b2980f49218df5ebaa0ac2171e22ec854354c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->