### PR TITLE
port(sonarjs): port prefer-default-last (S4524)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 27] = [
+pub const RULE_NAMES: [&str; 28] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -50,6 +50,7 @@ pub const RULE_NAMES: [&str; 27] = [
     "for-in",
     "prefer-while",
     "no-small-switch",
+    "prefer-default-last",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -27,4 +27,5 @@ mod no_nested_template_literals;
 mod no_redundant_boolean;
 mod no_small_switch;
 mod non_existent_operator;
+mod prefer_default_last;
 mod prefer_while;

--- a/crates/sonarjs/src/rules/prefer_default_last.rs
+++ b/crates/sonarjs/src/rules/prefer_default_last.rs
@@ -1,0 +1,55 @@
+//! Rule `prefer-default-last` (SonarJS key S4524).
+//!
+//! Clean-room port. The `default` clause of a `switch` statement should appear
+//! as the last clause, because placing it anywhere else makes the structure
+//! harder to read and understand.
+//!
+//! ## Detection
+//!
+//! If the `switch` has no `default` clause the rule is silent. When a `default`
+//! clause is found (`SwitchCase.test` is `None`) and its position is not the
+//! last element of `switch.cases`, the `default` keyword span (7 bytes) is
+//! reported.
+//!
+//! Behaviour is reproduced from the public RSPEC S4524 description only; no
+//! upstream source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! ## Flagged form
+//!
+//! ```js
+//! switch (x) {
+//!   default: break;   // default is not last — flagged
+//!   case 1: break;
+//! }
+//! ```
+//!
+//! ## Allowed form
+//!
+//! ```js
+//! switch (x) {
+//!   case 1: break;
+//!   default: break;   // default is last — OK
+//! }
+//! ```
+
+use oxc_ast::ast::SwitchStatement;
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "prefer-default-last";
+
+impl Scanner<'_> {
+    pub(crate) fn check_prefer_default_last(&mut self, switch: &SwitchStatement<'_>) {
+        let Some((pos, default_case)) =
+            switch.cases.iter().enumerate().find(|(_, c)| c.test.is_none())
+        else {
+            return;
+        };
+        if pos + 1 == switch.cases.len() {
+            return;
+        }
+        let start = default_case.span.start;
+        self.report(RULE_NAME, "defaultLast", Span::new(start, start + 7));
+    }
+}

--- a/crates/sonarjs/src/rules/prefer_default_last.rs
+++ b/crates/sonarjs/src/rules/prefer_default_last.rs
@@ -41,8 +41,11 @@ pub(crate) const RULE_NAME: &str = "prefer-default-last";
 
 impl Scanner<'_> {
     pub(crate) fn check_prefer_default_last(&mut self, switch: &SwitchStatement<'_>) {
-        let Some((pos, default_case)) =
-            switch.cases.iter().enumerate().find(|(_, c)| c.test.is_none())
+        let Some((pos, default_case)) = switch
+            .cases
+            .iter()
+            .enumerate()
+            .find(|(_, c)| c.test.is_none())
         else {
             return;
         };

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -84,6 +84,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_max_switch_cases(it);
         self.check_no_case_label_in_switch(it);
         self.check_no_small_switch(it);
+        self.check_prefer_default_last(it);
         self.switch_depth += 1;
         walk::walk_switch_statement(self, it);
         self.switch_depth -= 1;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1210,3 +1210,35 @@ fn does_not_report_no_small_switch_for_switch_with_two_cases_and_default() {
     let diagnostics = scan("no-small-switch", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_prefer_default_last_when_default_is_first() {
+    let source = "switch (x) { default: break; case 1: break; }";
+    let diagnostics = scan("prefer-default-last", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "prefer-default-last");
+    assert_eq!(diagnostics[0].message_id, "defaultLast");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_prefer_default_last_when_default_is_in_the_middle() {
+    let source = "switch (x) { case 1: break; default: break; case 2: break; }";
+    let diagnostics = scan("prefer-default-last", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "defaultLast");
+}
+
+#[test]
+fn does_not_report_prefer_default_last_when_default_is_last() {
+    let source = "switch (x) { case 1: break; default: break; }";
+    let diagnostics = scan("prefer-default-last", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_default_last_when_there_is_no_default() {
+    let source = "switch (x) { case 1: break; case 2: break; }";
+    let diagnostics = scan("prefer-default-last", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -113,6 +113,9 @@ const messages = Object.freeze({
   'no-small-switch': {
     smallSwitch: "This switch has too few cases; use an 'if' statement instead.",
   },
+  'prefer-default-last': {
+    defaultLast: "Move this 'default' clause to the end of the switch statement.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -162,6 +165,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow 'for' loops with no initializer and no update clause; use a 'while' loop instead",
   'no-small-switch':
     "Disallow switch statements with fewer than two real 'case' clauses; use an 'if' statement instead (default clause not counted)",
+  'prefer-default-last':
+    "Require the 'default' clause of a switch statement to appear as the last clause for readability",
 });
 
 const ruleTypes = Object.freeze({
@@ -192,6 +197,7 @@ const ruleTypes = Object.freeze({
   'for-in': 'suggestion',
   'prefer-while': 'suggestion',
   'no-small-switch': 'suggestion',
+  'prefer-default-last': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -222,6 +228,7 @@ const recommendedRuleConfig = Object.freeze({
   'for-in': 'error',
   'prefer-while': 'error',
   'no-small-switch': 'error',
+  'prefer-default-last': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -30,6 +30,7 @@ const expectedRuleNames = [
   'for-in',
   'prefer-while',
   'no-small-switch',
+  'prefer-default-last',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -985,6 +986,34 @@ describe('sonarjs native API', () => {
   it('does not report no-small-switch for a switch with two cases and a default', () => {
     const source = 'switch (x) { case 1: break; case 2: break; default: break; }';
     const diagnostics = scan('no-small-switch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports prefer-default-last when default is the first clause', () => {
+    const source = 'switch (x) { default: break; case 1: break; }';
+    const diagnostics = scan('prefer-default-last', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('prefer-default-last');
+    expect(diagnostics[0].messageId).toBe('defaultLast');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+  });
+
+  it('reports prefer-default-last when default is in the middle', () => {
+    const source = 'switch (x) { case 1: break; default: break; case 2: break; }';
+    const diagnostics = scan('prefer-default-last', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('defaultLast');
+  });
+
+  it('does not report prefer-default-last when default is the last clause', () => {
+    const source = 'switch (x) { case 1: break; default: break; }';
+    const diagnostics = scan('prefer-default-last', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-default-last when there is no default clause', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; }';
+    const diagnostics = scan('prefer-default-last', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -121,6 +121,7 @@ describe('sonarjs plugin shape', () => {
       'for-in',
       'prefer-while',
       'no-small-switch',
+      'prefer-default-last',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -149,6 +150,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['for-in']).toBe('object');
     expect(typeof plugin.rules['prefer-while']).toBe('object');
     expect(typeof plugin.rules['no-small-switch']).toBe('object');
+    expect(typeof plugin.rules['prefer-default-last']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -177,6 +179,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/for-in']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-while']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-small-switch']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/prefer-default-last']).toBe('error');
   });
 });
 
@@ -641,5 +644,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-small-switch)');
+  });
+
+  it('reports prefer-default-last when default is not the last clause through the adapter', () => {
+    const source = 'switch (x) { default: break; case 1: break; }';
+    const reports = runRule('prefer-default-last', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('defaultLast');
+  });
+
+  it('reports prefer-default-last through the CLI', () => {
+    const source = 'switch (x) { default: break; case 1: break; }';
+    const result = runOxlint('prefer-default-last', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(prefer-default-last)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13502,19 +13502,19 @@
       },
       {
         "name": "prefer-default-last",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule prefer-default-last (Sonar key S4524). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S4524. Reports a switch whose default clause is not the last case. Detection uses SwitchCase.test.is_none() to find the default clause and checks its position against cases.len(). Message and tests independently authored; no upstream source, fixtures, or messages consulted."
       },
       {
         "name": "prefer-immediate-return",


### PR DESCRIPTION
## Summary
Clean-room port of **`prefer-default-last`** (Sonar key S4524). Flags a `switch` whose `default` clause is not the last case. Reports the `default` keyword. Adds a sixth check to the existing `visit_switch_statement` hook.

## Tests
Rust unit tests (default first → 1, default in middle → 1, default last → 0, no default → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(prefer-default-last)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783986904&installation_id=136613492&pr_number=188&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F188&signature=1170610170f705ef4634c1f622647c63b4881797255c3410807af06ed72072fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->