### PR TITLE
feat(simple-import-sort): byte-exact upstream autofix parity

### DIFF
--- a/crates/simple_import_sort/src/lib.rs
+++ b/crates/simple_import_sort/src/lib.rs
@@ -33,6 +33,10 @@ pub fn scan_simple_import_sort(
         .unwrap_or_else(|_| SourceType::mjs())
         .with_module(true);
     let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    // Do not autofix source that does not parse: a partial AST can have unreliable
+    // spans, and running an autofix over broken code risks corrupting it. (Oxc is
+    // stricter than upstream's TypeScript parser on a few syntactically-invalid
+    // constructs, e.g. `import type Def, { Named }`, which upstream tolerates.)
     if !parser_return.errors.is_empty() {
         return SmallVec::new();
     }

--- a/crates/simple_import_sort/src/scanner.rs
+++ b/crates/simple_import_sort/src/scanner.rs
@@ -8,6 +8,7 @@
 use oxc_ast::ast::{
     Comment, CommentKind, ExportAllDeclaration, ExportNamedDeclaration, ImportDeclaration,
     ImportDeclarationSpecifier, ImportOrExportKind, ModuleExportName, Statement,
+    TSModuleDeclarationBody,
 };
 use oxc_span::Span;
 use oxlint_plugins_carton::{CompactString, SmallVec};
@@ -30,6 +31,24 @@ pub(crate) fn scan_import_chunks(
     options: &SimpleImportSortOptions,
     diagnostics: &mut SmallVec<[Diagnostic; 8]>,
 ) {
+    scan_import_chunks_in(
+        source_text,
+        line_index,
+        statements,
+        all_comments,
+        options,
+        diagnostics,
+    );
+}
+
+fn scan_import_chunks_in(
+    source_text: &str,
+    line_index: &LineIndex,
+    statements: &[Statement<'_>],
+    all_comments: &[Comment],
+    options: &SimpleImportSortOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+) {
     // extractChunks: ImportDeclaration → PartOfChunk, else NotPartOfChunk
     let mut chunk: SmallVec<[&ImportDeclaration<'_>; 16]> = SmallVec::new();
     for statement in statements {
@@ -45,6 +64,23 @@ pub(crate) fn scan_import_chunks(
                 diagnostics,
             );
             chunk.clear();
+            // Recurse into TSModuleDeclaration (declare module 'x' { ... })
+            if let Statement::TSModuleDeclaration(ts_mod) = statement {
+                if let Some(body) = &ts_mod.body {
+                    let inner_stmts = match body {
+                        TSModuleDeclarationBody::TSModuleBlock(block) => block.body.as_slice(),
+                        TSModuleDeclarationBody::TSModuleDeclaration(_) => &[],
+                    };
+                    scan_import_chunks_in(
+                        source_text,
+                        line_index,
+                        inner_stmts,
+                        all_comments,
+                        options,
+                        diagnostics,
+                    );
+                }
+            }
         }
     }
     report_import_chunk(
@@ -58,6 +94,22 @@ pub(crate) fn scan_import_chunks(
 }
 
 pub(crate) fn scan_export_chunks(
+    source_text: &str,
+    line_index: &LineIndex,
+    statements: &[Statement<'_>],
+    all_comments: &[Comment],
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+) {
+    scan_export_chunks_in(
+        source_text,
+        line_index,
+        statements,
+        all_comments,
+        diagnostics,
+    );
+}
+
+fn scan_export_chunks_in(
     source_text: &str,
     line_index: &LineIndex,
     statements: &[Statement<'_>],
@@ -110,6 +162,22 @@ pub(crate) fn scan_export_chunks(
             _ => {
                 report_export_chunk(source_text, line_index, all_comments, &chunk, diagnostics);
                 chunk.clear();
+                // Recurse into TSModuleDeclaration (declare module 'x' { ... })
+                if let Statement::TSModuleDeclaration(ts_mod) = statement {
+                    if let Some(body) = &ts_mod.body {
+                        let inner_stmts = match body {
+                            TSModuleDeclarationBody::TSModuleBlock(block) => block.body.as_slice(),
+                            TSModuleDeclarationBody::TSModuleDeclaration(_) => &[],
+                        };
+                        scan_export_chunks_in(
+                            source_text,
+                            line_index,
+                            inner_stmts,
+                            all_comments,
+                            diagnostics,
+                        );
+                    }
+                }
             }
         }
     }
@@ -319,8 +387,18 @@ fn build_import_items(
             last_line,
             node_index == 0,
         );
-        let comments_after =
-            shared::comments_after_node(all_comments, source_text, node_end, node_end_line);
+        let next_node_start = if node_index + 1 < chunk_len {
+            Some(chunk[node_index + 1].span.start)
+        } else {
+            None
+        };
+        let comments_after = shared::comments_after_node(
+            all_comments,
+            source_text,
+            node_end,
+            node_end_line,
+            next_node_start,
+        );
 
         // specifier spans and sort keys (only ImportSpecifier, not default/namespace)
         let spec_spans: SmallVec<[Span; 8]> = decl
@@ -474,8 +552,18 @@ fn build_export_items(
             last_line,
             node_index == 0,
         );
-        let comments_after =
-            shared::comments_after_node(all_comments, source_text, node_end, node_end_line);
+        let next_node_start = if node_index + 1 < chunk_len {
+            Some(chunk[node_index + 1].span().start)
+        } else {
+            None
+        };
+        let comments_after = shared::comments_after_node(
+            all_comments,
+            source_text,
+            node_end,
+            node_end_line,
+            next_node_start,
+        );
 
         let orig = node.source_str();
         let kind_str = import_kind_str(node.export_kind());
@@ -696,18 +784,28 @@ fn find_first_token_start_after(
     offset: u32,
 ) -> Option<u32> {
     // Find first comment at or after offset
-    for c in all_comments {
-        if c.span.start >= offset {
-            return Some(c.span.start);
+    let first_comment = all_comments
+        .iter()
+        .find(|c| c.span.start >= offset)
+        .map(|c| c.span.start);
+
+    // Find first non-whitespace at or after offset (may be real code or a comment)
+    let first_nonws = {
+        let after = source_text.get(offset as usize..)?;
+        if after.trim_matches(|c: char| c.is_whitespace()).is_empty() {
+            None
+        } else {
+            let skip = after.find(|c: char| !c.is_whitespace())?;
+            Some(offset + skip as u32)
         }
-    }
-    // Otherwise find first non-whitespace
-    let after = source_text.get(offset as usize..)?;
-    if after.trim_matches(|c: char| c.is_whitespace()).is_empty() {
-        None
-    } else {
-        let skip = after.find(|c: char| !c.is_whitespace())?;
-        Some(offset + skip as u32)
+    };
+
+    // Return the minimum of the two: if real code appears before the first comment,
+    // return the real code position (otherwise comments "swallow" the trailing text
+    // of adjacent items on the same line).
+    match (first_comment, first_nonws) {
+        (None, v) | (v, None) => v,
+        (Some(c), Some(nw)) => Some(c.min(nw)),
     }
 }
 
@@ -746,13 +844,45 @@ fn handle_last_semicolon(source_text: &str, node_span: Span, all_comments: &[Com
     let semi_start = abs_last - 1; // ';' is 1 byte
     let semi_line = shared::line_of(source_text, semi_start);
 
-    // Find next-to-last token (everything in node before the `;`)
+    // Find next-to-last token (the last NON-comment, non-whitespace byte before `;`).
+    // We need to scan backwards, skipping both whitespace AND trailing comment spans.
+    // This mirrors ESLint's `getLastTokens(node, { count: 2 })[0].range[1]` which
+    // returns the end of the last AST token (comments are not AST tokens in ESLint).
     let next_to_last_end = {
-        let before_semi = source_text
-            .get(node_span.start as usize..semi_start as usize)
-            .unwrap_or("");
-        let trimmed = before_semi.trim_end_matches(|c: char| c.is_whitespace());
-        node_span.start + trimmed.len() as u32
+        // Collect comments that end before semi_start (in reverse order)
+        let trailing_comments: SmallVec<[&Comment; 4]> = all_comments
+            .iter()
+            .filter(|c| c.span.start >= node_span.start && c.span.end <= semi_start)
+            .collect();
+
+        // Scan backwards from semi_start, skipping whitespace and then comments
+        let mut cursor = semi_start;
+        loop {
+            // Skip trailing whitespace
+            let before = source_text
+                .get(node_span.start as usize..cursor as usize)
+                .unwrap_or("");
+            let trimmed = before.trim_end_matches(|c: char| c.is_whitespace());
+            let ws_stripped = node_span.start + trimmed.len() as u32;
+            if ws_stripped == cursor {
+                break; // no whitespace to skip
+            }
+            cursor = ws_stripped;
+
+            // Check if cursor is right after a comment
+            let mut found_comment = false;
+            for c in trailing_comments.iter().rev() {
+                if c.span.end == cursor {
+                    cursor = c.span.start;
+                    found_comment = true;
+                    break;
+                }
+            }
+            if !found_comment {
+                break; // no comment at cursor, we're done
+            }
+        }
+        cursor
     };
     let ntl_line = shared::line_of(source_text, next_to_last_end.saturating_sub(1));
 
@@ -803,26 +933,29 @@ fn import_group(
     options: &SimpleImportSortOptions,
 ) -> (usize, usize) {
     let kind_rank_val = kind_rank(import_kind);
-    if options.import_groups.is_empty() {
-        // Default 5 groups
-        if style == SIDE_EFFECT_STYLE {
-            return (0, 0);
+    let custom_groups = match &options.import_groups {
+        None => {
+            // Default 5 groups
+            if style == SIDE_EFFECT_STYLE {
+                return (0, 0);
+            }
+            if original.starts_with("node:") {
+                return (1, 0);
+            }
+            if is_package_source(original) {
+                return (2, 0);
+            }
+            if original.starts_with('.') {
+                return (4, 0);
+            }
+            return (3, 0);
         }
-        if original.starts_with("node:") {
-            return (1, 0);
-        }
-        if is_package_source(original) {
-            return (2, 0);
-        }
-        if original.starts_with('.') {
-            return (4, 0);
-        }
-        return (3, 0);
-    }
-    // Custom groups: find longest match
+        Some(g) => g,
+    };
+    // Custom groups (possibly empty → single rest group): find longest match
     let match_source = import_match_source(style, kind_rank_val, original);
     let mut best: Option<(usize, usize, usize)> = None;
-    for (outer_index, group) in options.import_groups.iter().enumerate() {
+    for (outer_index, group) in custom_groups.iter().enumerate() {
         for (inner_index, pattern) in group.iter().enumerate() {
             let Ok(re) = regex::Regex::new(pattern.as_str()) else {
                 continue;
@@ -837,7 +970,7 @@ fn import_group(
         }
     }
     best.map(|(o, i, _)| (o, i))
-        .unwrap_or((options.import_groups.len(), 0))
+        .unwrap_or((custom_groups.len(), 0))
 }
 
 fn import_match_source(style: u8, kind_rank: u8, original: &str) -> CompactString {
@@ -878,19 +1011,14 @@ fn make_sorted_import_items<'a>(
     items: &'a [ImportExportItem],
     options: &SimpleImportSortOptions,
 ) -> OuterGroups<'a> {
-    let n_outer_groups = if options.import_groups.is_empty() {
-        5
-    } else {
-        options.import_groups.len()
+    let custom_groups = options.import_groups.as_ref();
+    let n_outer_groups = match custom_groups {
+        None => 5, // default groups
+        Some(g) => g.len(),
     };
-    let inner_counts: SmallVec<[usize; 8]> = if options.import_groups.is_empty() {
-        (0..n_outer_groups).map(|_| 1).collect()
-    } else {
-        options
-            .import_groups
-            .iter()
-            .map(|g| g.len().max(1))
-            .collect()
+    let inner_counts: SmallVec<[usize; 8]> = match custom_groups {
+        None => (0..n_outer_groups).map(|_| 1).collect(),
+        Some(g) => g.iter().map(|inner| inner.len().max(1)).collect(),
     };
 
     // Build bucket grid: [outer][inner] → vec of items
@@ -1053,31 +1181,58 @@ fn print_sorted_items<'a>(
 /// Find first token after `offset` that is:
 /// - not a line comment
 /// - not a block comment whose `.loc.end.line == base_line`
+///
+/// Mirrors `sourceCode.getTokenAfter(node, { includeComments: true, filter })`.
 fn find_next_valid_token(
     source_text: &str,
     all_comments: &[Comment],
     offset: u32,
     base_line: u32,
 ) -> Option<u32> {
-    for c in all_comments {
-        if c.span.start < offset {
-            continue;
-        }
+    // Collect comments at or after offset in order, so we can skip past them
+    // when searching for real (non-comment) code.
+    let relevant_comments: SmallVec<[&Comment; 4]> = all_comments
+        .iter()
+        .filter(|c| c.span.start >= offset)
+        .collect();
+
+    for c in &relevant_comments {
         match c.kind {
             CommentKind::Line => continue, // skip line comments
             CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                 let end_line = shared::line_of(source_text, c.span.end);
                 if end_line == base_line {
                     continue;
-                } // block comment on same line
+                } // block comment ending on same line → skip
             }
         }
         return Some(c.span.start);
     }
-    // Check for real (non-comment) code
-    let after = source_text.get(offset as usize..)?;
-    let skip = after.find(|c: char| !c.is_whitespace())?;
-    Some(offset + skip as u32)
+
+    // No valid comment found. Look for real (non-comment) non-whitespace code,
+    // but skip over comment spans so we don't mistake comment text for real code.
+    let mut cursor = offset;
+    for c in &relevant_comments {
+        // Scan the gap between cursor and the start of this comment
+        let gap = source_text
+            .get(cursor as usize..c.span.start as usize)
+            .unwrap_or("");
+        if gap
+            .chars()
+            .any(|ch| !ch.is_ascii_whitespace() && ch != '\r' && ch != '\n')
+        {
+            // Found real code in the gap before this comment
+            let skip = gap.find(|ch: char| !ch.is_whitespace()).unwrap_or(0);
+            return Some(cursor + skip as u32);
+        }
+        // Advance past this comment
+        cursor = c.span.end;
+    }
+
+    // Scan remaining text after all comments
+    let after = source_text.get(cursor as usize..)?;
+    let skip = after.find(|ch: char| !ch.is_whitespace())?;
+    Some(cursor + skip as u32)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/simple_import_sort/src/scanner.rs
+++ b/crates/simple_import_sort/src/scanner.rs
@@ -65,21 +65,21 @@ fn scan_import_chunks_in(
             );
             chunk.clear();
             // Recurse into TSModuleDeclaration (declare module 'x' { ... })
-            if let Statement::TSModuleDeclaration(ts_mod) = statement {
-                if let Some(body) = &ts_mod.body {
-                    let inner_stmts = match body {
-                        TSModuleDeclarationBody::TSModuleBlock(block) => block.body.as_slice(),
-                        TSModuleDeclarationBody::TSModuleDeclaration(_) => &[],
-                    };
-                    scan_import_chunks_in(
-                        source_text,
-                        line_index,
-                        inner_stmts,
-                        all_comments,
-                        options,
-                        diagnostics,
-                    );
-                }
+            if let Statement::TSModuleDeclaration(ts_mod) = statement
+                && let Some(body) = &ts_mod.body
+            {
+                let inner_stmts = match body {
+                    TSModuleDeclarationBody::TSModuleBlock(block) => block.body.as_slice(),
+                    TSModuleDeclarationBody::TSModuleDeclaration(_) => &[],
+                };
+                scan_import_chunks_in(
+                    source_text,
+                    line_index,
+                    inner_stmts,
+                    all_comments,
+                    options,
+                    diagnostics,
+                );
             }
         }
     }
@@ -163,20 +163,20 @@ fn scan_export_chunks_in(
                 report_export_chunk(source_text, line_index, all_comments, &chunk, diagnostics);
                 chunk.clear();
                 // Recurse into TSModuleDeclaration (declare module 'x' { ... })
-                if let Statement::TSModuleDeclaration(ts_mod) = statement {
-                    if let Some(body) = &ts_mod.body {
-                        let inner_stmts = match body {
-                            TSModuleDeclarationBody::TSModuleBlock(block) => block.body.as_slice(),
-                            TSModuleDeclarationBody::TSModuleDeclaration(_) => &[],
-                        };
-                        scan_export_chunks_in(
-                            source_text,
-                            line_index,
-                            inner_stmts,
-                            all_comments,
-                            diagnostics,
-                        );
-                    }
+                if let Statement::TSModuleDeclaration(ts_mod) = statement
+                    && let Some(body) = &ts_mod.body
+                {
+                    let inner_stmts = match body {
+                        TSModuleDeclarationBody::TSModuleBlock(block) => block.body.as_slice(),
+                        TSModuleDeclarationBody::TSModuleDeclaration(_) => &[],
+                    };
+                    scan_export_chunks_in(
+                        source_text,
+                        line_index,
+                        inner_stmts,
+                        all_comments,
+                        diagnostics,
+                    );
                 }
             }
         }

--- a/crates/simple_import_sort/src/shared.rs
+++ b/crates/simple_import_sort/src/shared.rs
@@ -158,6 +158,76 @@ pub(crate) fn remove_blank_lines(whitespace: &str) -> CompactString {
     print_tokens(&parse_whitespace(whitespace))
 }
 
+/// Collapse blank lines in the text of a single import/export statement.
+///
+/// Mirrors what upstream `getAllTokens` achieves: each gap *between* AST tokens
+/// is run through `parseWhitespace`, collapsing blank lines (two or more
+/// consecutive newlines → one). Crucially, string literals and comments are
+/// individual tokens in upstream and are emitted verbatim, so whitespace *inside*
+/// them must NOT be collapsed. We reproduce that with a tiny scanner that emits
+/// string literals (`"…"`/`'…'`) and comments (`/* … */`, `// …`) untouched and
+/// only collapses whitespace runs in the surrounding code. This is sound for
+/// import/export statements, which contain no regex/division `/` ambiguity.
+pub(crate) fn collapse_blank_lines_in_mixed_text(text: &str) -> CompactString {
+    let mut out = CompactString::new("");
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut i = 0usize;
+    while i < len {
+        let b = bytes[i];
+        match b {
+            b' ' | b'\t' | b'\n' | b'\r' => {
+                let start = i;
+                while i < len && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
+                    i += 1;
+                }
+                out.push_str(&remove_blank_lines(&text[start..i]));
+            }
+            b'"' | b'\'' => {
+                // String literal: copy verbatim through the matching unescaped quote.
+                let start = i;
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                out.push_str(&text[start..i.min(len)]);
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                // Block comment: copy verbatim through `*/`.
+                let start = i;
+                i += 2;
+                while i < len && !(bytes[i] == b'*' && i + 1 < len && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(len);
+                out.push_str(&text[start..i]);
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
+                // Line comment: copy verbatim up to (not including) the newline.
+                let start = i;
+                while i < len && bytes[i] != b'\n' && bytes[i] != b'\r' {
+                    i += 1;
+                }
+                out.push_str(&text[start..i]);
+            }
+            _ => {
+                let ch = text[i..].chars().next().unwrap_or('\0');
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    out
+}
+
 /// Mirrors `printTokens`: join token.code.
 pub(crate) fn print_tokens(tokens: &[Token]) -> CompactString {
     let mut out = CompactString::new("");
@@ -209,7 +279,34 @@ fn base_fold(s: &str) -> CompactString {
     out
 }
 
+/// ASCII collation rank table mirroring ICU DUCET order for the chars that
+/// appear in our sort keys after `source_sort_key` transformation.
+///
+/// ICU root collation differs from codepoint order for several ASCII chars.
+/// Empirically verified via `Intl.Collator("en", {sensitivity:"base", numeric:true})`:
+///   NUL < _ < - < , < . < [ < ] < @ < / < # < ~  (all before digits, digits before letters)
+///
+/// Returns `None` for chars not in the table (fall back to codepoint order).
+fn icu_ascii_rank(c: char) -> Option<u8> {
+    match c {
+        '\0' => Some(0),
+        '_' => Some(1),
+        '-' => Some(2),
+        ',' => Some(3),
+        '.' => Some(4),
+        '[' => Some(5),
+        ']' => Some(6),
+        '@' => Some(7),
+        '/' => Some(8),
+        '#' => Some(9),
+        '~' => Some(10),
+        _ => None,
+    }
+}
+
 /// Compare two pre-folded strings with numeric segments (numeric: true).
+/// Uses an explicit ICU-ordered rank table for ASCII punctuation chars that
+/// differ from codepoint order; falls back to codepoint for other chars.
 fn collator_compare_base_numeric(a: &str, b: &str) -> i32 {
     let mut ai = a.chars().peekable();
     let mut bi = b.chars().peekable();
@@ -231,7 +328,26 @@ fn collator_compare_base_numeric(a: &str, b: &str) -> i32 {
                     ai.next();
                     bi.next();
                     if ac != bc {
-                        return if ac < bc { -1 } else { 1 };
+                        // Use ICU rank table for chars in our domain
+                        let ra = icu_ascii_rank(ac);
+                        let rb = icu_ascii_rank(bc);
+                        let cmp = match (ra, rb) {
+                            (Some(ra), Some(rb)) => ra.cmp(&rb),
+                            (Some(_), None) => {
+                                // table char vs non-table char: table chars are all
+                                // punctuation/special → come before digits and letters
+                                std::cmp::Ordering::Less
+                            }
+                            (None, Some(_)) => std::cmp::Ordering::Greater,
+                            (None, None) => ac.cmp(&bc),
+                        };
+                        if cmp != std::cmp::Ordering::Equal {
+                            return if cmp == std::cmp::Ordering::Less {
+                                -1
+                            } else {
+                                1
+                            };
+                        }
                     }
                 }
             }
@@ -339,11 +455,20 @@ pub(crate) fn comments_after_node<'a>(
     source_text: &str,
     node_end: u32,
     node_end_line: u32,
+    // If `Some(pos)`, only include comments that start BEFORE this position.
+    // Used to exclude comments that belong to the next import/export node.
+    next_node_start: Option<u32>,
 ) -> SmallVec<[&'a Comment; 4]> {
     let mut result: SmallVec<[&'a Comment; 4]> = SmallVec::new();
     for comment in all_comments {
         if comment.span.start < node_end {
             continue;
+        }
+        // Stop at the next node if provided
+        if let Some(nns) = next_node_start
+            && comment.span.start >= nns
+        {
+            break;
         }
         let c_end_line = line_of(source_text, comment.span.end);
         if c_end_line == node_end_line {
@@ -562,16 +687,19 @@ pub(crate) fn import_style(decl: &ImportDeclaration<'_>, source_text: &str) -> u
 }
 
 fn has_open_brace_specifiers(source_text: &str, decl: &ImportDeclaration<'_>) -> bool {
+    // Returns true if the import has a `{ ... }` specifier list (even if empty or
+    // containing only comments). OXC gives empty `specifiers` when only comments
+    // are present (e.g. `import { /* X */ } from "pkg"`), so we cannot rely solely
+    // on `specifiers.is_empty()` – we check the source text for a `{` before `from`.
     let text = source_text
         .get(decl.span.start as usize..decl.span.end as usize)
         .unwrap_or("");
-    if let Some(open) = text.find('{')
-        && let Some(close_offset) = text[open..].find('}')
-    {
-        let between = &text[open + 1..open + close_offset];
-        return between.trim().is_empty();
-    }
-    false
+    // Find `{` before the `from` keyword
+    let from_pos = text
+        .find(" from ")
+        .or_else(|| text.find("\tfrom "))
+        .unwrap_or(text.len());
+    text[..from_pos].contains('{')
 }
 
 // ---------------------------------------------------------------------------
@@ -818,7 +946,11 @@ pub(crate) fn tokenize_specifier_interior(
         let spec_text = source_text
             .get(span.start as usize..span.end as usize)
             .unwrap_or("");
-        tokens.push(Token::identifier(spec_text));
+        // Collapse blank lines within the specifier text (e.g. `a\n\n  as\n\n  b`→`a\n  as\n  b`).
+        // Upstream's getAllTokens tokenizes the specifier into individual keyword/identifier
+        // tokens and calls parseWhitespace on each inter-token gap, achieving the same effect.
+        let spec_text_collapsed = collapse_blank_lines_in_mixed_text(spec_text);
+        tokens.push(Token::identifier(&spec_text_collapsed));
         cursor = span.end;
     }
     scan_gap_tokens(
@@ -917,40 +1049,53 @@ pub(crate) fn print_with_sorted_specifiers(
         .get(node_start as usize..node_end as usize)
         .unwrap_or("");
 
-    // ≤1 specifiers: no reordering needed
+    // Try to find { and } positions for blank-line collapsing.
+    // We need these even for ≤1 specifiers because upstream's getAllTokens
+    // still calls parseWhitespace on every inter-token gap, collapsing blank lines.
+    let brace_positions: Option<(usize, usize)> =
+        find_brace_positions(source_text, node_start, node_end, specifier_spans);
+
+    // ≤1 specifiers: no reordering needed, but still collapse blank lines.
     if specifier_spans.len() <= 1 {
-        return CompactString::from(node_text);
+        let Some((open_rel, close_rel)) = brace_positions else {
+            // No braces found (e.g. `import def from "x"`, `import "side-effect"`).
+            // Still collapse blank lines in the node text (upstream's getAllTokens
+            // applies parseWhitespace to every inter-token gap, including gaps that
+            // don't involve specifiers, such as the gap before a trailing `;`).
+            return collapse_blank_lines_in_mixed_text(node_text);
+        };
+
+        let open_brace_end_abs = node_start + open_rel as u32 + 1;
+        let close_brace_start_abs = node_start + close_rel as u32;
+
+        // Collapse blank lines in all three regions
+        let prefix = collapse_blank_lines_in_mixed_text(&node_text[..open_rel + 1]);
+        let interior = {
+            let tokens = tokenize_specifier_interior(
+                source_text,
+                open_brace_end_abs,
+                close_brace_start_abs,
+                specifier_spans,
+                all_comments,
+            );
+            print_tokens(&tokens)
+        };
+        let suffix = collapse_blank_lines_in_mixed_text(&node_text[close_rel..]);
+
+        let mut out = CompactString::new("");
+        out.push_str(&prefix);
+        out.push_str(&interior);
+        out.push_str(&suffix);
+        return out;
     }
 
-    // Find { and } within the node text (absolute positions)
-    // We need the FIRST `{` that is the specifier list open brace,
-    // and the LAST `}` before `from` (to exclude `with { ... }` clauses).
-    // Strategy: find all specifier spans and use them to bound the search.
-    let first_spec_start = specifier_spans[0].start;
-    let last_spec_end = specifier_spans[specifier_spans.len() - 1].end;
-
-    // Find `{` before first specifier
-    let before_first = source_text
-        .get(node_start as usize..first_spec_start as usize)
-        .unwrap_or("");
-    let open_rel = before_first.rfind('{');
-
-    // Find `}` after last specifier
-    let after_last = source_text
-        .get(last_spec_end as usize..node_end as usize)
-        .unwrap_or("");
-    let close_offset = after_last.find('}');
-
-    let (Some(open_rel), Some(close_offset_in_after)) = (open_rel, close_offset) else {
+    let Some((open_rel_in_node, close_rel_in_node)) = brace_positions else {
         return CompactString::from(node_text);
     };
 
-    let open_brace_abs = node_start + open_rel as u32; // position of `{`
+    let open_brace_abs = node_start + open_rel_in_node as u32; // position of `{`
     let open_brace_end = open_brace_abs + 1; // position after `{`
-    let close_brace_start = last_spec_end + close_offset_in_after as u32; // position of `}`
-
-    let open_rel_in_node = open_rel;
-    let close_rel_in_node = (close_brace_start - node_start) as usize;
+    let close_brace_start = node_start + close_rel_in_node as u32; // position of `}`
 
     // Tokenize the interior
     let interior_tokens = tokenize_specifier_interior(
@@ -1023,14 +1168,58 @@ pub(crate) fn print_with_sorted_specifiers(
         sorted_tokens.push(Token::newline(newline));
     }
 
-    // Reconstruct the full node text
+    // Reconstruct the full node text, collapsing blank lines in prefix and suffix
+    let prefix = collapse_blank_lines_in_mixed_text(&node_text[..open_rel_in_node + 1]);
+    let suffix = collapse_blank_lines_in_mixed_text(&node_text[close_rel_in_node..]);
+
     let mut out = CompactString::new("");
-    out.push_str(&node_text[..open_rel_in_node + 1]); // up to and including `{`
+    out.push_str(&prefix);
     out.push_str(&print_tokens(&items_result.before));
     out.push_str(&print_tokens(&sorted_tokens));
     out.push_str(&print_tokens(&items_result.after));
-    out.push_str(&node_text[close_rel_in_node..]); // from `}` onwards
+    out.push_str(&suffix);
     out
+}
+
+/// Find the positions of the specifier-list `{` and `}` within the node text.
+///
+/// Returns `(open_rel, close_rel)` as byte offsets from `node_start`, where
+/// `open_rel` points to `{` and `close_rel` points to `}`.
+///
+/// When `specifier_spans` is non-empty, uses them to bound the search.
+/// When empty (no specifiers), searches the whole node text.
+fn find_brace_positions(
+    source_text: &str,
+    node_start: u32,
+    node_end: u32,
+    specifier_spans: &[Span],
+) -> Option<(usize, usize)> {
+    let node_text = source_text.get(node_start as usize..node_end as usize)?;
+
+    if specifier_spans.is_empty() {
+        // No specifiers: find `{` and `}` in the node text.
+        // Use the FIRST `{` and the corresponding `}`.
+        let open_rel = node_text.find('{')?;
+        let close_rel = node_text.rfind('}')?;
+        if close_rel <= open_rel {
+            return None;
+        }
+        return Some((open_rel, close_rel));
+    }
+
+    let first_spec_start = specifier_spans[0].start;
+    let last_spec_end = specifier_spans[specifier_spans.len() - 1].end;
+
+    // Find `{` before first specifier
+    let before_first = source_text.get(node_start as usize..first_spec_start as usize)?;
+    let open_rel = before_first.rfind('{')?;
+
+    // Find `}` after last specifier
+    let after_last = source_text.get(last_spec_end as usize..node_end as usize)?;
+    let close_offset_in_after = after_last.find('}')?;
+    let close_rel = (last_spec_end - node_start) as usize + close_offset_in_after;
+
+    Some((open_rel, close_rel))
 }
 
 /// Trim after tokens for the last specifier when it had a comma but now doesn't.

--- a/crates/simple_import_sort/src/tests.rs
+++ b/crates/simple_import_sort/src/tests.rs
@@ -131,3 +131,19 @@ fn collator_handles_accents() {
         "import a from 'ä';\n\nimport b from '.';"
     );
 }
+
+#[test]
+fn preserves_blank_lines_inside_block_comments() {
+    // Upstream treats a block comment as a single token, so a blank line *inside*
+    // it must survive even though blank lines between tokens are collapsed.
+    let source = "import b from \"b\"\nimport /* x\n\ny */ a from \"a\"";
+    let diagnostics =
+        scan_simple_import_sort(source, "fixture.js", &SimpleImportSortOptions::default());
+
+    assert_eq!(diagnostics.len(), 1);
+    let fix = diagnostics[0].fix.as_ref().expect("fix");
+    assert_eq!(
+        fix.replacement.as_str(),
+        "import /* x\n\ny */ a from \"a\"\nimport b from \"b\""
+    );
+}

--- a/crates/simple_import_sort/src/types.rs
+++ b/crates/simple_import_sort/src/types.rs
@@ -28,7 +28,10 @@ pub struct Diagnostic {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct SimpleImportSortOptions {
-    pub import_groups: SmallVec<[SmallVec<[CompactString; 4]>; 8]>,
+    /// `None` means "use the 5 default groups".
+    /// `Some([])` means "explicit empty groups → single rest group, no blank-line separators".
+    /// `Some([...])` means custom groups.
+    pub import_groups: Option<SmallVec<[SmallVec<[CompactString; 4]>; 8]>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/npm/simple-import-sort/api.js
+++ b/npm/simple-import-sort/api.js
@@ -18,10 +18,11 @@ function normalizeGroups(groups) {
   if (!Array.isArray(groups)) {
     return undefined;
   }
+  // Preserve an explicitly-empty array as [] so the native layer can distinguish
+  // "no groups option" (undefined) from "explicit empty groups" ([]).
   return groups
     .filter(Array.isArray)
-    .map((group) => group.filter((value) => typeof value === 'string' && value.length > 0))
-    .filter((group) => group.length > 0);
+    .map((group) => group.filter((value) => typeof value === 'string' && value.length > 0));
 }
 
 module.exports = {

--- a/npm/simple-import-sort/src/lib.rs
+++ b/npm/simple-import-sort/src/lib.rs
@@ -63,7 +63,8 @@ mod napi_abi {
     ) -> Vec<Diagnostic> {
         let options = options.unwrap_or_default();
         let core_options = core::SimpleImportSortOptions {
-            import_groups: compact_groups(options.import_groups.unwrap_or_default()),
+            // None = use default 5 groups; Some([]) = explicit empty → single rest group
+            import_groups: options.import_groups.map(compact_groups),
         };
 
         core::scan_simple_import_sort(&source_text, &filename, &core_options)

--- a/npm/simple-import-sort/test/parity.json
+++ b/npm/simple-import-sort/test/parity.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Upstream parity ratchet for the eslint-plugin-simple-import-sort port. Fixtures under test/fixtures/*.json are captured verbatim from upstream by `pnpm run port:tests:simple-import-sort`; this file controls how strictly upstream.test.mjs replays them so parity can be ratcheted up without silently dropping coverage. Per-rule `level`: `off` quarantines the rule, `valid` asserts only that upstream-valid code produces no diagnostics, `count` additionally asserts the diagnostic count on invalid cases, `full` additionally asserts the applied autofix output matches upstream exactly. `skipParsers` lists parser kinds whose cases are counted but not asserted — Oxc does not parse Flow syntax. `eslint-disable` directive cases are always skipped (the linter core, not the rule, suppresses those). `quarantine.{valid,invalid}` lists individual cases (by index into the fixture array, with a reason) that the Rust port does not yet reproduce byte-for-byte; they remain captured and are reported in the suite's parity summary, so coverage is never silently truncated. Both rules enforce `full` on all valid cases and on every invalid case except the quarantined long tail of comment/whitespace/TypeScript edge cases tracked below for follow-up.",
+  "$comment": "Upstream parity ratchet for the eslint-plugin-simple-import-sort port. Fixtures under test/fixtures/*.json are captured verbatim from upstream by `pnpm run port:tests:simple-import-sort`; this file controls how strictly upstream.test.mjs replays them so parity can be ratcheted up without silently dropping coverage. Per-rule `level`: `off` quarantines the rule, `valid` asserts only that upstream-valid code produces no diagnostics, `count` additionally asserts the diagnostic count on invalid cases, `full` additionally asserts the applied autofix output matches upstream exactly. `skipParsers` lists parser kinds whose cases are counted but not asserted — Oxc does not parse Flow syntax. `eslint-disable` directive cases are always skipped (the linter core, not the rule, suppresses those). `quarantine.{valid,invalid}` lists individual cases (by index into the fixture array, with a reason) that the Rust port does not yet reproduce byte-for-byte; they remain captured and are reported in the suite's parity summary, so coverage is never silently truncated. Both rules enforce `full` (byte-exact autofix) on all valid cases and every invalid case; the only quarantined case is one imports fixture that exercises syntactically-invalid TypeScript Oxc cannot parse.",
   "rules": {
     "imports": {
       "level": "full",
@@ -8,28 +8,9 @@
         "valid": [],
         "invalid": [
           {
-            "index": 5,
-            "reason": "trailing guarding semicolon on its own line after a blank line"
-          },
-          { "index": 27, "reason": "specifier list with interleaved comments and newlines" },
-          { "index": 37, "reason": "degenerate/bare module paths with empty specifier lists" },
-          { "index": 38, "reason": "leading multi-line block comments attached across imports" },
-          { "index": 41, "reason": "trailing line/block comment redistribution between imports" },
-          { "index": 45, "reason": "comments interleaved within the import clause itself" },
-          { "index": 46, "reason": "empty `{}` specifier list spanning blank lines" },
-          { "index": 48, "reason": "indented (script-tag style) import chunk reconstruction" },
-          { "index": 49, "reason": "indented CRLF import chunk reconstruction" },
-          { "index": 52, "reason": "multi-group ordering with blank-line separators" },
-          { "index": 53, "reason": "multi-group ordering with blank-line separators" },
-          { "index": 58, "reason": "side-effect import ordering interleaved with blank lines" },
-          { "index": 64, "reason": "TypeScript type-import ordering and whitespace" },
-          { "index": 65, "reason": "TypeScript `@/` bare-package grouping" },
-          { "index": 67, "reason": "TypeScript import attributes (`with { type: 'json' }`)" },
-          {
-            "index": 68,
-            "reason": "imports nested inside `declare module` (non-top-level parent)"
-          },
-          { "index": 70, "reason": "TypeScript type-only specifier ordering" }
+            "index": 70,
+            "reason": "exercises syntactically-invalid TypeScript (`import type Def, { Named }`, which TypeScript itself rejects); Oxc reports a parse error, so the port declines to autofix unparseable source rather than act on a partial AST"
+          }
         ]
       }
     },
@@ -38,12 +19,7 @@
       "skipParsers": ["flow"],
       "quarantine": {
         "valid": [],
-        "invalid": [
-          { "index": 6, "reason": "comments interleaved within the export clause itself" },
-          { "index": 7, "reason": "empty `{}` specifier list spanning blank lines" },
-          { "index": 20, "reason": "TypeScript type-export ordering" },
-          { "index": 22, "reason": "exports nested inside `declare module` (non-top-level parent)" }
-        ]
+        "invalid": []
       }
     }
   }


### PR DESCRIPTION
## What

Brings the `simple-import-sort` Rust port to **byte-exact autofix parity** with upstream on every captured fixture except one syntactically-invalid-TypeScript case Oxc cannot parse. Builds on the merged test-sync infra (#106) and faithful reimplementation (#133), which already enforced `full` parity on 110/149 cases with 21 quarantined; this PR fixes the remaining 20 and ratchets to (effectively) full.

## Fixes (all verified against the upstream fixtures via a local replay loop)

- **Whole-node whitespace reconstruction** — collapse blank lines between tokens of *any* import/export (not just inside `{ }`), via a small scanner that emits string literals and comments verbatim, so blank lines inside block comments are preserved (matches upstream's opaque-token model). Guarded by a unit test.
- **ICU collation** — order ASCII punctuation in the transformed source keys by an ICU-root rank table (`_ < - < , < .` …) rather than code-point order.
- **Explicit empty `groups: []`** now means a single rest group (no default 5-group separation); `import_groups` becomes `Option` to distinguish unset from explicitly-empty (napi + `api.js` updated).
- **Nested `declare module { … }`** bodies are recursed so their imports/exports chunk correctly.
- Same-source **type-import style/kind ordering** fixed; comment-after attachment bounded by the next node.

## Quarantine

The port keeps its parse-error guard (it declines to autofix unparseable source rather than act on a partial AST). The single remaining quarantined fixture exercises `import type Def, { Named }` — invalid TypeScript that TypeScript itself rejects and Oxc rejects at parse time — documented in `parity.json`. Everything else enforces `full` (byte-exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783994728&installation_id=136613492&pr_number=210&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F210&signature=e86816b5248c29c281d4b4ef83b7cc52a72b14d719d4de0f8381e73a847fb282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->