### PR TITLE
test(storybook): replay upstream eslint-plugin-storybook test suite

### DIFF
--- a/npm/storybook/test/fixtures/await-interactions.json
+++ b/npm/storybook/test/fixtures/await-interactions.json
@@ -1,0 +1,437 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/await-interactions.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "Basic.play = async () => {\n  await userEvent.click(button)\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "WithModalOpen.play = ({ canvasElement }) => {\n  const MyButton = canvas.getByRole('button')\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "WithModalOpen.play = async ({ canvasElement }) => {\n  const MyButton = await canvas.findByRole('button')\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = await within(canvasElement).findByText(/Hello/i)\n  await userEvent.click(element, undefined, { clickCount: 2 })\n  await userEvent.click(await within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const WithModalOpen = {\n  play: async ({ canvasElement }) => {\n    const element: HTMLButtonElement = await within(canvasElement).findByText(/Hello/i)\n    await userEvent.click(element, undefined, { clickCount: 2 })\n    await userEvent.click(await within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "await expect(foo).toBe(bar)",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "Basic.play = async () => {\n  await waitForElementToBeRemoved(() => canvas.findByText('Loading...'))\n  await waitForElementToBeRemoved(() => userEvent.hover(canvas.getByTestId('password-error-info')))\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { userEvent } from '../utils'\nimport { within } from '@storybook/testing-library'\n\nBasic.play = async (context) => {\n  const canvas = within(context)\n  userEvent.click(canvas.getByRole('button'))\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "Basic.play = async () => {\n  const userEvent = { test: () => {} }\n  // should not complain\n  userEvent.test()\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "Basic.play = async () => userEvent.click(button)",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "Basic.play = async () => { return userEvent.click(button) }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async (context) => {\n    await FirstStory.play(context)\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async (context) => {\n    await FirstStory.play?.(context)\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async (context) => {\n    await FirstStory.play!(context)\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "import { expect } from '@storybook/jest'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  expect(args.onClick).toHaveBeenCalled()\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "toHaveBeenCalled"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "import { expect } from '@storybook/jest'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  await expect(args.onClick).toHaveBeenCalled()\n}"
+            }
+          ]
+        }
+      ],
+      "output": "import { expect } from '@storybook/jest'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  await expect(args.onClick).toHaveBeenCalled()\n}"
+    },
+    {
+      "code": "import { expect, findByText } from '@storybook/test'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  expect(args.onClick).toHaveBeenCalled()\n  const element = findByText(canvasElement, 'asdf')\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "toHaveBeenCalled"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "import { expect, findByText } from '@storybook/test'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  await expect(args.onClick).toHaveBeenCalled()\n  const element = findByText(canvasElement, 'asdf')\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "import { expect, findByText } from '@storybook/test'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  expect(args.onClick).toHaveBeenCalled()\n  const element = await findByText(canvasElement, 'asdf')\n}"
+            }
+          ]
+        }
+      ],
+      "output": "import { expect, findByText } from '@storybook/test'\nWithModalOpen.play = async ({ args }) => {\n  // should complain\n  await expect(args.onClick).toHaveBeenCalled()\n  const element = await findByText(canvasElement, 'asdf')\n}"
+    },
+    {
+      "code": "WithModalOpen.play = ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n\n  const foodItem = canvas.findByText(/Cheeseburger/i)\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n\n  const foodItem = await canvas.findByText(/Cheeseburger/i)\n}"
+            }
+          ]
+        }
+      ],
+      "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n\n  const foodItem = await canvas.findByText(/Cheeseburger/i)\n}"
+    },
+    {
+      "code": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n  const foodItem = canvas.findByText(/Cheeseburger/i)\n  userEvent.click(foodItem)\n  const modalButton = canvas.findByLabelText('increase quantity by one')\n  userEvent.click(modalButton)\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n  const foodItem = await canvas.findByText(/Cheeseburger/i)\n  userEvent.click(foodItem)\n  const modalButton = canvas.findByLabelText('increase quantity by one')\n  userEvent.click(modalButton)\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n  const foodItem = canvas.findByText(/Cheeseburger/i)\n  await userEvent.click(foodItem)\n  const modalButton = canvas.findByLabelText('increase quantity by one')\n  userEvent.click(modalButton)\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByLabelText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n  const foodItem = canvas.findByText(/Cheeseburger/i)\n  userEvent.click(foodItem)\n  const modalButton = await canvas.findByLabelText('increase quantity by one')\n  userEvent.click(modalButton)\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n  const foodItem = canvas.findByText(/Cheeseburger/i)\n  userEvent.click(foodItem)\n  const modalButton = canvas.findByLabelText('increase quantity by one')\n  await userEvent.click(modalButton)\n}"
+            }
+          ]
+        }
+      ],
+      "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement)\n  const foodItem = await canvas.findByText(/Cheeseburger/i)\n  await userEvent.click(foodItem)\n  const modalButton = await canvas.findByLabelText('increase quantity by one')\n  await userEvent.click(modalButton)\n}"
+    },
+    {
+      "code": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n  userEvent.click(element, undefined, { clickCount: 2 })\n  userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = await within(canvasElement).findByText(/Hello/i)\n  userEvent.click(element, undefined, { clickCount: 2 })\n  userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n  await userEvent.click(element, undefined, { clickCount: 2 })\n  userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n  userEvent.click(element, undefined, { clickCount: 2 })\n  await userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n  userEvent.click(element, undefined, { clickCount: 2 })\n  userEvent.click(await within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}"
+            }
+          ]
+        }
+      ],
+      "output": "WithModalOpen.play = async ({ canvasElement }) => {\n  const element: HTMLButtonElement = await within(canvasElement).findByText(/Hello/i)\n  await userEvent.click(element, undefined, { clickCount: 2 })\n  await userEvent.click(await within(canvasElement).findByText(/Hello/i), undefined, {\n    clickCount: 2,\n  })\n}"
+    },
+    {
+      "code": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n    userEvent.click(element, undefined, { clickCount: 2 })\n    userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    expect(args.onSubmit).toHaveBeenCalled()\n  }\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = await within(canvasElement).findByText(/Hello/i)\n    userEvent.click(element, undefined, { clickCount: 2 })\n    userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    expect(args.onSubmit).toHaveBeenCalled()\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n    await userEvent.click(element, undefined, { clickCount: 2 })\n    userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    expect(args.onSubmit).toHaveBeenCalled()\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n    userEvent.click(element, undefined, { clickCount: 2 })\n    await userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    expect(args.onSubmit).toHaveBeenCalled()\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n    userEvent.click(element, undefined, { clickCount: 2 })\n    userEvent.click(await within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    expect(args.onSubmit).toHaveBeenCalled()\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "toHaveBeenCalled"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = within(canvasElement).findByText(/Hello/i)\n    userEvent.click(element, undefined, { clickCount: 2 })\n    userEvent.click(within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    await expect(args.onSubmit).toHaveBeenCalled()\n  }\n}"
+            }
+          ]
+        }
+      ],
+      "output": "export const WithModalOpen = {\n  play: async ({ canvasElement, args }) => {\n    const element: HTMLButtonElement = await within(canvasElement).findByText(/Hello/i)\n    await userEvent.click(element, undefined, { clickCount: 2 })\n    await userEvent.click(await within(canvasElement).findByText(/Hello/i), undefined, {\n      clickCount: 2,\n    })\n    await expect(args.onSubmit).toHaveBeenCalled()\n  }\n}"
+    },
+    {
+      "code": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    waitForElementToBeRemoved(async () => {\n      canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = canvas.findByText('Loaded!')\n    userEvent.click(button)\n    waitFor(async () => {\n      expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "waitForElementToBeRemoved"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    await waitForElementToBeRemoved(async () => {\n      canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = canvas.findByText('Loaded!')\n    userEvent.click(button)\n    waitFor(async () => {\n      expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    waitForElementToBeRemoved(async () => {\n      await canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = canvas.findByText('Loaded!')\n    userEvent.click(button)\n    waitFor(async () => {\n      expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "findByText"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    waitForElementToBeRemoved(async () => {\n      canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = await canvas.findByText('Loaded!')\n    userEvent.click(button)\n    waitFor(async () => {\n      expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "userEvent"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    waitForElementToBeRemoved(async () => {\n      canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = canvas.findByText('Loaded!')\n    await userEvent.click(button)\n    waitFor(async () => {\n      expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "waitFor"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    waitForElementToBeRemoved(async () => {\n      canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = canvas.findByText('Loaded!')\n    userEvent.click(button)\n    await waitFor(async () => {\n      expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "toHaveBeenCalled"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    waitForElementToBeRemoved(async () => {\n      canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = canvas.findByText('Loaded!')\n    userEvent.click(button)\n    waitFor(async () => {\n      await expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+            }
+          ]
+        }
+      ],
+      "output": "export const AfterLoadingState = {\n  play: async ({ canvasElement, args }) => {\n    const canvas = within(canvasElement)\n    await waitForElementToBeRemoved(async () => {\n      await canvas.findByText('Loading...')\n    }, { timeout: 2000 })\n    const button = await canvas.findByText('Loaded!')\n    await userEvent.click(button)\n    await waitFor(async () => {\n      await expect(args.onSubmit).toHaveBeenCalled()\n    })\n  }\n}"
+    },
+    {
+      "code": "export const FourthStory = {\n  play: async (context) => {\n    FirstStory.play(context)\n    SecondStory.play!(context)\n    ThirdStory.play?.(context)\n  }\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "play"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const FourthStory = {\n  play: async (context) => {\n    await FirstStory.play(context)\n    SecondStory.play!(context)\n    ThirdStory.play?.(context)\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "play"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const FourthStory = {\n  play: async (context) => {\n    FirstStory.play(context)\n    await SecondStory.play!(context)\n    ThirdStory.play?.(context)\n  }\n}"
+            }
+          ]
+        },
+        {
+          "messageId": "interactionShouldBeAwaited",
+          "data": {
+            "method": "play"
+          },
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export const FourthStory = {\n  play: async (context) => {\n    FirstStory.play(context)\n    SecondStory.play!(context)\n    await ThirdStory.play?.(context)\n  }\n}"
+            }
+          ]
+        }
+      ],
+      "output": "export const FourthStory = {\n  play: async (context) => {\n    await FirstStory.play(context)\n    await SecondStory.play!(context)\n    await ThirdStory.play?.(context)\n  }\n}"
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/context-in-play-function.json
+++ b/npm/storybook/test/fixtures/context-in-play-function.json
@@ -1,0 +1,85 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/context-in-play-function.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export const SecondStory = {\n  play: async (context) => {\n    await FirstStory.play(context)\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async ({ ...context }) => {\n    await FirstStory.play({ ...context })\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async ({ canvasElement, ...context }) => {\n    await FirstStory.play({ canvasElement, ...context })\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = Template.bind({})\nSecondStory.play = async (ctx) => {\n  await FirstStory.play(ctx)\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = Template.bind({})\nSecondStory.play = async ({ canvasElement, ...ctx }) => {\n  await FirstStory.play({ canvasElement, ...ctx })\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async (ctx) => {\n    await FirstStory.play(ctx)\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async ({ ...ctx }) => {\n    await FirstStory.play({ ...ctx })\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async ({ canvasElement, ...ctx }) => {\n    await FirstStory.play({ canvasElement, ...ctx })\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async ({ context, canvasElement }) => {\n    await FirstStory.play(context)\n  }\n}",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export const SecondStory = {\n  play: async ({ canvasElement }) => {\n    await FirstStory.play({ canvasElement })\n  }\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "passContextToPlayFunction"
+        }
+      ]
+    },
+    {
+      "code": "export const SecondStory = {\n  play: async () => {\n    await FirstStory.play()\n  }\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "passContextToPlayFunction"
+        }
+      ]
+    },
+    {
+      "code": "export const SecondStory = Template.bind({})\nSecondStory.play = async ({ canvasElement }) => {\n  await FirstStory.play({ canvasElement })\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "passContextToPlayFunction"
+        }
+      ]
+    },
+    {
+      "code": "export const SecondStory = Template.bind({})\nSecondStory.play = async () => {\n  await FirstStory.play()\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "passContextToPlayFunction"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/csf-component.json
+++ b/npm/storybook/test/fixtures/csf-component.json
@@ -1,0 +1,48 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/csf-component.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export default { title: 'Button', component: Button }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Button', component: Button } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export default { title: 'Button' }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "missingComponentProperty"
+        }
+      ]
+    },
+    {
+      "code": "export default { title: 'Button' } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "missingComponentProperty"
+        }
+      ]
+    },
+    {
+      "code": "\n        const meta = { title: 'Button' } as Meta<typeof Button>\n        export default meta\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "missingComponentProperty"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/default-exports.json
+++ b/npm/storybook/test/fixtures/default-exports.json
@@ -1,0 +1,105 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/default-exports.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export default { }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Button', component: Button }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Button', component: Button } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      const meta = { title: 'Button', component: Button }\n      export default meta\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    const meta: ComponentMeta<typeof Button> = { title: 'Button', component: Button }\n    export default meta\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      import { config } from '#.storybook/preview'\n      const meta = config.meta({})\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      import { storiesOf } from '@storybook/react'\n      storiesOf('Component', module)\n    ",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export const Primary = () => <button>hello</button>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveDefaultExport",
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "export default {}\nexport const Primary = () => <button>hello</button>"
+            }
+          ]
+        }
+      ],
+      "output": "export default {}\nexport const Primary = () => <button>hello</button>"
+    },
+    {
+      "code": "import { MyComponent, Foo } from './MyComponent'\nexport const Primary = () => <button>hello</button>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveDefaultExport",
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "import { MyComponent, Foo } from './MyComponent'\nexport default { component: MyComponent }\nexport const Primary = () => <button>hello</button>"
+            }
+          ]
+        }
+      ],
+      "output": "import { MyComponent, Foo } from './MyComponent'\nexport default { component: MyComponent }\nexport const Primary = () => <button>hello</button>"
+    },
+    {
+      "code": "import MyComponent from './MyComponent'\nexport const Primary = () => <button>hello</button>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveDefaultExport",
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "import MyComponent from './MyComponent'\nexport default { component: MyComponent }\nexport const Primary = () => <button>hello</button>"
+            }
+          ]
+        }
+      ],
+      "output": "import MyComponent from './MyComponent'\nexport default { component: MyComponent }\nexport const Primary = () => <button>hello</button>"
+    },
+    {
+      "code": "import { MyComponentProps } from './MyComponent'\nexport const Primary = () => <button>hello</button>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveDefaultExport",
+          "suggestions": [
+            {
+              "messageId": "fixSuggestion",
+              "output": "import { MyComponentProps } from './MyComponent'\nexport default {}\nexport const Primary = () => <button>hello</button>"
+            }
+          ]
+        }
+      ],
+      "output": "import { MyComponentProps } from './MyComponent'\nexport default {}\nexport const Primary = () => <button>hello</button>"
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/hierarchy-separator.json
+++ b/npm/storybook/test/fixtures/hierarchy-separator.json
@@ -1,0 +1,69 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/hierarchy-separator.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export default {  }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Examples.Components' }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Examples/Components/Button' }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Examples/Components/Button' } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Examples.Components' } satisfies Meta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { ...props } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export default { title: 'Examples|Components/Button' }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "deprecatedHierarchySeparator",
+          "suggestions": [
+            {
+              "messageId": "useCorrectSeparators",
+              "output": "export default { title: 'Examples/Components/Button' }"
+            }
+          ]
+        }
+      ],
+      "output": "export default { title: 'Examples/Components/Button' }"
+    },
+    {
+      "code": "const meta = { title: 'Examples|Components/Button' }\nexport default meta",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "deprecatedHierarchySeparator",
+          "suggestions": [
+            {
+              "messageId": "useCorrectSeparators",
+              "output": "const meta = { title: 'Examples/Components/Button' }\nexport default meta"
+            }
+          ]
+        }
+      ],
+      "output": "const meta = { title: 'Examples/Components/Button' }\nexport default meta"
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/meta-inline-properties.json
+++ b/npm/storybook/test/fixtures/meta-inline-properties.json
@@ -1,0 +1,99 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/meta-inline-properties.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export default { title: 'Button', args: { primary: true } }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { title: 'Button', args: { primary: true } } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n      const title = 'foo';\n      const args = { a: 1 };\n      export default { title, args };\n    ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "title"
+          }
+        },
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "args"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n        export default { title: 'a' + 123 };\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "title"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n        export default { title: `a ${123}` };\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "title"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n        const title = 'a'\n\n        export default {\n          title,\n          component: Badge,\n        } as ComponentMeta<typeof Badge>\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "title"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n        export default {\n          title: someFunction(),\n        }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "title"
+          }
+        }
+      ]
+    },
+    {
+      "code": "const title = 'a'\n\nconst meta: ComponentMeta<typeof Badge> = {\n  title,\n  component: Badge,\n}\n\nexport default meta",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldHaveInlineProperties",
+          "data": {
+            "property": "title"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/meta-satisfies-type.json
+++ b/npm/storybook/test/fixtures/meta-satisfies-type.json
@@ -1,0 +1,69 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/meta-satisfies-type.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export default { title: 'Button', args: { primary: true } } satisfies Meta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "const meta = {\n      component: AccountForm,\n    } satisfies Meta<typeof AccountForm>;\n    export default meta;",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export default { title: 'Button', args: { primary: true } }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldSatisfyType"
+        }
+      ]
+    },
+    {
+      "code": "\n      const meta = {\n        component: AccountForm,\n      }\n      export default meta;\n    ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldSatisfyType"
+        }
+      ]
+    },
+    {
+      "code": "\n      const meta: Meta<typeof AccountForm> = {\n        component: AccountForm,\n      }\n      export default meta;",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldSatisfyType"
+        }
+      ],
+      "output": "\n      const meta = {\n        component: AccountForm,\n      } satisfies Meta<typeof AccountForm>\n      export default meta;"
+    },
+    {
+      "code": "export default { title: 'Button', args: { primary: true } } as Meta<typeof Button>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldSatisfyType"
+        }
+      ],
+      "output": "export default { title: 'Button', args: { primary: true } } satisfies Meta<typeof Button>"
+    },
+    {
+      "code": "\n      const meta = ( {\n        component: AccountForm,\n      }) as (Meta<typeof AccountForm> )\n      export default ( meta );",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "metaShouldSatisfyType"
+        }
+      ],
+      "output": "\n      const meta = ( {\n        component: AccountForm,\n      }) satisfies (Meta<typeof AccountForm> )\n      export default ( meta );"
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/no-redundant-story-name.json
+++ b/npm/storybook/test/fixtures/no-redundant-story-name.json
@@ -1,0 +1,82 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/no-redundant-story-name.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export const PrimaryButton = { name: 'The Primary Button' }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const PrimaryButton: Story = { name: 'The Primary Button' }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      const Default = {}\n      export const PrimaryButton = { ...Default, name: 'The Primary Button' }\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      export const PrimaryButton = Template.bind({})\n      PrimaryButton.storyName = 'The Primary Button'\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      export function PrimaryButton () {\n        return <div>Hello</div>\n      }\n      PrimaryButton.storyName = 'The Primary Button'\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      export function H1 () {\n        return <h1>Hello</h1>\n      }\n      H1.storyName = 'H1'\n    ",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export const PrimaryButton = { name: 'Primary Button' }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "storyNameIsRedundant",
+          "suggestions": [
+            {
+              "messageId": "removeRedundantName",
+              "output": "export const PrimaryButton = {  }"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "export const PrimaryButton: Story = { name: 'Primary Button' }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "storyNameIsRedundant",
+          "suggestions": [
+            {
+              "messageId": "removeRedundantName",
+              "output": "export const PrimaryButton: Story = {  }"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "export const PrimaryButton = Template.bind({})\nPrimaryButton.storyName = 'Primary Button'",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "storyNameIsRedundant",
+          "suggestions": [
+            {
+              "messageId": "removeRedundantName",
+              "output": "export const PrimaryButton = Template.bind({})"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/no-renderer-packages.json
+++ b/npm/storybook/test/fixtures/no-renderer-packages.json
@@ -1,0 +1,68 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/no-renderer-packages.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "import { something } from '@storybook/react-vite';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { something } from '@storybook/vue3-webpack5';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { something } from '@storybook/web-components-vite';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import React from 'react';\nimport { something } from 'some-other-package';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "import { something } from '@storybook/react';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noRendererPackages",
+          "data": {
+            "rendererPackage": "@storybook/react",
+            "suggestions": "@storybook/nextjs, @storybook/react-vite, @storybook/nextjs-vite, @storybook/react-webpack5, @storybook/react-native-web-vite"
+          }
+        }
+      ]
+    },
+    {
+      "code": "import { something } from '@storybook/vue3';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noRendererPackages",
+          "data": {
+            "rendererPackage": "@storybook/vue3",
+            "suggestions": "@storybook/vue3-vite, @storybook/vue3-webpack5"
+          }
+        }
+      ]
+    },
+    {
+      "code": "import { something } from '@storybook/web-components';\n\nexport const MyStory = {\n  // ...\n};",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noRendererPackages",
+          "data": {
+            "rendererPackage": "@storybook/web-components",
+            "suggestions": "@storybook/web-components-vite, @storybook/web-components-webpack5"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/no-stories-of.json
+++ b/npm/storybook/test/fixtures/no-stories-of.json
@@ -1,0 +1,30 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/no-stories-of.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n      import Button from '../components/Button';\n      export default {\n        title: 'Button',\n        component: Button\n      }\n\n      export const Primary = () => <Button primary />\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      import Button from '../components/Button';\n      export default {\n        title: 'Button',\n        component: Button\n      } as ComponentMeta<typeof Button>\n\n      export const Primary: Story = () => <Button primary />\n    ",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n        import { storiesOf } from '@storybook/react';\n        import Button from '../components/Button';\n\n        storiesOf('Button', module)\n          .add('primary', () => <Button primary />)\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "doNotUseStoriesOf"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/no-title-property-in-meta.json
+++ b/npm/storybook/test/fixtures/no-title-property-in-meta.json
@@ -1,0 +1,105 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/no-title-property-in-meta.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export default {  }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { component: Button }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { component: Button } as ComponentMeta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { component: Button } as Meta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { component: Button } satisfies Meta<typeof Button>",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default { ...props }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "const meta = preview.meta({ component: Button, title: 'Button' })\nexport default meta",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "const meta = preview.type<{ args: { theme: string } }>().meta({ component: Button, title: 'Button' })\nexport default meta",
+      "filename": "MyComponent.stories.ts"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export default { title: 'Button', component: Button }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noTitleInMeta",
+          "suggestions": [
+            {
+              "messageId": "removeTitleInMeta",
+              "output": "export default {  component: Button }"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "const meta = { component: Button, title: 'Button' }\nexport default meta",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noTitleInMeta",
+          "suggestions": [
+            {
+              "messageId": "removeTitleInMeta",
+              "output": "const meta = { component: Button,  }\nexport default meta"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "const meta = { component: Button, title: 'Button' } as Meta<typeof Button>\nexport default meta",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noTitleInMeta",
+          "suggestions": [
+            {
+              "messageId": "removeTitleInMeta",
+              "output": "const meta = { component: Button,  } as Meta<typeof Button>\nexport default meta"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "const meta = { component: Button, title: 'Button' } satisfies Meta<typeof Button>\nexport default meta",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "noTitleInMeta",
+          "suggestions": [
+            {
+              "messageId": "removeTitleInMeta",
+              "output": "const meta = { component: Button,  } satisfies Meta<typeof Button>\nexport default meta"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/no-uninstalled-addons.json
+++ b/npm/storybook/test/fixtures/no-uninstalled-addons.json
@@ -1,0 +1,215 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/no-uninstalled-addons.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "\n    export default {\n      addons: [\n        \"@storybook/addon-links\",\n        \"@storybook/addon-essentials\",\n        \"@storybook/addon-interactions\",\n        \"@storybook/preset-create-react-app\"\n      ]\n    }\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    export default {\n      addons: [\n        \"@storybook/addon-links\",\n        \"@storybook/addon-essentials\",\n        \"@storybook/addon-interactions\",\n        \"@storybook/preset-create-react-app\"\n      ]\n    } satisfies StorybookConfig\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n     const config: StorybookConfig = {\n        addons: [\n        \"@storybook/addon-links\",\n        \"@storybook/addon-essentials\",\n        \"@storybook/addon-interactions\",\n        \"@storybook/preset-create-react-app\"\n        ]\n      }\n      export default config\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    export const addons = [\n      \"@storybook/addon-links\",\n      \"@storybook/addon-essentials\",\n      \"@storybook/addon-interactions\",\n    ]\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n        ]\n      }\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    module.exports = {\n        addons: [\n          \"storybook-addon-valid-addon/register\",\n          \"addon-without-the-prefix/preset\",\n        ]\n      }\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"storybook-addon-valid-addon\",\n        ]\n      }\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"addon-without-the-prefix\",\n        ]\n      }\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      module.exports = {\n          addons: [\n            \"../my-local-addon\",\n            \"../my-local-addon/index.cjs\",\n            \"/Users/foo/my-local-addon/index.js\",\n            \"/mount/foo/my-local-addon/index.js\",\n            \"C:\\Users\\foo\\my-local-addon/index.js\",\n            \"D:\\Users\\foo\\my-local-addon/index.js\",\n          ]\n        }\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n    module.exports = {\n        addons: [\n          {\n            name: \"@storybook/addon-links\",\n          },\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          {\n            name: \"addon-without-the-prefix\",\n          },\n          {\n            name: \"storybook-addon-valid-addon/register.js\",\n          },\n        ]\n      }\n  ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      module.exports = {\n          addons: [\n            \"@storybook/addon-links\",\n            \"@storybook/addon-essentials\",\n            \"@storybook/addon-interactions\",\n            \"@storybook/not-installed-addon\",\n          ]\n        }\n    ",
+      "filename": "MyComponent.stories.js",
+      "options": [
+        {
+          "packageJsonLocation": "",
+          "ignore": ["@storybook/not-installed-addon"]
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n      module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          '@storybook/not-installed-addon'\n        ]\n      }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/not-installed-addon",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          {\n            name: '@storybook/not-installed-addon'\n          }\n        ]\n      }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/not-installed-addon",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          {\n            name: \"@storybook/addon-esentials\",\n          },\n          \"@storybook/addon-interactions\",\n        ]\n      }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/addon-esentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/adon-essentials\",\n          \"@storybook/addon-interactions\",\n        ]\n      }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/adon-essentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      module.exports = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"addon-withut-the-prefix\",\n          \"@storybook/addon-esentials\",\n        ]\n      }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "addon-withut-the-prefix",
+            "packageJsonPath": "storybook/"
+          }
+        },
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/addon-esentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      export default {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"addon-withut-the-prefix\",\n          \"@storybook/addon-esentials\",\n        ]\n      }\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "addon-withut-the-prefix",
+            "packageJsonPath": "storybook/"
+          }
+        },
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/addon-esentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      export default {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"addon-withut-the-prefix\",\n          \"@storybook/addon-esentials\",\n        ]\n      } satisfies StorybookConfig\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "addon-withut-the-prefix",
+            "packageJsonPath": "storybook/"
+          }
+        },
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/addon-esentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n      const config: StorybookConfig = {\n        addons: [\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"addon-withut-the-prefix\",\n          \"@storybook/addon-esentials\",\n        ]\n      }\n      export default config\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "addon-withut-the-prefix",
+            "packageJsonPath": "storybook/"
+          }
+        },
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/addon-esentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    },
+    {
+      "code": "\n        export const addons = [\n          \"../my-local-addon\",\n          \"@storybook/addon-links\",\n          \"@storybook/addon-essentials\",\n          \"@storybook/addon-interactions\",\n          \"addon-withut-the-prefix\",\n          \"@storybook/addon-esentials\",\n        ]\n      ",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "addon-withut-the-prefix",
+            "packageJsonPath": "storybook/"
+          }
+        },
+        {
+          "messageId": "addonIsNotInstalled",
+          "data": {
+            "addonName": "@storybook/addon-esentials",
+            "packageJsonPath": "storybook/"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/prefer-pascal-case.json
+++ b/npm/storybook/test/fixtures/prefer-pascal-case.json
@@ -1,0 +1,95 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/prefer-pascal-case.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export const Primary = {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const __namedExportsOrder = ['Secondary', 'Primary']",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const _primary = {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export const Primary: Story = {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      import { storiesOf } from '@storybook/react'\n      export const links = []\n      storiesOf('Component', module)\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      export default {\n        title: 'MyComponent',\n        component: MyComponent,\n        includeStories: ['SimpleStory', 'ComplexStory'],\n        excludeStories: /.*Data$/,\n      };\n\n      export const simpleData = { foo: 1, bar: 'baz' };\n      export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };\n\n      export const SimpleStory = () => <MyComponent data={simpleData} />;\n      export const ComplexStory = () => <MyComponent data={complexData} />;\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      export default {\n        title: 'MyComponent',\n        component: MyComponent,\n        includeStories: [MyComponent.name],\n      };\n\n      export const SimpleStory = () => <MyComponent />;\n    ",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export const primary = {}\nprimary.foo = 'bar'",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "usePascalCase",
+          "data": {
+            "name": "primary"
+          },
+          "suggestions": [
+            {
+              "messageId": "convertToPascalCase",
+              "output": "export const Primary = {}\nPrimary.foo = 'bar'"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "export const primary: Story = {}\nprimary.foo = 'bar'",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "usePascalCase",
+          "data": {
+            "name": "primary"
+          },
+          "suggestions": [
+            {
+              "messageId": "convertToPascalCase",
+              "output": "export const Primary: Story = {}\nPrimary.foo = 'bar'"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "export default {\n  title: 'MyComponent',\n  component: MyComponent,\n  includeStories: /.*Story$/,\n  excludeStories: /.*Data$/,\n};\nexport const simpleData = { foo: 1, bar: 'baz' };\nexport const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };\nexport const simpleStory = () => <MyComponent data={simpleData} />;\nsimpleStory.args = {};",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "usePascalCase",
+          "data": {
+            "name": "simpleStory"
+          },
+          "suggestions": [
+            {
+              "messageId": "convertToPascalCase",
+              "output": "export default {\n  title: 'MyComponent',\n  component: MyComponent,\n  includeStories: /.*Story$/,\n  excludeStories: /.*Data$/,\n};\nexport const simpleData = { foo: 1, bar: 'baz' };\nexport const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };\nexport const SimpleStory = () => <MyComponent data={simpleData} />;\nSimpleStory.args = {};"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/story-exports.json
+++ b/npm/storybook/test/fixtures/story-exports.json
@@ -1,0 +1,89 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/story-exports.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "export const Primary = {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default {}\nexport const Primary = {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default {} as ComponentMeta<typeof RestaurantDetailPage>\nexport const Primary = {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { storiesOf } from '@storybook/react'\nstoriesOf('MyComponent', module)",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "const Primary = {}\nconst Secondary = {}\nexport default {}\nexport { Primary, Secondary }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "\n      export default {\n        title: 'MyComponent',\n        component: MyComponent,\n        includeStories: [MyComponent.name],\n      };\n\n      export const SimpleStory = () => <MyComponent />;\n    ",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default {\n  excludeStories: /.*Data$/,\n}\n\nconst mockData = {}\nconst Primary = {}\n\nexport { mockData, Primary }",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export function Primary() {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default {}\nexport function Primary() {}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "export default {} as ComponentMeta<typeof RestaurantDetailPage>\nexport function Primary() {}",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "export default {\n  component: Button\n} as ComponentMeta<typeof RestaurantDetailPage>",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveStoryExport"
+        }
+      ]
+    },
+    {
+      "code": "export default {\n  excludeStories: /.*Data$/,\n}\n\nexport const mockData = {}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveStoryExportWithFilters"
+        }
+      ]
+    },
+    {
+      "code": "export default {\n  excludeStories: /.*Data$/,\n}\n\nconst mockData = {}\nconst Primary = {}\n\nexport { mockData }",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveStoryExportWithFilters"
+        }
+      ]
+    },
+    {
+      "code": "export default {\n  excludeStories: /.*Data$/,\n}\n\nexport function generateMockData() {}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "shouldHaveStoryExportWithFilters"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/use-storybook-expect.json
+++ b/npm/storybook/test/fixtures/use-storybook-expect.json
@@ -1,0 +1,60 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/use-storybook-expect.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "import { expect } from '@storybook/jest';\n\nDefault.play = () => {\n  expect(123).toEqual(123);\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { expect } from '@storybook/jest';\n\nexport const Basic = {\n  ...Default,\n  play: async (context) => {\n    expect(123).toEqual(123);\n  },\n};",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { expect } from '@storybook/test';\n\nDefault.play = () => {\n  expect(123).toEqual(123);\n}",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { expect } from '@storybook/test';\n\nexport const Basic = {\n  ...Default,\n  play: async (context) => {\n    expect(123).toEqual(123);\n  },\n};",
+      "filename": "MyComponent.stories.js"
+    },
+    {
+      "code": "import { expect } from 'storybook/test';\n\nDefault.play = () => {\n  expect(123).toEqual(123);\n}",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "Default.play = () => {\n  expect(123).toEqual(123);\n}",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "useExpectFromStorybook"
+        }
+      ]
+    },
+    {
+      "code": "const someInteraction = () => {\n  expect(123).toEqual(123);\n}\nDefault.play = someInteraction",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "useExpectFromStorybook"
+        }
+      ]
+    },
+    {
+      "code": "export const Basic = {\n  ...Default,\n  play: async (context) => {\n    expect(123).toEqual(123);\n  },\n};",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "useExpectFromStorybook"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/storybook/test/fixtures/use-storybook-testing-library.json
+++ b/npm/storybook/test/fixtures/use-storybook-testing-library.json
@@ -1,0 +1,74 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-storybook",
+    "ref": "v10.4.2",
+    "sourceFile": "src/rules/use-storybook-testing-library.test.ts",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-storybook-tests.ts"
+  },
+  "valid": [
+    {
+      "code": "import { within } from 'storybook/test'",
+      "filename": "MyComponent.stories.js"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "import { within } from '@testing-library/dom'",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "dontUseTestingLibraryDirectly",
+          "data": {
+            "library": "@testing-library/dom"
+          },
+          "suggestions": [
+            {
+              "messageId": "updateImports",
+              "output": "import { within } from 'storybook/test'"
+            }
+          ]
+        }
+      ],
+      "output": "import { within } from 'storybook/test'"
+    },
+    {
+      "code": "import userEvent from '@testing-library/user-event'",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "dontUseTestingLibraryDirectly",
+          "data": {
+            "library": "@testing-library/user-event"
+          },
+          "suggestions": [
+            {
+              "messageId": "updateImports",
+              "output": "import { userEvent } from 'storybook/test'"
+            }
+          ]
+        }
+      ],
+      "output": "import { userEvent } from 'storybook/test'"
+    },
+    {
+      "code": "import userEvent, { foo, bar as Bar } from '@testing-library/user-event'",
+      "filename": "MyComponent.stories.js",
+      "errors": [
+        {
+          "messageId": "dontUseTestingLibraryDirectly",
+          "data": {
+            "library": "@testing-library/user-event"
+          },
+          "suggestions": [
+            {
+              "messageId": "updateImports",
+              "output": "import { userEvent, foo, bar as Bar } from 'storybook/test'"
+            }
+          ]
+        }
+      ],
+      "output": "import { userEvent, foo, bar as Bar } from 'storybook/test'"
+    }
+  ]
+}

--- a/npm/storybook/test/parity.json
+++ b/npm/storybook/test/parity.json
@@ -1,0 +1,22 @@
+{
+  "//": "Parity ratchet for the upstream eslint-plugin-storybook test suite replayed by upstream.test.mjs. By default EVERY upstream case is enforced: valid cases must report zero diagnostics, invalid cases must match the upstream-declared messageId multiset and `data` placeholders, and (where the upstream case is autofixable or carries a single suggestion) applying the port's fixes must reproduce the upstream output. The entries below quarantine the specific cases where the current Rust port diverges from upstream; each is a known bug tracked for a follow-up fix PR, after which its entry is removed and the case becomes enforced. Indices are positions in the rule's fixture `valid`/`invalid` arrays (re-check after a submodule bump + re-sync).",
+  "skip": {
+    "await-interactions": {
+      "valid": [8],
+      "reason": "Port false-positives on a locally shadowed `userEvent` (`const userEvent = { test: () => {} }; userEvent.test()`); needs scope awareness to skip the redefined binding."
+    },
+    "no-redundant-story-name": {
+      "valid": [5],
+      "fixOutput": [2],
+      "reason": "valid[5]: port false-positives on a redundant-name case upstream accepts. invalid[2] fixOutput: the port's removal fix leaves a trailing newline upstream's suggestion does not."
+    },
+    "prefer-pascal-case": {
+      "fixOutput": [0, 1, 2],
+      "reason": "The port's autofix renames the export declaration identifier but not its other references (`primary.foo` stays lowercase); upstream's suggestion renames every reference."
+    },
+    "story-exports": {
+      "valid": [5],
+      "reason": "Port false-positives (shouldHaveStoryExportWithFilters) on a valid file that uses includeStories/excludeStories filters."
+    }
+  }
+}

--- a/npm/storybook/test/upstream.test.mjs
+++ b/npm/storybook/test/upstream.test.mjs
@@ -1,0 +1,193 @@
+// Replays the upstream eslint-plugin-storybook test suite (captured verbatim into
+// test/fixtures/*.json by `pnpm run port:tests:storybook`) against this plugin's
+// native scanner, so behaviour stays faithful to upstream as the submodule is
+// bumped. This is the guarantee that the port reproduces eslint-plugin-storybook's
+// own tests.
+//
+// For every upstream case:
+//   - valid   -> the port must report zero diagnostics (soundness).
+//   - invalid -> the multiset of reported messageIds must equal the upstream
+//                `errors[].messageId`; every upstream `data` placeholder must be
+//                reproduced; and where the upstream case is autofixable (a
+//                top-level `output`) or carries a single suggestion, applying the
+//                port's fixes must reproduce that output.
+//
+// Known divergences are quarantined per-case in test/parity.json (with a reason);
+// each is a tracked bug whose fix PR removes the entry and enforces the case.
+//
+// no-uninstalled-addons resolves installed addons from package.json on disk; the
+// upstream suite mocks `fs` with a fixed manifest, so we supply the same installed
+// set via scan options and ignore the environment-dependent `packageJsonPath`
+// placeholder (the addon name — what the rule is about — is still asserted).
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { implementedStorybookRuleNames, scanStorybook } from '../api.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(TEST_DIR, 'fixtures');
+const parity = JSON.parse(readFileSync(join(TEST_DIR, 'parity.json'), 'utf8'));
+
+// devDependencies the upstream no-uninstalled-addons test mocks `fs.readFileSync`
+// to return (code/lib/eslint-plugin/src/rules/no-uninstalled-addons.test.ts).
+const MOCKED_INSTALLED_ADDONS = Object.freeze([
+  '@storybook/addon-essentials',
+  '@storybook/addon-interactions',
+  '@storybook/preset-create-react-app',
+  '@storybook/addon-links',
+  'storybook-addon-valid-addon',
+  'addon-without-the-prefix',
+]);
+
+function scanOptionsFor(ruleName, testCase) {
+  const options = { ruleNames: [ruleName] };
+  if (ruleName === 'no-uninstalled-addons') {
+    options.installedAddons = [...MOCKED_INSTALLED_ADDONS];
+    options.packageJsonPath = 'package.json';
+    const ruleOptions = Array.isArray(testCase.options) ? testCase.options[0] : null;
+    if (ruleOptions && Array.isArray(ruleOptions.ignore)) {
+      options.ignoredAddons = ruleOptions.ignore;
+    }
+  }
+  return options;
+}
+
+function scan(ruleName, testCase) {
+  return scanStorybook(testCase.code, testCase.filename, scanOptionsFor(ruleName, testCase));
+}
+
+function applyFixes(code, diagnostics) {
+  const fixes = [];
+  for (const diagnostic of diagnostics) {
+    for (const fix of diagnostic.fixes ?? []) {
+      fixes.push(fix);
+    }
+  }
+  fixes.sort((a, b) => b.start - a.start);
+  return fixes.reduce(
+    (text, fix) => text.slice(0, fix.start) + fix.replacement + text.slice(fix.end),
+    code,
+  );
+}
+
+// The upstream output a faithful autofix should reproduce: the top-level `output`
+// when the rule auto-fixes, else the lone suggestion's output when the case has a
+// single error with a single suggestion (suggestion-only upstream rules that the
+// port implements as an autofix). Otherwise there is nothing single-valued to
+// assert.
+function expectedFixOutput(testCase) {
+  if (typeof testCase.output === 'string' && testCase.output !== testCase.code) {
+    return testCase.output;
+  }
+  if (Array.isArray(testCase.errors) && testCase.errors.length === 1) {
+    const suggestions = testCase.errors[0].suggestions;
+    if (
+      Array.isArray(suggestions) &&
+      suggestions.length === 1 &&
+      typeof suggestions[0].output === 'string'
+    ) {
+      return suggestions[0].output;
+    }
+  }
+  return undefined;
+}
+
+function dataMatches(ruleName, expectedData, actualData) {
+  const data = actualData ?? {};
+  return Object.entries(expectedData).every(([key, value]) => {
+    // packageJsonPath is the absolute path the rule was pointed at; the upstream
+    // suite asserts a mocked cwd-derived path we cannot reproduce here. The addon
+    // name (the rule's subject) is still asserted.
+    if (ruleName === 'no-uninstalled-addons' && key === 'packageJsonPath') {
+      return true;
+    }
+    return data[key] === value;
+  });
+}
+
+function label(testCase, index) {
+  const code = JSON.stringify(testCase.code);
+  const truncated = code.length > 70 ? `${code.slice(0, 70)}…"` : code;
+  return `#${index} ${truncated}`;
+}
+
+function skipList(ruleName, kind) {
+  const entry = parity.skip[ruleName];
+  return new Set(entry && Array.isArray(entry[kind]) ? entry[kind] : []);
+}
+
+const fixtureFiles = readdirSync(FIXTURES_DIR)
+  .filter((name) => name.endsWith('.json'))
+  .sort();
+
+describe('eslint-plugin-storybook upstream parity', () => {
+  it('has a fixture for every implemented rule', () => {
+    const ruleNames = fixtureFiles.map((name) => name.replace(/\.json$/, ''));
+    expect(ruleNames).toEqual([...implementedStorybookRuleNames()].sort());
+  });
+
+  for (const file of fixtureFiles) {
+    const ruleName = file.replace(/\.json$/, '');
+    const fixture = JSON.parse(readFileSync(join(FIXTURES_DIR, file), 'utf8'));
+    const skipValid = skipList(ruleName, 'valid');
+    const skipInvalid = skipList(ruleName, 'invalid');
+    const skipFixOutput = skipList(ruleName, 'fixOutput');
+
+    describe(ruleName, () => {
+      it('carries upstream provenance', () => {
+        expect(fixture.__generated.source).toBe('eslint-plugin-storybook');
+        expect(fixture.__generated.ref).toBeTruthy();
+      });
+
+      if (fixture.valid.length > 0) {
+        describe('valid', () => {
+          fixture.valid.forEach((testCase, index) => {
+            const test = skipValid.has(index) ? it.skip : it;
+            test(label(testCase, index), () => {
+              expect(scan(ruleName, testCase)).toEqual([]);
+            });
+          });
+        });
+      }
+
+      if (fixture.invalid.length > 0) {
+        describe('invalid', () => {
+          fixture.invalid.forEach((testCase, index) => {
+            const test = skipInvalid.has(index) ? it.skip : it;
+            test(label(testCase, index), () => {
+              const diagnostics = scan(ruleName, testCase);
+              const expected = testCase.errors ?? [];
+
+              const actualIds = diagnostics.map((d) => d.messageId).sort();
+              const expectedIds = expected.map((e) => e.messageId).sort();
+              expect(actualIds).toEqual(expectedIds);
+
+              for (const error of expected) {
+                if (!error.data) {
+                  continue;
+                }
+                const match = diagnostics.some(
+                  (d) =>
+                    d.messageId === error.messageId && dataMatches(ruleName, error.data, d.data),
+                );
+                expect(
+                  match,
+                  `data ${JSON.stringify(error.data)} for ${error.messageId} not reproduced`,
+                ).toBe(true);
+              }
+
+              const expectedOutput = expectedFixOutput(testCase);
+              if (expectedOutput !== undefined && !skipFixOutput.has(index)) {
+                expect(applyFixes(testCase.code, diagnostics)).toBe(expectedOutput);
+              }
+            });
+          });
+        });
+      }
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",
     "port:tests:simple-import-sort": "node tools/tasks/sync-simple-import-sort-tests.ts",
+    "port:tests:storybook": "node tools/tasks/sync-storybook-tests.ts",
     "profile": "node tools/tasks/profile.ts",
     "release": "node tools/tasks/release.ts",
     "security:audit": "node tools/tasks/security-audit.ts",

--- a/tools/tasks/sync-storybook-tests.ts
+++ b/tools/tasks/sync-storybook-tests.ts
@@ -1,0 +1,402 @@
+// Captures the upstream eslint-plugin-storybook test suite straight from the
+// vendored submodule and writes it to committed JSON fixtures, so our Vitest
+// suite replays the real upstream cases and tracks behaviour as the submodule is
+// bumped (oxc-style test syncing). Mirrors tools/tasks/sync-functional-tests.ts.
+//
+// Upstream drives cases through a classic *declarative* RuleTester: each
+// `<rule>.test.ts` calls `ruleTester.run('<rule>', rule, { valid, invalid })`
+// once at module top level (no async `it()` blocks, no snapshots). The shared
+// `../test-utils.ts` wraps `@typescript-eslint/rule-tester` and injects a default
+// `filename: 'MyComponent.stories.js'` into every case. We register synchronous
+// module hooks (`module.registerHooks`) that stub:
+//   - `../test-utils.ts`      -> a capturing RuleTester whose `run(name, _rule,
+//                                {valid, invalid})` records the arrays (applying
+//                                the same default filename as upstream) instead of
+//                                executing ESLint.
+//   - `./<rule>.ts` / `../rules/<rule>.ts` -> `export default {}`; the real rule
+//                                module pulls Storybook deps the shallow submodule
+//                                has not installed, and we only need the cases.
+//   - `ts-dedent`             -> a faithful reimplementation (not installed).
+//   - `@typescript-eslint/utils` -> an `AST_NODE_TYPES` proxy yielding member
+//                                names (some tests tag errors with `type:
+//                                AST_NODE_TYPES.X`, which we do not replay).
+//   - `vitest`                -> a `vi` mock stub (one test calls `vi.mock`/`vi.fn`
+//                                to fake `fs`); the calls must not crash.
+//
+// The upstream `.ts` test files run directly through Node's native type stripping
+// (Node >= 24). Cases carrying non-serialisable values (functions) are dropped and
+// counted (no silent truncation).
+//
+// Re-run with `pnpm run port:tests:storybook`, then `vp fmt` the generated
+// fixtures (the JSON is emitted with `JSON.stringify`, which always expands short
+// arrays the formatter collapses onto one line).
+
+import { registerHooks } from 'node:module';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    packageSubdir?: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type RawSuggestion = { messageId?: string; output?: string };
+type RawError = {
+  messageId?: string;
+  data?: Record<string, unknown>;
+  suggestions?: RawSuggestion[];
+};
+type RawCase = {
+  code?: string;
+  output?: string | null;
+  options?: unknown[];
+  filename?: string;
+  errors?: unknown;
+};
+type Capture = { valid: RawCase[]; invalid: RawCase[] };
+
+type NormSuggestion = { messageId: string; output?: string };
+type NormError = {
+  messageId: string;
+  data?: Record<string, unknown>;
+  suggestions?: NormSuggestion[];
+};
+type NormCase = {
+  code: string;
+  options?: unknown[];
+  filename: string;
+  output?: string;
+  errors?: NormError[];
+};
+
+type SyncGlobal = { captures: Record<string, Capture> };
+
+const ROOT = process.cwd();
+const SYNC_KEY = '__storybookSyncState__';
+const DEFAULT_FILENAME = 'MyComponent.stories.js';
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-storybook');
+if (!plugin) {
+  throw new Error('eslint-plugin-storybook is not registered in tools/port-targets.json');
+}
+
+const PKG = join(ROOT, plugin.submodule, plugin.packageSubdir ?? '.');
+const SRC_RULES_DIR = join(PKG, 'src', 'rules');
+const FIXTURES_DIR = join(ROOT, 'npm', 'storybook', 'test', 'fixtures');
+const REF = plugin.pinnedRef ?? `v${plugin.baselineVersion}`;
+
+if (!existsSync(SRC_RULES_DIR)) {
+  throw new Error(
+    `Upstream sources not found under ${PKG}. Run: git submodule update --init ${plugin.submodule}`,
+  );
+}
+
+mkdirSync(FIXTURES_DIR, { recursive: true });
+
+const state: SyncGlobal = { captures: {} };
+(globalThis as Record<string, unknown>)[SYNC_KEY] = state;
+
+registerStubHooks();
+
+const ruleNames = readdirSync(SRC_RULES_DIR)
+  .filter((file) => file.endsWith('.test.ts'))
+  .map((file) => file.slice(0, -'.test.ts'.length))
+  .sort();
+
+const summary: string[] = [];
+
+for (const rule of ruleNames) {
+  const testFile = join(SRC_RULES_DIR, `${rule}.test.ts`);
+  await import(pathToFileURL(testFile).href);
+
+  const captured = state.captures[rule] ?? { valid: [], invalid: [] };
+  const { cases, dropped } = normalizeCapture(captured);
+  writeFixture(rule, `src/rules/${rule}.test.ts`, cases);
+
+  summary.push(
+    `${rule}: ${cases.valid.length} valid, ${cases.invalid.length} invalid` +
+      `${dropped > 0 ? `, ${dropped} dropped` : ''}`,
+  );
+}
+
+console.log(`Synced eslint-plugin-storybook fixtures from upstream ${REF}:`);
+for (const line of summary) {
+  console.log(`- ${line}`);
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function writeFixture(rule: string, sourceFile: string, cases: Capture | NormalizedCapture): void {
+  const fixture = {
+    __generated: {
+      source: plugin!.npm,
+      ref: REF,
+      sourceFile,
+      license: plugin!.license,
+      tool: 'tools/tasks/sync-storybook-tests.ts',
+    },
+    valid: cases.valid,
+    invalid: cases.invalid,
+  };
+  writeFileSync(join(FIXTURES_DIR, `${rule}.json`), `${JSON.stringify(fixture, null, 2)}\n`);
+}
+
+type NormalizedCapture = { valid: NormCase[]; invalid: NormCase[] };
+
+function normalizeCapture(capture: Capture): { cases: NormalizedCapture; dropped: number } {
+  let dropped = 0;
+  const valid: NormCase[] = [];
+  const invalid: NormCase[] = [];
+
+  for (const raw of capture.valid) {
+    const normalized = normalizeCase(raw, false);
+    if (normalized) {
+      valid.push(normalized);
+    } else {
+      dropped += 1;
+    }
+  }
+  for (const raw of capture.invalid) {
+    const normalized = normalizeCase(raw, true);
+    if (normalized) {
+      invalid.push(normalized);
+    } else {
+      dropped += 1;
+    }
+  }
+
+  return { cases: { valid, invalid }, dropped };
+}
+
+// Keep only JSON-serialisable cases with a string `code`. A case carrying a
+// function (e.g. a custom parser) does not survive the round-trip and is dropped.
+function normalizeCase(raw: RawCase, isInvalid: boolean): NormCase | null {
+  if (raw == null || typeof raw.code !== 'string') {
+    return null;
+  }
+
+  const out: NormCase = {
+    code: raw.code,
+    filename: typeof raw.filename === 'string' ? raw.filename : DEFAULT_FILENAME,
+  };
+
+  if (Array.isArray(raw.options) && raw.options.length > 0) {
+    const options = safeClone(raw.options);
+    if (options === undefined) {
+      return null;
+    }
+    out.options = options as unknown[];
+  }
+
+  if (isInvalid) {
+    const errors = normalizeErrors(raw.errors);
+    if (errors.length > 0) {
+      out.errors = errors;
+    }
+    if (typeof raw.output === 'string') {
+      out.output = raw.output;
+    }
+  }
+
+  return out;
+}
+
+// Reduce each declared error to the fields we replay against: the messageId, the
+// asserted `data` placeholders, and the suggestion outputs (a `<messageId,
+// output>` pair). Position/`type` fields are not replayed (the Rust port reports
+// faithful messageIds but may flag different spans).
+function normalizeErrors(errors: unknown): NormError[] {
+  if (!Array.isArray(errors)) {
+    return [];
+  }
+  const out: NormError[] = [];
+  for (const error of errors) {
+    if (typeof error === 'string') {
+      out.push({ messageId: error });
+      continue;
+    }
+    if (!error || typeof error !== 'object') {
+      continue;
+    }
+    const e = error as RawError;
+    if (typeof e.messageId !== 'string') {
+      continue;
+    }
+    const norm: NormError = { messageId: e.messageId };
+    if (e.data && typeof e.data === 'object') {
+      const data = safeClone(e.data);
+      if (data !== undefined) {
+        norm.data = data as Record<string, unknown>;
+      }
+    }
+    if (Array.isArray(e.suggestions)) {
+      const suggestions: NormSuggestion[] = [];
+      for (const suggestion of e.suggestions) {
+        if (
+          suggestion &&
+          typeof suggestion === 'object' &&
+          typeof suggestion.messageId === 'string'
+        ) {
+          const s: NormSuggestion = { messageId: suggestion.messageId };
+          if (typeof suggestion.output === 'string') {
+            s.output = suggestion.output;
+          }
+          suggestions.push(s);
+        }
+      }
+      norm.suggestions = suggestions;
+    }
+    out.push(norm);
+  }
+  return out;
+}
+
+function safeClone(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
+// --- stubs -----------------------------------------------------------------
+
+function registerStubHooks(): void {
+  const stubSource: Record<string, string> = {
+    'test-utils': testUtilsStub(),
+    rule: 'export default {};',
+    dedent: dedentStub(),
+    'ts-utils': tsUtilsStub(),
+    vitest: vitestStub(),
+  };
+
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (specifier === 'ts-dedent') {
+        return { url: 'stub:///dedent', shortCircuit: true };
+      }
+      if (specifier === 'vitest') {
+        return { url: 'stub:///vitest', shortCircuit: true };
+      }
+      if (specifier === '@typescript-eslint/utils') {
+        return { url: 'stub:///ts-utils', shortCircuit: true };
+      }
+      if (/(^|\/)test-utils\.ts$/.test(specifier)) {
+        return { url: 'stub:///test-utils', shortCircuit: true };
+      }
+      // Relative rule imports: `./<rule>.ts` or `../rules/<rule>.ts` (but not the
+      // test file itself or the shared test-utils).
+      if (
+        /^\.{1,2}\//.test(specifier) &&
+        specifier.endsWith('.ts') &&
+        !specifier.endsWith('.test.ts')
+      ) {
+        return { url: 'stub:///rule', shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+    load(url, context, nextLoad) {
+      if (url.startsWith('stub:///')) {
+        const key = url.slice('stub:///'.length);
+        const source = stubSource[key];
+        if (source !== undefined) {
+          return { format: 'module', source, shortCircuit: true };
+        }
+      }
+      return nextLoad(url, context);
+    },
+  });
+}
+
+// Capturing RuleTester matching upstream `src/test-utils.ts`: every case is
+// merged onto the default `{ filename: 'MyComponent.stories.js' }`, string cases
+// become `{ filename, code }`.
+function testUtilsStub(): string {
+  return [
+    `const KEY = ${JSON.stringify(SYNC_KEY)};`,
+    `const DEFAULT = { filename: ${JSON.stringify(DEFAULT_FILENAME)} };`,
+    'function toValid(input) {',
+    '  if (typeof input === "string") return { ...DEFAULT, code: input };',
+    '  return { ...DEFAULT, ...(input || {}) };',
+    '}',
+    'function toInvalid(input) { return { ...DEFAULT, ...(input || {}) }; }',
+    'const ruleTester = {',
+    '  run(name, _rule, tests) {',
+    '    const valid = (tests && tests.valid ? tests.valid : []).map(toValid);',
+    '    const invalid = (tests && tests.invalid ? tests.invalid : []).map(toInvalid);',
+    '    globalThis[KEY].captures[name] = { valid, invalid };',
+    '  },',
+    '};',
+    'export default ruleTester;',
+  ].join('\n');
+}
+
+function tsUtilsStub(): string {
+  return [
+    'export const AST_NODE_TYPES = new Proxy({}, { get(_t, prop) { return String(prop); } });',
+    'export const ESLintUtils = {};',
+    'export const TSESLint = {};',
+    'export default { AST_NODE_TYPES };',
+  ].join('\n');
+}
+
+function vitestStub(): string {
+  return [
+    'function noop() {}',
+    'function fn() { const f = () => {}; f.mockReturnValue = () => f; f.mockImplementation = () => f; return f; }',
+    'const vi = {',
+    '  fn,',
+    '  mock: noop,',
+    '  mocked: (x) => x,',
+    '  spyOn: () => ({ mockReturnValue: () => {}, mockImplementation: () => {} }),',
+    '  importActual: async () => ({}),',
+    '  resetAllMocks: noop,',
+    '  restoreAllMocks: noop,',
+    '};',
+    'export { vi };',
+    'export function describe(_n, fn) { if (typeof fn === "function") fn(); }',
+    'export function it() {}',
+    'export const test = it;',
+    'export function expect() { return new Proxy(function () {}, { get() { return () => {}; }, apply() {} }); }',
+    'export function beforeAll() {} export function afterAll() {}',
+    'export function beforeEach() {} export function afterEach() {}',
+    'export default { vi, describe, it, test, expect };',
+  ].join('\n');
+}
+
+// Reimplementation of `ts-dedent` (the submodule does not install it): concatenate
+// the tagged-template parts, then remove the minimum leading whitespace shared by
+// all non-empty lines and trim surrounding blank lines.
+function dedentStub(): string {
+  return [
+    'function dedent(strings, ...values) {',
+    '  const raw = typeof strings === "string" ? [strings] : (strings.raw || strings);',
+    '  let result = "";',
+    '  for (let i = 0; i < raw.length; i++) {',
+    '    result += raw[i];',
+    '    if (i < values.length) result += String(values[i]);',
+    '  }',
+    '  const lines = result.split("\\n");',
+    '  let mindent = null;',
+    '  for (const line of lines) {',
+    '    const m = line.match(/^(\\s+)\\S/);',
+    '    if (m) { const indent = m[1].length; mindent = mindent === null ? indent : Math.min(mindent, indent); }',
+    '  }',
+    '  const out = mindent === null || mindent === 0 ? lines : lines.map((l) => l.slice(mindent));',
+    '  return out.join("\\n").trim();',
+    '}',
+    'export { dedent };',
+    'export default dedent;',
+  ].join('\n');
+}


### PR DESCRIPTION
## What

Establishes upstream test-parity infrastructure for the `eslint-plugin-storybook` port (issue #10), so the port's faithfulness is **guaranteed by eslint-plugin-storybook's own test suite** — auto-extracted from the vendored submodule — rather than only hand-written cases. Mirrors the existing regexp / functional / eslint-comments sync infra.

## How

- **`tools/tasks/sync-storybook-tests.ts`** (`pnpm run port:tests:storybook`): replays each upstream `src/rules/<rule>.test.ts` with `module.registerHooks` stubbing the shared `../test-utils.ts` declarative RuleTester (plus `ts-dedent`, `@typescript-eslint/utils`, `vitest`, and the rule modules), capturing every `valid`/`invalid` case into `npm/storybook/test/fixtures/<rule>.json` (code, options, filename, `output`, `errors[messageId/data/suggestions]`).
- **`npm/storybook/test/upstream.test.mjs`**: replays every captured case through the native scanner — `valid` ⇒ zero diagnostics; `invalid` ⇒ messageId multiset + `data` placeholders + autofix `output` (where single-valued).
- **`npm/storybook/test/parity.json`**: a per-case ratchet quarantining the rules that currently diverge from upstream, each with a reason; removed by its follow-up fix PR.

## Results

**11 of 16 rules pass full upstream parity immediately.** Quarantined for follow-up fixes:

| Rule | Divergence |
|---|---|
| `await-interactions` | false positive on a locally shadowed `userEvent` (needs scope awareness) |
| `no-redundant-story-name` | one valid false-positive + a trailing-newline in the removal fix |
| `prefer-pascal-case` | autofix renames the declaration but not its other references |
| `story-exports` | false positive on `includeStories`/`excludeStories` filters |

`no-uninstalled-addons` is replayed with the upstream-mocked installed-addon set supplied via scan options (the upstream suite mocks `fs`).

Follow-up PRs fix each quarantined rule and remove its `parity.json` entry until the suite enforces all 16 rules with zero skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783991824&installation_id=136613492&pr_number=195&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F195&signature=38b98e9a94eb1bb7aec409d0df9b907c6460451d6ec9ebba2f63c796b9417b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->