### PR TITLE
fix(simple-import-sort): newline detection + total export-source accessor

### DIFF
--- a/crates/simple_import_sort/src/scanner.rs
+++ b/crates/simple_import_sort/src/scanner.rs
@@ -226,7 +226,10 @@ impl<'a> ExportNode<'a> {
     }
     fn source_str(&self) -> &str {
         match self {
-            ExportNode::Named(d) => d.source.as_ref().expect("export-from").value.as_str(),
+            // `ExportNode::Named` is only constructed for export-from nodes
+            // (`is_export_from_named` guarantees `source.is_some()`); fall back to
+            // an empty key rather than panicking if that invariant ever changes.
+            ExportNode::Named(d) => d.source.as_ref().map_or("", |s| s.value.as_str()),
             ExportNode::All(d) => d.source.value.as_str(),
         }
     }

--- a/crates/simple_import_sort/src/shared.rs
+++ b/crates/simple_import_sort/src/shared.rs
@@ -893,10 +893,13 @@ pub(crate) fn needs_starting_newline(tokens: &[Token]) -> bool {
 // ---------------------------------------------------------------------------
 
 pub(crate) fn guess_newline(source_text: &str) -> &'static str {
-    if source_text.contains("\r\n") {
-        "\r\n"
-    } else {
-        "\n"
+    // Mirror upstream `guessNewline` = `/(\r?\n)/.exec(text)`: the FIRST newline
+    // in the file decides the style (not "any CRLF anywhere"), so a file whose
+    // first line ends in LF is treated as LF even if a later line uses CRLF.
+    match source_text.find('\n') {
+        Some(index) if index > 0 && source_text.as_bytes()[index - 1] == b'\r' => "\r\n",
+        Some(_) => "\n",
+        None => "\n",
     }
 }
 

--- a/crates/simple_import_sort/src/tests.rs
+++ b/crates/simple_import_sort/src/tests.rs
@@ -192,3 +192,20 @@ fn preserves_blank_lines_inside_block_comments() {
         "import /* x\n\ny */ a from \"a\"\nimport b from \"b\""
     );
 }
+
+#[test]
+fn newline_style_follows_the_first_newline() {
+    // Upstream `guessNewline` uses the FIRST newline in the file. Here the first
+    // line ends in LF, so inserted separators are LF even though a later line
+    // uses CRLF — must not switch the whole file to CRLF.
+    let source = "import b from 'b';\nimport a from 'a';\r\n";
+    let diagnostics =
+        scan_simple_import_sort(source, "fixture.js", &SimpleImportSortOptions::default());
+
+    assert_eq!(diagnostics.len(), 1);
+    let fix = diagnostics[0].fix.as_ref().expect("fix");
+    assert_eq!(
+        fix.replacement.as_str(),
+        "import a from 'a';\nimport b from 'b';"
+    );
+}


### PR DESCRIPTION
Final review polish. `guess_newline` now mirrors upstream's `guessNewline` (the **first** newline decides LF vs CRLF) instead of "any CRLF anywhere" — fixing wrong separators in the autofix on mixed-newline files. Also makes `ExportNode::source_str` total (no `expect`). Both verified locally; byte-exact parity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783997915&installation_id=136613492&pr_number=217&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F217&signature=6ddd6afd2809ef6ed3e896e4e0af00101acf3b493530dc5042cfcb0bd4ed231d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->