### PR TITLE
port(sonarjs): port prefer-while (S1264)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 25] = [
+pub const RULE_NAMES: [&str; 26] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -48,6 +48,7 @@ pub const RULE_NAMES: [&str; 25] = [
     "elseif-without-else",
     "no-case-label-in-switch",
     "for-in",
+    "prefer-while",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -26,3 +26,4 @@ mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_redundant_boolean;
 mod non_existent_operator;
+mod prefer_while;

--- a/crates/sonarjs/src/rules/prefer_while.rs
+++ b/crates/sonarjs/src/rules/prefer_while.rs
@@ -1,0 +1,35 @@
+//! Rule `prefer-while` (SonarJS key S1264).
+//!
+//! Clean-room port. Reports a `for` statement that has no initializer and no
+//! update clause, because such a loop is semantically equivalent to a `while`
+//! loop and should use `while` for clarity.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! ## Flagged
+//! - `for (; i < 10;) { i++; }` — no init, no update
+//! - `for (;;) {}` — no init, no test, no update (equivalent to `while (true)`)
+//!
+//! ## Not flagged
+//! - `for (let i = 0; i < 10;) {}` — has init
+//! - `for (; i < 10; i++) {}` — has update
+//! - `for (let i = 0; i < 10; i++) {}` — has both init and update
+//! - `while (x) {}` — not a for statement
+
+use oxc_ast::ast::ForStatement;
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "prefer-while";
+
+impl Scanner<'_> {
+    pub(crate) fn check_prefer_while(&mut self, stmt: &ForStatement<'_>) {
+        if stmt.init.is_some() || stmt.update.is_some() {
+            return;
+        }
+        let start = stmt.span.start;
+        self.report(RULE_NAME, "preferWhile", Span::new(start, start + 3));
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,7 +4,7 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, ConditionalExpression,
-    ExpressionStatement, ForInStatement, Function, IdentifierReference, IfStatement,
+    ExpressionStatement, ForInStatement, ForStatement, Function, IdentifierReference, IfStatement,
     LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
     SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
     YieldExpression,
@@ -129,6 +129,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
         self.check_for_in(it);
         walk::walk_for_in_statement(self, it);
+    }
+
+    fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
+        self.check_prefer_while(it);
+        walk::walk_for_statement(self, it);
     }
 
     fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1123,3 +1123,42 @@ fn does_not_report_for_in_when_body_is_directly_an_if_statement() {
     let diagnostics = scan("for-in", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_prefer_while_when_for_has_no_init_and_no_update() {
+    let source = "for (; i < 10;) { i++; }";
+    let diagnostics = scan("prefer-while", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "prefer-while");
+    assert_eq!(diagnostics[0].message_id, "preferWhile");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_prefer_while_when_for_has_no_init_no_test_no_update() {
+    let source = "for (;;) {}";
+    let diagnostics = scan("prefer-while", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "preferWhile");
+}
+
+#[test]
+fn does_not_report_prefer_while_when_for_has_init() {
+    let source = "for (let i = 0; i < 10;) {}";
+    let diagnostics = scan("prefer-while", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_while_when_for_has_update() {
+    let source = "for (; i < 10; i++) {}";
+    let diagnostics = scan("prefer-while", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_while_when_for_has_init_and_update() {
+    let source = "for (let i = 0; i < 10; i++) {}";
+    let diagnostics = scan("prefer-while", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -106,6 +106,10 @@ const messages = Object.freeze({
     forIn:
       "Wrap this 'for...in' loop body in an 'if' statement to filter out inherited properties.",
   },
+  'prefer-while': {
+    preferWhile:
+      "Replace this 'for' loop with a 'while' loop; it has no initializer or update clause.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -151,6 +155,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow labeled statements appearing directly in a switch case's consequent list, where they are likely mistaken 'case' clauses",
   'for-in':
     "Require a 'for...in' loop body to be a single 'if' statement that filters inherited properties (structural check only — the 'if' condition is not inspected)",
+  'prefer-while':
+    "Disallow 'for' loops with no initializer and no update clause; use a 'while' loop instead",
 });
 
 const ruleTypes = Object.freeze({
@@ -179,6 +185,7 @@ const ruleTypes = Object.freeze({
   'elseif-without-else': 'suggestion',
   'no-case-label-in-switch': 'problem',
   'for-in': 'suggestion',
+  'prefer-while': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -207,6 +214,7 @@ const recommendedRuleConfig = Object.freeze({
   'elseif-without-else': 'error',
   'no-case-label-in-switch': 'error',
   'for-in': 'error',
+  'prefer-while': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -28,6 +28,7 @@ const expectedRuleNames = [
   'elseif-without-else',
   'no-case-label-in-switch',
   'for-in',
+  'prefer-while',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -907,6 +908,40 @@ describe('sonarjs native API', () => {
   it('does not report for-in when body is directly an if statement (no block)', () => {
     const source = 'for (const k in o) if (cond) doStuff();';
     const diagnostics = scan('for-in', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports prefer-while when for loop has no init and no update', () => {
+    const source = 'for (; i < 10;) { i++; }';
+    const diagnostics = scan('prefer-while', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('prefer-while');
+    expect(diagnostics[0].messageId).toBe('preferWhile');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('reports prefer-while when for loop has no init, no test, and no update', () => {
+    const source = 'for (;;) {}';
+    const diagnostics = scan('prefer-while', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('preferWhile');
+  });
+
+  it('does not report prefer-while when for loop has an init clause', () => {
+    const source = 'for (let i = 0; i < 10;) {}';
+    const diagnostics = scan('prefer-while', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-while when for loop has an update clause', () => {
+    const source = 'for (; i < 10; i++) {}';
+    const diagnostics = scan('prefer-while', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-while when for loop has both init and update', () => {
+    const source = 'for (let i = 0; i < 10; i++) {}';
+    const diagnostics = scan('prefer-while', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -119,6 +119,7 @@ describe('sonarjs plugin shape', () => {
       'elseif-without-else',
       'no-case-label-in-switch',
       'for-in',
+      'prefer-while',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -145,6 +146,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['elseif-without-else']).toBe('object');
     expect(typeof plugin.rules['no-case-label-in-switch']).toBe('object');
     expect(typeof plugin.rules['for-in']).toBe('object');
+    expect(typeof plugin.rules['prefer-while']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -171,6 +173,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/elseif-without-else']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-case-label-in-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/for-in']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/prefer-while']).toBe('error');
   });
 });
 
@@ -601,5 +604,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(for-in)');
+  });
+
+  it('reports prefer-while through the adapter', () => {
+    const source = 'for (; i < 10;) { i++; }';
+    const reports = runRule('prefer-while', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('preferWhile');
+  });
+
+  it('reports prefer-while through the CLI', () => {
+    const source = 'for (;;) {}';
+    const result = runOxlint('prefer-while', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(prefer-while)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13630,19 +13630,19 @@
       },
       {
         "name": "prefer-while",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule prefer-while (Sonar key S1264). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1264). Reports a ForStatement with no init and no update clause — such a loop should use while instead. Reports the for keyword span. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "process-argv",


### PR DESCRIPTION
## Summary
Clean-room port of **`prefer-while`** (Sonar key S1264). Flags a `for` loop with no initializer and no update clause (`for (; cond;)`, `for (;;)`) — equivalent to a `while` loop and clearer written as one. Reports the `for` keyword. Adds a `visit_for_statement` hook.

## Tests
Rust unit tests (`for (; i<10;)` → 1, `for (;;)` → 1, has init → 0, has update → 0, full `for` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(prefer-while)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783985832&installation_id=136613492&pr_number=185&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F185&signature=e16967c322b4b911ff5cf9b62c3c0794e09aa3e2e450f33ee22737f9a31e39c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->