### PR TITLE
fix(storybook): faithful ts-dedent in the upstream test sync

### DIFF
--- a/npm/storybook/test/fixtures/no-redundant-story-name.json
+++ b/npm/storybook/test/fixtures/no-redundant-story-name.json
@@ -72,7 +72,7 @@
           "suggestions": [
             {
               "messageId": "removeRedundantName",
-              "output": "export const PrimaryButton = Template.bind({})"
+              "output": "export const PrimaryButton = Template.bind({})\n"
             }
           ]
         }

--- a/npm/storybook/test/parity.json
+++ b/npm/storybook/test/parity.json
@@ -7,8 +7,7 @@
     },
     "no-redundant-story-name": {
       "valid": [5],
-      "fixOutput": [2],
-      "reason": "valid[5]: port false-positives on a redundant-name case upstream accepts. invalid[2] fixOutput: the port's removal fix leaves a trailing newline upstream's suggestion does not."
+      "reason": "Port false-positives on `H1.storyName = 'H1'`: its story-name derivation does not split a letter→digit boundary the way upstream's lodash-style startCase does (`storyNameFromExport('H1') === 'H 1'`), so it wrongly treats the name as redundant."
     },
     "prefer-pascal-case": {
       "fixOutput": [0, 1, 2],

--- a/tools/tasks/sync-storybook-tests.ts
+++ b/tools/tasks/sync-storybook-tests.ts
@@ -375,26 +375,37 @@ function vitestStub(): string {
   ].join('\n');
 }
 
-// Reimplementation of `ts-dedent` (the submodule does not install it): concatenate
-// the tagged-template parts, then remove the minimum leading whitespace shared by
-// all non-empty lines and trim surrounding blank lines.
+// Faithful reimplementation of `ts-dedent` v2 (the submodule does not install it).
+// Mirrors the upstream algorithm EXACTLY — crucially it does NOT `.trim()`: it
+// strips only the trailing `\n<indent>` before the closing backtick and a single
+// leading `\n`, so a deliberate trailing blank line (e.g. a removal-fix `output`
+// that ends in a newline) is preserved. A full trim corrupts such expected outputs.
+// The storybook test files use `dedent` with no `${}` interpolations, but the
+// general (values) path is reproduced for fidelity. Uses the COOKED template
+// strings (`Array.from(templ)`), like ts-dedent.
 function dedentStub(): string {
   return [
-    'function dedent(strings, ...values) {',
-    '  const raw = typeof strings === "string" ? [strings] : (strings.raw || strings);',
-    '  let result = "";',
-    '  for (let i = 0; i < raw.length; i++) {',
-    '    result += raw[i];',
-    '    if (i < values.length) result += String(values[i]);',
+    'function dedent(templ, ...values) {',
+    '  let strings = Array.from(typeof templ === "string" ? [templ] : templ);',
+    '  // 1. Remove the trailing newline + indentation before the closing delimiter.',
+    '  strings[strings.length - 1] = strings[strings.length - 1].replace(/\\r?\\n([\\t ]*)$/, "");',
+    '  // 2. Collect indentation widths (a non-space char right after \\n counts as 0).',
+    '  const indentLengths = strings.reduce((arr, str) => {',
+    '    const matches = str.match(/\\n([\\t ]+|(?!\\s).)/g);',
+    '    if (matches) return arr.concat(matches.map((m) => { const x = m.match(/[\\t ]/g); return x ? x.length : 0; }));',
+    '    return arr;',
+    '  }, []);',
+    '  // 3. Strip the common (minimum) indentation from every line.',
+    '  if (indentLengths.length) {',
+    '    const pattern = new RegExp("\\\\n[\\\\t ]{" + Math.min(...indentLengths) + "}", "g");',
+    '    strings = strings.map((str) => str.replace(pattern, "\\n"));',
     '  }',
-    '  const lines = result.split("\\n");',
-    '  let mindent = null;',
-    '  for (const line of lines) {',
-    '    const m = line.match(/^(\\s+)\\S/);',
-    '    if (m) { const indent = m[1].length; mindent = mindent === null ? indent : Math.min(mindent, indent); }',
-    '  }',
-    '  const out = mindent === null || mindent === 0 ? lines : lines.map((l) => l.slice(mindent));',
-    '  return out.join("\\n").trim();',
+    '  // 4. Remove a single leading newline.',
+    '  strings[0] = strings[0].replace(/^\\r?\\n/, "");',
+    '  // 5. Interpolate values.',
+    '  let string = strings[0];',
+    '  for (let i = 0; i < values.length; i++) { string += String(values[i]) + strings[i + 1]; }',
+    '  return string;',
     '}',
     'export { dedent };',
     'export default dedent;',


### PR DESCRIPTION
## What

Fixes a fidelity bug in the storybook upstream-test sync tool (added in #195): the `dedent` stub did a full `.trim()`, which silently corrupted upstream expected outputs that intentionally end in a blank line.

Concretely, `no-redundant-story-name`'s CSF2 removal-fix output is written upstream as:

```ts
output: dedent`
  export const PrimaryButton = Template.bind({})

`,
```

Real `ts-dedent` preserves the trailing newline (`...bind({})\n`) — which is exactly what the port's `fixer.remove(node)` produces. The old stub trimmed it to `...bind({})`, manufacturing a false divergence (previously quarantined as `fixOutput[2]`).

## How

- Replace the `dedent` stub with a faithful port of **ts-dedent v2**: strip only the trailing `\n<indent>` before the closing delimiter and a single leading `\n` (no full trim), using the cooked template strings. The storybook tests use no `${}` interpolation, but the values path is reproduced for fidelity.
- Regenerate fixtures: **only `no-redundant-story-name`'s `invalid[2]` output changes** (gains its real trailing `\n`).
- Drop the now-passing `fixOutput` quarantine from `parity.json`.

The remaining quarantines (`await-interactions` valid[8], `no-redundant-story-name` valid[5], `prefer-pascal-case` fixOutput, `story-exports` valid[5]) are genuine port bugs fixed in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993080&installation_id=136613492&pr_number=200&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F200&signature=80c1d4a4597234595d8fdcfd77aede321518e2eb80d3b4c9b370e1b81e759c72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->