### PR TITLE
port(sonarjs): port no-useless-catch (S2737)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 29] = [
+pub const RULE_NAMES: [&str; 30] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -52,6 +52,7 @@ pub const RULE_NAMES: [&str; 29] = [
     "no-small-switch",
     "prefer-default-last",
     "no-inverted-boolean-check",
+    "no-useless-catch",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -27,6 +27,7 @@ mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_redundant_boolean;
 mod no_small_switch;
+mod no_useless_catch;
 mod non_existent_operator;
 mod prefer_default_last;
 mod prefer_while;

--- a/crates/sonarjs/src/rules/no_useless_catch.rs
+++ b/crates/sonarjs/src/rules/no_useless_catch.rs
@@ -1,0 +1,65 @@
+//! Rule `no-useless-catch` (SonarJS key S2737).
+//!
+//! Clean-room port. A `catch` clause that does nothing but rethrow the caught
+//! exception is useless: removing it leaves error propagation unchanged. The
+//! rule fires when ALL of the following hold:
+//!
+//! 1. The `catch` parameter is a simple binding identifier (`catch (e)`).
+//!    Destructured parameters (`catch ({ message })`) are excluded because they
+//!    cannot be a straight rethrow.
+//! 2. The `catch` body contains exactly ONE statement, and that statement is a
+//!    `ThrowStatement`.
+//! 3. The thrown expression (after stripping parentheses via
+//!    `get_inner_expression`) is an `Identifier` whose name equals the caught
+//!    parameter name.
+//!
+//! ## Flagged
+//!
+//! ```js
+//! try { f(); } catch (e) { throw e; }
+//! try { f(); } catch (err) { throw err; } finally { g(); }
+//! ```
+//!
+//! ## Not flagged
+//!
+//! ```js
+//! try { f(); } catch (e) { log(e); throw e; }   // two statements
+//! try { f(); } catch (e) { throw new Error(); }  // throws something else
+//! try { f(); } catch (e) { throw e.cause; }      // throws a member, not e
+//! try { f(); } catch ({ message }) { throw message; }  // destructured param
+//! try { f(); } catch (e) { handle(e); }          // no rethrow at all
+//! ```
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{BindingPattern, CatchClause, Expression, Statement};
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-useless-catch";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_useless_catch(&mut self, catch: &CatchClause<'_>) {
+        let Some(param) = &catch.param else { return };
+        let BindingPattern::BindingIdentifier(id) = &param.pattern else {
+            return;
+        };
+        let caught = id.name.as_str();
+        let [only] = catch.body.body.as_slice() else {
+            return;
+        };
+        let Statement::ThrowStatement(throw) = only else {
+            return;
+        };
+        let Expression::Identifier(thrown) = throw.argument.get_inner_expression() else {
+            return;
+        };
+        if thrown.name.as_str() != caught {
+            return;
+        }
+        let start = catch.span.start;
+        self.report(RULE_NAME, "uselessCatch", Span::new(start, start + 5));
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,7 +3,7 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, BindingIdentifier, ConditionalExpression,
+    AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
     ExpressionStatement, ForInStatement, ForStatement, Function, IdentifierReference, IfStatement,
     LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
     SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
@@ -196,5 +196,10 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {
         self.mark_generator_yield();
         walk::walk_yield_expression(self, it);
+    }
+
+    fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
+        self.check_no_useless_catch(it);
+        walk::walk_catch_clause(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1297,3 +1297,55 @@ fn does_not_report_inverted_boolean_check_for_negated_arithmetic() {
     let diagnostics = scan("no-inverted-boolean-check", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_useless_catch_for_catch_that_only_rethrows() {
+    let source = "try { f(); } catch (e) { throw e; }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-useless-catch");
+    assert_eq!(diagnostics[0].message_id, "uselessCatch");
+}
+
+#[test]
+fn reports_no_useless_catch_when_finally_is_present() {
+    let source = "try { f(); } catch (err) { throw err; } finally { g(); }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "uselessCatch");
+}
+
+#[test]
+fn does_not_report_no_useless_catch_when_body_has_two_statements() {
+    let source = "try { f(); } catch (e) { log(e); throw e; }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_useless_catch_when_throw_is_new_expression() {
+    let source = "try { f(); } catch (e) { throw new Error(); }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_useless_catch_when_throw_is_member_expression() {
+    let source = "try { f(); } catch (e) { throw e.cause; }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_useless_catch_when_no_throw_in_body() {
+    let source = "try { f(); } catch (e) { handle(e); }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_useless_catch_for_destructured_param() {
+    let source = "try { f(); } catch ({ message }) { throw message; }";
+    let diagnostics = scan("no-useless-catch", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -120,6 +120,9 @@ const messages = Object.freeze({
     invertedBooleanCheck:
       'Use the opposite comparison operator instead of negating this comparison.',
   },
+  'no-useless-catch': {
+    uselessCatch: "Remove this useless 'catch' clause; it only rethrows the caught exception.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -173,6 +176,8 @@ const ruleDescriptions = Object.freeze({
     "Require the 'default' clause of a switch statement to appear as the last clause for readability",
   'no-inverted-boolean-check':
     'Disallow negating a comparison expression; use the opposite comparison operator instead',
+  'no-useless-catch':
+    "Disallow 'catch' clauses that only rethrow the caught exception; remove them and let the error propagate naturally",
 });
 
 const ruleTypes = Object.freeze({
@@ -205,6 +210,7 @@ const ruleTypes = Object.freeze({
   'no-small-switch': 'suggestion',
   'prefer-default-last': 'suggestion',
   'no-inverted-boolean-check': 'suggestion',
+  'no-useless-catch': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -237,6 +243,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-small-switch': 'error',
   'prefer-default-last': 'error',
   'no-inverted-boolean-check': 'error',
+  'no-useless-catch': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -32,6 +32,7 @@ const expectedRuleNames = [
   'no-small-switch',
   'prefer-default-last',
   'no-inverted-boolean-check',
+  'no-useless-catch',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1055,6 +1056,45 @@ describe('sonarjs native API', () => {
   it('does not report no-inverted-boolean-check for !(a + b) (arithmetic, not comparison)', () => {
     const source = 'const r = !(a + b);';
     const diagnostics = scan('no-inverted-boolean-check', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-useless-catch for catch that only rethrows', () => {
+    const source = 'try { f(); } catch (e) { throw e; }';
+    const diagnostics = scan('no-useless-catch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-useless-catch');
+    expect(diagnostics[0].messageId).toBe('uselessCatch');
+  });
+
+  it('reports no-useless-catch for catch that only rethrows when finally is present', () => {
+    const source = 'try { f(); } catch (err) { throw err; } finally { g(); }';
+    const diagnostics = scan('no-useless-catch', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('uselessCatch');
+  });
+
+  it('does not report no-useless-catch when catch body has two statements', () => {
+    const source = 'try { f(); } catch (e) { log(e); throw e; }';
+    const diagnostics = scan('no-useless-catch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-useless-catch when throw argument is a new expression', () => {
+    const source = 'try { f(); } catch (e) { throw new Error(); }';
+    const diagnostics = scan('no-useless-catch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-useless-catch when throw argument is a member expression', () => {
+    const source = 'try { f(); } catch (e) { throw e.cause; }';
+    const diagnostics = scan('no-useless-catch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-useless-catch when catch body has no throw', () => {
+    const source = 'try { f(); } catch (e) { handle(e); }';
+    const diagnostics = scan('no-useless-catch', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -123,6 +123,7 @@ describe('sonarjs plugin shape', () => {
       'no-small-switch',
       'prefer-default-last',
       'no-inverted-boolean-check',
+      'no-useless-catch',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -153,6 +154,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-small-switch']).toBe('object');
     expect(typeof plugin.rules['prefer-default-last']).toBe('object');
     expect(typeof plugin.rules['no-inverted-boolean-check']).toBe('object');
+    expect(typeof plugin.rules['no-useless-catch']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -183,6 +185,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-small-switch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-default-last']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-inverted-boolean-check']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-useless-catch']).toBe('error');
   });
 });
 
@@ -681,5 +684,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-inverted-boolean-check)');
+  });
+
+  it('reports no-useless-catch for catch that only rethrows through the adapter', () => {
+    const source = 'try { f(); } catch (e) { throw e; }';
+    const reports = runRule('no-useless-catch', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('uselessCatch');
+  });
+
+  it('reports no-useless-catch through the CLI', () => {
+    const source = 'try { f(); } catch (e) { throw e; }';
+    const result = runOxlint('no-useless-catch', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-useless-catch)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13246,19 +13246,19 @@
       },
       {
         "name": "no-useless-catch",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-useless-catch (Sonar key S2737). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of S2737. Reports a catch clause whose entire body is a single rethrow of the caught identifier; destructured params, multi-statement bodies, and throws of other values are excluded. No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "no-useless-increment",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-useless-catch`** (Sonar key S2737). Flags a `catch` clause whose only statement rethrows the caught exception (`catch (e) { throw e; }`) — the `catch` can be removed and the error propagates unchanged (even with `finally`). Only simple-identifier params count; destructured params, multi-statement bodies, and throwing anything else (`throw new Error()`, `throw e.cause`) are not flagged. Adds a `visit_catch_clause` hook.

## Tests
Rust unit tests (`throw e`, `throw err` + `finally` → 1; extra statement, `new Error()`, member throw, destructured param, no rethrow → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-useless-catch)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783988556&installation_id=136613492&pr_number=191&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F191&signature=dd37deee0515f6552ed1ca29e13a324c2da0364c97f466dcac2b40c898a72e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->