### PR TITLE
port(regexp): port unicode-property (narrow form)

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -17,10 +17,10 @@ use crate::helpers::{
     first_surrogate_pair_escape, first_unicode_escape_as_hex, first_uppercase_hex_escape,
     first_useless_escape, first_useless_one_quantifier, group_prefix, has_assertion_contradiction,
     has_mergeable_quantifier_concatenation, has_preferable_set_operation,
-    has_simplifiable_set_operation, has_standalone_backslash, has_useless_set_operand,
-    has_useless_word_boundary, mention_char, pattern_ends_with_lazy_quantifier,
-    pattern_has_empty_string_literal, pattern_is_safe_to_add_i_flag, skip_escape, sorted_flags,
-    string_literal_value_with_span,
+    has_simplifiable_set_operation, has_standalone_backslash, has_unnecessary_general_category_key,
+    has_useless_set_operand, has_useless_word_boundary, mention_char,
+    pattern_ends_with_lazy_quantifier, pattern_has_empty_string_literal,
+    pattern_is_safe_to_add_i_flag, skip_escape, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -819,6 +819,14 @@ impl<'a> Scanner<'a> {
         // De Morgan). See `has_simplifiable_set_operation` for boundaries.
         if flags.contains('v') && has_simplifiable_set_operation(pattern) {
             self.report("simplify-set-operations", "unexpected", span);
+        }
+
+        // `unicode-property` (narrow form): under the upstream default config
+        // (`generalCategory: "never"`) an explicit General_Category key in a
+        // `\p{gc=...}` / `\p{General_Category=...}` property escape is redundant
+        // and can be dropped. Only this clearly-redundant key form is flagged.
+        if has_unnecessary_general_category_key(pattern) {
+            self.report("unicode-property", "unnecessaryGc", span);
         }
 
         // `no-potentially-useless-backreference` (narrow form): only flag the

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -2661,6 +2661,54 @@ fn try_pair(
     mergeable
 }
 
+/// Narrow-form detector for `unicode-property`.
+///
+/// Returns `true` when the pattern contains a Unicode-property escape
+/// `\p{key=value}` / `\P{key=value}` whose `key` is the General_Category key
+/// written explicitly (`gc` or `General_Category`). Under the upstream default
+/// configuration (`generalCategory: "never"`) such an explicit GC key is
+/// redundant — `\p{gc=L}` is equivalent to `\p{L}` — and upstream reports it
+/// with the `unnecessaryGc` message.
+///
+/// Soundness: only the key-value form (`\p{key=value}`) with an exact `gc` or
+/// `General_Category` key is flagged. The keyless form `\p{L}` (no `=`),
+/// `\p{Script=...}`, `\p{scx=...}`, binary properties, and any other key are
+/// never flagged, so every non-option upstream valid shape stays clean. The
+/// key comparison is exact (case-sensitive), matching the canonical aliases
+/// the upstream alias map recognises for the General_Category key.
+pub(crate) fn has_unnecessary_general_category_key(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            // `\p{...}` / `\P{...}` property escape (works the same inside or
+            // outside a character class, so no special class handling needed).
+            if matches!(bytes.get(index + 1), Some(b'p') | Some(b'P'))
+                && bytes.get(index + 2) == Some(&b'{')
+            {
+                let body_start = index + 3;
+                if let Some(rel_close) = bytes[body_start..].iter().position(|&b| b == b'}') {
+                    let body = &bytes[body_start..body_start + rel_close];
+                    if let Some(eq) = body.iter().position(|&b| b == b'=') {
+                        let key = &body[..eq];
+                        if key == b"gc" || key == b"General_Category" {
+                            return true;
+                        }
+                    }
+                    index = body_start + rel_close + 1;
+                    continue;
+                }
+                index += 3;
+                continue;
+            }
+            index = skip_escape(bytes, index);
+            continue;
+        }
+        index += 1;
+    }
+    false
+}
+
 pub(crate) fn mention_char(ch: char) -> CompactString {
     let mut text = CompactString::new("U+");
     let code = ch as u32;

--- a/crates/regexp/src/lib.rs
+++ b/crates/regexp/src/lib.rs
@@ -24,7 +24,7 @@ use crate::usage::collect_whole_pattern_regex_spans;
 
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc};
 
-pub const RULE_NAMES: [&str; 75] = [
+pub const RULE_NAMES: [&str; 76] = [
     "no-invalid-regexp",
     "no-empty-character-class",
     "no-empty-group",
@@ -100,6 +100,7 @@ pub const RULE_NAMES: [&str; 75] = [
     "no-useless-set-operand",
     "prefer-set-operation",
     "simplify-set-operations",
+    "unicode-property",
 ];
 
 pub fn implemented_regexp_rule_names() -> &'static [&'static str] {

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -116,8 +116,45 @@ fn exposes_initial_regexp_rule_names() {
             "no-useless-set-operand",
             "prefer-set-operation",
             "simplify-set-operations",
+            "unicode-property",
         ]
     );
+}
+
+mod unicode_property {
+    use super::*;
+
+    #[test]
+    fn reports_unnecessary_general_category_key() {
+        for src in [
+            "const a = /\\p{gc=L}/u;",
+            "const a = /\\p{gc=Letter}/u;",
+            "const a = /\\p{General_Category=L}/u;",
+            "const a = /\\p{General_Category=Letter}/u;",
+            "const a = /\\P{gc=L}/u;",
+        ] {
+            assert_eq!(
+                rule_ids_for(src, "unicode-property").as_slice(),
+                &["unnecessaryGc"],
+                "expected report for {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_other_property_forms() {
+        // Keyless property — no `=`.
+        assert!(rule_ids_for("const a = /\\p{L}/u;", "unicode-property").is_empty());
+        assert!(rule_ids_for("const a = /\\p{Letter}/u;", "unicode-property").is_empty());
+        // Script key, not General_Category.
+        assert!(rule_ids_for("const a = /\\p{Script=Greek}/u;", "unicode-property").is_empty());
+        assert!(rule_ids_for("const a = /\\p{sc=Grek}/u;", "unicode-property").is_empty());
+        assert!(rule_ids_for("const a = /\\p{scx=Greek}/u;", "unicode-property").is_empty());
+        // Binary property.
+        assert!(rule_ids_for("const a = /\\p{ASCII}/u;", "unicode-property").is_empty());
+        // No property escape at all.
+        assert!(rule_ids_for("const a = /abc/u;", "unicode-property").is_empty());
+    }
 }
 
 mod simplify_set_operations {

--- a/npm/regexp/index.js
+++ b/npm/regexp/index.js
@@ -300,6 +300,10 @@ const messages = Object.freeze({
     unexpected:
       'This set operation can be simplified (an intersection with a negated class is a subtraction, or De Morgan applies).',
   },
+  'unicode-property': {
+    unnecessaryGc:
+      'Unnecessary explicit General_Category key in a Unicode property escape; drop the redundant `gc=` / `General_Category=` prefix.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -418,6 +422,8 @@ const ruleDescriptions = Object.freeze({
     'prefer character class set operations instead of lookarounds (narrow: v-mode char lookaround adjacent to a char element)',
   'simplify-set-operations':
     'simplify unnecessarily complex set operations (narrow: v-mode `&&` intersection with a negated nested-class operand)',
+  'unicode-property':
+    'enforce consistent naming of unicode properties (narrow: flag a redundant explicit `gc=` / `General_Category=` key)',
 });
 const ruleTypes = Object.freeze({
   'no-invalid-regexp': 'problem',
@@ -495,6 +501,7 @@ const ruleTypes = Object.freeze({
   'no-useless-set-operand': 'suggestion',
   'prefer-set-operation': 'suggestion',
   'simplify-set-operations': 'suggestion',
+  'unicode-property': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -667,7 +674,8 @@ function ruleCategory(ruleName) {
     ruleName === 'sort-alternatives' ||
     ruleName === 'prefer-predefined-assertion' ||
     ruleName === 'negation' ||
-    ruleName === 'no-useless-lazy'
+    ruleName === 'no-useless-lazy' ||
+    ruleName === 'unicode-property'
   ) {
     return 'Stylistic Issues';
   }

--- a/npm/regexp/test/api.test.mjs
+++ b/npm/regexp/test/api.test.mjs
@@ -80,6 +80,7 @@ describe('regexp native API', () => {
       'no-useless-set-operand',
       'prefer-set-operation',
       'simplify-set-operations',
+      'unicode-property',
     ]);
   });
 

--- a/npm/regexp/test/fixtures/unicode-property.json
+++ b/npm/regexp/test/fixtures/unicode-property.json
@@ -1,0 +1,68 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-regexp",
+    "version": "3.1.0",
+    "sourceFile": "tests/lib/rules/unicode-property.ts",
+    "snapshotFile": "tests/lib/rules/__snapshots__/unicode-property.ts.eslintsnap",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-regexp-tests.ts"
+  },
+  "valid": [],
+  "invalid": [
+    {
+      "code": "/\\P{ASCII}/u;\n/\\P{Hex_Digit}/u;\n/\\P{Hex}/u;\n\n/\\p{L}/u;\n/\\p{Letter}/u;\n/\\p{gc=L}/u;\n/\\p{gc=Letter}/u;\n/\\p{General_Category=L}/u;\n/\\p{General_Category=Letter}/u;\n\n/\\p{sc=Grek}/u;\n/\\p{sc=Greek}/u;\n/\\p{Script=Grek}/u;\n/\\p{Script=Greek}/u;\n\n/\\p{scx=Grek}/u;\n/\\p{scx=Greek}/u;\n/\\p{Script_Extensions=Grek}/u;\n/\\p{Script_Extensions=Greek}/u;\n\n// Binary Properties\n// https://github.com/tc39/ecma262/issues/3286\n// /\\p{White_Space} \\p{space} \\p{WSpace}/u;\n\n// General_Category\n/\\p{Control} \\p{Cc} \\p{cntrl}/u;\n/\\p{Mark} \\p{M} \\p{Combining_Mark}/u;\n/\\p{Decimal_Number} \\p{Nd} \\p{digit}/u;\n/\\p{Punctuation} \\p{P} \\p{punct}/u;",
+      "errorCount": 8,
+      "errors": [
+        {
+          "message": "Unnecessary 'gc=' in Unicode property.",
+          "line": 7,
+          "column": 5,
+          "endColumn": 7
+        },
+        {
+          "message": "Unnecessary 'gc=' in Unicode property.",
+          "line": 8,
+          "column": 5,
+          "endColumn": 7
+        },
+        {
+          "message": "Unnecessary 'General_Category=' in Unicode property.",
+          "line": 9,
+          "column": 5,
+          "endColumn": 21
+        },
+        {
+          "message": "Unnecessary 'General_Category=' in Unicode property.",
+          "line": 9,
+          "column": 5,
+          "endColumn": 21
+        },
+        {
+          "message": "Excepted long Script property. Use 'Greek' instead.",
+          "line": 9,
+          "column": 8,
+          "endColumn": 12
+        },
+        {
+          "message": "Excepted long Script property. Use 'Greek' instead.",
+          "line": 9,
+          "column": 12,
+          "endColumn": 16
+        },
+        {
+          "message": "Excepted long Script property. Use 'Greek' instead.",
+          "line": 9,
+          "column": 9,
+          "endColumn": 13
+        },
+        {
+          "message": "Excepted long Script property. Use 'Greek' instead.",
+          "line": 9,
+          "column": 23,
+          "endColumn": 27
+        }
+      ],
+      "output": "/\\P{ASCII}/u;\n/\\P{Hex_Digit}/u;\n/\\P{Hex}/u;\n\n/\\p{L}/u;\n/\\p{Letter}/u;\n/\\p{L}/u;\n/\\p{Letter}/u;\n/\\p{L}/u;"
+    }
+  ]
+}

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -226,6 +226,11 @@ const validCases = [
   ['simplify-set-operations', 'non-negated nested operand', 'const re = /[a&&b&&[c]]/v;\n'],
   ['simplify-set-operations', 'subtraction not intersection', 'const re = /[a--b--[c]]/v;\n'],
   ['simplify-set-operations', 'not v-mode', 'const re = /[a&&[^b]]/u;\n'],
+  // unicode-property
+  ['unicode-property', 'keyless property', 'const re = /\\p{L}/u;\n'],
+  ['unicode-property', 'long keyless property', 'const re = /\\p{Letter}/u;\n'],
+  ['unicode-property', 'script key', 'const re = /\\p{Script=Greek}/u;\n'],
+  ['unicode-property', 'binary property', 'const re = /\\p{ASCII}/u;\n'],
 ];
 
 const invalidCases = [
@@ -676,6 +681,15 @@ const invalidCases = [
     'const re = /[[^a]&&[^b]]/v;\n',
     ['unexpected'],
   ],
+  // unicode-property
+  ['unicode-property', 'gc short key', 'const re = /\\p{gc=L}/u;\n', ['unnecessaryGc']],
+  [
+    'unicode-property',
+    'General_Category long key',
+    'const re = /\\p{General_Category=Letter}/u;\n',
+    ['unnecessaryGc'],
+  ],
+  ['unicode-property', 'negated gc key', 'const re = /\\P{gc=L}/u;\n', ['unnecessaryGc']],
 ];
 
 function runRule(ruleName, sourceText, filename = 'fixture.js') {

--- a/npm/regexp/test/upstream.test.mjs
+++ b/npm/regexp/test/upstream.test.mjs
@@ -59,6 +59,12 @@ for (const file of fixtureFiles) {
 
   describe(rule, () => {
     describe('valid', () => {
+      // Some rules (e.g. fully option-driven ones) have all their upstream
+      // valid cases dropped during sync, leaving none to replay. Register a
+      // placeholder so the suite is not empty (vitest errors on empty suites).
+      if (fixture.valid.length === 0) {
+        it.skip('no replayable valid cases', () => {});
+      }
       fixture.valid.forEach((testCase, index) => {
         const label = `#${index} ${JSON.stringify(testCase.code)}`;
         // 'off' rules are quarantined; show the gap as a skip rather than hide it.
@@ -70,6 +76,9 @@ for (const file of fixtureFiles) {
     });
 
     describe('invalid', () => {
+      if (fixture.invalid.length === 0) {
+        it.skip('no replayable invalid cases', () => {});
+      }
       fixture.invalid.forEach((testCase, index) => {
         const label = `#${index} ${JSON.stringify(testCase.code)}`;
         // Invalid cases are only enforced (count parity) at level 'full'.

--- a/status.json
+++ b/status.json
@@ -9707,19 +9707,19 @@
       },
       {
         "name": "unicode-property",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule unicode-property."
+        "notes": "Narrow form: under the upstream default config (generalCategory: 'never') an explicit General_Category key in a \\p{gc=...} / \\p{General_Category=...} property escape is redundant. has_unnecessary_general_category_key flags only that key-value form with an exact 'gc' or 'General_Category' key; keyless properties, Script keys, and binary properties are never flagged."
       },
       {
         "name": "use-ignore-case",


### PR DESCRIPTION
Ports `unicode-property` from eslint-plugin-regexp in **narrow form**.

## Narrow subset
Under the upstream default configuration (`generalCategory: "never"`), an explicit General_Category key in a `\p{gc=...}` / `\p{General_Category=...}` property escape is redundant — `\p{gc=L}` is equivalent to `\p{L}`. The new helper `has_unnecessary_general_category_key` flags **only** that exact key-value form (key exactly `gc` or `General_Category`), emitting the `unnecessaryGc` message.

## Valid soundness
The generated fixture has **0 valid / 1 invalid** cases (9 option-bearing cases dropped). With an empty `valid[]`, valid-soundness is trivially satisfied — there is no non-option valid case to false-positive on. Keyless properties (`\p{L}`), Script keys (`\p{Script=Greek}`, `\p{sc=Grek}`), and binary properties (`\p{ASCII}`) are never flagged by construction.

## Meaningful detection
The single non-option invalid case (`allForms`, the "test default configuration" case) contains `\p{gc=L}`, `\p{gc=Letter}`, `\p{General_Category=L}`, `\p{General_Category=Letter}` — the rule fires on it. Fixture level stays at the default `valid` (invalid count not asserted).

## Verification
- `cargo test -p oxlint-plugins-regexp`: 210 passed.
- `cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings`: clean.
- Prettier check clean on all touched JS/JSON; `status.json` trailing newline preserved.

This is the first PR in a stacked chain of the final 7 regexp rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784002099&installation_id=136613492&pr_number=219&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F219&signature=a76b404be04dbb4592d26c3798ead4b401d09bef998c6ed07289ac3780c17111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->