### PR TITLE
fix(storybook): await-interactions skips a locally shadowed userEvent

### DIFF
--- a/crates/storybook/src/scanner.rs
+++ b/crates/storybook/src/scanner.rs
@@ -693,6 +693,15 @@ impl<'a> Scanner<'a> {
 
     fn scan_variable_declaration(&mut self, declaration: &'a VariableDeclaration<'a>) {
         for declarator in &declaration.declarations {
+            // Upstream await-interactions resets its "userEvent came from storybook"
+            // flag on EVERY `userEvent` variable declarator (nested ones included),
+            // disabling the rule when `userEvent` is locally redefined. The prepass
+            // only sees top-level declarations, so catch nested bindings here. A
+            // `const`/`let` is always declared before it is used (TDZ), so the flag
+            // is set before any `userEvent` call in scope is checked.
+            if binding_identifier_name(&declarator.id) == Some("userEvent") {
+                self.user_event_is_non_storybook = true;
+            }
             if let Some(init) = &declarator.init {
                 self.scan_expression(init, ParentKind::Other);
             }

--- a/crates/storybook/src/tests.rs
+++ b/crates/storybook/src/tests.rs
@@ -94,6 +94,14 @@ fn scans_story_exports_and_story_names() {
 }
 
 #[test]
+fn await_interactions_skips_locally_shadowed_user_event() {
+    // A locally declared `userEvent` shadows the storybook import, so upstream does
+    // not require its calls to be awaited.
+    let source = "Basic.play = async () => {\n  const userEvent = { test: () => {} };\n  userEvent.test();\n};";
+    assert_eq!(scan("await-interactions", source).len(), 0);
+}
+
+#[test]
 fn no_redundant_story_name_splits_letter_digit_boundary() {
     // Upstream `storyNameFromExport('H1') === 'H 1'`, so `H1.storyName = 'H1'` is
     // NOT redundant. The port must split the letter→digit boundary the same way.

--- a/npm/storybook/test/parity.json
+++ b/npm/storybook/test/parity.json
@@ -1,10 +1,6 @@
 {
   "//": "Parity ratchet for the upstream eslint-plugin-storybook test suite replayed by upstream.test.mjs. By default EVERY upstream case is enforced: valid cases must report zero diagnostics, invalid cases must match the upstream-declared messageId multiset and `data` placeholders, and (where the upstream case is autofixable or carries a single suggestion) applying the port's fixes must reproduce the upstream output. The entries below quarantine the specific cases where the current Rust port diverges from upstream; each is a known bug tracked for a follow-up fix PR, after which its entry is removed and the case becomes enforced. Indices are positions in the rule's fixture `valid`/`invalid` arrays (re-check after a submodule bump + re-sync).",
   "skip": {
-    "await-interactions": {
-      "valid": [8],
-      "reason": "Port false-positives on a locally shadowed `userEvent` (`const userEvent = { test: () => {} }; userEvent.test()`); needs scope awareness to skip the redefined binding."
-    },
     "prefer-pascal-case": {
       "fixOutput": [0, 1, 2],
       "reason": "The port's autofix renames the export declaration identifier but not its other references (`primary.foo` stays lowercase); upstream's suggestion renames every reference."


### PR DESCRIPTION
## What

Fixes an `await-interactions` false positive (issue #10 parity follow-up):

```js
Basic.play = async () => {
  const userEvent = { test: () => {} }
  userEvent.test() // locally shadowed — must NOT be flagged
}
```

## Why

Upstream disables the rule for the whole file once `userEvent` is declared as a local variable (it resets its "userEvent is the storybook import" flag on every `userEvent` declarator). The port set that flag only from **top-level** declarations seen in the prepass, so a `userEvent` bound inside the play function was missed.

## How

- Set `user_event_is_non_storybook` from nested `userEvent` declarators encountered during the scan (TDZ guarantees the binding is visited before any in-scope `userEvent` call is checked; only `valid[8]` declares a `userEvent` var, so no invalid case is affected).
- Remove the `await-interactions` quarantine from `parity.json`; add a Rust unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993988&installation_id=136613492&pr_number=206&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F206&signature=1fbe4ecac17429ea0c84e4781d1d1a0dfbfb632446cdf5a7ed42349c70d0ec0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->