### PR TITLE
fix(eslint-json): no-duplicate-keys full upstream parity (JSON5 identifier escapes)

### DIFF
--- a/crates/eslint_json/src/lib.rs
+++ b/crates/eslint_json/src/lib.rs
@@ -901,7 +901,11 @@ impl<'a> Parser<'a> {
                     return None;
                 }
                 Some(MemberFact {
-                    key: CompactString::from(ident),
+                    // JSON5 identifier names may carry Unicode escapes (e.g.
+                    // `foot`), which momoa decodes for the key's value while
+                    // the raw key keeps the source text. Mirror that so duplicate
+                    // and sort comparisons see the decoded name.
+                    key: decode_identifier_escapes(ident),
                     raw_key: CompactString::from(ident),
                     name_span: ByteSpan {
                         start,
@@ -1221,6 +1225,61 @@ fn push_utf16_units(ch: char, units: &mut SmallVec<[u16; 16]>) {
 
 fn is_identifier_continue(ch: char) -> bool {
     ch.is_alphanumeric() || matches!(ch, '_' | '$')
+}
+
+// Decode the Unicode escapes (`\uXXXX` or `\u{...}`) that a JSON5 identifier
+// name may contain, returning the identifier's value. Non-escaped identifiers
+// pass through unchanged so the common case allocates the raw text verbatim.
+fn decode_identifier_escapes(ident: &str) -> CompactString {
+    if !ident.contains('\\') {
+        return CompactString::from(ident);
+    }
+
+    let mut out = CompactString::new("");
+    let mut chars = ident.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' || chars.peek() != Some(&'u') {
+            out.push(ch);
+            continue;
+        }
+        chars.next();
+
+        let code = if chars.peek() == Some(&'{') {
+            chars.next();
+            let mut value = 0u32;
+            let mut any = false;
+            while let Some(&candidate) = chars.peek() {
+                if candidate == '}' {
+                    chars.next();
+                    break;
+                }
+                let Some(digit) = candidate.to_digit(16) else {
+                    break;
+                };
+                value = value.saturating_mul(16).saturating_add(digit);
+                any = true;
+                chars.next();
+            }
+            any.then_some(value)
+        } else {
+            let mut value = 0u32;
+            let mut count = 0;
+            while count < 4 {
+                let Some(digit) = chars.peek().and_then(|candidate| candidate.to_digit(16)) else {
+                    break;
+                };
+                value = value * 16 + digit;
+                count += 1;
+                chars.next();
+            }
+            (count == 4).then_some(value)
+        };
+
+        if let Some(ch) = code.and_then(char::from_u32) {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 fn utf16_offset(source_text: &str, byte_offset: usize) -> u32 {

--- a/npm/eslint-json/test/parity.json
+++ b/npm/eslint-json/test/parity.json
@@ -1,10 +1,6 @@
 {
   "_doc": "Per-rule upstream-parity enforcement level for the synced @eslint/json fixtures (see test/upstream.test.mjs). Levels: 'full' (the default for any rule not listed here) = exact parity is enforced for every valid and invalid case — each reported error's messageId, data, and 1-indexed location must match upstream, and cases declaring `output` must autofix to the same text. 'off' = quarantined; the Rust core still diverges from upstream for this rule, so its valid and invalid cases are registered as skipped (coverage stays visible) until the divergence is fixed and the rule is promoted to 'full'. The end state is zero 'off' entries. Regenerate fixtures with `pnpm run port:tests:eslint-json`.",
   "rules": {
-    "no-duplicate-keys": {
-      "level": "off",
-      "reason": "JSON5 unquoted identifier keys that use Unicode escapes (e.g. `fo\\u006ft` === `foot`) are not decoded before duplicate comparison, so the duplicate is missed. Fixed in the no-duplicate-keys parity PR."
-    },
     "no-unsafe-values": {
       "level": "off",
       "reason": "Two divergences: (1) zero literals written with a fraction/exponent (`0.00000`, `0e0000000`, `.0`, `0.`) are misclassified as subnormal; (2) literal lone surrogate code units in string values are not detected. Fixed in the no-unsafe-values parity PR."


### PR DESCRIPTION
First of three per-rule parity PRs following the harness infra in #220.

## Problem
Upstream momoa decodes the Unicode escapes in a JSON5 unquoted identifier key when computing the key value (`getKey` → decoded, `getRawKey` → raw source). The port compared the raw identifier text, so a duplicate spelled with an escape was missed — e.g. `{foot: 1, foot: 2}` (`foot` === `foot`).

## Fix
`decode_identifier_escapes` resolves `\uXXXX` / `\u{...}` into the member's **comparison** key, leaving `raw_key` (the reported `data.key`) as the verbatim source text. String keys were already decoded by the string tokenizer; only identifier keys needed this.

## Parity
Promotes `no-duplicate-keys` from quarantined to **full** exact parity — all 23 upstream cases (8 valid + 15 invalid) now enforced (messageId, data, and 1-indexed location). `parity.json` updated; the other two rules remain `off` pending their PRs.

## Testing
- `vp test` — `eslint-json upstream parity > no-duplicate-keys` green.
- Local replay of the full upstream suite + targeted clippy/cargo-fmt on the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784003763&installation_id=136613492&pr_number=226&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F226&signature=c77de43d3045acbb0b4d5450c3efa39de5bfe723914741c92202a935e387e48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->