### PR TITLE
port(sonarjs): port no-unthrown-error (S3984)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 36] = [
+pub const RULE_NAMES: [&str; 37] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -59,6 +59,7 @@ pub const RULE_NAMES: [&str; 36] = [
     "no-primitive-wrappers",
     "no-skipped-tests",
     "prefer-single-boolean-return",
+    "no-unthrown-error",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -31,6 +31,7 @@ mod no_redundant_jump;
 mod no_redundant_optional;
 mod no_skipped_tests;
 mod no_small_switch;
+mod no_unthrown_error;
 mod no_useless_catch;
 mod non_existent_operator;
 mod prefer_default_last;

--- a/crates/sonarjs/src/rules/no_unthrown_error.rs
+++ b/crates/sonarjs/src/rules/no_unthrown_error.rs
@@ -1,0 +1,53 @@
+//! Rule `no-unthrown-error` (SonarJS key S3984).
+//!
+//! Clean-room port. Creating an `Error` (or an Error subtype) with `new` and
+//! immediately discarding the result as a bare statement is almost certainly a
+//! bug: the developer most likely meant to `throw` it.
+//!
+//! **Heuristic**: the callee identifier name ends with `"Error"`. This covers
+//! the built-in types (`Error`, `TypeError`, `RangeError`, `SyntaxError`,
+//! `ReferenceError`, `EvalError`, `URIError`, `AggregateError`) and any
+//! user-defined class whose name follows the same convention (`FooError`,
+//! `MyError`, etc.). Names that do not end with `"Error"` (e.g. `new Foo()`)
+//! are left to other rules.
+//!
+//! **Flagged**: an `ExpressionStatement` whose `expression`, after stripping
+//! parentheses via `get_inner_expression()`, is a `NewExpression` whose
+//! `callee`, after the same stripping, is an `Identifier` whose name ends
+//! with `"Error"` (case-sensitive; `new error()` is NOT flagged).
+//!
+//! **Not flagged**:
+//! - `throw new Error('boom');` — a `ThrowStatement`, not an
+//!   `ExpressionStatement`; `visit_expression_statement` never sees it.
+//! - `const e = new Error();` — captured in a variable; the statement node is
+//!   a `VariableDeclaration`, not an `ExpressionStatement`.
+//! - `new Foo();` — the callee name `"Foo"` does not end with `"Error"`.
+//! - `foo(new Error());` — the statement's expression is a `CallExpression`
+//!   (not a `NewExpression`); the check returns early before inspecting the
+//!   callee.
+//! - `new error();` — lower-case; does not match the suffix `"Error"`.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S3984) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{Expression, ExpressionStatement};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-unthrown-error";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_unthrown_error(&mut self, stmt: &ExpressionStatement<'_>) {
+        let Expression::NewExpression(new_expr) = stmt.expression.get_inner_expression() else {
+            return;
+        };
+        let Expression::Identifier(callee) = new_expr.callee.get_inner_expression() else {
+            return;
+        };
+        if !callee.name.as_str().ends_with("Error") {
+            return;
+        }
+        self.report(RULE_NAME, "unthrownError", stmt.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -214,6 +214,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_expression_statement(&mut self, it: &ExpressionStatement<'a>) {
         self.check_constructor_for_side_effects(it);
+        self.check_no_unthrown_error(it);
         walk::walk_expression_statement(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1719,3 +1719,57 @@ fn does_not_report_prefer_single_boolean_return_block_has_two_statements() {
     let diagnostics = scan("prefer-single-boolean-return", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_unthrown_error_for_new_error_bare_statement() {
+    let source = "new Error('boom');";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-unthrown-error");
+    assert_eq!(diagnostics[0].message_id, "unthrownError");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_no_unthrown_error_for_new_type_error_bare_statement() {
+    let source = "new TypeError('x');";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unthrownError");
+}
+
+#[test]
+fn reports_no_unthrown_error_for_user_defined_error_subtype_bare_statement() {
+    let source = "new MyError();";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unthrownError");
+}
+
+#[test]
+fn does_not_report_no_unthrown_error_when_error_is_thrown() {
+    let source = "throw new Error('boom');";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_unthrown_error_when_error_is_assigned() {
+    let source = "const e = new Error();";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_unthrown_error_for_non_error_constructor() {
+    let source = "new Foo();";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_unthrown_error_when_error_passed_as_argument() {
+    let source = "foo(new Error());";
+    let diagnostics = scan("no-unthrown-error", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -145,6 +145,9 @@ const messages = Object.freeze({
     preferSingleBooleanReturn:
       "Replace this if/else returning booleans with a single 'return' of the condition.",
   },
+  'no-unthrown-error': {
+    unthrownError: 'Throw this error or remove this useless statement.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -212,6 +215,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow committed skipped tests (.skip member or x-prefixed Jasmine calls); re-enable or remove them instead',
   'prefer-single-boolean-return':
     'Disallow if/else structures where both branches return a boolean literal; return the condition directly instead',
+  'no-unthrown-error':
+    "Disallow creating an Error (or Error subtype) with 'new' as a bare statement without throwing it; the value is discarded and this is almost always a bug",
 });
 
 const ruleTypes = Object.freeze({
@@ -251,6 +256,7 @@ const ruleTypes = Object.freeze({
   'no-primitive-wrappers': 'problem',
   'no-skipped-tests': 'problem',
   'prefer-single-boolean-return': 'suggestion',
+  'no-unthrown-error': 'problem',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -290,6 +296,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-primitive-wrappers': 'error',
   'no-skipped-tests': 'error',
   'prefer-single-boolean-return': 'error',
+  'no-unthrown-error': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -39,6 +39,7 @@ const expectedRuleNames = [
   'no-primitive-wrappers',
   'no-skipped-tests',
   'prefer-single-boolean-return',
+  'no-unthrown-error',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1380,6 +1381,52 @@ describe('sonarjs native API', () => {
   it('does not report prefer-single-boolean-return when consequent block has two statements', () => {
     const source = 'function f() { if (c) { return true; bar(); } else { return false; } }';
     const diagnostics = scan('prefer-single-boolean-return', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-unthrown-error for new Error as a bare statement', () => {
+    const source = "new Error('boom');";
+    const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-unthrown-error');
+    expect(diagnostics[0].messageId).toBe('unthrownError');
+  });
+
+  it('reports no-unthrown-error for new TypeError as a bare statement', () => {
+    const source = "new TypeError('x');";
+    const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('unthrownError');
+  });
+
+  it('reports no-unthrown-error for a user-defined Error subtype as a bare statement', () => {
+    const source = 'new MyError();';
+    const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('unthrownError');
+  });
+
+  it('does not report no-unthrown-error when the error is thrown', () => {
+    const source = "throw new Error('boom');";
+    const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-unthrown-error when the error is assigned to a variable', () => {
+    const source = 'const e = new Error();';
+    const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-unthrown-error for new Foo() (callee does not end with Error)', () => {
+    const source = 'new Foo();';
+    const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-unthrown-error when the error is passed as a call argument', () => {
+    const source = 'foo(new Error());';
+    const diagnostics = scan('no-unthrown-error', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -130,6 +130,7 @@ describe('sonarjs plugin shape', () => {
       'no-primitive-wrappers',
       'no-skipped-tests',
       'prefer-single-boolean-return',
+      'no-unthrown-error',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -167,6 +168,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-primitive-wrappers']).toBe('object');
     expect(typeof plugin.rules['no-skipped-tests']).toBe('object');
     expect(typeof plugin.rules['prefer-single-boolean-return']).toBe('object');
+    expect(typeof plugin.rules['no-unthrown-error']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -204,6 +206,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-primitive-wrappers']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-skipped-tests']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-single-boolean-return']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-unthrown-error']).toBe('error');
   });
 });
 
@@ -821,5 +824,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(prefer-single-boolean-return)');
+  });
+
+  it('reports no-unthrown-error for new Error as a bare statement through the adapter', () => {
+    const source = "new Error('boom');";
+    const reports = runRule('no-unthrown-error', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('unthrownError');
+  });
+
+  it('reports no-unthrown-error through the CLI', () => {
+    const source = "new TypeError('x');";
+    const result = runOxlint('no-unthrown-error', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-unthrown-error)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13166,19 +13166,19 @@
       },
       {
         "name": "no-unthrown-error",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-unthrown-error (Sonar key S3984). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (S3984). Flags a NewExpression used as a bare ExpressionStatement whose callee identifier name ends with 'Error' (covers Error, TypeError, RangeError, SyntaxError, ReferenceError, EvalError, URIError, AggregateError, and user-defined FooError). ThrowStatement, VariableDeclaration, and call-argument forms are correctly not flagged. No upstream source, tests, fixtures, or messages consulted."
       },
       {
         "name": "no-unused-collection",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-unthrown-error`** (Sonar key S3984). Flags a `new …Error(...)` created as a bare expression statement (its value discarded), e.g. `new Error('boom');` — almost always a forgotten `throw`. Uses an "ends with `Error`" name heuristic (covers built-in error types and user-defined `FooError`). `throw`, assignments, and arguments are naturally not flagged (different statement/expression shapes). Reuses the existing `visit_expression_statement` hook.

## Tests
Rust unit tests (`new Error`/`TypeError`/`MyError` statement → 1; `throw new Error`, `const e = new Error`, `new Foo`, `foo(new Error())` → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-unthrown-error)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783994358&installation_id=136613492&pr_number=208&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F208&signature=7855ab375fe9a887ccf064ae49a0f88320bc26a4ca0b8bd22b58e9f34113d2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->