### PR TITLE
port(sonarjs): port no-function-declaration-in-block (S1530)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 42] = [
+pub const RULE_NAMES: [&str; 43] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -65,6 +65,7 @@ pub const RULE_NAMES: [&str; 42] = [
     "todo-tag",
     "no-sonar-comments",
     "array-constructor",
+    "no-function-declaration-in-block",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -20,6 +20,7 @@ mod no_delete_var;
 mod no_duplicate_in_composite;
 mod no_empty_character_class;
 mod no_exclusive_tests;
+mod no_function_declaration_in_block;
 mod no_identical_conditions;
 mod no_identical_expressions;
 mod no_inverted_boolean_check;

--- a/crates/sonarjs/src/rules/no_function_declaration_in_block.rs
+++ b/crates/sonarjs/src/rules/no_function_declaration_in_block.rs
@@ -1,0 +1,49 @@
+//! Rule `no-function-declaration-in-block` (SonarJS key S1530).
+//!
+//! Clean-room port. A function *declaration* nested directly inside a block
+//! (an `if`/`else` body, a loop body, a `try`/`catch` body, or a bare block)
+//! is confusing: historically its scope and hoisting behaviour differed between
+//! engines and between sloppy and strict mode. Code that needs a function in
+//! such a position should use a function *expression* assigned to a variable,
+//! or move the declaration to the top level of the enclosing function or
+//! module.
+//!
+//! **Flagged** — a `function` declaration that is a direct statement of a
+//! block:
+//! - `if (cond) { function f() {} }`
+//! - `for (;;) { function f() {} }`
+//! - `{ function f() {} }` (a bare block).
+//!
+//! **Not flagged**:
+//! - `function f() {}` at the top level of a module or function body — the body
+//!   of a function is not a block statement, so a declaration there is allowed.
+//! - `if (cond) { const f = function () {}; }` — a function expression, not a
+//!   declaration.
+//! - `declare function f(): void;` inside a block — an ambient TypeScript
+//!   declaration produces no runtime binding.
+//!
+//! Narrow form: only declarations whose immediate parent is a block statement
+//! are reported; function declarations appearing directly in a `switch` case
+//! body are a documented follow-up. Behaviour is reproduced from the public
+//! RSPEC description (S1530) only; no upstream source, tests, fixtures, or
+//! message strings were consulted or copied.
+
+use oxc_ast::ast::{BlockStatement, Statement};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-function-declaration-in-block";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_function_declaration_in_block(&mut self, block: &BlockStatement<'_>) {
+        for statement in &block.body {
+            let Statement::FunctionDeclaration(func) = statement else {
+                continue;
+            };
+            if func.declare {
+                continue;
+            }
+            self.report(RULE_NAME, "noFunctionDeclarationInBlock", func.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,12 +3,12 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, BindingIdentifier, CallExpression, CatchClause,
-    ConditionalExpression, DoWhileStatement, ExpressionStatement, ForInStatement, ForOfStatement,
-    ForStatement, Function, FunctionBody, IdentifierReference, IfStatement, LabeledStatement,
-    LogicalExpression, NewExpression, Program, RegExpLiteral, StaticMemberExpression, SwitchCase,
-    SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
-    UnaryExpression, WhileStatement, YieldExpression,
+    AssignmentExpression, BinaryExpression, BindingIdentifier, BlockStatement, CallExpression,
+    CatchClause, ConditionalExpression, DoWhileStatement, ExpressionStatement, ForInStatement,
+    ForOfStatement, ForStatement, Function, FunctionBody, IdentifierReference, IfStatement,
+    LabeledStatement, LogicalExpression, NewExpression, Program, RegExpLiteral,
+    StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSPropertySignature,
+    TSUnionType, TemplateLiteral, UnaryExpression, WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -78,6 +78,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_todo_tag(&it.comments);
         self.check_no_sonar_comments(&it.comments);
         walk::walk_program(self, it);
+    }
+
+    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
+        self.check_no_function_declaration_in_block(it);
+        walk::walk_block_statement(self, it);
     }
 
     fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1978,3 +1978,39 @@ fn does_not_report_array_constructor_for_unrelated_member_call() {
     let diagnostics = scan("array-constructor", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_function_declaration_in_block_for_if_block() {
+    let source = "if (cond) { function f() {} }";
+    let diagnostics = scan("no-function-declaration-in-block", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "noFunctionDeclarationInBlock");
+}
+
+#[test]
+fn reports_no_function_declaration_in_block_for_bare_block() {
+    let source = "{ function f() {} }";
+    let diagnostics = scan("no-function-declaration-in-block", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_function_declaration_in_block_for_top_level() {
+    let source = "function f() {}";
+    let diagnostics = scan("no-function-declaration-in-block", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_function_declaration_in_block_for_nested_function_body() {
+    let source = "function outer() { function inner() {} }";
+    let diagnostics = scan("no-function-declaration-in-block", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_function_declaration_in_block_for_function_expression() {
+    let source = "if (cond) { const f = function () {}; }";
+    let diagnostics = scan("no-function-declaration-in-block", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -163,6 +163,10 @@ const messages = Object.freeze({
   'array-constructor': {
     arrayConstructor: 'Use an array literal instead of the Array constructor.',
   },
+  'no-function-declaration-in-block': {
+    noFunctionDeclarationInBlock:
+      'Move this function declaration out of the block, or use a function expression instead.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -242,6 +246,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow NOSONAR comments; they suppress analysis and can hide real issues that should be fixed',
   'array-constructor':
     'Disallow the Array constructor in favor of array literals, except for the single-argument length form',
+  'no-function-declaration-in-block':
+    'Disallow function declarations nested directly inside a block; use a function expression or move it to the top level',
 });
 
 const ruleTypes = Object.freeze({
@@ -287,6 +293,7 @@ const ruleTypes = Object.freeze({
   'todo-tag': 'suggestion',
   'no-sonar-comments': 'suggestion',
   'array-constructor': 'suggestion',
+  'no-function-declaration-in-block': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -332,6 +339,7 @@ const recommendedRuleConfig = Object.freeze({
   'todo-tag': 'error',
   'no-sonar-comments': 'error',
   'array-constructor': 'error',
+  'no-function-declaration-in-block': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -45,6 +45,7 @@ const expectedRuleNames = [
   'todo-tag',
   'no-sonar-comments',
   'array-constructor',
+  'no-function-declaration-in-block',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1603,6 +1604,38 @@ describe('sonarjs native API', () => {
   it('does not report array-constructor for an array literal', () => {
     const source = 'const a = [1, 2, 3];';
     const diagnostics = scan('array-constructor', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-function-declaration-in-block for a function declared in an if block', () => {
+    const source = 'if (cond) {\n  function f() {}\n}';
+    const diagnostics = scan('no-function-declaration-in-block', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-function-declaration-in-block');
+    expect(diagnostics[0].messageId).toBe('noFunctionDeclarationInBlock');
+  });
+
+  it('reports no-function-declaration-in-block for a function declared in a bare block', () => {
+    const source = '{\n  function f() {}\n}';
+    const diagnostics = scan('no-function-declaration-in-block', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report no-function-declaration-in-block for a top-level declaration', () => {
+    const source = 'function f() {}';
+    const diagnostics = scan('no-function-declaration-in-block', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-function-declaration-in-block for a nested function body declaration', () => {
+    const source = 'function outer() {\n  function inner() {}\n}';
+    const diagnostics = scan('no-function-declaration-in-block', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-function-declaration-in-block for a function expression in a block', () => {
+    const source = 'if (cond) {\n  const f = function () {};\n}';
+    const diagnostics = scan('no-function-declaration-in-block', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -136,6 +136,7 @@ describe('sonarjs plugin shape', () => {
       'todo-tag',
       'no-sonar-comments',
       'array-constructor',
+      'no-function-declaration-in-block',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -179,6 +180,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['todo-tag']).toBe('object');
     expect(typeof plugin.rules['no-sonar-comments']).toBe('object');
     expect(typeof plugin.rules['array-constructor']).toBe('object');
+    expect(typeof plugin.rules['no-function-declaration-in-block']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -222,6 +224,9 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/todo-tag']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-sonar-comments']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/array-constructor']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-function-declaration-in-block']).toBe(
+      'error',
+    );
   });
 });
 
@@ -941,5 +946,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(array-constructor)');
+  });
+
+  it('reports no-function-declaration-in-block through the adapter', () => {
+    const source = 'if (cond) {\n  function f() {}\n}';
+    const reports = runRule('no-function-declaration-in-block', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('noFunctionDeclarationInBlock');
+  });
+
+  it('reports no-function-declaration-in-block through the CLI', () => {
+    const source = 'if (cond) {\n  function f() {}\n}';
+    const result = runOxlint('no-function-declaration-in-block', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-function-declaration-in-block)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12126,19 +12126,19 @@
       },
       {
         "name": "no-function-declaration-in-block",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-function-declaration-in-block (Sonar key S1530). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S1530). Flags a FunctionDeclaration that is a direct statement child of a BlockStatement (if/loop/try bodies, bare blocks); reported via check_no_function_declaration_in_block from visit_block_statement. Function bodies are FunctionBody nodes (not BlockStatement) so top-of-function declarations are not flagged; ambient `declare function` is skipped. Narrow form: function declarations directly in a switch-case body are a documented follow-up. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-global-this",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-function-declaration-in-block` rule (Sonar key S1530).

Flags a `function` declaration that is a direct statement child of a block statement:

- **Flagged:** `if (cond) { function f() {} }`, `for (;;) { function f() {} }`, `{ function f() {} }`
- **Not flagged:** top-level `function f() {}`, a declaration at the top of a function body (`function outer() { function inner() {} }`), a function expression in a block, or an ambient `declare function`.

Implemented via `check_no_function_declaration_in_block` from a new `visit_block_statement` hook. Function bodies are `FunctionBody` nodes rather than `BlockStatement`, so top-of-function declarations are correctly excluded. Function declarations directly in a `switch`-case body are a documented narrow-form follow-up. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784003192&installation_id=136613492&pr_number=224&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F224&signature=7b7af0009deaaf464ec4c9c6c007c74bc7b0a58a9f0da5b698fee7b1c4eed143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->