### PR TITLE
port(sonarjs): port array-constructor (S1528)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 41] = [
+pub const RULE_NAMES: [&str; 42] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -64,6 +64,7 @@ pub const RULE_NAMES: [&str; 41] = [
     "fixme-tag",
     "todo-tag",
     "no-sonar-comments",
+    "array-constructor",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -2,6 +2,7 @@
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
 mod arguments_usage;
+mod array_constructor;
 mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;

--- a/crates/sonarjs/src/rules/array_constructor.rs
+++ b/crates/sonarjs/src/rules/array_constructor.rs
@@ -1,0 +1,70 @@
+//! Rule `array-constructor` (SonarJS key S1528).
+//!
+//! Clean-room port. The `Array` constructor is an error-prone way to build an
+//! array: `Array(1, 2, 3)` produces `[1, 2, 3]`, but `Array(3)` produces a
+//! sparse array of length 3 with no elements. The single-argument form is the
+//! only one whose meaning is unambiguous, so any other arity should use an
+//! array literal (`[]`) instead.
+//!
+//! **Flagged** — a call or `new` of the bare `Array` identifier with an
+//! argument count other than one, and no TypeScript type arguments:
+//! - `Array(1, 2, 3)` — multiple arguments.
+//! - `new Array(1, 2, 3)` — multiple arguments.
+//! - `Array()` / `new Array()` — zero arguments (use `[]`).
+//!
+//! **Not flagged**:
+//! - `Array(500)` / `new Array(len)` — a single argument is the (unambiguous)
+//!   array length.
+//! - `Array<number>(1, 2, 3)` — explicit type arguments signal an intentional
+//!   typed construction.
+//! - `foo.Array(1, 2)` — the callee is not the bare `Array` identifier.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S1528) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{CallExpression, Expression, NewExpression};
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "array-constructor";
+
+impl Scanner<'_> {
+    pub(crate) fn check_array_constructor_call(&mut self, expr: &CallExpression<'_>) {
+        self.check_array_constructor(
+            &expr.callee,
+            expr.type_arguments.is_some(),
+            expr.arguments.len(),
+            expr.span,
+        );
+    }
+
+    pub(crate) fn check_array_constructor_new(&mut self, expr: &NewExpression<'_>) {
+        self.check_array_constructor(
+            &expr.callee,
+            expr.type_arguments.is_some(),
+            expr.arguments.len(),
+            expr.span,
+        );
+    }
+
+    fn check_array_constructor(
+        &mut self,
+        callee: &Expression<'_>,
+        has_type_arguments: bool,
+        argument_count: usize,
+        span: Span,
+    ) {
+        if has_type_arguments || argument_count == 1 {
+            return;
+        }
+        let Expression::Identifier(identifier) = callee.get_inner_expression() else {
+            return;
+        };
+        if identifier.name.as_str() != "Array" {
+            return;
+        }
+        self.report(RULE_NAME, "arrayConstructor", span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -212,6 +212,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
         self.check_no_skipped_tests_call(it);
+        self.check_array_constructor_call(it);
         walk::walk_call_expression(self, it);
     }
 
@@ -228,6 +229,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
         self.check_no_primitive_wrappers(it);
+        self.check_array_constructor_new(it);
         walk::walk_new_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1927,3 +1927,54 @@ fn does_not_report_no_sonar_comments_for_source_with_no_comments() {
     let diagnostics = scan("no-sonar-comments", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_array_constructor_for_multi_argument_call() {
+    let source = "const a = Array(1, 2, 3);";
+    let diagnostics = scan("array-constructor", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "array-constructor");
+    assert_eq!(diagnostics[0].message_id, "arrayConstructor");
+}
+
+#[test]
+fn reports_array_constructor_for_multi_argument_new_expression() {
+    let source = "const a = new Array(1, 2, 3);";
+    let diagnostics = scan("array-constructor", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn reports_array_constructor_for_zero_argument_new_expression() {
+    let source = "const a = new Array();";
+    let diagnostics = scan("array-constructor", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_array_constructor_for_single_argument_length_form() {
+    let source = "const a = new Array(500);";
+    let diagnostics = scan("array-constructor", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_array_constructor_when_type_arguments_present() {
+    let source = "const a = Array<number>(1, 2, 3);";
+    let diagnostics = scan("array-constructor", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_array_constructor_for_array_literal() {
+    let source = "const a = [1, 2, 3];";
+    let diagnostics = scan("array-constructor", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_array_constructor_for_unrelated_member_call() {
+    let source = "const a = foo.Array(1, 2, 3);";
+    let diagnostics = scan("array-constructor", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -160,6 +160,9 @@ const messages = Object.freeze({
   'no-sonar-comments': {
     noSonarComments: 'Remove this NOSONAR comment and fix the underlying issue.',
   },
+  'array-constructor': {
+    arrayConstructor: 'Use an array literal instead of the Array constructor.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -237,6 +240,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow TODO-tagged comments; a TODO marks incomplete work that should be tracked and completed',
   'no-sonar-comments':
     'Disallow NOSONAR comments; they suppress analysis and can hide real issues that should be fixed',
+  'array-constructor':
+    'Disallow the Array constructor in favor of array literals, except for the single-argument length form',
 });
 
 const ruleTypes = Object.freeze({
@@ -281,6 +286,7 @@ const ruleTypes = Object.freeze({
   'fixme-tag': 'suggestion',
   'todo-tag': 'suggestion',
   'no-sonar-comments': 'suggestion',
+  'array-constructor': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -325,6 +331,7 @@ const recommendedRuleConfig = Object.freeze({
   'fixme-tag': 'error',
   'todo-tag': 'error',
   'no-sonar-comments': 'error',
+  'array-constructor': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -44,6 +44,7 @@ const expectedRuleNames = [
   'fixme-tag',
   'todo-tag',
   'no-sonar-comments',
+  'array-constructor',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1564,6 +1565,44 @@ describe('sonarjs native API', () => {
   it('does not report no-sonar-comments for source with no comments', () => {
     const source = 'const a = 1;';
     const diagnostics = scan('no-sonar-comments', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports array-constructor for a call with multiple arguments', () => {
+    const source = 'const a = Array(1, 2, 3);';
+    const diagnostics = scan('array-constructor', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('array-constructor');
+    expect(diagnostics[0].messageId).toBe('arrayConstructor');
+  });
+
+  it('reports array-constructor for a new expression with multiple arguments', () => {
+    const source = 'const a = new Array(1, 2, 3);';
+    const diagnostics = scan('array-constructor', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('reports array-constructor for a call with no arguments', () => {
+    const source = 'const a = new Array();';
+    const diagnostics = scan('array-constructor', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report array-constructor for a single-argument length form', () => {
+    const source = 'const a = new Array(500);';
+    const diagnostics = scan('array-constructor', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report array-constructor when type arguments are present', () => {
+    const source = 'const a = Array<number>(1, 2, 3);';
+    const diagnostics = scan('array-constructor', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report array-constructor for an array literal', () => {
+    const source = 'const a = [1, 2, 3];';
+    const diagnostics = scan('array-constructor', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -135,6 +135,7 @@ describe('sonarjs plugin shape', () => {
       'fixme-tag',
       'todo-tag',
       'no-sonar-comments',
+      'array-constructor',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -177,6 +178,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['fixme-tag']).toBe('object');
     expect(typeof plugin.rules['todo-tag']).toBe('object');
     expect(typeof plugin.rules['no-sonar-comments']).toBe('object');
+    expect(typeof plugin.rules['array-constructor']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -219,6 +221,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/fixme-tag']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/todo-tag']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-sonar-comments']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/array-constructor']).toBe('error');
   });
 });
 
@@ -921,5 +924,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-sonar-comments)');
+  });
+
+  it('reports array-constructor for a multi-argument call through the adapter', () => {
+    const source = 'const a = Array(1, 2, 3);';
+    const reports = runRule('array-constructor', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('arrayConstructor');
+  });
+
+  it('reports array-constructor through the CLI', () => {
+    const source = 'const a = new Array(1, 2, 3);';
+    const result = runOxlint('array-constructor', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(array-constructor)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10126,19 +10126,19 @@
       },
       {
         "name": "array-constructor",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule array-constructor (Sonar key S1528). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1528). Flags CallExpression/NewExpression whose callee is the bare `Array` identifier when the argument count is not exactly one and no TypeScript type arguments are present; the single-argument length form and explicitly typed constructions are allowed. Implemented via check_array_constructor_call/check_array_constructor_new from visit_call_expression/visit_new_expression. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "arrow-function-convention",


### PR DESCRIPTION
Clean-room port of the SonarJS `array-constructor` rule (Sonar key S1528).

Flags a call or `new` of the bare `Array` identifier whose argument count is not exactly one and which has no TypeScript type arguments:

- **Flagged:** `Array(1, 2, 3)`, `new Array(1, 2, 3)`, `Array()`, `new Array()`
- **Not flagged:** `new Array(500)` (single-argument length form), `Array<number>(1, 2, 3)` (explicit type arguments), `[1, 2, 3]` (literal), `foo.Array(1, 2)` (non-bare callee)

Implemented via `check_array_constructor_call`/`check_array_constructor_new` from the existing `visit_call_expression`/`visit_new_expression` hooks. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784002500&installation_id=136613492&pr_number=222&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F222&signature=676683a0d83e2bebcf8de375efb75517f4e6a9ad6381a50504fe62b43aa2b519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->