### PR TITLE
port(sonarjs): port no-inverted-boolean-check (S1940)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 28] = [
+pub const RULE_NAMES: [&str; 29] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -51,6 +51,7 @@ pub const RULE_NAMES: [&str; 28] = [
     "prefer-while",
     "no-small-switch",
     "prefer-default-last",
+    "no-inverted-boolean-check",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -20,6 +20,7 @@ mod no_empty_character_class;
 mod no_exclusive_tests;
 mod no_identical_conditions;
 mod no_identical_expressions;
+mod no_inverted_boolean_check;
 mod no_labels;
 mod no_nested_conditional;
 mod no_nested_switch;

--- a/crates/sonarjs/src/rules/no_inverted_boolean_check.rs
+++ b/crates/sonarjs/src/rules/no_inverted_boolean_check.rs
@@ -1,0 +1,60 @@
+//! Rule `no-inverted-boolean-check` (SonarJS key S1940).
+//!
+//! Clean-room port. Reports a logical-NOT applied directly to a comparison
+//! expression. Negating a comparison makes the intent harder to read; the
+//! opposite comparison operator should be used instead. For example,
+//! `!(a === b)` is clearer as `a !== b`, and `!(a < b)` is clearer as `a >= b`.
+//!
+//! ## Covered comparison operators
+//!
+//! The following `BinaryExpression` operators are flagged when negated:
+//! - Equality: `==` (`Equality`), `===` (`StrictEquality`)
+//! - Inequality: `!=` (`Inequality`), `!==` (`StrictInequality`)
+//! - Ordering: `<` (`LessThan`), `<=` (`LessEqualThan`), `>` (`GreaterThan`),
+//!   `>=` (`GreaterEqualThan`)
+//!
+//! ## Explicitly excluded
+//!
+//! - Logical operators `&&` and `||` — these produce a `LogicalExpression`
+//!   (not a `BinaryExpression`) and are therefore naturally excluded.
+//! - Arithmetic binary operators such as `+`, `-`, `*`, `/` — these are
+//!   `BinaryExpression` nodes but their operators do not appear in the targeted
+//!   set, so they are filtered out by the `matches!` guard.
+//! - Plain negation of a non-comparison: `!a`, `!foo()` — the argument is not
+//!   a `BinaryExpression` at all, so the early-return fires.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Expression, UnaryExpression};
+use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-inverted-boolean-check";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_inverted_boolean_check(&mut self, expr: &UnaryExpression<'_>) {
+        if expr.operator != UnaryOperator::LogicalNot {
+            return;
+        }
+        let Expression::BinaryExpression(binary) = expr.argument.get_inner_expression() else {
+            return;
+        };
+        let is_comparison = matches!(
+            binary.operator,
+            BinaryOperator::Equality
+                | BinaryOperator::StrictEquality
+                | BinaryOperator::Inequality
+                | BinaryOperator::StrictInequality
+                | BinaryOperator::LessThan
+                | BinaryOperator::LessEqualThan
+                | BinaryOperator::GreaterThan
+                | BinaryOperator::GreaterEqualThan
+        );
+        if !is_comparison {
+            return;
+        }
+        self.report(RULE_NAME, "invertedBooleanCheck", expr.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -109,6 +109,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
         self.check_no_redundant_boolean_unary(it);
         self.check_no_delete_var(it);
+        self.check_no_inverted_boolean_check(it);
         walk::walk_unary_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1242,3 +1242,58 @@ fn does_not_report_prefer_default_last_when_there_is_no_default() {
     let diagnostics = scan("prefer-default-last", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_inverted_boolean_check_for_negated_strict_equality() {
+    let source = "const r = !(a === b);";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-inverted-boolean-check");
+    assert_eq!(diagnostics[0].message_id, "invertedBooleanCheck");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_inverted_boolean_check_for_negated_less_than() {
+    let source = "const r = !(a < b);";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "invertedBooleanCheck");
+}
+
+#[test]
+fn reports_inverted_boolean_check_for_negated_strict_inequality() {
+    let source = "const r = !(x !== y);";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "invertedBooleanCheck");
+}
+
+#[test]
+fn reports_inverted_boolean_check_for_negated_greater_equal() {
+    let source = "const r = !(a >= b);";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "invertedBooleanCheck");
+}
+
+#[test]
+fn does_not_report_inverted_boolean_check_for_negated_logical_and() {
+    let source = "const r = !(a && b);";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_inverted_boolean_check_for_plain_negation() {
+    let source = "const r = !a;";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_inverted_boolean_check_for_negated_arithmetic() {
+    let source = "const r = !(a + b);";
+    let diagnostics = scan("no-inverted-boolean-check", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -116,6 +116,10 @@ const messages = Object.freeze({
   'prefer-default-last': {
     defaultLast: "Move this 'default' clause to the end of the switch statement.",
   },
+  'no-inverted-boolean-check': {
+    invertedBooleanCheck:
+      'Use the opposite comparison operator instead of negating this comparison.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -167,6 +171,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow switch statements with fewer than two real 'case' clauses; use an 'if' statement instead (default clause not counted)",
   'prefer-default-last':
     "Require the 'default' clause of a switch statement to appear as the last clause for readability",
+  'no-inverted-boolean-check':
+    'Disallow negating a comparison expression; use the opposite comparison operator instead',
 });
 
 const ruleTypes = Object.freeze({
@@ -198,6 +204,7 @@ const ruleTypes = Object.freeze({
   'prefer-while': 'suggestion',
   'no-small-switch': 'suggestion',
   'prefer-default-last': 'suggestion',
+  'no-inverted-boolean-check': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -229,6 +236,7 @@ const recommendedRuleConfig = Object.freeze({
   'prefer-while': 'error',
   'no-small-switch': 'error',
   'prefer-default-last': 'error',
+  'no-inverted-boolean-check': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -31,6 +31,7 @@ const expectedRuleNames = [
   'prefer-while',
   'no-small-switch',
   'prefer-default-last',
+  'no-inverted-boolean-check',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1014,6 +1015,46 @@ describe('sonarjs native API', () => {
   it('does not report prefer-default-last when there is no default clause', () => {
     const source = 'switch (x) { case 1: break; case 2: break; }';
     const diagnostics = scan('prefer-default-last', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-inverted-boolean-check for !(a === b)', () => {
+    const source = 'const r = !(a === b);';
+    const diagnostics = scan('no-inverted-boolean-check', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-inverted-boolean-check');
+    expect(diagnostics[0].messageId).toBe('invertedBooleanCheck');
+  });
+
+  it('reports no-inverted-boolean-check for !(a < b)', () => {
+    const source = 'const r = !(a < b);';
+    const diagnostics = scan('no-inverted-boolean-check', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('invertedBooleanCheck');
+  });
+
+  it('reports no-inverted-boolean-check for !(x !== y)', () => {
+    const source = 'const r = !(x !== y);';
+    const diagnostics = scan('no-inverted-boolean-check', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('invertedBooleanCheck');
+  });
+
+  it('does not report no-inverted-boolean-check for !(a && b) (logical, not comparison)', () => {
+    const source = 'const r = !(a && b);';
+    const diagnostics = scan('no-inverted-boolean-check', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-inverted-boolean-check for !a (no comparison)', () => {
+    const source = 'const r = !a;';
+    const diagnostics = scan('no-inverted-boolean-check', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-inverted-boolean-check for !(a + b) (arithmetic, not comparison)', () => {
+    const source = 'const r = !(a + b);';
+    const diagnostics = scan('no-inverted-boolean-check', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -122,6 +122,7 @@ describe('sonarjs plugin shape', () => {
       'prefer-while',
       'no-small-switch',
       'prefer-default-last',
+      'no-inverted-boolean-check',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -151,6 +152,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['prefer-while']).toBe('object');
     expect(typeof plugin.rules['no-small-switch']).toBe('object');
     expect(typeof plugin.rules['prefer-default-last']).toBe('object');
+    expect(typeof plugin.rules['no-inverted-boolean-check']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -180,6 +182,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/prefer-while']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-small-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-default-last']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-inverted-boolean-check']).toBe('error');
   });
 });
 
@@ -661,5 +664,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(prefer-default-last)');
+  });
+
+  it('reports no-inverted-boolean-check for !(a === b) through the adapter', () => {
+    const source = 'const r = !(a === b);';
+    const reports = runRule('no-inverted-boolean-check', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('invertedBooleanCheck');
+  });
+
+  it('reports no-inverted-boolean-check through the CLI', () => {
+    const source = 'const r = !(a === b);';
+    const result = runOxlint('no-inverted-boolean-check', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-inverted-boolean-check)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12494,19 +12494,19 @@
       },
       {
         "name": "no-inverted-boolean-check",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-inverted-boolean-check (Sonar key S1940). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S1940. Reports a logical-NOT applied directly to a comparison BinaryExpression (==, ===, !=, !==, <, <=, >, >=). Logical operators && and || are LogicalExpression nodes and are naturally excluded. No upstream source, tests, fixtures, or messages were consulted."
       },
       {
         "name": "no-ip-forward",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-inverted-boolean-check`** (Sonar key S1940). Flags a logical-NOT applied to a comparison (`!(a === b)`), which reads more clearly with the opposite operator (`a !== b`). Covers `==`/`===`/`!=`/`!==`/`<`/`<=`/`>`/`>=`. `&&`/`||` are `LogicalExpression` (not `BinaryExpression`) so they're naturally excluded. Reuses the existing `visit_unary_expression` hook.

## Tests
Rust unit tests (negated `===`, `<`, `!==` → 1; `&&`, plain `!`, `+` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-inverted-boolean-check)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783987685&installation_id=136613492&pr_number=190&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F190&signature=fe5ee4a9617c3792a4219f4a31a435c087bb47314322a6e6939a142e5797be76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->