### PR TITLE
port(sonarjs): port no-tab (S105)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 37] = [
+pub const RULE_NAMES: [&str; 38] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -60,6 +60,7 @@ pub const RULE_NAMES: [&str; 37] = [
     "no-skipped-tests",
     "prefer-single-boolean-return",
     "no-unthrown-error",
+    "no-tab",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -31,6 +31,7 @@ mod no_redundant_jump;
 mod no_redundant_optional;
 mod no_skipped_tests;
 mod no_small_switch;
+mod no_tab;
 mod no_unthrown_error;
 mod no_useless_catch;
 mod non_existent_operator;

--- a/crates/sonarjs/src/rules/no_tab.rs
+++ b/crates/sonarjs/src/rules/no_tab.rs
@@ -1,0 +1,46 @@
+//! Rule `no-tab` (SonarJS key S105).
+//!
+//! Clean-room port. Tab characters render inconsistently across editors and
+//! tools — different environments show them as different numbers of spaces,
+//! breaking visual alignment. Only spaces should be used for indentation and
+//! spacing within source files.
+//!
+//! This rule is RAW TEXT based: it scans the raw source text for tab bytes
+//! (0x09). For each source line that contains at least one tab, exactly one
+//! diagnostic is emitted, located at the FIRST tab on that line. Tabs found
+//! anywhere on the line — including inside string literals or comments — are
+//! counted, because the rule is about the physical characters in the file, not
+//! about semantic context.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-tab";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_tab(&mut self) {
+        let bytes = self.source_text.as_bytes();
+        let mut spans: SmallVec<[Span; 8]> = SmallVec::new();
+        let mut line_has_tab = false;
+        let mut i = 0usize;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\n' => line_has_tab = false,
+                b'\t' if !line_has_tab => {
+                    line_has_tab = true;
+                    spans.push(Span::new(i as u32, i as u32 + 1));
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        for span in spans {
+            self.report(RULE_NAME, "noTab", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -6,7 +6,7 @@ use oxc_ast::ast::{
     AssignmentExpression, BinaryExpression, BindingIdentifier, CallExpression, CatchClause,
     ConditionalExpression, DoWhileStatement, ExpressionStatement, ForInStatement, ForOfStatement,
     ForStatement, Function, FunctionBody, IdentifierReference, IfStatement, LabeledStatement,
-    LogicalExpression, NewExpression, RegExpLiteral, StaticMemberExpression, SwitchCase,
+    LogicalExpression, NewExpression, Program, RegExpLiteral, StaticMemberExpression, SwitchCase,
     SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
     UnaryExpression, WhileStatement, YieldExpression,
 };
@@ -72,6 +72,11 @@ impl Scanner<'_> {
 }
 
 impl<'a> Visit<'a> for Scanner<'a> {
+    fn visit_program(&mut self, it: &Program<'a>) {
+        self.check_no_tab();
+        walk::walk_program(self, it);
+    }
+
     fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {
         self.check_no_nested_template_literals(it);
         self.template_literal_depth += 1;

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1773,3 +1773,44 @@ fn does_not_report_no_unthrown_error_when_error_passed_as_argument() {
     let diagnostics = scan("no-unthrown-error", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_tab_for_leading_tab() {
+    let source = "\tconst x = 1;";
+    let diagnostics = scan("no-tab", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-tab");
+    assert_eq!(diagnostics[0].message_id, "noTab");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+}
+
+#[test]
+fn reports_no_tab_for_tab_in_middle_of_line() {
+    let source = "const x\t= 1;";
+    let diagnostics = scan("no-tab", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noTab");
+}
+
+#[test]
+fn reports_no_tab_once_when_only_second_line_has_tab() {
+    let source = "a();\n\tb();";
+    let diagnostics = scan("no-tab", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noTab");
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+}
+
+#[test]
+fn reports_no_tab_twice_when_both_lines_have_tabs() {
+    let source = "\ta();\n\tb();";
+    let diagnostics = scan("no-tab", source);
+    assert_eq!(diagnostics.len(), 2);
+}
+
+#[test]
+fn does_not_report_no_tab_for_source_without_tabs() {
+    let source = "const x = 1;";
+    let diagnostics = scan("no-tab", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -148,6 +148,9 @@ const messages = Object.freeze({
   'no-unthrown-error': {
     unthrownError: 'Throw this error or remove this useless statement.',
   },
+  'no-tab': {
+    noTab: 'Replace this tab character with spaces.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -217,6 +220,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow if/else structures where both branches return a boolean literal; return the condition directly instead',
   'no-unthrown-error':
     "Disallow creating an Error (or Error subtype) with 'new' as a bare statement without throwing it; the value is discarded and this is almost always a bug",
+  'no-tab':
+    'Disallow tab characters in source files; tabs render inconsistently across editors and tools, so spaces should be used instead',
 });
 
 const ruleTypes = Object.freeze({
@@ -257,6 +262,7 @@ const ruleTypes = Object.freeze({
   'no-skipped-tests': 'problem',
   'prefer-single-boolean-return': 'suggestion',
   'no-unthrown-error': 'problem',
+  'no-tab': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -297,6 +303,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-skipped-tests': 'error',
   'prefer-single-boolean-return': 'error',
   'no-unthrown-error': 'error',
+  'no-tab': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -40,6 +40,7 @@ const expectedRuleNames = [
   'no-skipped-tests',
   'prefer-single-boolean-return',
   'no-unthrown-error',
+  'no-tab',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1427,6 +1428,40 @@ describe('sonarjs native API', () => {
   it('does not report no-unthrown-error when the error is passed as a call argument', () => {
     const source = 'foo(new Error());';
     const diagnostics = scan('no-unthrown-error', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-tab for a line with a leading tab', () => {
+    const source = '\tconst x = 1;';
+    const diagnostics = scan('no-tab', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-tab');
+    expect(diagnostics[0].messageId).toBe('noTab');
+  });
+
+  it('reports no-tab for a line with a tab in the middle', () => {
+    const source = 'const x\t= 1;';
+    const diagnostics = scan('no-tab', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noTab');
+  });
+
+  it('reports no-tab once for two lines where only the second has a tab', () => {
+    const source = 'a();\n\tb();';
+    const diagnostics = scan('no-tab', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('noTab');
+  });
+
+  it('reports no-tab twice when two lines each contain a tab', () => {
+    const source = '\ta();\n\tb();';
+    const diagnostics = scan('no-tab', source);
+    expect(diagnostics).toHaveLength(2);
+  });
+
+  it('does not report no-tab for source with no tab characters', () => {
+    const source = 'const x = 1;';
+    const diagnostics = scan('no-tab', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -131,6 +131,7 @@ describe('sonarjs plugin shape', () => {
       'no-skipped-tests',
       'prefer-single-boolean-return',
       'no-unthrown-error',
+      'no-tab',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -169,6 +170,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-skipped-tests']).toBe('object');
     expect(typeof plugin.rules['prefer-single-boolean-return']).toBe('object');
     expect(typeof plugin.rules['no-unthrown-error']).toBe('object');
+    expect(typeof plugin.rules['no-tab']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -207,6 +209,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-skipped-tests']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/prefer-single-boolean-return']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-unthrown-error']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-tab']).toBe('error');
   });
 });
 
@@ -374,6 +377,13 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('for-in', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('forIn');
+  });
+
+  it('reports no-tab for a line with a leading tab through the adapter', () => {
+    const source = '\tconst x = 1;';
+    const reports = runRule('no-tab', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noTab');
   });
 });
 
@@ -841,5 +851,15 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-unthrown-error)');
+  });
+
+  it('reports no-tab through the CLI', () => {
+    const source = '\tconst x = 1;';
+    const result = runOxlint('no-tab', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-tab)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13038,19 +13038,19 @@
       },
       {
         "name": "no-tab",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-tab (Sonar key S105). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S105). Raw text scan of self.source_text bytes \u2014 one diagnostic per source line at the first tab character on that line. Tabs anywhere on a line (including inside strings and comments) are counted. Implemented via check_no_tab called from visit_program before the AST walk. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-table-as-layout",


### PR DESCRIPTION
## Summary
Clean-room port of **`no-tab`** (Sonar key S105). Flags tab characters in source (which render inconsistently across editors). A raw byte scan reports one diagnostic per line at the first tab on that line; tabs anywhere — including in strings/comments — count. Runs once via a new `visit_program` hook before the AST walk (the plugin's first raw-text rule).

## Tests
Rust unit tests (leading tab, mid-line tab, one of two lines, both lines → 2, no tab → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(no-tab)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783995302&installation_id=136613492&pr_number=211&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F211&signature=73dd519d184c0847218f93e83f5a209cc0fdcd84a4703c3a3e5a5573a74c004d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->