### PR TITLE
fix(functional): no-promise-reject arity + no-conditional switch-break semantics

### DIFF
--- a/crates/functional/src/expressions.rs
+++ b/crates/functional/src/expressions.rs
@@ -380,16 +380,16 @@ impl<'a> Scanner<'a> {
         expression: &'a NewExpression<'a>,
         context: FunctionContext,
     ) {
-        // `new Promise(executor)` can reject only when the executor declares a
-        // second `reject` parameter, mirroring upstream's `arguments[0].params
-        // .length >= 2` check.
+        // `new Promise(executor)` can reject only when the executor declares
+        // exactly two parameters (`(resolve, reject) => ...`), mirroring
+        // upstream's `arguments[0].params.length === 2` check.
         let executor_can_reject = expression.arguments.first().is_some_and(|argument| {
             let params = match argument {
                 Argument::ArrowFunctionExpression(function) => Some(&function.params),
                 Argument::FunctionExpression(function) => Some(&function.params),
                 _ => None,
             };
-            params.is_some_and(|params| params.items.len() >= 2)
+            params.is_some_and(|params| params.items.len() == 2)
         });
         if is_identifier_expression(&expression.callee, "Promise") && executor_can_reject {
             self.report(

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -324,7 +324,10 @@ impl<'a> Scanner<'a> {
             return true;
         }
         if let Statement::BlockStatement(block) = branch {
-            return block.body.iter().any(|stmt| self.is_if_returning_branch(stmt));
+            return block
+                .body
+                .iter()
+                .any(|stmt| self.is_if_returning_branch(stmt));
         }
         false
     }

--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -288,59 +288,90 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    /// Whether a branch statement guarantees an abrupt completion (return,
-    /// throw, break, or continue) — the syntactic basis of `no-conditional-
-    /// statements`' `allowReturningBranches: true`. A `never`-returning call
-    /// would also count upstream, but that needs type information.
-    fn branch_is_returning(&self, statement: &Statement<'a>) -> bool {
+    /// A statement that, inside an `if`, counts as a returning branch (upstream
+    /// `isIfReturningBranch`): a nested `if` (checked on its own), return,
+    /// throw, break, or continue.
+    fn is_if_returning_branch(&self, statement: &Statement<'a>) -> bool {
+        matches!(
+            statement,
+            Statement::IfStatement(_)
+                | Statement::ReturnStatement(_)
+                | Statement::ThrowStatement(_)
+                | Statement::BreakStatement(_)
+                | Statement::ContinueStatement(_)
+        )
+    }
+
+    /// A statement that, inside a `switch` case, counts as a returning branch
+    /// (upstream `isSwitchReturningBranch`): a nested `switch`, return, throw, a
+    /// *labeled* break (an unlabeled break only exits the switch), or continue.
+    fn is_switch_returning_branch(&self, statement: &Statement<'a>) -> bool {
         match statement {
-            Statement::ReturnStatement(_)
+            Statement::SwitchStatement(_)
+            | Statement::ReturnStatement(_)
             | Statement::ThrowStatement(_)
-            | Statement::BreakStatement(_)
             | Statement::ContinueStatement(_) => true,
-            Statement::BlockStatement(block) => block
-                .body
-                .last()
-                .is_some_and(|last| self.branch_is_returning(last)),
-            Statement::IfStatement(inner) => inner.alternate.as_ref().is_some_and(|alternate| {
-                self.branch_is_returning(&inner.consequent) && self.branch_is_returning(alternate)
-            }),
+            Statement::BreakStatement(break_statement) => break_statement.label.is_some(),
             _ => false,
         }
+    }
+
+    /// An `if` branch (consequent/alternate) is returning when it is directly a
+    /// returning statement or a block whose body contains one. A `never`-typed
+    /// expression also counts upstream, but that needs type information.
+    fn if_branch_returns(&self, branch: &Statement<'a>) -> bool {
+        if self.is_if_returning_branch(branch) {
+            return true;
+        }
+        if let Statement::BlockStatement(block) = branch {
+            return block.body.iter().any(|stmt| self.is_if_returning_branch(stmt));
+        }
+        false
     }
 
     /// An `if` is "returning" when its consequent is returning and, if present,
     /// its alternate is too (an `if` without `else` only needs the consequent).
     fn if_all_branches_return(&self, statement: &IfStatement<'a>) -> bool {
-        if !self.branch_is_returning(&statement.consequent) {
+        if !self.if_branch_returns(&statement.consequent) {
             return false;
         }
         match &statement.alternate {
-            Some(alternate) => self.branch_is_returning(alternate),
+            Some(alternate) => self.if_branch_returns(alternate),
             None => true,
         }
     }
 
-    /// A `switch` is "returning" when every case is returning. Empty
-    /// (fall-through) cases inherit the returning status of the case they fall
-    /// into, so cases are walked bottom-up.
+    /// A `switch` is "returning" when every non-empty case contains a returning
+    /// statement (empty fall-through cases are allowed). Mirrors upstream
+    /// `getSwitchViolations`; `never`-typed cases need type information.
     fn switch_all_cases_return(&self, cases: &[SwitchCase<'a>]) -> bool {
-        if cases.is_empty() {
+        for case in cases {
+            if case.consequent.is_empty() {
+                continue;
+            }
+            if case
+                .consequent
+                .iter()
+                .any(|stmt| self.is_switch_returning_branch(stmt))
+            {
+                continue;
+            }
+            let all_blocks = case
+                .consequent
+                .iter()
+                .all(|stmt| matches!(stmt, Statement::BlockStatement(_)));
+            if all_blocks
+                && let Some(Statement::BlockStatement(block)) = case.consequent.last()
+                && block
+                    .body
+                    .iter()
+                    .any(|stmt| self.is_switch_returning_branch(stmt))
+            {
+                continue;
+            }
             return false;
         }
-        let mut following_returns = false;
-        for case in cases.iter().rev() {
-            if !case.consequent.is_empty() {
-                following_returns = case
-                    .consequent
-                    .last()
-                    .is_some_and(|last| self.branch_is_returning(last));
-            }
-            if !following_returns {
-                return false;
-            }
-        }
-        following_returns
+        true
     }
 
     fn scan_for_init(&mut self, init: &'a ForStatementInit<'a>, context: FunctionContext) {

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -606,6 +606,9 @@ fn no_conditional_statements_allow_returning_branches() {
     let if_else_partial = "function f(i) { if (i) { return 1; } else { g(); } }";
     let switch_returns = "function f(i) { switch (i) { case 1: return 1; default: return 2; } }";
     let switch_partial = "function f(i) { switch (i) { case 1: g(); default: return 2; } }";
+    let switch_fallthrough = "function f(i) { switch (i) { case 1: case 2: return 1; } }";
+    let switch_break = "function f(i) { switch (i) { case 1: g(); break; default: return 2; } }";
+    let if_break_loop = "for (;;) { if (i) { break; } }";
 
     // Default: every if/switch is reported.
     assert_eq!(count(if_returns, &base), 1);
@@ -618,7 +621,12 @@ fn no_conditional_statements_allow_returning_branches() {
     assert_eq!(count(if_else_returns, &allow), 0);
     assert_eq!(count(if_else_partial, &allow), 1);
 
-    // switch: allowed only when every case is returning (fall-through inherits).
+    // switch: allowed only when every non-empty case returns; empty fall-through
+    // cases inherit the next case. An unlabeled `break` does NOT count as
+    // returning inside a switch (it only exits the switch), unlike inside an if.
     assert_eq!(count(switch_returns, &allow), 0);
     assert_eq!(count(switch_partial, &allow), 1);
+    assert_eq!(count(switch_fallthrough, &allow), 0);
+    assert_eq!(count(switch_break, &allow), 1);
+    assert_eq!(count(if_break_loop, &allow), 0);
 }


### PR DESCRIPTION
Two findings from the **final confirmation review** (the review that gates "zero major findings"). Both were verified against the vendored upstream source in `upstream/eslint-plugin-functional/src/rules/`.

## 1. no-promise-reject — exact executor arity (MAJOR, full-parity rule)
Upstream `checkNewExpression` uses `node.arguments[0].params.length === 2`. The port used `>= 2`, so `new Promise((resolve, reject, extra) => …)` (3-param executor) was a false positive. Changed to `== 2`. The 2-param fixture case still matches; no parity regression.

## 2. no-conditional-statements allowReturningBranches — faithful branch semantics
The returning-branch detection now mirrors upstream's separate `isIfReturningBranch` / `isSwitchReturningBranch`:
- An unlabeled `break` counts as returning inside an **if** branch but **not** inside a **switch** case (where it merely exits the switch) — upstream line 224 requires a *labeled* break for switches. Previously a switch of `break`-only cases was wrongly allowed.
- A branch/case is returning when **any** of its statements returns (was: only the last statement); empty fall-through `switch` cases are allowed.
- A nested `if`/`switch` counts as returning (its own violations are checked separately).

`never`-typed branches and `"ifExhaustive"` exhaustiveness still require type information and remain documented limitations.

## Tests
Extended the Rust unit tests with switch-with-unlabeled-break (now reported), empty fall-through (allowed), and if-`break`-in-loop (allowed) cases.

## Review provenance
The confirmation review also re-verified the earlier fixes (#171/#174/#178) are correct — including hand-traced `switch_all_cases_return` cases — and found no other major issues (the per-rule rescan is shared repo-wide architecture, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783984769&installation_id=136613492&pr_number=182&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F182&signature=e6c71bdb3fac7b0ac86a4fd0b7d38055f17251ae410a96618839093e18df34e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->