### PR TITLE
fix(storybook): story-exports ignores an unresolvable story filter

### DIFF
--- a/crates/storybook/src/helpers.rs
+++ b/crates/storybook/src/helpers.rs
@@ -274,45 +274,70 @@ pub(crate) fn is_play_call(call: &CallExpression<'_>) -> bool {
 }
 
 pub(crate) fn story_filters_from_meta(meta: &ObjectExpression<'_>) -> StoryFilters {
+    // Upstream builds `{ excludeStories: getDescriptor(meta, ...), includeStories:
+    // getDescriptor(meta, ...) }` inside a try/catch and discards the WHOLE config
+    // if either call throws (`getDescriptor` throws on a non-literal array element
+    // such as `includeStories: [MyComponent.name]`), so the file is treated as
+    // having no filter. Mirror that: if either descriptor fails to resolve, return
+    // empty (unfiltered) filters.
+    let include = match find_object_property(meta, "includeStories") {
+        Some(property) => descriptor_from_expression(&property.value),
+        None => Ok(None),
+    };
+    let exclude = match find_object_property(meta, "excludeStories") {
+        Some(property) => descriptor_from_expression(&property.value),
+        None => Ok(None),
+    };
+    let (Ok(include), Ok(exclude)) = (include, exclude) else {
+        return StoryFilters::default();
+    };
+
     let mut filters = StoryFilters::default();
-    if let Some(property) = find_object_property(meta, "includeStories")
-        && let Some(descriptor) = descriptor_from_expression(&property.value)
-    {
+    if let Some(descriptor) = include {
         filters.include.push(descriptor);
         filters.has_filter = true;
     }
-    if let Some(property) = find_object_property(meta, "excludeStories")
-        && let Some(descriptor) = descriptor_from_expression(&property.value)
-    {
+    if let Some(descriptor) = exclude {
         filters.exclude.push(descriptor);
         filters.has_filter = true;
     }
     filters
 }
 
-pub(crate) fn descriptor_from_expression(expression: &Expression<'_>) -> Option<Descriptor> {
+/// Returned by [`descriptor_from_expression`] when upstream `getDescriptor` would
+/// throw, signalling the whole filter config must be discarded.
+pub(crate) struct InvalidDescriptor;
+
+// Mirrors upstream `getDescriptor`. `Ok(Some(_))` is a resolved filter, `Ok(None)`
+// means the property is not a descriptor shape upstream recognises (no filter), and
+// `Err(_)` means upstream `getDescriptor` would throw — an array containing a
+// non-string-literal element (or a hole/spread), which discards the whole config.
+pub(crate) fn descriptor_from_expression(
+    expression: &Expression<'_>,
+) -> Result<Option<Descriptor>, InvalidDescriptor> {
     match expression.get_inner_expression() {
         Expression::ArrayExpression(array) => {
             let mut names = SmallVec::new();
             for element in &array.elements {
-                if let Some(Expression::StringLiteral(literal)) = element
+                let Some(Expression::StringLiteral(literal)) = element
                     .as_expression()
                     .map(Expression::get_inner_expression)
-                {
-                    names.push(CompactString::from(literal.value.as_str()));
-                }
+                else {
+                    return Err(InvalidDescriptor);
+                };
+                names.push(CompactString::from(literal.value.as_str()));
             }
-            Some(Descriptor::Names(names))
+            Ok(Some(Descriptor::Names(names)))
         }
         Expression::StringLiteral(literal) => {
             let mut names = SmallVec::new();
             names.push(CompactString::from(literal.value.as_str()));
-            Some(Descriptor::Names(names))
+            Ok(Some(Descriptor::Names(names)))
         }
-        Expression::RegExpLiteral(literal) => Some(Descriptor::Regex(CompactString::from(
+        Expression::RegExpLiteral(literal) => Ok(Some(Descriptor::Regex(CompactString::from(
             literal.regex.pattern.text.as_str(),
-        ))),
-        _ => None,
+        )))),
+        _ => Ok(None),
     }
 }
 

--- a/crates/storybook/src/tests.rs
+++ b/crates/storybook/src/tests.rs
@@ -94,6 +94,15 @@ fn scans_story_exports_and_story_names() {
 }
 
 #[test]
+fn story_exports_ignores_unresolvable_filter() {
+    // A non-string-literal `includeStories` element makes upstream `getDescriptor`
+    // throw, discarding the filter; the file then has a valid story export.
+    let source = "export default { title: 'C', component: C, includeStories: [C.name] };\n\
+         export const SimpleStory = () => null;";
+    assert_eq!(scan("story-exports", source).len(), 0);
+}
+
+#[test]
 fn scans_imports_and_addons() {
     assert_eq!(
         scan(

--- a/npm/storybook/test/parity.json
+++ b/npm/storybook/test/parity.json
@@ -12,10 +12,6 @@
     "prefer-pascal-case": {
       "fixOutput": [0, 1, 2],
       "reason": "The port's autofix renames the export declaration identifier but not its other references (`primary.foo` stays lowercase); upstream's suggestion renames every reference."
-    },
-    "story-exports": {
-      "valid": [5],
-      "reason": "Port false-positives (shouldHaveStoryExportWithFilters) on a valid file that uses includeStories/excludeStories filters."
     }
   }
 }


### PR DESCRIPTION
## What

Fixes a `story-exports` false positive (issue #10 parity follow-up). A story file whose meta uses a non-statically-resolvable `includeStories`/`excludeStories` element was wrongly reported as having no story export:

```js
export default {
  title: 'MyComponent',
  component: MyComponent,
  includeStories: [MyComponent.name], // non-literal element
};
export const SimpleStory = () => <MyComponent />; // a real story
```

## Why

Upstream parses the filter with `getDescriptor`, which **throws** on a non-string-literal array element; the throw is caught and the entire filter config is discarded, so the file is treated as unfiltered and `SimpleStory` still counts. The port instead silently collected only the literal elements, yielding an empty name filter that matched nothing → false `shouldHaveStoryExportWithFilters`.

## How

- `descriptor_from_expression` now returns `Result<Option<Descriptor>, InvalidDescriptor>` and returns `Err` on any non-string-literal array element (or hole/spread) — mirroring the upstream throw.
- `story_filters_from_meta` discards **both** filters when either descriptor fails (matching upstream's single try/catch around both).
- Removes the `story-exports` quarantine from `parity.json`; adds a Rust unit test.

The previously-quarantined upstream valid case is now enforced by the parity suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993431&installation_id=136613492&pr_number=203&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F203&signature=d9bc08e55b1879465a3b18d0a55895d408422bcf0be0e515f7f53fda318e30ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->