### PR TITLE
port(sonarjs): port no-skipped-tests (S1607)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 34] = [
+pub const RULE_NAMES: [&str; 35] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -57,6 +57,7 @@ pub const RULE_NAMES: [&str; 34] = [
     "prefer-immediate-return",
     "no-redundant-jump",
     "no-primitive-wrappers",
+    "no-skipped-tests",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -29,6 +29,7 @@ mod no_primitive_wrappers;
 mod no_redundant_boolean;
 mod no_redundant_jump;
 mod no_redundant_optional;
+mod no_skipped_tests;
 mod no_small_switch;
 mod no_useless_catch;
 mod non_existent_operator;

--- a/crates/sonarjs/src/rules/no_skipped_tests.rs
+++ b/crates/sonarjs/src/rules/no_skipped_tests.rs
@@ -1,0 +1,59 @@
+//! Rule `no-skipped-tests` (SonarJS key S1607).
+//!
+//! Clean-room port. Skipped tests accumulate silently: once skipped, they may
+//! never be re-enabled, rotting away while the author forgets why they were
+//! disabled. CI passes, but coverage quietly shrinks.
+//!
+//! **Covered forms**:
+//! 1. `.skip` member access on a known test-runner identifier:
+//!    `describe.skip(...)`, `it.skip(...)`, `test.skip(...)`,
+//!    `context.skip(...)`, `suite.skip(...)`, `specify.skip(...)`.
+//!    A `StaticMemberExpression` whose property is `skip` and whose object is a
+//!    bare identifier in the runner set is flagged. Chained or namespaced forms
+//!    (`myFramework.describe.skip`) are not flagged because the object is not a
+//!    bare identifier.
+//! 2. `x`-prefixed Jasmine-style calls: `xit(...)`, `xdescribe(...)`,
+//!    `xtest(...)`, `xcontext(...)`, `xspecify(...)`. A `CallExpression` whose
+//!    callee (after stripping parentheses) is a bare identifier in the x-set.
+//!
+//! Both forms share the `skippedTest` messageId. The member-expression span is
+//! reported for form 1; the call-expression span for form 2.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S1607) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{CallExpression, Expression, StaticMemberExpression};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-skipped-tests";
+
+const TEST_RUNNERS: [&str; 6] = ["describe", "it", "test", "context", "suite", "specify"];
+
+const X_RUNNERS: [&str; 5] = ["xit", "xdescribe", "xtest", "xcontext", "xspecify"];
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_skipped_tests_member(&mut self, member: &StaticMemberExpression<'_>) {
+        if member.property.name.as_str() != "skip" {
+            return;
+        }
+        let Expression::Identifier(object) = member.object.get_inner_expression() else {
+            return;
+        };
+        if !TEST_RUNNERS.contains(&object.name.as_str()) {
+            return;
+        }
+        self.report(RULE_NAME, "skippedTest", member.span);
+    }
+
+    pub(crate) fn check_no_skipped_tests_call(&mut self, call: &CallExpression<'_>) {
+        let Expression::Identifier(callee) = call.callee.get_inner_expression() else {
+            return;
+        };
+        if !X_RUNNERS.contains(&callee.name.as_str()) {
+            return;
+        }
+        self.report(RULE_NAME, "skippedTest", call.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,12 +3,12 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, BindingIdentifier, CatchClause, ConditionalExpression,
-    DoWhileStatement, ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function,
-    FunctionBody, IdentifierReference, IfStatement, LabeledStatement, LogicalExpression,
-    NewExpression, RegExpLiteral, StaticMemberExpression, SwitchCase, SwitchStatement,
-    TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral, UnaryExpression,
-    WhileStatement, YieldExpression,
+    AssignmentExpression, BinaryExpression, BindingIdentifier, CallExpression, CatchClause,
+    ConditionalExpression, DoWhileStatement, ExpressionStatement, ForInStatement, ForOfStatement,
+    ForStatement, Function, FunctionBody, IdentifierReference, IfStatement, LabeledStatement,
+    LogicalExpression, NewExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
+    SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
+    UnaryExpression, WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -197,7 +197,13 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
         self.check_no_exclusive_tests(it);
+        self.check_no_skipped_tests_member(it);
         walk::walk_static_member_expression(self, it);
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        self.check_no_skipped_tests_call(it);
+        walk::walk_call_expression(self, it);
     }
 
     fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1595,3 +1595,73 @@ fn does_not_report_no_primitive_wrappers_for_unknown_constructor() {
     let diagnostics = scan("no-primitive-wrappers", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_skipped_tests_for_describe_skip() {
+    let source = "describe.skip('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-skipped-tests");
+    assert_eq!(diagnostics[0].message_id, "skippedTest");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_no_skipped_tests_for_it_skip() {
+    let source = "it.skip('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "skippedTest");
+}
+
+#[test]
+fn reports_no_skipped_tests_for_test_skip() {
+    let source = "test.skip('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "skippedTest");
+}
+
+#[test]
+fn reports_no_skipped_tests_for_xit() {
+    let source = "xit('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "skippedTest");
+}
+
+#[test]
+fn reports_no_skipped_tests_for_xdescribe() {
+    let source = "xdescribe('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "skippedTest");
+}
+
+#[test]
+fn does_not_report_no_skipped_tests_for_it_without_skip() {
+    let source = "it('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_skipped_tests_for_describe_without_skip() {
+    let source = "describe('x', () => {});";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_skipped_tests_for_unknown_runner_with_skip() {
+    let source = "foo.skip();";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_skipped_tests_for_xfoo_not_in_x_set() {
+    let source = "xfoo();";
+    let diagnostics = scan("no-skipped-tests", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -138,6 +138,9 @@ const messages = Object.freeze({
     primitiveWrapper:
       "Use the primitive type instead of the 'new Number/String/Boolean' wrapper object.",
   },
+  'no-skipped-tests': {
+    skippedTest: 'Re-enable or remove this skipped test.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -201,6 +204,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow jump statements (continue without label, return without value) that do not change the control flow because execution would proceed the same way anyway',
   'no-primitive-wrappers':
     "Disallow using 'new' with the primitive wrapper constructors Number, String, or Boolean, which create wrapper objects instead of primitive values",
+  'no-skipped-tests':
+    'Disallow committed skipped tests (.skip member or x-prefixed Jasmine calls); re-enable or remove them instead',
 });
 
 const ruleTypes = Object.freeze({
@@ -238,6 +243,7 @@ const ruleTypes = Object.freeze({
   'prefer-immediate-return': 'suggestion',
   'no-redundant-jump': 'suggestion',
   'no-primitive-wrappers': 'problem',
+  'no-skipped-tests': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -275,6 +281,7 @@ const recommendedRuleConfig = Object.freeze({
   'prefer-immediate-return': 'error',
   'no-redundant-jump': 'error',
   'no-primitive-wrappers': 'error',
+  'no-skipped-tests': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -37,6 +37,7 @@ const expectedRuleNames = [
   'prefer-immediate-return',
   'no-redundant-jump',
   'no-primitive-wrappers',
+  'no-skipped-tests',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1285,6 +1286,53 @@ describe('sonarjs native API', () => {
   it('does not report no-primitive-wrappers for new Foo() (unknown constructor)', () => {
     const source = 'const f = new Foo();';
     const diagnostics = scan('no-primitive-wrappers', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-skipped-tests for describe.skip(...)', () => {
+    const source = "describe.skip('x', () => {});";
+    const diagnostics = scan('no-skipped-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-skipped-tests');
+    expect(diagnostics[0].messageId).toBe('skippedTest');
+  });
+
+  it('reports no-skipped-tests for it.skip(...)', () => {
+    const source = "it.skip('x', () => {});";
+    const diagnostics = scan('no-skipped-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('skippedTest');
+  });
+
+  it('reports no-skipped-tests for xit(...)', () => {
+    const source = "xit('x', () => {});";
+    const diagnostics = scan('no-skipped-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('skippedTest');
+  });
+
+  it('reports no-skipped-tests for xdescribe(...)', () => {
+    const source = "xdescribe('x', () => {});";
+    const diagnostics = scan('no-skipped-tests', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('skippedTest');
+  });
+
+  it('does not report no-skipped-tests for it(...) (no skip)', () => {
+    const source = "it('x', () => {});";
+    const diagnostics = scan('no-skipped-tests', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-skipped-tests for foo.skip() (unknown runner)', () => {
+    const source = 'foo.skip();';
+    const diagnostics = scan('no-skipped-tests', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-skipped-tests for xfoo() (not in x-set)', () => {
+    const source = 'xfoo();';
+    const diagnostics = scan('no-skipped-tests', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -128,6 +128,7 @@ describe('sonarjs plugin shape', () => {
       'prefer-immediate-return',
       'no-redundant-jump',
       'no-primitive-wrappers',
+      'no-skipped-tests',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -163,6 +164,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['prefer-immediate-return']).toBe('object');
     expect(typeof plugin.rules['no-redundant-jump']).toBe('object');
     expect(typeof plugin.rules['no-primitive-wrappers']).toBe('object');
+    expect(typeof plugin.rules['no-skipped-tests']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -198,6 +200,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/prefer-immediate-return']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-redundant-jump']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-primitive-wrappers']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-skipped-tests']).toBe('error');
   });
 });
 
@@ -781,5 +784,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-primitive-wrappers)');
+  });
+
+  it('reports no-skipped-tests for describe.skip through the adapter', () => {
+    const source = "describe.skip('x', () => {});";
+    const reports = runRule('no-skipped-tests', source, { filename: 'sample.js' });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('skippedTest');
+  });
+
+  it('reports no-skipped-tests through the CLI', () => {
+    const source = "xit('x', () => {});";
+    const result = runOxlint('no-skipped-tests', source, 'sample.js');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-skipped-tests)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12990,19 +12990,19 @@
       },
       {
         "name": "no-skipped-tests",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-skipped-tests (Sonar key S1607). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1607). Covers both .skip member form (describe/it/test/context/suite/specify) and x-prefixed Jasmine calls (xit/xdescribe/xtest/xcontext/xspecify). Both forms share the skippedTest messageId. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-small-switch",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-skipped-tests`** (Sonar key S1607). Flags skipped-test markers in two forms: `.skip` on a known test runner (`describe`/`it`/`test`/`context`/`suite`/`specify`) and Jasmine `x`-prefixed bare calls (`xit`/`xdescribe`/`xtest`/`xcontext`/`xspecify`). Reuses the existing `visit_static_member_expression` hook for `.skip` and adds a `visit_call_expression` hook for the x-prefixed forms (no double-reporting).

## Tests
Rust unit tests (`describe.skip`, `it.skip`, `xit`, `xdescribe` → 1; plain `it`, `foo.skip`, `xfoo` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-skipped-tests)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783992750&installation_id=136613492&pr_number=199&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F199&signature=0ad93ed8a8ee898cce3bd776f92a7efccd9cd6a7fc825721bd27c8f326921348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->