### PR TITLE
port(sonarjs): port todo-tag (S1135)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 39] = [
+pub const RULE_NAMES: [&str; 40] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -62,6 +62,7 @@ pub const RULE_NAMES: [&str; 39] = [
     "no-unthrown-error",
     "no-tab",
     "fixme-tag",
+    "todo-tag",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -40,3 +40,4 @@ mod prefer_default_last;
 mod prefer_immediate_return;
 mod prefer_single_boolean_return;
 mod prefer_while;
+mod todo_tag;

--- a/crates/sonarjs/src/rules/todo_tag.rs
+++ b/crates/sonarjs/src/rules/todo_tag.rs
@@ -1,0 +1,36 @@
+//! Rule `todo-tag` (SonarJS key S1135).
+//!
+//! Clean-room port. Flags comments containing the all-caps `TODO` tag, which
+//! mark incomplete work that should be tracked and completed. Each comment that
+//! contains the tag is reported once, at the comment's span.
+//!
+//! Scope/heuristic: the conventional all-caps `TODO` is matched as a
+//! case-sensitive substring of the comment text (covers `// TODO`,
+//! `/* TODO: ... */`, `// TODO do x`). Lowercase/mixed-case variants (`todo`,
+//! `ToDo`) are intentionally not matched in this port; case-insensitive
+//! matching would require allocation in the core and is a follow-up.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::Comment;
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "todo-tag";
+
+impl Scanner<'_> {
+    pub(crate) fn check_todo_tag(&mut self, comments: &[Comment]) {
+        let mut spans: SmallVec<[Span; 8]> = SmallVec::new();
+        for comment in comments {
+            if self.text(comment.span).contains("TODO") {
+                spans.push(comment.span);
+            }
+        }
+        for span in spans {
+            self.report(RULE_NAME, "todoTag", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -75,6 +75,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_program(&mut self, it: &Program<'a>) {
         self.check_no_tab();
         self.check_fixme_tag(&it.comments);
+        self.check_todo_tag(&it.comments);
         walk::walk_program(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1860,3 +1860,40 @@ fn does_not_report_fixme_tag_for_source_with_no_comments() {
     let diagnostics = scan("fixme-tag", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_todo_tag_for_line_comment_containing_todo() {
+    let source = "// TODO do x";
+    let diagnostics = scan("todo-tag", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "todo-tag");
+    assert_eq!(diagnostics[0].message_id, "todoTag");
+}
+
+#[test]
+fn reports_todo_tag_for_block_comment_containing_todo() {
+    let source = "/* TODO: later */";
+    let diagnostics = scan("todo-tag", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_todo_tag_for_fixme_comment() {
+    let source = "// FIXME do x";
+    let diagnostics = scan("todo-tag", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_todo_tag_for_lowercase_todo() {
+    let source = "// todo";
+    let diagnostics = scan("todo-tag", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_todo_tag_for_source_with_no_comments() {
+    let source = "const a = 1;";
+    let diagnostics = scan("todo-tag", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -154,6 +154,9 @@ const messages = Object.freeze({
   'fixme-tag': {
     fixmeTag: 'Address this FIXME-tagged comment.',
   },
+  'todo-tag': {
+    todoTag: 'Complete the task tracked by this TODO-tagged comment.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -227,6 +230,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow tab characters in source files; tabs render inconsistently across editors and tools, so spaces should be used instead',
   'fixme-tag':
     'Disallow FIXME-tagged comments; a FIXME marks code that is known-broken and must be addressed before shipping',
+  'todo-tag':
+    'Disallow TODO-tagged comments; a TODO marks incomplete work that should be tracked and completed',
 });
 
 const ruleTypes = Object.freeze({
@@ -269,6 +274,7 @@ const ruleTypes = Object.freeze({
   'no-unthrown-error': 'problem',
   'no-tab': 'suggestion',
   'fixme-tag': 'suggestion',
+  'todo-tag': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -311,6 +317,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-unthrown-error': 'error',
   'no-tab': 'error',
   'fixme-tag': 'error',
+  'todo-tag': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -42,6 +42,7 @@ const expectedRuleNames = [
   'no-unthrown-error',
   'no-tab',
   'fixme-tag',
+  'todo-tag',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1503,6 +1504,39 @@ describe('sonarjs native API', () => {
   it('does not report fixme-tag for source with no comments', () => {
     const source = 'const a = 1;';
     const diagnostics = scan('fixme-tag', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports todo-tag for a line comment containing TODO', () => {
+    const source = '// TODO do x';
+    const diagnostics = scan('todo-tag', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('todo-tag');
+    expect(diagnostics[0].messageId).toBe('todoTag');
+  });
+
+  it('reports todo-tag for a block comment containing TODO', () => {
+    const source = '/* TODO: later */';
+    const diagnostics = scan('todo-tag', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('todoTag');
+  });
+
+  it('does not report todo-tag for a comment containing FIXME but not TODO', () => {
+    const source = '// FIXME do x';
+    const diagnostics = scan('todo-tag', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report todo-tag for lowercase todo (case-sensitive match only)', () => {
+    const source = '// todo';
+    const diagnostics = scan('todo-tag', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report todo-tag for source with no comments', () => {
+    const source = 'const a = 1;';
+    const diagnostics = scan('todo-tag', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -133,6 +133,7 @@ describe('sonarjs plugin shape', () => {
       'no-unthrown-error',
       'no-tab',
       'fixme-tag',
+      'todo-tag',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -173,6 +174,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-unthrown-error']).toBe('object');
     expect(typeof plugin.rules['no-tab']).toBe('object');
     expect(typeof plugin.rules['fixme-tag']).toBe('object');
+    expect(typeof plugin.rules['todo-tag']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -213,6 +215,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-unthrown-error']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-tab']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/fixme-tag']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/todo-tag']).toBe('error');
   });
 });
 
@@ -881,5 +884,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(fixme-tag)');
+  });
+
+  it('reports todo-tag for a line comment containing TODO through the adapter', () => {
+    const source = '// TODO do x';
+    const reports = runRule('todo-tag', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('todoTag');
+  });
+
+  it('reports todo-tag through the CLI', () => {
+    const source = '// TODO do x';
+    const result = runOxlint('todo-tag', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(todo-tag)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -14046,19 +14046,19 @@
       },
       {
         "name": "todo-tag",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule todo-tag (Sonar key S1135). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of SonarJS S1135. Reports comments containing the all-caps TODO tag (case-sensitive substring), one diagnostic per matching comment, scanned from Program.comments. Lowercase/mixed-case variants are a documented follow-up. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "too-many-break-or-continue-in-loop",


### PR DESCRIPTION
## Summary
Clean-room port of **`todo-tag`** (Sonar key S1135). Flags comments containing the all-caps `TODO` tag. Sibling of `fixme-tag`: scans `Program.comments` from the existing `visit_program` hook, one diagnostic per matching comment. Case-sensitive all-caps match (lowercase/mixed-case is a documented follow-up).

## Tests
Rust unit tests (line/block `TODO` → 1; `FIXME`, lowercase `todo`, no comment → 0), native-API vitest, adapter vitest, and an oxlint `jsPlugins` CLI integration test (`sonarjs(todo-tag)`).

## Clean-room (LGPL-3.0)
Implemented from the public RSPEC description and observed behaviour only. No upstream source, tests, fixtures, helpers, or messages copied; message authored independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783996531&installation_id=136613492&pr_number=214&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F214&signature=2f49a089db72ae57a7a20ad811d237cd4c0a7e362febbd2c4811fb58e595264a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->