### PR TITLE
port(sonarjs): port no-primitive-wrappers (S1533)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 33] = [
+pub const RULE_NAMES: [&str; 34] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -56,6 +56,7 @@ pub const RULE_NAMES: [&str; 33] = [
     "no-redundant-optional",
     "prefer-immediate-return",
     "no-redundant-jump",
+    "no-primitive-wrappers",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -25,6 +25,7 @@ mod no_labels;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;
+mod no_primitive_wrappers;
 mod no_redundant_boolean;
 mod no_redundant_jump;
 mod no_redundant_optional;

--- a/crates/sonarjs/src/rules/no_primitive_wrappers.rs
+++ b/crates/sonarjs/src/rules/no_primitive_wrappers.rs
@@ -1,0 +1,46 @@
+//! Rule `no-primitive-wrappers` (SonarJS key S1533).
+//!
+//! Clean-room port. Calling `new Number(...)`, `new String(...)`, or
+//! `new Boolean(...)` creates a wrapper *object* rather than a primitive value.
+//! This has surprising consequences: `typeof new Number(1) === 'object'`, and
+//! `new Boolean(false)` is truthy because any object is truthy. The wrapper
+//! object form should never be used; use the bare conversion calls (`Number(x)`,
+//! `String(x)`, `Boolean(x)`) when a type conversion is needed, or just the
+//! primitive literals directly.
+//!
+//! **Flagged**:
+//! - `new Number(1)` — wraps a number in an object.
+//! - `new String('x')` — wraps a string in an object.
+//! - `new Boolean(false)` — wraps a boolean in an object (always truthy!).
+//! - `const n = new Number(x);` — assignment doesn't change the object-ness.
+//!
+//! **Not flagged**:
+//! - `Number(1)` — plain call (no `new`), performs a type conversion to a
+//!   primitive; this is fine.
+//! - `new Array(3)` — not a primitive wrapper constructor.
+//! - `new Foo()` — not a primitive wrapper constructor.
+//! - `String(x)` — plain conversion call.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S1533) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{Expression, NewExpression};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-primitive-wrappers";
+
+const WRAPPERS: [&str; 3] = ["Number", "String", "Boolean"];
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_primitive_wrappers(&mut self, expr: &NewExpression<'_>) {
+        let Expression::Identifier(callee) = expr.callee.get_inner_expression() else {
+            return;
+        };
+        if !WRAPPERS.contains(&callee.name.as_str()) {
+            return;
+        }
+        self.report(RULE_NAME, "primitiveWrapper", expr.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -6,9 +6,9 @@ use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
     DoWhileStatement, ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function,
     FunctionBody, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression,
-    RegExpLiteral, StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType,
-    TSPropertySignature, TSUnionType, TemplateLiteral, UnaryExpression, WhileStatement,
-    YieldExpression,
+    NewExpression, RegExpLiteral, StaticMemberExpression, SwitchCase, SwitchStatement,
+    TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral, UnaryExpression,
+    WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -208,6 +208,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_expression_statement(&mut self, it: &ExpressionStatement<'a>) {
         self.check_constructor_for_side_effects(it);
         walk::walk_expression_statement(self, it);
+    }
+
+    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+        self.check_no_primitive_wrappers(it);
+        walk::walk_new_expression(self, it);
     }
 
     fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1548,3 +1548,50 @@ fn does_not_report_redundant_jump_for_non_block_loop_body() {
     let diagnostics = scan("no-redundant-jump", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_primitive_wrappers_for_new_number() {
+    let source = "const n = new Number(1);";
+    let diagnostics = scan("no-primitive-wrappers", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-primitive-wrappers");
+    assert_eq!(diagnostics[0].message_id, "primitiveWrapper");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_no_primitive_wrappers_for_new_string() {
+    let source = "const s = new String('x');";
+    let diagnostics = scan("no-primitive-wrappers", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "primitiveWrapper");
+}
+
+#[test]
+fn reports_no_primitive_wrappers_for_new_boolean() {
+    let source = "const b = new Boolean(false);";
+    let diagnostics = scan("no-primitive-wrappers", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "primitiveWrapper");
+}
+
+#[test]
+fn does_not_report_no_primitive_wrappers_for_call_without_new() {
+    let source = "const n = Number(1);";
+    let diagnostics = scan("no-primitive-wrappers", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_primitive_wrappers_for_new_array() {
+    let source = "const a = new Array(3);";
+    let diagnostics = scan("no-primitive-wrappers", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_primitive_wrappers_for_unknown_constructor() {
+    let source = "const f = new Foo();";
+    let diagnostics = scan("no-primitive-wrappers", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -134,6 +134,10 @@ const messages = Object.freeze({
   'no-redundant-jump': {
     redundantJump: 'Remove this redundant jump; it does not change the control flow.',
   },
+  'no-primitive-wrappers': {
+    primitiveWrapper:
+      "Use the primitive type instead of the 'new Number/String/Boolean' wrapper object.",
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -195,6 +199,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow declaring a local variable solely to immediately return or throw it; return or throw the initializer expression directly',
   'no-redundant-jump':
     'Disallow jump statements (continue without label, return without value) that do not change the control flow because execution would proceed the same way anyway',
+  'no-primitive-wrappers':
+    "Disallow using 'new' with the primitive wrapper constructors Number, String, or Boolean, which create wrapper objects instead of primitive values",
 });
 
 const ruleTypes = Object.freeze({
@@ -231,6 +237,7 @@ const ruleTypes = Object.freeze({
   'no-redundant-optional': 'suggestion',
   'prefer-immediate-return': 'suggestion',
   'no-redundant-jump': 'suggestion',
+  'no-primitive-wrappers': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -267,6 +274,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-redundant-optional': 'error',
   'prefer-immediate-return': 'error',
   'no-redundant-jump': 'error',
+  'no-primitive-wrappers': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -36,6 +36,7 @@ const expectedRuleNames = [
   'no-redundant-optional',
   'prefer-immediate-return',
   'no-redundant-jump',
+  'no-primitive-wrappers',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1244,6 +1245,46 @@ describe('sonarjs native API', () => {
   it('does not report no-redundant-jump for a labeled continue', () => {
     const source = 'outer: for (;;) { foo(); continue outer; }';
     const diagnostics = scan('no-redundant-jump', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-primitive-wrappers for new Number(1)', () => {
+    const source = 'const n = new Number(1);';
+    const diagnostics = scan('no-primitive-wrappers', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-primitive-wrappers');
+    expect(diagnostics[0].messageId).toBe('primitiveWrapper');
+  });
+
+  it('reports no-primitive-wrappers for new String("x")', () => {
+    const source = "const s = new String('x');";
+    const diagnostics = scan('no-primitive-wrappers', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('primitiveWrapper');
+  });
+
+  it('reports no-primitive-wrappers for new Boolean(false)', () => {
+    const source = 'const b = new Boolean(false);';
+    const diagnostics = scan('no-primitive-wrappers', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('primitiveWrapper');
+  });
+
+  it('does not report no-primitive-wrappers for Number(1) (call, no new)', () => {
+    const source = 'const n = Number(1);';
+    const diagnostics = scan('no-primitive-wrappers', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-primitive-wrappers for new Array(3) (not a primitive wrapper)', () => {
+    const source = 'const a = new Array(3);';
+    const diagnostics = scan('no-primitive-wrappers', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-primitive-wrappers for new Foo() (unknown constructor)', () => {
+    const source = 'const f = new Foo();';
+    const diagnostics = scan('no-primitive-wrappers', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -127,6 +127,7 @@ describe('sonarjs plugin shape', () => {
       'no-redundant-optional',
       'prefer-immediate-return',
       'no-redundant-jump',
+      'no-primitive-wrappers',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -161,6 +162,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-redundant-optional']).toBe('object');
     expect(typeof plugin.rules['prefer-immediate-return']).toBe('object');
     expect(typeof plugin.rules['no-redundant-jump']).toBe('object');
+    expect(typeof plugin.rules['no-primitive-wrappers']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -195,6 +197,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-optional']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-immediate-return']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-jump']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-primitive-wrappers']).toBe('error');
   });
 });
 
@@ -761,5 +764,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-redundant-jump)');
+  });
+
+  it('reports no-primitive-wrappers for new Number(1) through the adapter', () => {
+    const source = 'const n = new Number(1);';
+    const reports = runRule('no-primitive-wrappers', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('primitiveWrapper');
+  });
+
+  it('reports no-primitive-wrappers through the CLI', () => {
+    const source = 'const n = new Number(1);';
+    const result = runOxlint('no-primitive-wrappers', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-primitive-wrappers)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12750,19 +12750,19 @@
       },
       {
         "name": "no-primitive-wrappers",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-primitive-wrappers (Sonar key S1533). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (S1533). Reports NewExpression whose callee is an identifier named Number, String, or Boolean. Rust core uses visit_new_expression + get_inner_expression(); NAPI adapter wires the rule into the plugin. Tests authored independently \u2014 no upstream source, fixtures, or messages copied."
       },
       {
         "name": "no-redundant-assignments",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-primitive-wrappers`** (Sonar key S1533). Flags `new Number(x)`, `new String(x)`, `new Boolean(x)` — these create wrapper **objects** (`typeof` is `'object'`; `new Boolean(false)` is truthy) instead of primitives. Conversion calls without `new` (`Number(1)`) and other constructors (`new Array`, `new Foo`) are not flagged. Adds a `visit_new_expression` hook.

## Tests
Rust unit tests (`new Number`/`String`/`Boolean` → 1; `Number()` call, `new Array(3)`, `new Foo()` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-primitive-wrappers)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783992156&installation_id=136613492&pr_number=196&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F196&signature=b5b008be84b064038fb6fe591359807b2fe62066155470861654e9146a440f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->