### PR TITLE
fix(storybook): faithful startCase naming + gate semantic build

### DIFF
--- a/crates/storybook/src/helpers.rs
+++ b/crates/storybook/src/helpers.rs
@@ -412,11 +412,17 @@ pub(crate) fn to_pascal_case(name: &str) -> CompactString {
 }
 
 pub(crate) fn story_name_from_export(name: &str) -> CompactString {
+    // Faithful port of `@storybook/csf`'s `toStartCaseStr`: `_`, `-` and `.` become
+    // word separators; spaces are inserted at camelCase / acronym / letter↔digit
+    // boundaries; the first letter of every word is upper-cased; and runs of spaces
+    // collapse with the result trimmed. `previous` tracks the ORIGINAL character so
+    // boundary detection runs on the pre-capitalised text (matching upstream's
+    // ordered regex passes, which capitalise last).
     let mut out = CompactString::new("");
     let mut previous: Option<char> = None;
     let mut chars = name.chars().peekable();
     while let Some(ch) = chars.next() {
-        if matches!(ch, '_' | '-') {
+        if matches!(ch, '_' | '-' | '.') {
             if !out.ends_with(' ') && !out.is_empty() {
                 out.push(' ');
             }
@@ -434,8 +440,16 @@ pub(crate) fn story_name_from_export(name: &str) -> CompactString {
                 out.push(' ');
             }
         }
-        out.push(ch);
+        // Upper-case the first letter of each word (start of output or after a space).
+        if out.is_empty() || out.ends_with(' ') {
+            out.push(ch.to_ascii_uppercase());
+        } else {
+            out.push(ch);
+        }
         previous = Some(ch);
+    }
+    while out.ends_with(' ') {
+        out.pop();
     }
     out
 }

--- a/crates/storybook/src/lib.rs
+++ b/crates/storybook/src/lib.rs
@@ -207,14 +207,21 @@ pub fn scan_storybook(
         return SmallVec::new();
     }
 
-    // Semantic analysis resolves identifier references, which `prefer-pascal-case`
-    // uses to rename every use of a renamed story export. The other rules do not
-    // read it. Benign semantic errors (e.g. redeclarations) do not block scanning.
-    let semantic = SemanticBuilder::new()
-        .build(&parser_return.program)
-        .semantic;
-    let scoping = semantic.scoping();
-    let nodes = semantic.nodes();
+    // Semantic analysis resolves identifier references, which only `prefer-pascal-case`
+    // uses (to rename every use of a renamed story export). Build it only when that
+    // rule is active so the other 15 rules don't pay for an extra AST walk. Benign
+    // semantic errors (e.g. redeclarations) do not block scanning.
+    let needs_semantic = options
+        .rule_names
+        .iter()
+        .any(|name| name == "prefer-pascal-case");
+    let semantic = needs_semantic.then(|| {
+        SemanticBuilder::new()
+            .build(&parser_return.program)
+            .semantic
+    });
+    let scoping = semantic.as_ref().map(|semantic| semantic.scoping());
+    let nodes = semantic.as_ref().map(|semantic| semantic.nodes());
 
     let mut scanner = Scanner {
         source_text,

--- a/crates/storybook/src/scanner.rs
+++ b/crates/storybook/src/scanner.rs
@@ -32,10 +32,11 @@ pub(crate) struct Scanner<'a> {
     pub(crate) line_index: LineIndex,
     pub(crate) diagnostics: SmallVec<[Diagnostic; 16]>,
     /// Scoping from semantic analysis; resolves an export's references for
-    /// `prefer-pascal-case` renaming.
-    pub(crate) scoping: &'a Scoping,
+    /// `prefer-pascal-case` renaming. `None` when that rule is not active.
+    pub(crate) scoping: Option<&'a Scoping>,
     /// AST nodes from semantic analysis; maps a reference back to its identifier.
-    pub(crate) nodes: &'a AstNodes<'a>,
+    /// `None` when `prefer-pascal-case` is not active.
+    pub(crate) nodes: Option<&'a AstNodes<'a>>,
     pub(crate) variables: FastHashMap<CompactString, VariableInfo<'a>>,
     pub(crate) function_stack: SmallVec<[FunctionFrame; 8]>,
     pub(crate) first_non_import_span: Option<Span>,
@@ -660,10 +661,12 @@ impl<'a> Scanner<'a> {
         });
         // Upstream renames every (non-declaration) reference to the export too, so the
         // autofix never leaves a dangling lowercase use such as `primary.foo`.
-        if let Some(symbol_id) = symbol_id {
-            for reference in self.scoping.get_resolved_references(symbol_id) {
+        if let Some(symbol_id) = symbol_id
+            && let (Some(scoping), Some(nodes)) = (self.scoping, self.nodes)
+        {
+            for reference in scoping.get_resolved_references(symbol_id) {
                 if let AstKind::IdentifierReference(identifier) =
-                    self.nodes.get_node(reference.node_id()).kind()
+                    nodes.get_node(reference.node_id()).kind()
                 {
                     fixes.push(DiagnosticFix {
                         start: identifier.span.start,

--- a/crates/storybook/src/tests.rs
+++ b/crates/storybook/src/tests.rs
@@ -94,6 +94,28 @@ fn scans_story_exports_and_story_names() {
 }
 
 #[test]
+fn story_name_from_export_matches_start_case() {
+    use crate::helpers::story_name_from_export;
+    for (input, expected) in [
+        ("PrimaryButton", "Primary Button"),
+        ("someName", "Some Name"),
+        ("camelCase", "Camel Case"),
+        ("snake_case", "Snake Case"),
+        ("kebab-case", "Kebab Case"),
+        ("foo.bar", "Foo Bar"),
+        ("H1", "H 1"),
+        ("someName1234", "Some Name 1234"),
+        ("__FOOBAR__", "FOOBAR"),
+    ] {
+        assert_eq!(
+            story_name_from_export(input).as_str(),
+            expected,
+            "input: {input}"
+        );
+    }
+}
+
+#[test]
 fn prefer_pascal_case_renames_references() {
     // The autofix must rename the declaration AND every reference to the export.
     let source = "export const primary = {};\nprimary.foo = 'bar';";


### PR DESCRIPTION
## What

Two follow-ups from a full review of the eslint-plugin-storybook port (issue #10).

### 1. Faithful `storyNameFromExport`

`story_name_from_export` now fully mirrors `@storybook/csf`'s `toStartCaseStr`:
- upper-cases the first letter of every word,
- treats `.` as a word separator (in addition to `_`/`-`),
- trims trailing whitespace.

Previously it inserted word boundaries but never capitalised, so `storyNameFromExport('someName')` returned `'some Name'` instead of `'Some Name'`. That made `no-redundant-story-name` miss redundant `name`/`storyName` annotations on any lowercase-initial export (a real-world false negative not covered by upstream's own rule fixtures). A new unit test pins the behaviour to upstream's startCase cases (`camelCase`→`Camel Case`, `__FOOBAR__`→`FOOBAR`, `H1`→`H 1`, …).

### 2. Gate the semantic build

`prefer-pascal-case` is the only rule that needs oxc semantic analysis (to rename an export's references). The build now runs **only when that rule is active** instead of on every `scan_storybook` call, so the other 15 rules don't pay for an extra AST walk. `Scanner.scoping`/`nodes` become `Option`.

## Verification

Locally on the storybook crate (warm shared target): `cargo test` (9 passing, incl. the new startCase + reference-rename tests) and `cargo clippy -- -D warnings`. Upstream parity suite (all 16 rules, zero skips) re-runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783996830&installation_id=136613492&pr_number=215&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F215&signature=8e2f27e25e852c189c601b37eec6374eb7200a182411a8e94c8c3598165c91c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->