### PR TITLE
port(regexp): port no-potentially-useless-backreference (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -760,6 +760,19 @@ impl<'a> Scanner<'a> {
         let mut analysis = PatternAnalysis::new();
         analysis.scan(pattern, flags.contains('v'));
 
+        // `no-potentially-useless-backreference` (narrow form): only flag the
+        // syntactically clear case where group N is directly followed by `?`
+        // or `*` (so the group may not have matched at the point of the
+        // backref). Alternative-branch cases require reachability analysis and
+        // are deferred.
+        if analysis.has_potentially_useless_backreference {
+            self.report(
+                "no-potentially-useless-backreference",
+                "potentiallyUselessBackreference",
+                span,
+            );
+        }
+
         // `no-useless-flag` (narrow form): the `s` flag only affects the
         // matching of `.`; the `m` flag only affects `^` and `$`. If neither
         // syntax appears in the pattern, the flag is provably inert. Other

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -24,7 +24,7 @@ use crate::usage::collect_whole_pattern_regex_spans;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 67] = [
+pub const RULE_NAMES: [&str; 68] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -92,6 +92,7 @@ pub const RULE_NAMES: [&str; 67] = [
     "no-useless-lazy",
     "no-misleading-unicode-character",
     "no-standalone-backslash",
+    "no-potentially-useless-backreference",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -17,6 +17,8 @@ use crate::helpers::{
 pub(crate) struct GroupState {
     pub(crate) check_empty: bool,
     pub(crate) capturing: bool,
+    /// 1-based capture group number (0 for non-capturing groups).
+    pub(crate) capture_number: u32,
     pub(crate) is_lookaround: bool,
     pub(crate) is_non_capturing: bool,
     /// Byte offset of the body start (after the prefix). Used by
@@ -62,6 +64,7 @@ impl GroupState {
         Self {
             check_empty: false,
             capturing: false,
+            capture_number: 0,
             is_lookaround: false,
             is_non_capturing: false,
             body_start: 0,
@@ -80,6 +83,7 @@ impl GroupState {
     fn group(
         check_empty: bool,
         capturing: bool,
+        capture_number: u32,
         is_lookaround: bool,
         is_non_capturing: bool,
         body_start: usize,
@@ -87,6 +91,7 @@ impl GroupState {
         Self {
             check_empty,
             capturing,
+            capture_number,
             is_lookaround,
             is_non_capturing,
             body_start,
@@ -232,6 +237,16 @@ pub(crate) struct PatternAnalysis {
     /// breaks the grapheme semantics of any ZWJ-joined sequence it might
     /// have been intended to match. `no-misleading-unicode-character`.
     pub(crate) has_misleading_unicode_character: bool,
+    /// Bitmask of capturing-group indices (1-based, bits 1..=31) whose closing
+    /// `)` is immediately followed by `?` or `*` — meaning the group's capture
+    /// may be absent at match time. Used by `no-potentially-useless-backreference`
+    /// to detect `\N` that references such an optionally-quantified group.
+    pub(crate) optionally_quantified_groups: u32,
+    /// `true` when a backreference `\N` targets a capturing group that was
+    /// preceded by `?` or `*` (so the group may not have matched). Only the
+    /// clear syntactic case is flagged; alternative branches are deferred.
+    /// `no-potentially-useless-backreference`.
+    pub(crate) has_potentially_useless_backreference: bool,
 }
 
 impl PatternAnalysis {
@@ -260,6 +275,17 @@ impl PatternAnalysis {
                         let n = u32::from(next - b'0');
                         if n > self.capture_count {
                             self.has_useless_backreference = true;
+                        }
+                        // `no-potentially-useless-backreference`: flag \N when
+                        // group N (already opened, so n <= capture_count) is
+                        // directly followed by `?` or `*` in the pattern. Only
+                        // the first 31 groups are tracked (bitmask width).
+                        if n >= 1
+                            && n <= self.capture_count
+                            && n <= 31
+                            && self.optionally_quantified_groups & (1 << n) != 0
+                        {
+                            self.has_potentially_useless_backreference = true;
                         }
                     }
                     self.mark_content(&mut groups);
@@ -365,9 +391,15 @@ impl PatternAnalysis {
                     if prefix.capturing {
                         self.capture_count = self.capture_count.saturating_add(1);
                     }
+                    let capture_number = if prefix.capturing {
+                        self.capture_count
+                    } else {
+                        0
+                    };
                     groups.push(GroupState::group(
                         prefix.check_empty,
                         prefix.capturing,
+                        capture_number,
                         prefix.is_lookaround,
                         prefix.is_non_capturing,
                         prefix.next,
@@ -389,6 +421,17 @@ impl PatternAnalysis {
                         }
                         if group.is_lookaround && !group.seen_pipe && !group.current_has_content {
                             self.has_empty_lookaround = true;
+                        }
+                        // `no-potentially-useless-backreference`: record which
+                        // capturing groups are directly followed by `?` or `*`.
+                        // Only track groups 1..=31 (bitmask width). The check
+                        // uses index+1 because `index` currently points at `)`.
+                        if group.capturing
+                            && group.capture_number >= 1
+                            && group.capture_number <= 31
+                            && matches!(bytes.get(index + 1).copied(), Some(b'?') | Some(b'*'))
+                        {
+                            self.optionally_quantified_groups |= 1 << group.capture_number;
                         }
                         // `(?=...)?` and friends: a `?` immediately after the
                         // closing paren of a lookaround makes the assertion

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -108,8 +108,61 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-lazy",
             "no-misleading-unicode-character",
             "no-standalone-backslash",
+            "no-potentially-useless-backreference",
         ]
     );
+}
+
+mod no_potentially_useless_backreference {
+    use super::*;
+
+    #[test]
+    fn reports_backreference_to_optional_group() {
+        assert_eq!(
+            rule_ids_for(
+                "const a = /(a)?\\1/;",
+                "no-potentially-useless-backreference"
+            )
+            .as_slice(),
+            &["potentiallyUselessBackreference"]
+        );
+        assert_eq!(
+            rule_ids_for(
+                "const a = /(a)*\\1/;",
+                "no-potentially-useless-backreference"
+            )
+            .as_slice(),
+            &["potentiallyUselessBackreference"]
+        );
+    }
+
+    #[test]
+    fn ignores_valid_backreferences() {
+        assert!(
+            rule_ids_for("const a = /()\\1/;", "no-potentially-useless-backreference").is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "const a = /(a)+\\1/;",
+                "no-potentially-useless-backreference"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "const a = /(a+)b|\\1/;",
+                "no-potentially-useless-backreference"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "const a = /(?=(a))\\1/;",
+                "no-potentially-useless-backreference"
+            )
+            .is_empty()
+        );
+    }
 }
 
 mod no_standalone_backslash {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -255,6 +255,10 @@ const messages = Object.freeze({
     unexpected:
       "Unexpected standalone backslash (`\\`). It looks like an escape sequence, but it's a single `\\` character pattern.",
   },
+  'no-potentially-useless-backreference': {
+    potentiallyUselessBackreference:
+      'Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -358,6 +362,8 @@ const ruleDescriptions = Object.freeze({
   'no-misleading-unicode-character':
     'disallow character classes that contain a ZWJ (U+200D) and match it as a separate atom',
   'no-standalone-backslash': 'disallow standalone backslashes (`\\`)',
+  'no-potentially-useless-backreference':
+    'disallow backreferences to capturing groups that might not have matched (narrow: optional/star-quantified groups)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -427,6 +433,7 @@ const ruleTypes = Object.freeze({
   'no-useless-lazy': 'suggestion',
   'no-misleading-unicode-character': 'problem',
   'no-standalone-backslash': 'suggestion',
+  'no-potentially-useless-backreference': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -445,6 +452,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-legacy-features': 'error',
   'no-non-standard-flag': 'error',
   'no-invisible-character': 'error',
+  'no-potentially-useless-backreference': 'warn',
 });
 
 const implementedRuleNames = Object.freeze(implementedRegexpRuleNames());
@@ -599,7 +607,8 @@ function ruleCategory(ruleName) {
     ruleName === 'optimal-lookaround-quantifier' ||
     ruleName === 'no-dupe-disjunctions' ||
     ruleName === 'no-useless-backreference' ||
-    ruleName === 'no-misleading-unicode-character'
+    ruleName === 'no-misleading-unicode-character' ||
+    ruleName === 'no-potentially-useless-backreference'
   ) {
     return 'Possible Errors';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -72,6 +72,7 @@ describe('regexp native API', () => {
       'no-useless-lazy',
       'no-misleading-unicode-character',
       'no-standalone-backslash',
+      'no-potentially-useless-backreference',
     ]);
   });
 

--- a/npm/regexp/test/fixtures/no-potentially-useless-backreference.json
+++ b/npm/regexp/test/fixtures/no-potentially-useless-backreference.json
@@ -1,0 +1,116 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-regexp",
+    "version": "3.1.0",
+    "sourceFile": "tests/lib/rules/no-potentially-useless-backreference.ts",
+    "snapshotFile": "tests/lib/rules/__snapshots__/no-potentially-useless-backreference.ts.eslintsnap",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-regexp-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "/()\\1/"
+    },
+    {
+      "code": "/(a*)(?:a|\\1)/"
+    },
+    {
+      "code": "/(a)+\\1/"
+    },
+    {
+      "code": "/(?=(a))\\1/"
+    },
+    {
+      "code": "/([\\q{a}])\\1/v"
+    },
+    {
+      "code": "/(a+)b|\\1/"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n            var foo = /(a+)b\\1/;\n\n            var foo = /(a)?b\\1/;\n            var foo = /((a)|c)+b\\2/;",
+      "errorCount": 2,
+      "errors": [
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 4,
+          "column": 29,
+          "endColumn": 31
+        },
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 5,
+          "column": 33,
+          "endColumn": 35
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/(a)?\\1/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 1,
+          "column": 6,
+          "endColumn": 8
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/(a)*\\1/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 1,
+          "column": 6,
+          "endColumn": 8
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/(?:(a)|b)\\1/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 1,
+          "column": 11,
+          "endColumn": 13
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/(?:(a)|b)+\\1/",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 1,
+          "column": 12,
+          "endColumn": 14
+        }
+      ],
+      "output": null
+    },
+    {
+      "code": "/(?:([\\q{a}])|b)\\1/v",
+      "errorCount": 1,
+      "errors": [
+        {
+          "message": "Some paths leading to the backreference do not go through the referenced capturing group or the captured text might be reset before reaching the backreference.",
+          "line": 1,
+          "column": 17,
+          "endColumn": 19
+        }
+      ],
+      "output": null
+    }
+  ]
+}

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -187,6 +187,9 @@ const validCases = [
     'v-mode valid control escapes',
     'const re = /[[\\cA-\\cZ]--\\cX]/v;\n',
   ],
+  // no-potentially-useless-backreference
+  ['no-potentially-useless-backreference', 'group without quantifier', 'const re = /()\\1/;\n'],
+  ['no-potentially-useless-backreference', 'group with plus quantifier', 'const re = /(a)+\\1/;\n'],
 ];
 
 const invalidCases = [
@@ -504,6 +507,19 @@ const invalidCases = [
   ['no-standalone-backslash', '\\c at end of pattern', 'const re = /\\c/;\n', ['unexpected']],
   ['no-standalone-backslash', '\\c followed by digit', 'const re = /\\c1/;\n', ['unexpected']],
   ['no-standalone-backslash', '\\c inside class', 'const re = /[\\c]/;\n', ['unexpected']],
+  // no-potentially-useless-backreference
+  [
+    'no-potentially-useless-backreference',
+    'group with ? quantifier',
+    'const re = /(a)?\\1/;\n',
+    ['potentiallyUselessBackreference'],
+  ],
+  [
+    'no-potentially-useless-backreference',
+    'group with * quantifier',
+    'const re = /(a)*\\1/;\n',
+    ['potentiallyUselessBackreference'],
+  ],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/status.json
+++ b/status.json
@@ -8955,7 +8955,7 @@
       },
       {
         "name": "no-potentially-useless-backreference",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,


### PR DESCRIPTION
## Summary

- Adds the `no-potentially-useless-backreference` rule (narrow form) to the regexp Oxlint plugin
- Detects backreferences `\N` where capturing group N is directly followed by `?` or `*`, meaning the group may not have matched at the point the backreference is evaluated
- Implementation tracks optionally-quantified groups (up to 31 groups) as a bitmask in `PatternAnalysis.optionally_quantified_groups`, set in the `)` handler when the closing paren is followed by `?` or `*`
- The `\\` handler checks `\N` against the bitmask and sets `has_potentially_useless_backreference` when a match is found
- `GroupState` gains a `capture_number: u32` field (0 for non-capturing) to allow the `)` handler to know which group just closed
- Alternative-branch reachability cases (e.g. `(?:(a)|b)\1`) are deferred — only the syntactically unambiguous direct-quantifier case is flagged
- All 6 upstream `valid[]` cases emit zero diagnostics; 2 of the 6 upstream `invalid[]` cases are caught

## Test plan

- [ ] `cargo test -p oxlint-plugins-regexp` — 189 tests pass (2 new)
- [ ] `cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings` — clean
- [ ] `vitest run npm/regexp/test/api.test.mjs npm/regexp/test/plugin.test.mjs` — 225 tests pass
- [ ] All upstream `valid[]` cases fire zero diagnostics
- [ ] `no-potentially-useless-backreference.json` fixture generated from upstream test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783987213&installation_id=136613492&pr_number=189&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F189&signature=375a29bf1d2b5d9e71dcb02dae6814e369ca576dae9d3822c21e0be23e7fcb16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->