### PR TITLE
port(sonarjs): port for-in (S1535)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 24] = [
+pub const RULE_NAMES: [&str; 25] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -47,6 +47,7 @@ pub const RULE_NAMES: [&str; 24] = [
     "max-union-size",
     "elseif-without-else",
     "no-case-label-in-switch",
+    "for-in",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -6,6 +6,7 @@ mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
 mod elseif_without_else;
+mod for_in;
 mod generator_without_yield;
 mod max_switch_cases;
 mod max_union_size;

--- a/crates/sonarjs/src/rules/for_in.rs
+++ b/crates/sonarjs/src/rules/for_in.rs
@@ -1,0 +1,51 @@
+//! Rule `for-in` (SonarJS key S1535).
+//!
+//! Clean-room port. Reports a `for...in` loop whose body does not consist of a
+//! single `if` statement. A `for...in` loop iterates over both own and inherited
+//! enumerable properties, so conventional practice is to guard the body with an
+//! `if` statement (e.g. `if (Object.prototype.hasOwnProperty.call(obj, key))`)
+//! to filter out inherited properties. This rule enforces that structural shape
+//! only — it checks whether the body is a single `if` statement, but does NOT
+//! inspect the `if` condition itself. Any `if` guard satisfies the rule.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! ## Flagged
+//! - `for (k in o) { doStuff(k); }` — body is not a single `if`
+//! - `for (k in o) doStuff(k);` — single non-`if` statement
+//! - `for (k in o) {}` — empty block contains no `if`
+//! - `for (k in o) { if (a) {} doStuff(); }` — block has two statements
+//!
+//! ## Not flagged
+//! - `for (k in o) { if (o.hasOwnProperty(k)) { doStuff(k); } }` — single `if` in block
+//! - `for (k in o) if (cond) doStuff();` — body is directly an `if` statement
+
+use oxc_ast::ast::{ForInStatement, Statement};
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "for-in";
+
+/// Returns `true` when `body` is either directly an `IfStatement` or a
+/// `BlockStatement` containing exactly one `IfStatement`.
+fn is_single_if_body(body: &Statement<'_>) -> bool {
+    match body {
+        Statement::IfStatement(_) => true,
+        Statement::BlockStatement(block) => {
+            block.body.len() == 1 && matches!(block.body.first(), Some(Statement::IfStatement(_)))
+        }
+        _ => false,
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_for_in(&mut self, stmt: &ForInStatement<'_>) {
+        if is_single_if_body(&stmt.body) {
+            return;
+        }
+        let start = stmt.span.start;
+        self.report(RULE_NAME, "forIn", Span::new(start, start + 3));
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,9 +4,10 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, ConditionalExpression,
-    ExpressionStatement, Function, IdentifierReference, IfStatement, LabeledStatement,
-    LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase, SwitchStatement,
-    TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression, YieldExpression,
+    ExpressionStatement, ForInStatement, Function, IdentifierReference, IfStatement,
+    LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
+    SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
+    YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -123,6 +124,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_all_duplicated_branches_if(it);
         self.check_elseif_without_else(it);
         walk::walk_if_statement(self, it);
+    }
+
+    fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
+        self.check_for_in(it);
+        walk::walk_for_in_statement(self, it);
     }
 
     fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1075,3 +1075,51 @@ fn does_not_report_no_case_label_in_switch_for_label_outside_switch() {
     let diagnostics = scan("no-case-label-in-switch", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_for_in_when_body_is_block_with_non_if_statement() {
+    let source = "for (const k in o) { doStuff(k); }";
+    let diagnostics = scan("for-in", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "for-in");
+    assert_eq!(diagnostics[0].message_id, "forIn");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_for_in_when_body_is_single_non_if_statement_no_block() {
+    let source = "for (const k in o) doStuff(k);";
+    let diagnostics = scan("for-in", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "forIn");
+}
+
+#[test]
+fn reports_for_in_when_body_is_empty_block() {
+    let source = "for (const k in o) {}";
+    let diagnostics = scan("for-in", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "forIn");
+}
+
+#[test]
+fn reports_for_in_when_block_has_two_statements() {
+    let source = "for (const k in o) { if (a) {} doStuff(); }";
+    let diagnostics = scan("for-in", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "forIn");
+}
+
+#[test]
+fn does_not_report_for_in_when_body_block_contains_single_if() {
+    let source = "for (const k in o) { if (o.hasOwnProperty(k)) { doStuff(k); } }";
+    let diagnostics = scan("for-in", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_for_in_when_body_is_directly_an_if_statement() {
+    let source = "for (const k in o) if (cond) doStuff();";
+    let diagnostics = scan("for-in", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -102,6 +102,10 @@ const messages = Object.freeze({
     caseLabelInSwitch:
       "Remove this misleading label; it looks like a 'case' clause but is a labeled statement.",
   },
+  'for-in': {
+    forIn:
+      "Wrap this 'for...in' loop body in an 'if' statement to filter out inherited properties.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -145,6 +149,8 @@ const ruleDescriptions = Object.freeze({
     "Require a final 'else' clause when an 'if … else if' chain is present, to explicitly handle the remaining case",
   'no-case-label-in-switch':
     "Disallow labeled statements appearing directly in a switch case's consequent list, where they are likely mistaken 'case' clauses",
+  'for-in':
+    "Require a 'for...in' loop body to be a single 'if' statement that filters inherited properties (structural check only — the 'if' condition is not inspected)",
 });
 
 const ruleTypes = Object.freeze({
@@ -172,6 +178,7 @@ const ruleTypes = Object.freeze({
   'max-union-size': 'suggestion',
   'elseif-without-else': 'suggestion',
   'no-case-label-in-switch': 'problem',
+  'for-in': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -199,6 +206,7 @@ const recommendedRuleConfig = Object.freeze({
   'max-union-size': 'error',
   'elseif-without-else': 'error',
   'no-case-label-in-switch': 'error',
+  'for-in': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -27,6 +27,7 @@ const expectedRuleNames = [
   'max-union-size',
   'elseif-without-else',
   'no-case-label-in-switch',
+  'for-in',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -865,6 +866,47 @@ describe('sonarjs native API', () => {
   it('does not report no-case-label-in-switch for a label outside any switch', () => {
     const source = 'lbl: for (;;) {}';
     const diagnostics = scan('no-case-label-in-switch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports for-in when body is a block with a non-if statement', () => {
+    const source = 'for (const k in o) { doStuff(k); }';
+    const diagnostics = scan('for-in', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('for-in');
+    expect(diagnostics[0].messageId).toBe('forIn');
+  });
+
+  it('reports for-in when body is a single non-if statement (no block)', () => {
+    const source = 'for (const k in o) doStuff(k);';
+    const diagnostics = scan('for-in', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('forIn');
+  });
+
+  it('reports for-in when body is an empty block', () => {
+    const source = 'for (const k in o) {}';
+    const diagnostics = scan('for-in', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('forIn');
+  });
+
+  it('reports for-in when block has two statements (if plus another)', () => {
+    const source = 'for (const k in o) { if (a) {} doStuff(); }';
+    const diagnostics = scan('for-in', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('forIn');
+  });
+
+  it('does not report for-in when body block contains exactly one if statement', () => {
+    const source = 'for (const k in o) { if (o.hasOwnProperty(k)) { doStuff(k); } }';
+    const diagnostics = scan('for-in', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report for-in when body is directly an if statement (no block)', () => {
+    const source = 'for (const k in o) if (cond) doStuff();';
+    const diagnostics = scan('for-in', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -118,6 +118,7 @@ describe('sonarjs plugin shape', () => {
       'max-union-size',
       'elseif-without-else',
       'no-case-label-in-switch',
+      'for-in',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -143,6 +144,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['max-union-size']).toBe('object');
     expect(typeof plugin.rules['elseif-without-else']).toBe('object');
     expect(typeof plugin.rules['no-case-label-in-switch']).toBe('object');
+    expect(typeof plugin.rules['for-in']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -168,6 +170,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/max-union-size']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/elseif-without-else']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-case-label-in-switch']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/for-in']).toBe('error');
   });
 });
 
@@ -328,6 +331,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('max-union-size', source, { filename: 'sample.ts' });
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('maxUnionSize');
+  });
+
+  it('reports for-in when body is a block with no if statement through the adapter', () => {
+    const source = 'for (const k in o) { doStuff(k); }';
+    const reports = runRule('for-in', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('forIn');
   });
 });
 
@@ -581,5 +591,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-case-label-in-switch)');
+  });
+
+  it('reports for-in through the CLI', () => {
+    const source = 'for (const k in o) { doStuff(k); }';
+    const result = runOxlint('for-in', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(for-in)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11198,19 +11198,19 @@
       },
       {
         "name": "for-in",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule for-in (Sonar key S1535). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1535). Structural-only check: reports a for...in loop whose body is not a single if statement (directly or as the sole statement in a block). Does not inspect the if condition. No upstream source, fixtures, tests, or messages consulted or copied."
       },
       {
         "name": "for-loop-increment-sign",


### PR DESCRIPTION
## Summary
Clean-room port of **`for-in`** (Sonar key S1535). Flags a `for...in` loop whose body is not a single `if` statement — keys should be filtered (e.g. `hasOwnProperty`). Structural check only (does not inspect the `if` condition). Reports the `for` keyword. Adds a `visit_for_in_statement` hook.

## Tests
Rust unit tests (non-if body, single non-if statement, empty block, two-statement block → 1; single `if` in block, direct `if` body → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(for-in)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783985206&installation_id=136613492&pr_number=183&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F183&signature=09a3d32c63173c7668ccab5a80647bedc9891ff2f613f302397511b59e6e1732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->