### PR TITLE
port(sonarjs): port no-small-switch (S1301)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 26] = [
+pub const RULE_NAMES: [&str; 27] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -49,6 +49,7 @@ pub const RULE_NAMES: [&str; 26] = [
     "no-case-label-in-switch",
     "for-in",
     "prefer-while",
+    "no-small-switch",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -25,5 +25,6 @@ mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_redundant_boolean;
+mod no_small_switch;
 mod non_existent_operator;
 mod prefer_while;

--- a/crates/sonarjs/src/rules/no_small_switch.rs
+++ b/crates/sonarjs/src/rules/no_small_switch.rs
@@ -1,0 +1,37 @@
+//! Rule `no-small-switch` (SonarJS key S1301).
+//!
+//! Clean-room port. A `switch` statement with fewer than two real `case`
+//! clauses should be rewritten as an `if` statement because the switch
+//! construct adds syntactic weight with no structural benefit.
+//!
+//! ## Counting
+//!
+//! Only `SwitchCase` entries whose `test` field is `Some(…)` are counted —
+//! that is, real `case X:` clauses. The `default:` clause, whose `test` is
+//! `None`, is deliberately excluded from the count. A `switch` with one `case`
+//! and a `default` is just an if/else, and a `switch` with zero `case` clauses
+//! (only `default`, or empty) is just a block.
+//!
+//! When the real-case count is **strictly less than 2** the `switch` keyword
+//! span is reported.
+//!
+//! Behaviour is reproduced from the public RSPEC S1301 description only; no
+//! upstream source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::SwitchStatement;
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-small-switch";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_small_switch(&mut self, switch: &SwitchStatement<'_>) {
+        let case_count = switch.cases.iter().filter(|c| c.test.is_some()).count();
+        if case_count >= 2 {
+            return;
+        }
+        let start = switch.span.start;
+        self.report(RULE_NAME, "smallSwitch", Span::new(start, start + 6));
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -83,6 +83,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_all_duplicated_branches_switch(it);
         self.check_max_switch_cases(it);
         self.check_no_case_label_in_switch(it);
+        self.check_no_small_switch(it);
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1162,3 +1162,51 @@ fn does_not_report_prefer_while_when_for_has_init_and_update() {
     let diagnostics = scan("prefer-while", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_small_switch_for_switch_with_one_case() {
+    let source = "switch (x) { case 1: break; }";
+    let diagnostics = scan("no-small-switch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-small-switch");
+    assert_eq!(diagnostics[0].message_id, "smallSwitch");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_no_small_switch_for_switch_with_one_case_and_default() {
+    let source = "switch (x) { case 1: break; default: break; }";
+    let diagnostics = scan("no-small-switch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "smallSwitch");
+}
+
+#[test]
+fn reports_no_small_switch_for_switch_with_only_default() {
+    let source = "switch (x) { default: break; }";
+    let diagnostics = scan("no-small-switch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "smallSwitch");
+}
+
+#[test]
+fn reports_no_small_switch_for_empty_switch() {
+    let source = "switch (x) {}";
+    let diagnostics = scan("no-small-switch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "smallSwitch");
+}
+
+#[test]
+fn does_not_report_no_small_switch_for_switch_with_two_cases() {
+    let source = "switch (x) { case 1: break; case 2: break; }";
+    let diagnostics = scan("no-small-switch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_small_switch_for_switch_with_two_cases_and_default() {
+    let source = "switch (x) { case 1: break; case 2: break; default: break; }";
+    let diagnostics = scan("no-small-switch", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -110,6 +110,9 @@ const messages = Object.freeze({
     preferWhile:
       "Replace this 'for' loop with a 'while' loop; it has no initializer or update clause.",
   },
+  'no-small-switch': {
+    smallSwitch: "This switch has too few cases; use an 'if' statement instead.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -157,6 +160,8 @@ const ruleDescriptions = Object.freeze({
     "Require a 'for...in' loop body to be a single 'if' statement that filters inherited properties (structural check only — the 'if' condition is not inspected)",
   'prefer-while':
     "Disallow 'for' loops with no initializer and no update clause; use a 'while' loop instead",
+  'no-small-switch':
+    "Disallow switch statements with fewer than two real 'case' clauses; use an 'if' statement instead (default clause not counted)",
 });
 
 const ruleTypes = Object.freeze({
@@ -186,6 +191,7 @@ const ruleTypes = Object.freeze({
   'no-case-label-in-switch': 'problem',
   'for-in': 'suggestion',
   'prefer-while': 'suggestion',
+  'no-small-switch': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -215,6 +221,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-case-label-in-switch': 'error',
   'for-in': 'error',
   'prefer-while': 'error',
+  'no-small-switch': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -29,6 +29,7 @@ const expectedRuleNames = [
   'no-case-label-in-switch',
   'for-in',
   'prefer-while',
+  'no-small-switch',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -942,6 +943,48 @@ describe('sonarjs native API', () => {
   it('does not report prefer-while when for loop has both init and update', () => {
     const source = 'for (let i = 0; i < 10; i++) {}';
     const diagnostics = scan('prefer-while', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-small-switch for a switch with one case clause', () => {
+    const source = 'switch (x) { case 1: break; }';
+    const diagnostics = scan('no-small-switch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-small-switch');
+    expect(diagnostics[0].messageId).toBe('smallSwitch');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('reports no-small-switch for a switch with one case and a default', () => {
+    const source = 'switch (x) { case 1: break; default: break; }';
+    const diagnostics = scan('no-small-switch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('smallSwitch');
+  });
+
+  it('reports no-small-switch for a switch with only a default clause', () => {
+    const source = 'switch (x) { default: break; }';
+    const diagnostics = scan('no-small-switch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('smallSwitch');
+  });
+
+  it('reports no-small-switch for an empty switch', () => {
+    const source = 'switch (x) {}';
+    const diagnostics = scan('no-small-switch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('smallSwitch');
+  });
+
+  it('does not report no-small-switch for a switch with two case clauses', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; }';
+    const diagnostics = scan('no-small-switch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-small-switch for a switch with two cases and a default', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; default: break; }';
+    const diagnostics = scan('no-small-switch', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -120,6 +120,7 @@ describe('sonarjs plugin shape', () => {
       'no-case-label-in-switch',
       'for-in',
       'prefer-while',
+      'no-small-switch',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -147,6 +148,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-case-label-in-switch']).toBe('object');
     expect(typeof plugin.rules['for-in']).toBe('object');
     expect(typeof plugin.rules['prefer-while']).toBe('object');
+    expect(typeof plugin.rules['no-small-switch']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -174,6 +176,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-case-label-in-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/for-in']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-while']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-small-switch']).toBe('error');
   });
 });
 
@@ -621,5 +624,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(prefer-while)');
+  });
+
+  it('reports no-small-switch for a switch with one case through the adapter', () => {
+    const source = 'switch (x) { case 1: break; }';
+    const reports = runRule('no-small-switch', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('smallSwitch');
+  });
+
+  it('reports no-small-switch through the CLI', () => {
+    const source = 'switch (x) { case 1: break; }';
+    const result = runOxlint('no-small-switch', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-small-switch)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13006,19 +13006,19 @@
       },
       {
         "name": "no-small-switch",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-small-switch (Sonar key S1301). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (S1301). Counts SwitchCase entries with test.is_some() only; default clause (test is None) is excluded from the count. Reports the switch keyword span when real-case count < 2. No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "no-sonar-comments",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-small-switch`** (Sonar key S1301). Flags a `switch` with fewer than two non-`default` `case` clauses — such a switch should be an `if` statement. The `default` clause is not counted (documented clean-room choice: a single `case` plus `default` is just if/else). Reports the `switch` keyword. Adds a fifth check to the existing `visit_switch_statement` hook.

## Tests
Rust unit tests (1 case → 1, 1 case + default → 1, only default → 1, 2 cases → 0, 2 cases + default → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-small-switch)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783986395&installation_id=136613492&pr_number=186&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F186&signature=1f0e8a06206d7014aac3ce6d9212b736e01a5fd351c982fc7981a708b445339f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->