### PR TITLE
port(sonarjs): port prefer-immediate-return (S1488)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 31] = [
+pub const RULE_NAMES: [&str; 32] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -54,6 +54,7 @@ pub const RULE_NAMES: [&str; 31] = [
     "no-inverted-boolean-check",
     "no-useless-catch",
     "no-redundant-optional",
+    "prefer-immediate-return",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -31,4 +31,5 @@ mod no_small_switch;
 mod no_useless_catch;
 mod non_existent_operator;
 mod prefer_default_last;
+mod prefer_immediate_return;
 mod prefer_while;

--- a/crates/sonarjs/src/rules/prefer_immediate_return.rs
+++ b/crates/sonarjs/src/rules/prefer_immediate_return.rs
@@ -1,0 +1,120 @@
+//! Rule `prefer-immediate-return` (SonarJS key S1488).
+//!
+//! Clean-room port. Declaring a local variable only to immediately `return` or
+//! `throw` it on the next statement is unnecessary indirection — return or
+//! throw the expression directly instead.
+//!
+//! The rule fires on a `FunctionBody` whose **last two statements** are:
+//!
+//! 1. A `VariableDeclaration` with **exactly one** declarator whose binding is
+//!    a simple `BindingIdentifier` (name N) and whose `init` is `Some(_)`.
+//! 2. Either a `ReturnStatement` with `argument` that resolves (after stripping
+//!    parentheses via `get_inner_expression`) to an `Identifier` named N, or a
+//!    `ThrowStatement` whose `argument` resolves to an `Identifier` named N.
+//!
+//! The reported span is the span of the last statement (the return/throw).
+//!
+//! ## Scope
+//!
+//! Only `FunctionBody` nodes are checked (function declarations, function
+//! expressions, methods, and arrow functions with block bodies). Non-function
+//! bare blocks (`{ … }`, `if` bodies, etc.) are **out of scope** for this
+//! check — detecting them requires distinguishing block-statement bodies from
+//! function bodies, which is left as a follow-up.
+//!
+//! ## Flagged
+//!
+//! ```js
+//! function f() { const x = compute(); return x; }
+//! function f() { let y = a + b; return y; }
+//! function f() { const e = new Error(); throw e; }
+//! const g = () => { const x = 1; return x; };
+//! ```
+//!
+//! ## Not flagged
+//!
+//! ```js
+//! // only one statement — direct return, nothing to flag
+//! function f() { return compute(); }
+//! // extra statements between the declaration and the return
+//! function f() { const x = 1; doStuff(); return x; }
+//! // returns a different identifier
+//! function f() { const x = 1; return y; }
+//! // two declarators
+//! function f() { const x = 1, y = 2; return x; }
+//! // no init — `let x;` declares without a value
+//! function f() { let x; return x; }
+//! // returns an expression, not the bare identifier
+//! function f() { const x = 1; return x + 1; }
+//! ```
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{BindingPattern, Expression, FunctionBody, Statement};
+use oxc_span::GetSpan;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "prefer-immediate-return";
+
+/// If `stmt` is a `VariableDeclaration` with exactly one declarator that has a
+/// simple `BindingIdentifier` id and a non-`None` init, returns the bound name.
+/// Otherwise returns `None`.
+fn declared_single_name<'a>(stmt: &'a Statement) -> Option<&'a str> {
+    let Statement::VariableDeclaration(decl) = stmt else {
+        return None;
+    };
+    if decl.declarations.len() != 1 {
+        return None;
+    }
+    let declarator = &decl.declarations[0];
+    if declarator.init.is_none() {
+        return None;
+    }
+    let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+        return None;
+    };
+    Some(id.name.as_str())
+}
+
+/// If `stmt` is a `ReturnStatement` or `ThrowStatement` whose argument
+/// (after stripping parentheses) is a plain `Identifier`, returns that name.
+/// Otherwise returns `None`.
+fn returned_or_thrown_name<'a>(stmt: &'a Statement) -> Option<&'a str> {
+    match stmt {
+        Statement::ReturnStatement(ret) => {
+            let expr = ret.argument.as_ref()?.get_inner_expression();
+            let Expression::Identifier(id) = expr else {
+                return None;
+            };
+            Some(id.name.as_str())
+        }
+        Statement::ThrowStatement(thr) => {
+            let expr = thr.argument.get_inner_expression();
+            let Expression::Identifier(id) = expr else {
+                return None;
+            };
+            Some(id.name.as_str())
+        }
+        _ => None,
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_prefer_immediate_return(&mut self, body: &FunctionBody<'_>) {
+        let [.., second_last, last] = body.statements.as_slice() else {
+            return;
+        };
+        let Some(decl_name) = declared_single_name(second_last) else {
+            return;
+        };
+        let Some(ret_name) = returned_or_thrown_name(last) else {
+            return;
+        };
+        if decl_name != ret_name {
+            return;
+        }
+        self.report(RULE_NAME, "preferImmediateReturn", last.span());
+    }
+}

--- a/crates/sonarjs/src/rules/prefer_immediate_return.rs
+++ b/crates/sonarjs/src/rules/prefer_immediate_return.rs
@@ -69,9 +69,7 @@ fn declared_single_name<'a>(stmt: &'a Statement) -> Option<&'a str> {
         return None;
     }
     let declarator = &decl.declarations[0];
-    if declarator.init.is_none() {
-        return None;
-    }
+    declarator.init.as_ref()?;
     let BindingPattern::BindingIdentifier(id) = &declarator.id else {
         return None;
     };

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,10 +4,10 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
-    ExpressionStatement, ForInStatement, ForStatement, Function, IdentifierReference, IfStatement,
-    LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
-    SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
-    UnaryExpression, YieldExpression,
+    ExpressionStatement, ForInStatement, ForStatement, Function, FunctionBody,
+    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
+    StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSPropertySignature,
+    TSUnionType, TemplateLiteral, UnaryExpression, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -206,5 +206,10 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
         self.check_no_useless_catch(it);
         walk::walk_catch_clause(self, it);
+    }
+
+    fn visit_function_body(&mut self, it: &FunctionBody<'a>) {
+        self.check_prefer_immediate_return(it);
+        walk::walk_function_body(self, it);
     }
 }

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,10 +4,10 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
-    ExpressionStatement, ForInStatement, ForStatement, Function, FunctionBody,
-    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral,
-    StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSPropertySignature,
-    TSUnionType, TemplateLiteral, UnaryExpression, YieldExpression,
+    ExpressionStatement, ForInStatement, ForStatement, Function, FunctionBody, IdentifierReference,
+    IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression,
+    SwitchCase, SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType,
+    TemplateLiteral, UnaryExpression, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1395,3 +1395,71 @@ fn does_not_report_no_redundant_optional_for_optional_property_with_null_not_und
     let diagnostics = scan("no-redundant-optional", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_prefer_immediate_return_for_const_declared_then_returned() {
+    let source = "function f() { const x = compute(); return x; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "prefer-immediate-return");
+    assert_eq!(diagnostics[0].message_id, "preferImmediateReturn");
+}
+
+#[test]
+fn reports_prefer_immediate_return_for_const_declared_then_thrown() {
+    let source = "function f() { const e = new Error(); throw e; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "preferImmediateReturn");
+}
+
+#[test]
+fn reports_prefer_immediate_return_for_arrow_function_block_body() {
+    let source = "const g = () => { const x = 1; return x; };";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "preferImmediateReturn");
+}
+
+#[test]
+fn does_not_report_prefer_immediate_return_for_direct_return() {
+    let source = "function f() { return compute(); }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_immediate_return_when_statement_between_decl_and_return() {
+    let source = "function f() { const x = 1; doStuff(); return x; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_immediate_return_when_return_uses_different_identifier() {
+    let source = "function f() { const x = 1; return y; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_immediate_return_when_return_is_not_bare_identifier() {
+    let source = "function f() { const x = 1; return x + 1; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_immediate_return_when_declaration_has_two_declarators() {
+    let source = "function f() { const x = 1, y = 2; return x; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_prefer_immediate_return_when_declarator_has_no_init() {
+    // `let x;` has no initializer — there is nothing to inline
+    let source = "function f() { let x; return x; }";
+    let diagnostics = scan("prefer-immediate-return", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -127,6 +127,10 @@ const messages = Object.freeze({
     redundantOptional:
       "Remove this redundant 'undefined' type; the '?' optional marker already allows it.",
   },
+  'prefer-immediate-return': {
+    preferImmediateReturn:
+      'Return or throw this expression directly instead of assigning it to a temporary variable first.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -184,6 +188,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow 'catch' clauses that only rethrow the caught exception; remove them and let the error propagate naturally",
   'no-redundant-optional':
     "Disallow optional property signatures whose type annotation already includes 'undefined'; the '?' marker already permits undefined",
+  'prefer-immediate-return':
+    'Disallow declaring a local variable solely to immediately return or throw it; return or throw the initializer expression directly',
 });
 
 const ruleTypes = Object.freeze({
@@ -218,6 +224,7 @@ const ruleTypes = Object.freeze({
   'no-inverted-boolean-check': 'suggestion',
   'no-useless-catch': 'suggestion',
   'no-redundant-optional': 'suggestion',
+  'prefer-immediate-return': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -252,6 +259,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-inverted-boolean-check': 'error',
   'no-useless-catch': 'error',
   'no-redundant-optional': 'error',
+  'prefer-immediate-return': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -34,6 +34,7 @@ const expectedRuleNames = [
   'no-inverted-boolean-check',
   'no-useless-catch',
   'no-redundant-optional',
+  'prefer-immediate-return',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1136,6 +1137,58 @@ describe('sonarjs native API', () => {
   it('does not report no-redundant-optional for optional property with null but not undefined', () => {
     const source = 'interface I { c?: string | null; }';
     const diagnostics = scan('no-redundant-optional', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports prefer-immediate-return for const declared then immediately returned', () => {
+    const source = 'function f() { const x = compute(); return x; }';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('prefer-immediate-return');
+    expect(diagnostics[0].messageId).toBe('preferImmediateReturn');
+  });
+
+  it('reports prefer-immediate-return for const declared then immediately thrown', () => {
+    const source = 'function f() { const e = new Error(); throw e; }';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('preferImmediateReturn');
+  });
+
+  it('reports prefer-immediate-return for arrow function with block body', () => {
+    const source = 'const g = () => { const x = 1; return x; };';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('preferImmediateReturn');
+  });
+
+  it('does not report prefer-immediate-return for a direct return (only one statement)', () => {
+    const source = 'function f() { return compute(); }';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-immediate-return when a statement appears between decl and return', () => {
+    const source = 'function f() { const x = 1; doStuff(); return x; }';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-immediate-return when return uses a different identifier', () => {
+    const source = 'function f() { const x = 1; return y; }';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-immediate-return when return is not the bare identifier', () => {
+    const source = 'function f() { const x = 1; return x + 1; }';
+    const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report prefer-immediate-return when the declaration has two declarators', () => {
+    const source = 'function f() { const x = 1, y = 2; return x; }';
+    const diagnostics = scan('prefer-immediate-return', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -125,6 +125,7 @@ describe('sonarjs plugin shape', () => {
       'no-inverted-boolean-check',
       'no-useless-catch',
       'no-redundant-optional',
+      'prefer-immediate-return',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -157,6 +158,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-inverted-boolean-check']).toBe('object');
     expect(typeof plugin.rules['no-useless-catch']).toBe('object');
     expect(typeof plugin.rules['no-redundant-optional']).toBe('object');
+    expect(typeof plugin.rules['prefer-immediate-return']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -189,6 +191,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-inverted-boolean-check']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-useless-catch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-optional']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/prefer-immediate-return']).toBe('error');
   });
 });
 
@@ -721,5 +724,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-redundant-optional)');
+  });
+
+  it('reports prefer-immediate-return through the adapter', () => {
+    const source = 'function f() { const x = compute(); return x; }';
+    const reports = runRule('prefer-immediate-return', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('preferImmediateReturn');
+  });
+
+  it('reports prefer-immediate-return through the CLI', () => {
+    const source = 'function f() { const x = compute(); return x; }';
+    const result = runOxlint('prefer-immediate-return', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(prefer-immediate-return)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13518,19 +13518,19 @@
       },
       {
         "name": "prefer-immediate-return",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule prefer-immediate-return (Sonar key S1488). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only — never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S1488. Reports a FunctionBody whose last two statements are a single-declarator variable declaration (with initializer) followed by a return/throw of that same identifier. Non-function bare blocks are out of scope (follow-up). Message and tests independently authored; no upstream source, fixtures, or messages consulted."
       },
       {
         "name": "prefer-object-literal",


### PR DESCRIPTION
## Summary
Clean-room port of **`prefer-immediate-return`** (Sonar key S1488). Flags a function body whose last two statements declare a single variable and then immediately `return` (or `throw`) that same variable (`const x = expr; return x;`) — return/throw the expression directly. Scope: function bodies (functions, methods, block-body arrows); non-function blocks are a documented follow-up. Adds a `visit_function_body` hook.

## Tests
Rust unit tests (return-var, throw-var, arrow → 1; direct return, intervening statement, different id, expression return, two declarators, no-init → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(prefer-immediate-return)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783990479&installation_id=136613492&pr_number=193&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F193&signature=b256ae888e6ad1a5db7f2e94c120ab9781bd741b2b45f52c7598b976f1613542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->