### PR TITLE
port(sonarjs): port no-sonar-comments (S1291)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 40] = [
+pub const RULE_NAMES: [&str; 41] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -63,6 +63,7 @@ pub const RULE_NAMES: [&str; 40] = [
     "no-tab",
     "fixme-tag",
     "todo-tag",
+    "no-sonar-comments",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -32,6 +32,7 @@ mod no_redundant_jump;
 mod no_redundant_optional;
 mod no_skipped_tests;
 mod no_small_switch;
+mod no_sonar_comments;
 mod no_tab;
 mod no_unthrown_error;
 mod no_useless_catch;

--- a/crates/sonarjs/src/rules/no_sonar_comments.rs
+++ b/crates/sonarjs/src/rules/no_sonar_comments.rs
@@ -1,0 +1,36 @@
+//! Rule `no-sonar-comments` (SonarJS key S1291).
+//!
+//! Clean-room port. Flags `NOSONAR` comments, which suppress SonarQube/SonarJS
+//! analysis on a line and so can hide real issues; they should be removed and
+//! the underlying problem fixed (or a documented, reviewed suppression used).
+//! Each comment that contains the tag is reported once, at the comment's span.
+//!
+//! Scope/heuristic: the conventional all-caps `NOSONAR` is matched as a
+//! case-sensitive substring of the comment text. Lowercase/mixed-case variants
+//! are intentionally not matched in this port; case-insensitive matching would
+//! require allocation in the core and is a follow-up.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::Comment;
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-sonar-comments";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_sonar_comments(&mut self, comments: &[Comment]) {
+        let mut spans: SmallVec<[Span; 8]> = SmallVec::new();
+        for comment in comments {
+            if self.text(comment.span).contains("NOSONAR") {
+                spans.push(comment.span);
+            }
+        }
+        for span in spans {
+            self.report(RULE_NAME, "noSonarComments", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -76,6 +76,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_tab();
         self.check_fixme_tag(&it.comments);
         self.check_todo_tag(&it.comments);
+        self.check_no_sonar_comments(&it.comments);
         walk::walk_program(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1897,3 +1897,33 @@ fn does_not_report_todo_tag_for_source_with_no_comments() {
     let diagnostics = scan("todo-tag", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_sonar_comments_for_comment_containing_nosonar() {
+    let source = "// NOSONAR suppress this";
+    let diagnostics = scan("no-sonar-comments", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-sonar-comments");
+    assert_eq!(diagnostics[0].message_id, "noSonarComments");
+}
+
+#[test]
+fn reports_no_sonar_comments_for_block_comment_containing_nosonar() {
+    let source = "/* NOSONAR */";
+    let diagnostics = scan("no-sonar-comments", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_sonar_comments_for_plain_comment() {
+    let source = "// just a comment";
+    let diagnostics = scan("no-sonar-comments", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_sonar_comments_for_source_with_no_comments() {
+    let source = "const a = 1;";
+    let diagnostics = scan("no-sonar-comments", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -157,6 +157,9 @@ const messages = Object.freeze({
   'todo-tag': {
     todoTag: 'Complete the task tracked by this TODO-tagged comment.',
   },
+  'no-sonar-comments': {
+    noSonarComments: 'Remove this NOSONAR comment and fix the underlying issue.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -232,6 +235,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow FIXME-tagged comments; a FIXME marks code that is known-broken and must be addressed before shipping',
   'todo-tag':
     'Disallow TODO-tagged comments; a TODO marks incomplete work that should be tracked and completed',
+  'no-sonar-comments':
+    'Disallow NOSONAR comments; they suppress analysis and can hide real issues that should be fixed',
 });
 
 const ruleTypes = Object.freeze({
@@ -275,6 +280,7 @@ const ruleTypes = Object.freeze({
   'no-tab': 'suggestion',
   'fixme-tag': 'suggestion',
   'todo-tag': 'suggestion',
+  'no-sonar-comments': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -318,6 +324,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-tab': 'error',
   'fixme-tag': 'error',
   'todo-tag': 'error',
+  'no-sonar-comments': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -43,6 +43,7 @@ const expectedRuleNames = [
   'no-tab',
   'fixme-tag',
   'todo-tag',
+  'no-sonar-comments',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1537,6 +1538,32 @@ describe('sonarjs native API', () => {
   it('does not report todo-tag for source with no comments', () => {
     const source = 'const a = 1;';
     const diagnostics = scan('todo-tag', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-sonar-comments for a comment containing NOSONAR', () => {
+    const source = '// NOSONAR suppress this';
+    const diagnostics = scan('no-sonar-comments', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-sonar-comments');
+    expect(diagnostics[0].messageId).toBe('noSonarComments');
+  });
+
+  it('reports no-sonar-comments for a block comment containing NOSONAR', () => {
+    const source = '/* NOSONAR */';
+    const diagnostics = scan('no-sonar-comments', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report no-sonar-comments for a plain comment', () => {
+    const source = '// just a comment';
+    const diagnostics = scan('no-sonar-comments', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-sonar-comments for source with no comments', () => {
+    const source = 'const a = 1;';
+    const diagnostics = scan('no-sonar-comments', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -134,6 +134,7 @@ describe('sonarjs plugin shape', () => {
       'no-tab',
       'fixme-tag',
       'todo-tag',
+      'no-sonar-comments',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -175,6 +176,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-tab']).toBe('object');
     expect(typeof plugin.rules['fixme-tag']).toBe('object');
     expect(typeof plugin.rules['todo-tag']).toBe('object');
+    expect(typeof plugin.rules['no-sonar-comments']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -216,6 +218,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-tab']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/fixme-tag']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/todo-tag']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-sonar-comments']).toBe('error');
   });
 });
 
@@ -901,5 +904,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(todo-tag)');
+  });
+
+  it('reports no-sonar-comments for a NOSONAR comment through the adapter', () => {
+    const source = '// NOSONAR suppress this';
+    const reports = runRule('no-sonar-comments', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noSonarComments');
+  });
+
+  it('reports no-sonar-comments through the CLI', () => {
+    const source = '// NOSONAR suppress this';
+    const result = runOxlint('no-sonar-comments', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-sonar-comments)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13022,19 +13022,19 @@
       },
       {
         "name": "no-sonar-comments",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-sonar-comments (Sonar key S1291). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1291). Scans Program.comments for the case-sensitive substring \"NOSONAR\" and reports one diagnostic per matching comment span. Implemented via check_no_sonar_comments called from visit_program before the AST walk. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-tab",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-sonar-comments` rule (Sonar key S1291).

Scans `Program.comments` for the case-sensitive substring `NOSONAR` and reports one diagnostic per matching comment span, mirroring the existing `fixme-tag`/`todo-tag` comment-scan pattern. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784001819&installation_id=136613492&pr_number=218&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F218&signature=4c877d5362aa8759bcc87efb98dfa43ad9fdf998f95472c29584f98def575c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->