### PR TITLE
fix(functional): discount break to switch's own label in allowReturningBranches

### DIFF
--- a/crates/functional/src/statements.rs
+++ b/crates/functional/src/statements.rs
@@ -47,23 +47,7 @@ impl<'a> Scanner<'a> {
                 }
             }
             Statement::SwitchStatement(statement) => {
-                let allowed = self.options.allow_returning_branches
-                    && self.switch_all_cases_return(&statement.cases);
-                if !allowed {
-                    self.report(
-                        "no-conditional-statements",
-                        "unexpectedSwitch",
-                        "Unexpected switch, use a conditional expression instead.",
-                        statement.span,
-                    );
-                }
-                self.scan_expression(&statement.discriminant, context);
-                for case in &statement.cases {
-                    if let Some(test) = &case.test {
-                        self.scan_expression(test, context);
-                    }
-                    self.scan_statement_list(&case.consequent, context);
-                }
+                self.scan_switch(statement, context, None);
             }
             Statement::ForStatement(statement) => {
                 self.report(
@@ -205,7 +189,14 @@ impl<'a> Scanner<'a> {
             }
             Statement::ClassDeclaration(class) => self.scan_class(class, context),
             Statement::LabeledStatement(labeled) => {
-                self.scan_statement(&labeled.body, context);
+                // A `break <label>` that targets the switch's own enclosing label
+                // merely exits the switch, so the label must be known when
+                // deciding whether a case is "returning".
+                if let Statement::SwitchStatement(switch) = &labeled.body {
+                    self.scan_switch(switch, context, Some(labeled.label.name.as_str()));
+                } else {
+                    self.scan_statement(&labeled.body, context);
+                }
             }
             Statement::TSModuleDeclaration(module) => {
                 self.scan_ts_module_declaration(module, context);
@@ -303,15 +294,24 @@ impl<'a> Scanner<'a> {
     }
 
     /// A statement that, inside a `switch` case, counts as a returning branch
-    /// (upstream `isSwitchReturningBranch`): a nested `switch`, return, throw, a
-    /// *labeled* break (an unlabeled break only exits the switch), or continue.
-    fn is_switch_returning_branch(&self, statement: &Statement<'a>) -> bool {
+    /// (upstream `isSwitchReturningBranch`): a nested `switch`, return, throw, or
+    /// continue. A break counts only when it carries a label that targets some
+    /// construct *outside* this switch; an unlabeled break — or one targeting the
+    /// switch's own enclosing label (`switch_label`) — merely exits the switch.
+    fn is_switch_returning_branch(
+        &self,
+        statement: &Statement<'a>,
+        switch_label: Option<&str>,
+    ) -> bool {
         match statement {
             Statement::SwitchStatement(_)
             | Statement::ReturnStatement(_)
             | Statement::ThrowStatement(_)
             | Statement::ContinueStatement(_) => true,
-            Statement::BreakStatement(break_statement) => break_statement.label.is_some(),
+            Statement::BreakStatement(break_statement) => match &break_statement.label {
+                Some(label) => switch_label != Some(label.name.as_str()),
+                None => false,
+            },
             _ => false,
         }
     }
@@ -347,7 +347,13 @@ impl<'a> Scanner<'a> {
     /// A `switch` is "returning" when every non-empty case contains a returning
     /// statement (empty fall-through cases are allowed). Mirrors upstream
     /// `getSwitchViolations`; `never`-typed cases need type information.
-    fn switch_all_cases_return(&self, cases: &[SwitchCase<'a>]) -> bool {
+    /// `switch_label` is the label of the statement directly wrapping the switch,
+    /// if any (used to discount a `break <own-label>`).
+    fn switch_all_cases_return(
+        &self,
+        cases: &[SwitchCase<'a>],
+        switch_label: Option<&str>,
+    ) -> bool {
         for case in cases {
             if case.consequent.is_empty() {
                 continue;
@@ -355,7 +361,7 @@ impl<'a> Scanner<'a> {
             if case
                 .consequent
                 .iter()
-                .any(|stmt| self.is_switch_returning_branch(stmt))
+                .any(|stmt| self.is_switch_returning_branch(stmt, switch_label))
             {
                 continue;
             }
@@ -368,13 +374,40 @@ impl<'a> Scanner<'a> {
                 && block
                     .body
                     .iter()
-                    .any(|stmt| self.is_switch_returning_branch(stmt))
+                    .any(|stmt| self.is_switch_returning_branch(stmt, switch_label))
             {
                 continue;
             }
             return false;
         }
         true
+    }
+
+    /// Report and traverse a `switch`. `switch_label` is the label of the
+    /// statement directly wrapping it, if any.
+    fn scan_switch(
+        &mut self,
+        statement: &'a SwitchStatement<'a>,
+        context: FunctionContext,
+        switch_label: Option<&str>,
+    ) {
+        let allowed = self.options.allow_returning_branches
+            && self.switch_all_cases_return(&statement.cases, switch_label);
+        if !allowed {
+            self.report(
+                "no-conditional-statements",
+                "unexpectedSwitch",
+                "Unexpected switch, use a conditional expression instead.",
+                statement.span,
+            );
+        }
+        self.scan_expression(&statement.discriminant, context);
+        for case in &statement.cases {
+            if let Some(test) = &case.test {
+                self.scan_expression(test, context);
+            }
+            self.scan_statement_list(&case.consequent, context);
+        }
     }
 
     fn scan_for_init(&mut self, init: &'a ForStatementInit<'a>, context: FunctionContext) {

--- a/crates/functional/src/tests.rs
+++ b/crates/functional/src/tests.rs
@@ -609,6 +609,8 @@ fn no_conditional_statements_allow_returning_branches() {
     let switch_fallthrough = "function f(i) { switch (i) { case 1: case 2: return 1; } }";
     let switch_break = "function f(i) { switch (i) { case 1: g(); break; default: return 2; } }";
     let if_break_loop = "for (;;) { if (i) { break; } }";
+    let switch_self_label = "outer: switch (i) { case 1: break outer; }";
+    let switch_outer_label = "outer: for (;;) { switch (i) { case 1: break outer; } }";
 
     // Default: every if/switch is reported.
     assert_eq!(count(if_returns, &base), 1);
@@ -629,4 +631,8 @@ fn no_conditional_statements_allow_returning_branches() {
     assert_eq!(count(switch_fallthrough, &allow), 0);
     assert_eq!(count(switch_break, &allow), 1);
     assert_eq!(count(if_break_loop, &allow), 0);
+    // A `break <label>` targeting the switch's own enclosing label only exits the
+    // switch (reported); one targeting an outer construct is returning (allowed).
+    assert_eq!(count(switch_self_label, &allow), 1);
+    assert_eq!(count(switch_outer_label, &allow), 0);
 }


### PR DESCRIPTION
Final edge case from the confirmation-review gate. Verified against `upstream/eslint-plugin-functional/src/rules/no-conditional-statements.ts` (lines 188 + 224).

Upstream's `isSwitchReturningBranch` counts a `break <label>` as a returning branch only when the label does **not** name the switch's own enclosing `LabeledStatement` (`statement.label.name !== label`). A `break` that targets the switch's own label just exits the switch — equivalent to an unlabeled break — so the case is **not** returning.

The port previously treated *any* labeled break as returning, so `outer: switch (i) { case 1: break outer; }` was wrongly allowed under `allowReturningBranches: true` (false negative).

## Fix
- Thread the enclosing label into switch scanning via a new `scan_switch(statement, context, switch_label)` helper, called with `Some(label)` from the `LabeledStatement` arm when it directly wraps a switch, and `None` otherwise.
- `is_switch_returning_branch` now treats a labeled break as returning only when its label differs from the switch's own enclosing label; a break targeting an **outer** construct still counts as returning.

## Tests
- `outer: switch (i) { case 1: break outer; }` → reported (self-label break).
- `outer: for (;;) { switch (i) { case 1: break outer; } }` → allowed (break escapes to the outer loop).

This was the only residual finding from the final verification; all other checks (no-promise-reject arity, the six if/switch traces, panic/recursion safety) came back correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783985656&installation_id=136613492&pr_number=184&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F184&signature=da782d02d87179aa81b24f7e087c706e8398a6911bd2c05cfece74677737c6d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->