### PR TITLE
port(sonarjs): port no-redundant-jump (S3626)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 32] = [
+pub const RULE_NAMES: [&str; 33] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -55,6 +55,7 @@ pub const RULE_NAMES: [&str; 32] = [
     "no-useless-catch",
     "no-redundant-optional",
     "prefer-immediate-return",
+    "no-redundant-jump",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -26,6 +26,7 @@ mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_redundant_boolean;
+mod no_redundant_jump;
 mod no_redundant_optional;
 mod no_small_switch;
 mod no_useless_catch;

--- a/crates/sonarjs/src/rules/no_redundant_jump.rs
+++ b/crates/sonarjs/src/rules/no_redundant_jump.rs
@@ -1,0 +1,91 @@
+//! Rule `no-redundant-jump` (SonarJS key S3626).
+//!
+//! Clean-room port. A jump statement that does not change control flow is
+//! redundant. This rule covers two cases:
+//!
+//! 1. **`continue;`** (with no label) as the last statement in a loop body
+//!    block — the loop iteration would end at that point anyway.
+//! 2. **`return;`** (with no argument) as the last statement in a function
+//!    body — the function would return there anyway.
+//!
+//! Labeled `continue` statements are **not** flagged (they change which loop
+//! is continued). `return` statements with a value are **not** flagged (they
+//! carry a result). Non-block loop bodies (e.g. `while (x) foo();`) are also
+//! not flagged.
+//!
+//! ## Flagged
+//!
+//! ```js
+//! for (;;) { foo(); continue; }
+//! while (x) { foo(); continue; }
+//! do { foo(); continue; } while (x);
+//! for (const a of b) { foo(); continue; }
+//! for (k in o) { foo(); continue; }
+//! function f() { foo(); return; }
+//! const g = () => { foo(); return; };
+//! ```
+//!
+//! ## Not flagged
+//!
+//! ```js
+//! // continue is not the last statement
+//! for (;;) { if (x) continue; foo(); }
+//! // labeled continue — changes which loop is continued
+//! outer: for (;;) { foo(); continue outer; }
+//! // return with a value
+//! function f() { foo(); return x; }
+//! // no trailing return
+//! function f() { foo(); }
+//! // non-block loop body
+//! while (x) foo();
+//! ```
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{FunctionBody, Statement};
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-redundant-jump";
+
+/// Returns the span of a redundant trailing `continue;` in a loop body, or
+/// `None` if the body has no such statement.
+///
+/// Only block bodies are checked. Non-block bodies cannot end with a bare
+/// `continue;` that is also the *only* thing being done (they are a single
+/// statement anyway), so they are intentionally excluded.
+fn trailing_redundant_continue(body: &Statement) -> Option<Span> {
+    let Statement::BlockStatement(block) = body else {
+        return None;
+    };
+    let Statement::ContinueStatement(cont) = block.body.last()? else {
+        return None;
+    };
+    if cont.label.is_some() {
+        return None;
+    }
+    Some(cont.span)
+}
+
+impl Scanner<'_> {
+    /// Check a loop body for a redundant trailing `continue;`.
+    pub(crate) fn check_redundant_continue(&mut self, loop_body: &Statement<'_>) {
+        let Some(span) = trailing_redundant_continue(loop_body) else {
+            return;
+        };
+        self.report(RULE_NAME, "redundantJump", span);
+    }
+
+    /// Check a function body for a redundant trailing `return;`.
+    pub(crate) fn check_redundant_return(&mut self, body: &FunctionBody<'_>) {
+        let Some(Statement::ReturnStatement(ret)) = body.statements.last() else {
+            return;
+        };
+        if ret.argument.is_some() {
+            return;
+        }
+        self.report(RULE_NAME, "redundantJump", ret.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,10 +4,11 @@
 
 use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
-    ExpressionStatement, ForInStatement, ForStatement, Function, FunctionBody, IdentifierReference,
-    IfStatement, LabeledStatement, LogicalExpression, RegExpLiteral, StaticMemberExpression,
-    SwitchCase, SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType,
-    TemplateLiteral, UnaryExpression, YieldExpression,
+    DoWhileStatement, ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function,
+    FunctionBody, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression,
+    RegExpLiteral, StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType,
+    TSPropertySignature, TSUnionType, TemplateLiteral, UnaryExpression, WhileStatement,
+    YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -131,12 +132,29 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
         self.check_for_in(it);
+        self.check_redundant_continue(&it.body);
         walk::walk_for_in_statement(self, it);
     }
 
     fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
         self.check_prefer_while(it);
+        self.check_redundant_continue(&it.body);
         walk::walk_for_statement(self, it);
+    }
+
+    fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
+        self.check_redundant_continue(&it.body);
+        walk::walk_while_statement(self, it);
+    }
+
+    fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
+        self.check_redundant_continue(&it.body);
+        walk::walk_do_while_statement(self, it);
+    }
+
+    fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
+        self.check_redundant_continue(&it.body);
+        walk::walk_for_of_statement(self, it);
     }
 
     fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
@@ -210,6 +228,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_function_body(&mut self, it: &FunctionBody<'a>) {
         self.check_prefer_immediate_return(it);
+        self.check_redundant_return(it);
         walk::walk_function_body(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1463,3 +1463,88 @@ fn does_not_report_prefer_immediate_return_when_declarator_has_no_init() {
     let diagnostics = scan("prefer-immediate-return", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_redundant_jump_for_trailing_continue_in_for_loop() {
+    let source = "for (;;) { foo(); continue; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-redundant-jump");
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn reports_redundant_jump_for_trailing_continue_in_while_loop() {
+    let source = "while (x) { foo(); continue; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn reports_redundant_jump_for_trailing_continue_in_do_while_loop() {
+    let source = "do { foo(); continue; } while (x);";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn reports_redundant_jump_for_trailing_continue_in_for_of_loop() {
+    let source = "for (const a of b) { foo(); continue; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn reports_redundant_jump_for_trailing_continue_in_for_in_loop() {
+    let source = "for (k in o) { foo(); continue; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn reports_redundant_jump_for_trailing_return_in_function() {
+    let source = "function f() { foo(); return; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn reports_redundant_jump_for_trailing_return_in_arrow_function() {
+    let source = "const g = () => { foo(); return; };";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "redundantJump");
+}
+
+#[test]
+fn does_not_report_redundant_jump_when_continue_is_not_last() {
+    let source = "for (;;) { if (x) continue; foo(); }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_redundant_jump_for_return_with_value() {
+    let source = "function f() { foo(); return x; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_redundant_jump_for_labeled_continue() {
+    let source = "outer: for (;;) { foo(); continue outer; }";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_redundant_jump_for_non_block_loop_body() {
+    let source = "while (x) foo();";
+    let diagnostics = scan("no-redundant-jump", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -131,6 +131,9 @@ const messages = Object.freeze({
     preferImmediateReturn:
       'Return or throw this expression directly instead of assigning it to a temporary variable first.',
   },
+  'no-redundant-jump': {
+    redundantJump: 'Remove this redundant jump; it does not change the control flow.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -190,6 +193,8 @@ const ruleDescriptions = Object.freeze({
     "Disallow optional property signatures whose type annotation already includes 'undefined'; the '?' marker already permits undefined",
   'prefer-immediate-return':
     'Disallow declaring a local variable solely to immediately return or throw it; return or throw the initializer expression directly',
+  'no-redundant-jump':
+    'Disallow jump statements (continue without label, return without value) that do not change the control flow because execution would proceed the same way anyway',
 });
 
 const ruleTypes = Object.freeze({
@@ -225,6 +230,7 @@ const ruleTypes = Object.freeze({
   'no-useless-catch': 'suggestion',
   'no-redundant-optional': 'suggestion',
   'prefer-immediate-return': 'suggestion',
+  'no-redundant-jump': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -260,6 +266,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-useless-catch': 'error',
   'no-redundant-optional': 'error',
   'prefer-immediate-return': 'error',
+  'no-redundant-jump': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -35,6 +35,7 @@ const expectedRuleNames = [
   'no-useless-catch',
   'no-redundant-optional',
   'prefer-immediate-return',
+  'no-redundant-jump',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1189,6 +1190,60 @@ describe('sonarjs native API', () => {
   it('does not report prefer-immediate-return when the declaration has two declarators', () => {
     const source = 'function f() { const x = 1, y = 2; return x; }';
     const diagnostics = scan('prefer-immediate-return', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-redundant-jump for trailing continue in a for(;;) loop body', () => {
+    const source = 'for (;;) { foo(); continue; }';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-redundant-jump');
+    expect(diagnostics[0].messageId).toBe('redundantJump');
+  });
+
+  it('reports no-redundant-jump for trailing continue in a while loop body', () => {
+    const source = 'while (x) { foo(); continue; }';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantJump');
+  });
+
+  it('reports no-redundant-jump for trailing continue in a do-while loop body', () => {
+    const source = 'do { foo(); continue; } while (x);';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantJump');
+  });
+
+  it('reports no-redundant-jump for trailing continue in a for-of loop body', () => {
+    const source = 'for (const a of b) { foo(); continue; }';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantJump');
+  });
+
+  it('reports no-redundant-jump for trailing return; in a function body', () => {
+    const source = 'function f() { foo(); return; }';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('redundantJump');
+  });
+
+  it('does not report no-redundant-jump when continue is not the last statement', () => {
+    const source = 'for (;;) { if (x) continue; foo(); }';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-redundant-jump for return with a value', () => {
+    const source = 'function f() { foo(); return x; }';
+    const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-redundant-jump for a labeled continue', () => {
+    const source = 'outer: for (;;) { foo(); continue outer; }';
+    const diagnostics = scan('no-redundant-jump', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -126,6 +126,7 @@ describe('sonarjs plugin shape', () => {
       'no-useless-catch',
       'no-redundant-optional',
       'prefer-immediate-return',
+      'no-redundant-jump',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -159,6 +160,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-useless-catch']).toBe('object');
     expect(typeof plugin.rules['no-redundant-optional']).toBe('object');
     expect(typeof plugin.rules['prefer-immediate-return']).toBe('object');
+    expect(typeof plugin.rules['no-redundant-jump']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -192,6 +194,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-useless-catch']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-optional']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-immediate-return']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-redundant-jump']).toBe('error');
   });
 });
 
@@ -741,5 +744,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(prefer-immediate-return)');
+  });
+
+  it('reports no-redundant-jump for trailing continue through the adapter', () => {
+    const source = 'for (;;) { foo(); continue; }';
+    const reports = runRule('no-redundant-jump', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('redundantJump');
+  });
+
+  it('reports no-redundant-jump through the CLI', () => {
+    const source = 'function f() { foo(); return; }';
+    const result = runOxlint('no-redundant-jump', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-redundant-jump)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12798,19 +12798,19 @@
       },
       {
         "name": "no-redundant-jump",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-redundant-jump (Sonar key S3626). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S3626. Reports a trailing unlabeled continue; as the last statement of a loop body block (for, while, do-while, for-in, for-of) and a trailing return; (no value) as the last statement of a function body. Labeled continue and valued return are excluded. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-redundant-optional",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-redundant-jump`** (Sonar key S3626). Flags a bare `continue;` as the last statement of a loop body (`for`/`for-in`/`for-of`/`while`/`do-while`) and a bare `return;` as the last statement of a function body — neither changes control flow. Labeled `continue` and valued `return` are excluded. Wires `check_redundant_continue` into all five loop hooks and `check_redundant_return` into `visit_function_body`.

## Tests
Rust unit tests across all loop kinds + function `return`, plus negatives (continue not last, valued return, labeled continue), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-redundant-jump)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783991372&installation_id=136613492&pr_number=194&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F194&signature=aebcc4e29e87a6883dbdac92e308b3f4c545dc0438067f42e4c4a7ad79f7d1fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->