### PR TITLE
port(sonarjs): port no-redundant-optional (S4782)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 30] = [
+pub const RULE_NAMES: [&str; 31] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -53,6 +53,7 @@ pub const RULE_NAMES: [&str; 30] = [
     "prefer-default-last",
     "no-inverted-boolean-check",
     "no-useless-catch",
+    "no-redundant-optional",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -26,6 +26,7 @@ mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_redundant_boolean;
+mod no_redundant_optional;
 mod no_small_switch;
 mod no_useless_catch;
 mod non_existent_operator;

--- a/crates/sonarjs/src/rules/no_redundant_optional.rs
+++ b/crates/sonarjs/src/rules/no_redundant_optional.rs
@@ -39,9 +39,10 @@ pub(crate) const RULE_NAME: &str = "no-redundant-optional";
 fn type_has_undefined(ty: &TSType) -> bool {
     match ty {
         TSType::TSUndefinedKeyword(_) => true,
-        TSType::TSUnionType(union) => {
-            union.types.iter().any(|t| matches!(t, TSType::TSUndefinedKeyword(_)))
-        }
+        TSType::TSUnionType(union) => union
+            .types
+            .iter()
+            .any(|t| matches!(t, TSType::TSUndefinedKeyword(_))),
         _ => false,
     }
 }

--- a/crates/sonarjs/src/rules/no_redundant_optional.rs
+++ b/crates/sonarjs/src/rules/no_redundant_optional.rs
@@ -1,0 +1,62 @@
+//! Rule `no-redundant-optional` (SonarJS key S4782).
+//!
+//! Clean-room port. A TypeScript property declared optional with `?` AND whose
+//! type annotation already includes the `undefined` keyword is redundant — the
+//! `?` marker already permits `undefined`. Flag the property signature so the
+//! developer can remove the explicit `undefined` from the type.
+//!
+//! **Scope**: `TSPropertySignature` nodes only — property signatures inside
+//! interfaces and object type literals. Optional function parameters
+//! (`x?: T | undefined`) and optional class fields are **out of scope** for
+//! this rule; those shapes require type-aware analysis and are left for a
+//! follow-up.
+//!
+//! **Trigger**: a `TSPropertySignature` where ALL of:
+//! 1. `optional == true` (the `?` marker is present).
+//! 2. The property has a `type_annotation`.
+//! 3. That annotation's type IS `undefined` directly, OR is a union that
+//!    contains `undefined` as one of its members.
+//!
+//! **DO flag**: `interface I { a?: string | undefined; }`,
+//! `interface I { b?: undefined; }`,
+//! `interface I { c?: number | string | undefined; }`.
+//!
+//! **DON'T flag**: `interface I { a?: string; }` (no `undefined` in type),
+//! `interface I { b: string | undefined; }` (not optional — no `?`),
+//! `interface I { c?: string | null; }` (`null`, not `undefined`).
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{TSPropertySignature, TSType};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-redundant-optional";
+
+/// Returns `true` when `ty` is `undefined` directly or is a union that
+/// contains `undefined` as one of its member types.
+fn type_has_undefined(ty: &TSType) -> bool {
+    match ty {
+        TSType::TSUndefinedKeyword(_) => true,
+        TSType::TSUnionType(union) => {
+            union.types.iter().any(|t| matches!(t, TSType::TSUndefinedKeyword(_)))
+        }
+        _ => false,
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_redundant_optional(&mut self, prop: &TSPropertySignature<'_>) {
+        if !prop.optional {
+            return;
+        }
+        let Some(annotation) = &prop.type_annotation else {
+            return;
+        };
+        if !type_has_undefined(&annotation.type_annotation) {
+            return;
+        }
+        self.report(RULE_NAME, "redundantOptional", prop.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -6,8 +6,8 @@ use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
     ExpressionStatement, ForInStatement, ForStatement, Function, IdentifierReference, IfStatement,
     LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
-    SwitchStatement, TSIntersectionType, TSUnionType, TemplateLiteral, UnaryExpression,
-    YieldExpression,
+    SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
+    UnaryExpression, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -160,6 +160,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_ts_intersection_type(&mut self, it: &TSIntersectionType<'a>) {
         self.check_no_duplicate_in_composite(&it.types);
         walk::walk_ts_intersection_type(self, it);
+    }
+
+    fn visit_ts_property_signature(&mut self, it: &TSPropertySignature<'a>) {
+        self.check_no_redundant_optional(it);
+        walk::walk_ts_property_signature(self, it);
     }
 
     fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1349,3 +1349,49 @@ fn does_not_report_no_useless_catch_for_destructured_param() {
     let diagnostics = scan("no-useless-catch", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_redundant_optional_for_union_with_undefined() {
+    let source = "interface I { a?: string | undefined; }";
+    let diagnostics = scan("no-redundant-optional", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-redundant-optional");
+    assert_eq!(diagnostics[0].message_id, "redundantOptional");
+}
+
+#[test]
+fn reports_no_redundant_optional_for_undefined_type_directly() {
+    let source = "interface I { b?: undefined; }";
+    let diagnostics = scan("no-redundant-optional", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantOptional");
+}
+
+#[test]
+fn reports_no_redundant_optional_for_multi_member_union_with_undefined() {
+    let source = "interface I { c?: number | string | undefined; }";
+    let diagnostics = scan("no-redundant-optional", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantOptional");
+}
+
+#[test]
+fn does_not_report_no_redundant_optional_when_no_undefined_in_type() {
+    let source = "interface I { a?: string; }";
+    let diagnostics = scan("no-redundant-optional", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_redundant_optional_for_non_optional_property_with_undefined() {
+    let source = "interface I { b: string | undefined; }";
+    let diagnostics = scan("no-redundant-optional", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_redundant_optional_for_optional_property_with_null_not_undefined() {
+    let source = "interface I { c?: string | null; }";
+    let diagnostics = scan("no-redundant-optional", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -123,6 +123,10 @@ const messages = Object.freeze({
   'no-useless-catch': {
     uselessCatch: "Remove this useless 'catch' clause; it only rethrows the caught exception.",
   },
+  'no-redundant-optional': {
+    redundantOptional:
+      "Remove this redundant 'undefined' type; the '?' optional marker already allows it.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -178,6 +182,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow negating a comparison expression; use the opposite comparison operator instead',
   'no-useless-catch':
     "Disallow 'catch' clauses that only rethrow the caught exception; remove them and let the error propagate naturally",
+  'no-redundant-optional':
+    "Disallow optional property signatures whose type annotation already includes 'undefined'; the '?' marker already permits undefined",
 });
 
 const ruleTypes = Object.freeze({
@@ -211,6 +217,7 @@ const ruleTypes = Object.freeze({
   'prefer-default-last': 'suggestion',
   'no-inverted-boolean-check': 'suggestion',
   'no-useless-catch': 'suggestion',
+  'no-redundant-optional': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -244,6 +251,7 @@ const recommendedRuleConfig = Object.freeze({
   'prefer-default-last': 'error',
   'no-inverted-boolean-check': 'error',
   'no-useless-catch': 'error',
+  'no-redundant-optional': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -33,6 +33,7 @@ const expectedRuleNames = [
   'prefer-default-last',
   'no-inverted-boolean-check',
   'no-useless-catch',
+  'no-redundant-optional',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1095,6 +1096,46 @@ describe('sonarjs native API', () => {
   it('does not report no-useless-catch when catch body has no throw', () => {
     const source = 'try { f(); } catch (e) { handle(e); }';
     const diagnostics = scan('no-useless-catch', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-redundant-optional for optional property with union including undefined', () => {
+    const source = 'interface I { a?: string | undefined; }';
+    const diagnostics = scan('no-redundant-optional', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-redundant-optional');
+    expect(diagnostics[0].messageId).toBe('redundantOptional');
+  });
+
+  it('reports no-redundant-optional for optional property typed as undefined directly', () => {
+    const source = 'interface I { b?: undefined; }';
+    const diagnostics = scan('no-redundant-optional', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantOptional');
+  });
+
+  it('reports no-redundant-optional for optional property with multi-member union including undefined', () => {
+    const source = 'interface I { c?: number | string | undefined; }';
+    const diagnostics = scan('no-redundant-optional', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantOptional');
+  });
+
+  it('does not report no-redundant-optional for optional property without undefined in type', () => {
+    const source = 'interface I { a?: string; }';
+    const diagnostics = scan('no-redundant-optional', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-redundant-optional for non-optional property with undefined in type', () => {
+    const source = 'interface I { b: string | undefined; }';
+    const diagnostics = scan('no-redundant-optional', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-redundant-optional for optional property with null but not undefined', () => {
+    const source = 'interface I { c?: string | null; }';
+    const diagnostics = scan('no-redundant-optional', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -124,6 +124,7 @@ describe('sonarjs plugin shape', () => {
       'prefer-default-last',
       'no-inverted-boolean-check',
       'no-useless-catch',
+      'no-redundant-optional',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -155,6 +156,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['prefer-default-last']).toBe('object');
     expect(typeof plugin.rules['no-inverted-boolean-check']).toBe('object');
     expect(typeof plugin.rules['no-useless-catch']).toBe('object');
+    expect(typeof plugin.rules['no-redundant-optional']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -186,6 +188,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/prefer-default-last']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-inverted-boolean-check']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-useless-catch']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-redundant-optional']).toBe('error');
   });
 });
 
@@ -701,5 +704,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-useless-catch)');
+  });
+
+  it('reports no-redundant-optional through the adapter', () => {
+    const source = 'interface I { a?: string | undefined; }';
+    const reports = runRule('no-redundant-optional', source, { filename: 'sample.ts' });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('redundantOptional');
+  });
+
+  it('reports no-redundant-optional through the CLI', () => {
+    const source = 'interface I { a?: string | undefined; }';
+    const result = runOxlint('no-redundant-optional', source, 'sample.ts');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-redundant-optional)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12814,19 +12814,19 @@
       },
       {
         "name": "no-redundant-optional",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-redundant-optional (Sonar key S4782). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S4782). Scope: TSPropertySignature only (interfaces and object type literals). Optional function parameters and optional class fields are out of scope (follow-up). SonarJS upstream is LGPL-3.0; no upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-redundant-parentheses",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-redundant-optional`** (Sonar key S4782). Flags an optional TS property signature whose type also includes `undefined` (`foo?: T | undefined`, `foo?: undefined`) — the `?` already permits `undefined`. Scope: interface / type-literal property signatures; optional parameters and class fields are a documented follow-up. Adds a `visit_ts_property_signature` hook.

## Tests
Rust unit tests (`?: T | undefined`, `?: undefined`, `?: a|b|undefined` → 1; `?: string`, `: string|undefined` (not optional), `?: string|null` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-redundant-optional)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783989336&installation_id=136613492&pr_number=192&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F192&signature=80a4533091562d3cecadd6eb1ba45ddee671328702e37d0be698022fc6b7840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->