### PR TITLE
fix(storybook): no-redundant-story-name splits letter→digit boundaries

### DIFF
--- a/crates/storybook/src/helpers.rs
+++ b/crates/storybook/src/helpers.rs
@@ -420,6 +420,7 @@ pub(crate) fn story_name_from_export(name: &str) -> CompactString {
             if !out.ends_with(' ')
                 && ((prev.is_ascii_lowercase() && ch.is_ascii_uppercase())
                     || (prev.is_ascii_digit() && ch.is_ascii_alphabetic())
+                    || (prev.is_ascii_alphabetic() && ch.is_ascii_digit())
                     || (prev.is_ascii_uppercase() && ch.is_ascii_uppercase() && next_is_lower))
             {
                 out.push(' ');

--- a/crates/storybook/src/tests.rs
+++ b/crates/storybook/src/tests.rs
@@ -94,6 +94,14 @@ fn scans_story_exports_and_story_names() {
 }
 
 #[test]
+fn no_redundant_story_name_splits_letter_digit_boundary() {
+    // Upstream `storyNameFromExport('H1') === 'H 1'`, so `H1.storyName = 'H1'` is
+    // NOT redundant. The port must split the letter→digit boundary the same way.
+    let source = "export function H1() {\n  return null;\n}\nH1.storyName = 'H1';";
+    assert_eq!(scan("no-redundant-story-name", source).len(), 0);
+}
+
+#[test]
 fn story_exports_ignores_unresolvable_filter() {
     // A non-string-literal `includeStories` element makes upstream `getDescriptor`
     // throw, discarding the filter; the file then has a valid story export.

--- a/npm/storybook/test/parity.json
+++ b/npm/storybook/test/parity.json
@@ -5,10 +5,6 @@
       "valid": [8],
       "reason": "Port false-positives on a locally shadowed `userEvent` (`const userEvent = { test: () => {} }; userEvent.test()`); needs scope awareness to skip the redefined binding."
     },
-    "no-redundant-story-name": {
-      "valid": [5],
-      "reason": "Port false-positives on `H1.storyName = 'H1'`: its story-name derivation does not split a letter→digit boundary the way upstream's lodash-style startCase does (`storyNameFromExport('H1') === 'H 1'`), so it wrongly treats the name as redundant."
-    },
     "prefer-pascal-case": {
       "fixOutput": [0, 1, 2],
       "reason": "The port's autofix renames the export declaration identifier but not its other references (`primary.foo` stays lowercase); upstream's suggestion renames every reference."


### PR DESCRIPTION
## What

Fixes a `no-redundant-story-name` false positive (issue #10 parity follow-up):

```js
export function H1() { return <h1>Hello</h1> }
H1.storyName = 'H1' // NOT redundant
```

## Why

Upstream derives the implicit story name via lodash-style `startCase` (`storyNameFromExport`), which inserts a space at **letter→digit** boundaries: `storyNameFromExport('H1') === 'H 1'`. Since `'H1' !== 'H 1'`, the annotation is not redundant.

The port's `story_name_from_export` handled digit→letter but not letter→digit, deriving `'H1'` and wrongly reporting `storyNameIsRedundant`.

## How

- Add the symmetric `letter → digit` boundary to `story_name_from_export` (the only fixture name with a digit is `H1`; `PrimaryButton` cases are unaffected).
- Remove the `no-redundant-story-name` quarantine from `parity.json`; add a Rust unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993715&installation_id=136613492&pr_number=205&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F205&signature=2fb803d63a9d6bf15472e5bb6ba7e690d0fd9920a370abd7ee274646e308e989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->