### PR TITLE
fix(simple-import-sort): full-review fixes (brace detection, perf, docs)

### DIFF
--- a/crates/simple_import_sort/src/lib.rs
+++ b/crates/simple_import_sort/src/lib.rs
@@ -15,6 +15,10 @@ use oxlint_plugins_carton::SmallVec;
 
 use crate::types::LineIndex;
 
+/// Precompiled regex groups built once per `scan_simple_import_sort` call.
+/// `[outer][inner]` — `None` means the pattern failed to compile.
+type CompiledGroupsOwned = SmallVec<[SmallVec<[Option<regex::Regex>; 4]>; 8]>;
+
 pub use crate::types::{Diagnostic, DiagnosticFix, DiagnosticLoc, SimpleImportSortOptions};
 
 pub const RULE_NAMES: [&str; 2] = ["exports", "imports"];
@@ -48,12 +52,29 @@ pub fn scan_simple_import_sort(
     let line_index = LineIndex::new(source_text);
     let mut diagnostics = SmallVec::new();
 
+    // Precompile regex patterns for custom import groups once per scan.
+    // Each pattern that fails to compile is silently skipped (None), matching
+    // the per-call behaviour in import_group before this optimisation.
+    let compiled_groups: Option<CompiledGroupsOwned> =
+        options.import_groups.as_ref().map(|groups| {
+            groups
+                .iter()
+                .map(|inner| {
+                    inner
+                        .iter()
+                        .map(|pat| regex::Regex::new(pat.as_str()).ok())
+                        .collect()
+                })
+                .collect()
+        });
+
     scanner::scan_import_chunks(
         source_text,
         &line_index,
         &parser_return.program.body,
         &all_comments,
         options,
+        compiled_groups.as_deref(),
         &mut diagnostics,
     );
     scanner::scan_export_chunks(

--- a/crates/simple_import_sort/src/scanner.rs
+++ b/crates/simple_import_sort/src/scanner.rs
@@ -20,6 +20,14 @@ use crate::shared::{
 use crate::types::{Diagnostic, DiagnosticFix, LineIndex, RuleKind, SimpleImportSortOptions};
 
 // ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+/// Precompiled regex groups: `compiled_groups[outer][inner]` is `Some(Regex)` for
+/// patterns that compiled successfully, or `None` for those that failed.
+type CompiledGroups<'g> = &'g [SmallVec<[Option<regex::Regex>; 4]>];
+
+// ---------------------------------------------------------------------------
 // Public entry points
 // ---------------------------------------------------------------------------
 
@@ -29,6 +37,7 @@ pub(crate) fn scan_import_chunks(
     statements: &[Statement<'_>],
     all_comments: &[Comment],
     options: &SimpleImportSortOptions,
+    compiled_groups: Option<CompiledGroups<'_>>,
     diagnostics: &mut SmallVec<[Diagnostic; 8]>,
 ) {
     scan_import_chunks_in(
@@ -37,6 +46,7 @@ pub(crate) fn scan_import_chunks(
         statements,
         all_comments,
         options,
+        compiled_groups,
         diagnostics,
     );
 }
@@ -47,6 +57,7 @@ fn scan_import_chunks_in(
     statements: &[Statement<'_>],
     all_comments: &[Comment],
     options: &SimpleImportSortOptions,
+    compiled_groups: Option<CompiledGroups<'_>>,
     diagnostics: &mut SmallVec<[Diagnostic; 8]>,
 ) {
     // extractChunks: ImportDeclaration → PartOfChunk, else NotPartOfChunk
@@ -61,6 +72,7 @@ fn scan_import_chunks_in(
                 all_comments,
                 &chunk,
                 options,
+                compiled_groups,
                 diagnostics,
             );
             chunk.clear();
@@ -78,6 +90,7 @@ fn scan_import_chunks_in(
                     inner_stmts,
                     all_comments,
                     options,
+                    compiled_groups,
                     diagnostics,
                 );
             }
@@ -89,6 +102,7 @@ fn scan_import_chunks_in(
         all_comments,
         &chunk,
         options,
+        compiled_groups,
         diagnostics,
     );
 }
@@ -124,8 +138,13 @@ fn scan_export_chunks_in(
             Statement::ExportNamedDeclaration(decl) if is_export_from_named(decl) => {
                 // isPartOfChunk: check for grouping comment
                 let last_end = chunk.last().map(|n| n.span().end);
-                let part =
-                    export_is_part_of_chunk(source_text, all_comments, decl.span.start, last_end);
+                let part = export_is_part_of_chunk(
+                    source_text,
+                    line_index,
+                    all_comments,
+                    decl.span.start,
+                    last_end,
+                );
                 if part == ChunkPart::NewChunk {
                     report_export_chunk(source_text, line_index, all_comments, &chunk, diagnostics);
                     chunk.clear();
@@ -134,8 +153,13 @@ fn scan_export_chunks_in(
             }
             Statement::ExportAllDeclaration(decl) => {
                 let last_end = chunk.last().map(|n| n.span().end);
-                let part =
-                    export_is_part_of_chunk(source_text, all_comments, decl.span.start, last_end);
+                let part = export_is_part_of_chunk(
+                    source_text,
+                    line_index,
+                    all_comments,
+                    decl.span.start,
+                    last_end,
+                );
                 if part == ChunkPart::NewChunk {
                     report_export_chunk(source_text, line_index, all_comments, &chunk, diagnostics);
                     chunk.clear();
@@ -254,12 +278,13 @@ enum ChunkPart {
 /// Returns NewChunk if there's a "grouping comment" before this node.
 fn export_is_part_of_chunk(
     source_text: &str,
+    line_index: &LineIndex,
     all_comments: &[Comment],
     node_start: u32,
     last_node_end: Option<u32>,
 ) -> ChunkPart {
-    let node_start_line = shared::line_of(source_text, node_start);
-    let last_end_line = last_node_end.map(|e| shared::line_of(source_text, e));
+    let node_start_line = line_index.line_for_offset(source_text, node_start);
+    let last_end_line = last_node_end.map(|e| line_index.line_for_offset(source_text, e));
 
     for comment in all_comments {
         // Only consider comments that start before the node
@@ -269,8 +294,8 @@ fn export_is_part_of_chunk(
         // Mirrors upstream `isPartOfChunk` filter in exports.js:
         //   (lastNode == null || comment.loc.start.line > lastNode.loc.end.line)
         //   && comment.loc.end.line < node.loc.start.line
-        let c_start_line = shared::line_of(source_text, comment.span.start);
-        let c_end_line = shared::line_of(source_text, comment.span.end);
+        let c_start_line = line_index.line_for_offset(source_text, comment.span.start);
+        let c_end_line = line_index.line_for_offset(source_text, comment.span.end);
 
         let after_last = match last_end_line {
             None => true,
@@ -312,6 +337,7 @@ fn report_import_chunk(
     all_comments: &[Comment],
     chunk: &[&ImportDeclaration<'_>],
     options: &SimpleImportSortOptions,
+    compiled_groups: Option<CompiledGroups<'_>>,
     diagnostics: &mut SmallVec<[Diagnostic; 8]>,
 ) {
     if chunk.is_empty() {
@@ -322,21 +348,31 @@ fn report_import_chunk(
     // handleLastSemicolon
     let last_node_end = handle_last_semicolon(
         source_text,
+        line_index,
         chunk.last().expect("non-empty").span,
         all_comments,
     );
 
     let items = build_import_items(
         source_text,
+        line_index,
         all_comments,
         chunk,
         last_node_end,
         options,
+        compiled_groups,
         newline,
     );
 
     let sorted_items = make_sorted_import_items(&items, options);
-    let sorted = print_sorted_items(&sorted_items, &items, source_text, all_comments, newline);
+    let sorted = print_sorted_items(
+        &sorted_items,
+        &items,
+        source_text,
+        line_index,
+        all_comments,
+        newline,
+    );
 
     let start = items[0].start;
     let end = items[items.len() - 1].end;
@@ -351,12 +387,15 @@ fn report_import_chunk(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_import_items(
     source_text: &str,
+    line_index: &LineIndex,
     all_comments: &[Comment],
     chunk: &[&ImportDeclaration<'_>],
     last_node_end: u32,
     options: &SimpleImportSortOptions,
+    compiled_groups: Option<CompiledGroups<'_>>,
     newline: &str,
 ) -> SmallVec<[ImportExportItem; 16]> {
     let chunk_len = chunk.len();
@@ -372,16 +411,19 @@ fn build_import_items(
 
         // last_line for commentsBefore filter
         let last_line = if node_index == 0 {
-            shared::line_of(source_text, node_start).saturating_sub(1)
+            line_index
+                .line_for_offset(source_text, node_start)
+                .saturating_sub(1)
         } else {
-            shared::line_of(source_text, chunk[node_index - 1].span.end)
+            line_index.line_for_offset(source_text, chunk[node_index - 1].span.end)
         };
-        let node_start_line = shared::line_of(source_text, node_start);
-        let node_end_line = shared::line_of(source_text, node_end);
+        let node_start_line = line_index.line_for_offset(source_text, node_start);
+        let node_end_line = line_index.line_for_offset(source_text, node_end);
 
         let comments_before = shared::comments_before_node(
             all_comments,
             source_text,
+            line_index,
             node_start,
             node_start_line,
             last_line,
@@ -395,6 +437,7 @@ fn build_import_items(
         let comments_after = shared::comments_after_node(
             all_comments,
             source_text,
+            line_index,
             node_end,
             node_end_line,
             next_node_start,
@@ -443,7 +486,8 @@ fn build_import_items(
         let kind_str = import_kind_str(decl.import_kind);
         let orig = decl.source.value.as_str();
         let source = shared::get_source(orig, kind_str);
-        let (outer_group, inner_group) = import_group(style, decl.import_kind, orig, options);
+        let (outer_group, inner_group) =
+            import_group(style, decl.import_kind, orig, options, compiled_groups);
 
         let item = build_item(
             source_text,
@@ -483,10 +527,21 @@ fn report_export_chunk(
     }
     let newline = guess_newline(source_text);
 
-    let last_node_end =
-        handle_last_semicolon(source_text, chunk[chunk.len() - 1].span(), all_comments);
+    let last_node_end = handle_last_semicolon(
+        source_text,
+        line_index,
+        chunk[chunk.len() - 1].span(),
+        all_comments,
+    );
 
-    let items = build_export_items(source_text, all_comments, chunk, last_node_end, newline);
+    let items = build_export_items(
+        source_text,
+        line_index,
+        all_comments,
+        chunk,
+        last_node_end,
+        newline,
+    );
 
     // sortImportExportItems – single group for exports
     let sorted_refs = sort_import_export_items(items.iter().collect());
@@ -503,7 +558,14 @@ fn report_export_chunk(
         v
     };
 
-    let sorted = print_sorted_items(&outer, &items, source_text, all_comments, newline);
+    let sorted = print_sorted_items(
+        &outer,
+        &items,
+        source_text,
+        line_index,
+        all_comments,
+        newline,
+    );
 
     let start = items[0].start;
     let end = items[items.len() - 1].end;
@@ -520,6 +582,7 @@ fn report_export_chunk(
 
 fn build_export_items(
     source_text: &str,
+    line_index: &LineIndex,
     all_comments: &[Comment],
     chunk: &[ExportNode<'_>],
     last_node_end: u32,
@@ -537,16 +600,19 @@ fn build_export_items(
         };
 
         let last_line = if node_index == 0 {
-            shared::line_of(source_text, node_start).saturating_sub(1)
+            line_index
+                .line_for_offset(source_text, node_start)
+                .saturating_sub(1)
         } else {
-            shared::line_of(source_text, chunk[node_index - 1].span().end)
+            line_index.line_for_offset(source_text, chunk[node_index - 1].span().end)
         };
-        let node_start_line = shared::line_of(source_text, node_start);
-        let node_end_line = shared::line_of(source_text, node_end);
+        let node_start_line = line_index.line_for_offset(source_text, node_start);
+        let node_end_line = line_index.line_for_offset(source_text, node_end);
 
         let comments_before = shared::comments_before_node(
             all_comments,
             source_text,
+            line_index,
             node_start,
             node_start_line,
             last_line,
@@ -560,6 +626,7 @@ fn build_export_items(
         let comments_after = shared::comments_after_node(
             all_comments,
             source_text,
+            line_index,
             node_end,
             node_end_line,
             next_node_start,
@@ -818,7 +885,12 @@ fn find_first_token_start_after(
 /// If the last token of `node_span` is `;` and it's NOT on the same line as
 /// the next-to-last token, AND there's code after the `;`, adjust the node end
 /// to the next-to-last token's end (i.e. the end of the `from "..."` string).
-fn handle_last_semicolon(source_text: &str, node_span: Span, all_comments: &[Comment]) -> u32 {
+fn handle_last_semicolon(
+    source_text: &str,
+    line_index: &LineIndex,
+    node_span: Span,
+    all_comments: &[Comment],
+) -> u32 {
     let text = source_text
         .get(node_span.start as usize..node_span.end as usize)
         .unwrap_or("");
@@ -834,15 +906,15 @@ fn handle_last_semicolon(source_text: &str, node_span: Span, all_comments: &[Com
 
     let abs_last = node_span.start + last_byte_offset as u32;
     let last_char = source_text
-        .get(abs_last as usize - 1..abs_last as usize)
+        .get(abs_last.saturating_sub(1) as usize..abs_last as usize)
         .unwrap_or("");
 
     if last_char != ";" {
         return node_span.end;
     }
 
-    let semi_start = abs_last - 1; // ';' is 1 byte
-    let semi_line = shared::line_of(source_text, semi_start);
+    let semi_start = abs_last.saturating_sub(1); // ';' is 1 byte
+    let semi_line = line_index.line_for_offset(source_text, semi_start);
 
     // Find next-to-last token (the last NON-comment, non-whitespace byte before `;`).
     // We need to scan backwards, skipping both whitespace AND trailing comment spans.
@@ -884,7 +956,7 @@ fn handle_last_semicolon(source_text: &str, node_span: Span, all_comments: &[Com
         }
         cursor
     };
-    let ntl_line = shared::line_of(source_text, next_to_last_end.saturating_sub(1));
+    let ntl_line = line_index.line_for_offset(source_text, next_to_last_end.saturating_sub(1));
 
     if ntl_line == semi_line {
         // Same line → semicolon belongs to this node
@@ -931,11 +1003,12 @@ fn import_group(
     import_kind: ImportOrExportKind,
     original: &str,
     options: &SimpleImportSortOptions,
+    compiled_groups: Option<CompiledGroups<'_>>,
 ) -> (usize, usize) {
     let kind_rank_val = kind_rank(import_kind);
-    let custom_groups = match &options.import_groups {
+    match &options.import_groups {
         None => {
-            // Default 5 groups
+            // Default 5 groups — fast path, no regex involved
             if style == SIDE_EFFECT_STYLE {
                 return (0, 0);
             }
@@ -948,29 +1021,49 @@ fn import_group(
             if original.starts_with('.') {
                 return (4, 0);
             }
-            return (3, 0);
+            (3, 0)
         }
-        Some(g) => g,
-    };
-    // Custom groups (possibly empty → single rest group): find longest match
-    let match_source = import_match_source(style, kind_rank_val, original);
-    let mut best: Option<(usize, usize, usize)> = None;
-    for (outer_index, group) in custom_groups.iter().enumerate() {
-        for (inner_index, pattern) in group.iter().enumerate() {
-            let Ok(re) = regex::Regex::new(pattern.as_str()) else {
-                continue;
-            };
-            let Some(m) = re.find(match_source.as_str()) else {
-                continue;
-            };
-            let len = m.end() - m.start();
-            if best.is_none_or(|(_, _, bl)| len > bl) {
-                best = Some((outer_index, inner_index, len));
+        Some(raw_groups) => {
+            // Custom groups: find longest match using precompiled regexes when available.
+            let match_source = import_match_source(style, kind_rank_val, original);
+            let mut best: Option<(usize, usize, usize)> = None;
+
+            if let Some(cg) = compiled_groups {
+                // Use precompiled regexes (PERF-2 fast path)
+                for (outer_index, inner) in cg.iter().enumerate() {
+                    for (inner_index, maybe_re) in inner.iter().enumerate() {
+                        let Some(re) = maybe_re else { continue };
+                        let Some(m) = re.find(match_source.as_str()) else {
+                            continue;
+                        };
+                        let len = m.end() - m.start();
+                        if best.is_none_or(|(_, _, bl)| len > bl) {
+                            best = Some((outer_index, inner_index, len));
+                        }
+                    }
+                }
+            } else {
+                // Fallback: compile per-call (should not happen in normal flow)
+                for (outer_index, group) in raw_groups.iter().enumerate() {
+                    for (inner_index, pattern) in group.iter().enumerate() {
+                        let Ok(re) = regex::Regex::new(pattern.as_str()) else {
+                            continue;
+                        };
+                        let Some(m) = re.find(match_source.as_str()) else {
+                            continue;
+                        };
+                        let len = m.end() - m.start();
+                        if best.is_none_or(|(_, _, bl)| len > bl) {
+                            best = Some((outer_index, inner_index, len));
+                        }
+                    }
+                }
             }
+
+            best.map(|(o, i, _)| (o, i))
+                .unwrap_or((raw_groups.len(), 0))
         }
     }
-    best.map(|(o, i, _)| (o, i))
-        .unwrap_or((custom_groups.len(), 0))
 }
 
 fn import_match_source(style: u8, kind_rank: u8, original: &str) -> CompactString {
@@ -1113,6 +1206,7 @@ fn print_sorted_items<'a>(
     sorted_items: &OuterGroups<'a>,
     original_items: &[ImportExportItem],
     source_text: &str,
+    line_index: &LineIndex,
     all_comments: &[Comment],
     newline: &str,
 ) -> CompactString {
@@ -1162,14 +1256,15 @@ fn print_sorted_items<'a>(
         && last_sorted.needs_newline
     {
         let lo_end = last_original.node_end;
-        let lo_end_line = shared::line_of(source_text, lo_end);
+        let lo_end_line = line_index.line_for_offset(source_text, lo_end);
 
         // Find first token after lo that is NOT a line comment and NOT a
         // block comment ending on the same line as lo
-        let next = find_next_valid_token(source_text, all_comments, lo_end, lo_end_line);
+        let next =
+            find_next_valid_token(source_text, line_index, all_comments, lo_end, lo_end_line);
 
         if let Some(next_start) = next
-            && shared::line_of(source_text, next_start) == lo_end_line
+            && line_index.line_for_offset(source_text, next_start) == lo_end_line
         {
             result.push_str(newline);
         }
@@ -1185,6 +1280,7 @@ fn print_sorted_items<'a>(
 /// Mirrors `sourceCode.getTokenAfter(node, { includeComments: true, filter })`.
 fn find_next_valid_token(
     source_text: &str,
+    line_index: &LineIndex,
     all_comments: &[Comment],
     offset: u32,
     base_line: u32,
@@ -1200,7 +1296,7 @@ fn find_next_valid_token(
         match c.kind {
             CommentKind::Line => continue, // skip line comments
             CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
-                let end_line = shared::line_of(source_text, c.span.end);
+                let end_line = line_index.line_for_offset(source_text, c.span.end);
                 if end_line == base_line {
                     continue;
                 } // block comment ending on same line → skip

--- a/crates/simple_import_sort/src/shared.rs
+++ b/crates/simple_import_sort/src/shared.rs
@@ -8,6 +8,8 @@ use oxc_span::Span;
 use oxlint_plugins_carton::{CompactString, SmallVec};
 use unicode_normalization::UnicodeNormalization;
 
+use crate::types::LineIndex;
+
 // ---------------------------------------------------------------------------
 // Constants (mirrors imports.js / exports.js)
 // ---------------------------------------------------------------------------
@@ -388,22 +390,6 @@ pub(crate) fn compare(a: &str, b: &str) -> i32 {
 }
 
 // ---------------------------------------------------------------------------
-// Line number helpers
-// ---------------------------------------------------------------------------
-
-/// Get the 1-based line number for a byte offset.
-pub(crate) fn line_of(source_text: &str, offset: u32) -> u32 {
-    let offset = (offset as usize).min(source_text.len());
-    let mut line = 1u32;
-    for b in source_text[..offset].bytes() {
-        if b == b'\n' {
-            line += 1;
-        }
-    }
-    line
-}
-
-// ---------------------------------------------------------------------------
 // Comment helpers
 // ---------------------------------------------------------------------------
 
@@ -423,6 +409,7 @@ pub(crate) fn comment_text<'a>(source_text: &'a str, comment: &Comment) -> &'a s
 pub(crate) fn comments_before_node<'a>(
     all_comments: &'a [Comment],
     source_text: &str,
+    line_index: &LineIndex,
     node_start: u32,
     node_start_line: u32,
     last_line: u32,
@@ -437,8 +424,8 @@ pub(crate) fn comments_before_node<'a>(
         if comment.span.end > node_start {
             continue;
         }
-        let c_start_line = line_of(source_text, comment.span.start);
-        let c_end_line = line_of(source_text, comment.span.end);
+        let c_start_line = line_index.line_for_offset(source_text, comment.span.start);
+        let c_end_line = line_index.line_for_offset(source_text, comment.span.end);
         if c_start_line <= node_start_line
             && c_end_line > last_line
             && (!is_first_node || c_start_line > last_line)
@@ -453,6 +440,7 @@ pub(crate) fn comments_before_node<'a>(
 pub(crate) fn comments_after_node<'a>(
     all_comments: &'a [Comment],
     source_text: &str,
+    line_index: &LineIndex,
     node_end: u32,
     node_end_line: u32,
     // If `Some(pos)`, only include comments that start BEFORE this position.
@@ -470,7 +458,7 @@ pub(crate) fn comments_after_node<'a>(
         {
             break;
         }
-        let c_end_line = line_of(source_text, comment.span.end);
+        let c_end_line = line_index.line_for_offset(source_text, comment.span.end);
         if c_end_line == node_end_line {
             result.push(comment);
         } else {
@@ -1049,47 +1037,24 @@ pub(crate) fn print_with_sorted_specifiers(
         .get(node_start as usize..node_end as usize)
         .unwrap_or("");
 
-    // Try to find { and } positions for blank-line collapsing.
-    // We need these even for ≤1 specifiers because upstream's getAllTokens
-    // still calls parseWhitespace on every inter-token gap, collapsing blank lines.
-    let brace_positions: Option<(usize, usize)> =
-        find_brace_positions(source_text, node_start, node_end, specifier_spans);
-
-    // ≤1 specifiers: no reordering needed, but still collapse blank lines.
+    // ≤1 specifiers: no reordering possible. Upstream returns
+    // `printTokens(getAllTokens(node))`, i.e. the whole node re-emitted with
+    // `parseWhitespace` applied to every inter-token gap — which is exactly
+    // `collapse_blank_lines_in_mixed_text` over the node text (it preserves
+    // string literals and comments verbatim and collapses blank lines elsewhere).
+    // This also correctly handles `import "x" with { … }` import attributes and
+    // empty `import { } from "x"` lists without mistaking a `with`-clause `{` or
+    // a comment `{` for a specifier brace.
     if specifier_spans.len() <= 1 {
-        let Some((open_rel, close_rel)) = brace_positions else {
-            // No braces found (e.g. `import def from "x"`, `import "side-effect"`).
-            // Still collapse blank lines in the node text (upstream's getAllTokens
-            // applies parseWhitespace to every inter-token gap, including gaps that
-            // don't involve specifiers, such as the gap before a trailing `;`).
-            return collapse_blank_lines_in_mixed_text(node_text);
-        };
-
-        let open_brace_end_abs = node_start + open_rel as u32 + 1;
-        let close_brace_start_abs = node_start + close_rel as u32;
-
-        // Collapse blank lines in all three regions
-        let prefix = collapse_blank_lines_in_mixed_text(&node_text[..open_rel + 1]);
-        let interior = {
-            let tokens = tokenize_specifier_interior(
-                source_text,
-                open_brace_end_abs,
-                close_brace_start_abs,
-                specifier_spans,
-                all_comments,
-            );
-            print_tokens(&tokens)
-        };
-        let suffix = collapse_blank_lines_in_mixed_text(&node_text[close_rel..]);
-
-        let mut out = CompactString::new("");
-        out.push_str(&prefix);
-        out.push_str(&interior);
-        out.push_str(&suffix);
-        return out;
+        return collapse_blank_lines_in_mixed_text(node_text);
     }
 
-    let Some((open_rel_in_node, close_rel_in_node)) = brace_positions else {
+    // >1 specifiers: locate the specifier braces (comment/string-aware so a `{`
+    // inside a comment, or a later `with { … }` brace, is never mistaken for the
+    // specifier list) and reorder the interior.
+    let Some((open_rel_in_node, close_rel_in_node)) =
+        find_brace_positions(source_text, node_start, specifier_spans)
+    else {
         return CompactString::from(node_text);
     };
 
@@ -1183,43 +1148,73 @@ pub(crate) fn print_with_sorted_specifiers(
 
 /// Find the positions of the specifier-list `{` and `}` within the node text.
 ///
-/// Returns `(open_rel, close_rel)` as byte offsets from `node_start`, where
-/// `open_rel` points to `{` and `close_rel` points to `}`.
+/// Locate the specifier-list braces of an import/export with >1 specifiers.
 ///
-/// When `specifier_spans` is non-empty, uses them to bound the search.
-/// When empty (no specifiers), searches the whole node text.
+/// Returns `(open_rel, close_rel)` as byte offsets from `node_start`. The open
+/// brace is the first real `{` in the statement and the close brace is the first
+/// real `}` at/after the last specifier — "real" meaning not inside a string
+/// literal or comment, so a `{`/`}` inside a comment, or a later `with { … }`
+/// import-attributes brace, is never mistaken for the specifier list.
 fn find_brace_positions(
     source_text: &str,
     node_start: u32,
-    node_end: u32,
     specifier_spans: &[Span],
 ) -> Option<(usize, usize)> {
-    let node_text = source_text.get(node_start as usize..node_end as usize)?;
-
-    if specifier_spans.is_empty() {
-        // No specifiers: find `{` and `}` in the node text.
-        // Use the FIRST `{` and the corresponding `}`.
-        let open_rel = node_text.find('{')?;
-        let close_rel = node_text.rfind('}')?;
-        if close_rel <= open_rel {
-            return None;
-        }
-        return Some((open_rel, close_rel));
-    }
-
-    let first_spec_start = specifier_spans[0].start;
     let last_spec_end = specifier_spans[specifier_spans.len() - 1].end;
+    let node_text = source_text.get(node_start as usize..)?;
 
-    // Find `{` before first specifier
-    let before_first = source_text.get(node_start as usize..first_spec_start as usize)?;
-    let open_rel = before_first.rfind('{')?;
-
-    // Find `}` after last specifier
-    let after_last = source_text.get(last_spec_end as usize..node_end as usize)?;
-    let close_offset_in_after = after_last.find('}')?;
-    let close_rel = (last_spec_end - node_start) as usize + close_offset_in_after;
-
+    let open_rel = find_real_byte(node_text, 0, b'{')?;
+    let close_from = (last_spec_end.saturating_sub(node_start)) as usize;
+    let close_rel = find_real_byte(node_text, close_from, b'}')?;
+    if close_rel <= open_rel {
+        return None;
+    }
     Some((open_rel, close_rel))
+}
+
+/// Index of the first `target` byte at/after `from` that is not inside a string
+/// literal (`"…"`/`'…'`) or comment (`/*…*/`, `//…`). `target` must not be a
+/// string/comment delimiter (`{`/`}` are the only callers).
+fn find_real_byte(text: &str, from: usize, target: u8) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut i = from;
+    while i < len {
+        let b = bytes[i];
+        if b == target {
+            return Some(i);
+        }
+        match b {
+            b'"' | b'\'' => {
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    let end = bytes[i] == b;
+                    i += 1;
+                    if end {
+                        break;
+                    }
+                }
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i < len && !(bytes[i] == b'*' && i + 1 < len && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(len);
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
+                while i < len && bytes[i] != b'\n' && bytes[i] != b'\r' {
+                    i += 1;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 /// Trim after tokens for the last specifier when it had a comma but now doesn't.

--- a/crates/simple_import_sort/src/tests.rs
+++ b/crates/simple_import_sort/src/tests.rs
@@ -133,6 +133,51 @@ fn collator_handles_accents() {
 }
 
 #[test]
+fn import_attributes_with_clause_is_not_treated_as_specifiers() {
+    // A `with { … }` import-attributes clause on a default import must not be
+    // mistaken for the specifier list. No blank lines → no change → no report.
+    let sorted = "import foo from \"./data.json\" with {\n  type: \"json\"\n}";
+    assert!(
+        scan_simple_import_sort(sorted, "file.ts", &SimpleImportSortOptions::default()).is_empty()
+    );
+
+    // A blank line inside the `with` block collapses (upstream token model), but
+    // the attribute content is preserved — never dropped.
+    let blank = "import foo from \"./data.json\" with {\n\n  type: \"json\"\n}";
+    let diagnostics =
+        scan_simple_import_sort(blank, "file.ts", &SimpleImportSortOptions::default());
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("fix")
+            .replacement
+            .as_str(),
+        "import foo from \"./data.json\" with {\n  type: \"json\"\n}"
+    );
+}
+
+#[test]
+fn comment_brace_is_not_mistaken_for_specifier_brace() {
+    // A `{` inside a comment before the first specifier must not be picked as the
+    // specifier open brace (would otherwise shatter the comment / specifiers).
+    let source = "import { /* { */ b, a } from \"mod\"";
+    let diagnostics =
+        scan_simple_import_sort(source, "file.js", &SimpleImportSortOptions::default());
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("fix")
+            .replacement
+            .as_str(),
+        "import { /* { */ a,b } from \"mod\""
+    );
+}
+
+#[test]
 fn preserves_blank_lines_inside_block_comments() {
     // Upstream treats a block comment as a single token, so a blank line *inside*
     // it must survive even though blank lines between tokens are collapsed.

--- a/crates/simple_import_sort/src/types.rs
+++ b/crates/simple_import_sort/src/types.rs
@@ -78,4 +78,13 @@ impl LineIndex {
             .sum::<usize>();
         ((line_index + 1) as u32, column as u32)
     }
+
+    /// Return the 1-based line number for `offset`, using binary search on
+    /// `line_starts`. Mirrors `line_of(source_text, offset)` in shared.rs but
+    /// runs in O(log n) instead of O(source_len).
+    pub(crate) fn line_for_offset(&self, source_text: &str, offset: u32) -> u32 {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        (line_index.saturating_sub(1) + 1) as u32
+    }
 }

--- a/npm/simple-import-sort/README.md
+++ b/npm/simple-import-sort/README.md
@@ -1,13 +1,65 @@
 # @oxlint-plugins/oxlint-plugin-simple-import-sort
 
-Rust-backed Oxlint plugin port of `eslint-plugin-simple-import-sort`.
+Rust-backed Oxlint plugin port of [`eslint-plugin-simple-import-sort`](https://github.com/lydell/eslint-plugin-simple-import-sort) — opinionated import/export sorting with autofixable diagnostics. The rule logic and sorting algorithm run in Rust through NAPI-RS; the JavaScript wrapper stays compatible with Oxlint's JS plugin API.
+
+This is unofficial community work and is not an official Oxlint or eslint-plugin-simple-import-sort project.
+
+## Usage
+
+```jsonc
+{
+  "jsPlugins": [
+    {
+      "name": "simple-import-sort",
+      "specifier": "@oxlint-plugins/oxlint-plugin-simple-import-sort",
+    },
+  ],
+  "rules": {
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+  },
+}
+```
+
+### `imports` rule — `groups` option
+
+Custom groups control how imports are bucketed and separated by blank lines. Pass a 2-D array of regex strings; each outer array is a group (blank-line separator) and each inner array is a sub-group (no blank line between them). Patterns are matched against the import source string (with a `\0` prefix for side-effect imports and a `\0` suffix for type imports).
+
+```jsonc
+{
+  "rules": {
+    "simple-import-sort/imports": [
+      "error",
+      {
+        "groups": [
+          // Side-effect imports
+          ["^\\u0000"],
+          // Node built-ins
+          ["^node:"],
+          // Packages
+          ["^@?\\w"],
+          // Internal aliases
+          ["^~"],
+          // Relative imports
+          ["^\\."],
+        ],
+      },
+    ],
+  },
+}
+```
 
 ## Rules
 
-- `simple-import-sort/imports`
-- `simple-import-sort/exports`
+| Rule      | Description                                        | Status |
+| --------- | -------------------------------------------------- | ------ |
+| `imports` | Sort import declarations within each chunk         | ported |
+| `exports` | Sort re-export declarations and named export lists | ported |
 
-The native implementation sorts import/export chunks and named specifiers and
-returns autofix ranges through the Oxlint JavaScript plugin adapter. It covers
-the common module-sorting path; the upstream plugin's exhaustive comment
-printer is not duplicated yet.
+## Test parity
+
+Upstream test cases are captured verbatim from the vendored submodule by `pnpm run port:tests:simple-import-sort` and replayed against this plugin in a Rust replay harness, so behavior tracks upstream as the submodule is bumped. All 88 upstream invalid cases are exercised; one is quarantined because it uses a construct (`import type X, {Y}`) that TypeScript itself rejects and Oxc declines to parse.
+
+## Attribution
+
+Rule behavior, sorting algorithm, and test cases are derived from [`eslint-plugin-simple-import-sort`](https://github.com/lydell/eslint-plugin-simple-import-sort) (MIT, © Simon Lydell). See [`LICENSE`](./LICENSE).

--- a/npm/simple-import-sort/api.d.ts
+++ b/npm/simple-import-sort/api.d.ts
@@ -28,3 +28,9 @@ export function scanSimpleImportSort(
   filename?: string,
   options?: SimpleImportSortScanOptions,
 ): Diagnostic[];
+
+declare const _default: {
+  implementedSimpleImportSortRuleNames: typeof implementedSimpleImportSortRuleNames;
+  scanSimpleImportSort: typeof scanSimpleImportSort;
+};
+export default _default;

--- a/npm/simple-import-sort/test/parity.json
+++ b/npm/simple-import-sort/test/parity.json
@@ -9,7 +9,7 @@
         "invalid": [
           {
             "index": 70,
-            "reason": "exercises syntactically-invalid TypeScript (`import type Def, { Named }`, which TypeScript itself rejects); Oxc reports a parse error, so the port declines to autofix unparseable source rather than act on a partial AST"
+            "reason": "exercises syntactically-invalid TypeScript (`import type X, {} from \"…\"` / `import type X, {Y} from \"…\"`, which TypeScript itself rejects); Oxc reports a parse error, so the port declines to autofix unparseable source rather than act on a partial AST"
           }
         ]
       }


### PR DESCRIPTION
Addresses the major + selected minor findings from a full-spectrum review (design, correctness, security, performance, tests, docs) of the merged `simple-import-sort` port.

## Correctness (could corrupt autofix output on plausible code)
- **Import attributes**: `import x from "m" with { … }` on a default/namespace/side-effect import previously had its `with { … }` braces mistaken for the specifier list and its content collapsed/dropped. The `≤1 specifier` path now reconstructs the whole node via the comment/string-aware blank-line collapse (mirrors upstream `printTokens(getAllTokens(node))`).
- **Comment braces**: a `{`/`}` inside a comment before the first specifier (e.g. `import { /* { */ a, b }`) was picked as the specifier brace. `find_brace_positions` now scans comment/string-aware. Both fixed and guarded by new unit tests.

## Performance
- Replace the O(source_len) `line_of` with `LineIndex::line_for_offset` (binary search), removing the O(nodes × comments × source_len) hot path on large files.
- Precompile custom import-group regexes once per scan (was recompiled per import).
- `saturating_sub` on span-offset subtractions for malformed-input safety.

## Docs / accuracy
- README: upstream attribution (Simon Lydell, MIT), Usage + `groups` option docs.
- `api.d.ts`: add the missing default export; `parity.json`: correct the quarantine reason.

All 9 Rust unit tests pass; byte-exact upstream parity is unchanged (only the one invalid-TypeScript fixture remains quarantined). Verified locally; clippy/test run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783997537&installation_id=136613492&pr_number=216&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F216&signature=4fe8c4869c9a738f2f5ef6a020a5d64898f27166dca459187b1e8617b90f4947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->