### PR TITLE
port(sonarjs): port no-inconsistent-returns (S3801)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 43] = [
+pub const RULE_NAMES: [&str; 44] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -66,6 +66,7 @@ pub const RULE_NAMES: [&str; 43] = [
     "no-sonar-comments",
     "array-constructor",
     "no-function-declaration-in-block",
+    "no-inconsistent-returns",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -99,6 +100,7 @@ pub fn scan_sonarjs(
         conditional_depth: 0,
         if_chain_seen: SmallVec::new(),
         generator_yield_stack: SmallVec::new(),
+        return_kind_stack: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -23,6 +23,7 @@ mod no_exclusive_tests;
 mod no_function_declaration_in_block;
 mod no_identical_conditions;
 mod no_identical_expressions;
+mod no_inconsistent_returns;
 mod no_inverted_boolean_check;
 mod no_labels;
 mod no_nested_conditional;

--- a/crates/sonarjs/src/rules/no_inconsistent_returns.rs
+++ b/crates/sonarjs/src/rules/no_inconsistent_returns.rs
@@ -1,0 +1,73 @@
+//! Rule `no-inconsistent-returns` (SonarJS key S3801).
+//!
+//! Clean-room port. A function that sometimes returns a value (`return x;`) and
+//! sometimes returns nothing (`return;`) is confusing: a caller cannot tell from
+//! one `return` whether the function is meant to produce a value, and the bare
+//! `return` silently yields `undefined`. Such a function should return a value
+//! on every path or on none.
+//!
+//! ## Stack-based return tracking
+//!
+//! A `return` statement always binds to the **nearest enclosing function or
+//! arrow** — it can never cross a function boundary. A stack of frames (one per
+//! open function/arrow scope) therefore attributes each `return` to the correct
+//! innermost scope. Each frame records whether the scope has seen an explicit
+//! value return and whether it has seen an explicit bare return; when the frame
+//! is popped, the scope is reported if **both** were seen.
+//!
+//! ```js
+//! function f(x) {
+//!   if (!x) return;      // bare return
+//!   return x.value;      // value return → f is flagged
+//! }
+//! ```
+//!
+//! **Flagged**: a function/arrow whose body contains at least one `return x;`
+//! and at least one bare `return;`.
+//!
+//! **Not flagged**:
+//! - a scope that only ever returns values, or only ever returns nothing;
+//! - returns belonging to a nested function/arrow (tracked on their own frame).
+//!
+//! Narrow form: only the mix of two *explicit* return statements is reported;
+//! the case of an explicit value return combined with an implicit fall-through
+//! (no trailing `return`) is a documented follow-up. Behaviour is reproduced
+//! from the public RSPEC description (S3801) only; no upstream source, tests,
+//! fixtures, or message strings were consulted or copied.
+
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-inconsistent-returns";
+
+impl Scanner<'_> {
+    /// Pushes a tracking frame when entering a function or arrow scope.
+    pub(crate) fn enter_return_scope(&mut self, span: Span) {
+        self.return_kind_stack.push((span, false, false));
+    }
+
+    /// Records a `return` in the innermost open scope. `has_argument` is `true`
+    /// for `return x;` and `false` for a bare `return;`.
+    pub(crate) fn record_return(&mut self, has_argument: bool) {
+        let Some((_, has_value_return, has_bare_return)) = self.return_kind_stack.last_mut() else {
+            return;
+        };
+        if has_argument {
+            *has_value_return = true;
+        } else {
+            *has_bare_return = true;
+        }
+    }
+
+    /// Pops the innermost frame and reports the scope when it mixed an explicit
+    /// value return with an explicit bare return.
+    pub(crate) fn leave_return_scope(&mut self) {
+        let Some((span, has_value_return, has_bare_return)) = self.return_kind_stack.pop() else {
+            return;
+        };
+        if has_value_return && has_bare_return {
+            self.report(RULE_NAME, "inconsistentReturns", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -3,12 +3,13 @@
 //! `check_*` rule body lives under [`crate::rules`].
 
 use oxc_ast::ast::{
-    AssignmentExpression, BinaryExpression, BindingIdentifier, BlockStatement, CallExpression,
-    CatchClause, ConditionalExpression, DoWhileStatement, ExpressionStatement, ForInStatement,
-    ForOfStatement, ForStatement, Function, FunctionBody, IdentifierReference, IfStatement,
-    LabeledStatement, LogicalExpression, NewExpression, Program, RegExpLiteral,
-    StaticMemberExpression, SwitchCase, SwitchStatement, TSIntersectionType, TSPropertySignature,
-    TSUnionType, TemplateLiteral, UnaryExpression, WhileStatement, YieldExpression,
+    ArrowFunctionExpression, AssignmentExpression, BinaryExpression, BindingIdentifier,
+    BlockStatement, CallExpression, CatchClause, ConditionalExpression, DoWhileStatement,
+    ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function, FunctionBody,
+    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, NewExpression, Program,
+    RegExpLiteral, ReturnStatement, StaticMemberExpression, SwitchCase, SwitchStatement,
+    TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral, UnaryExpression,
+    WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -37,6 +38,12 @@ pub(crate) struct Scanner<'a> {
     /// entry to a generator with a body and popped on exit; `generator-without-yield`
     /// reports generators whose frame is still `false` when popped.
     pub(crate) generator_yield_stack: SmallVec<[bool; 8]>,
+    /// Stack of frames, one per currently-open function or arrow scope, tracking
+    /// whether that scope has seen an explicit value `return x;` and an explicit
+    /// bare `return;`. Each tuple is `(span, has_value_return, has_bare_return)`.
+    /// Pushed on entry to a function/arrow and popped on exit;
+    /// `no-inconsistent-returns` reports a scope whose frame has both kinds set.
+    pub(crate) return_kind_stack: SmallVec<[(Span, bool, bool); 8]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -240,8 +247,21 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
         let track = self.enter_generator(it);
+        self.enter_return_scope(it.span);
         walk::walk_function(self, it, flags);
+        self.leave_return_scope();
         self.leave_generator(it, track);
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        self.enter_return_scope(it.span);
+        walk::walk_arrow_function_expression(self, it);
+        self.leave_return_scope();
+    }
+
+    fn visit_return_statement(&mut self, it: &ReturnStatement<'a>) {
+        self.record_return(it.argument.is_some());
+        walk::walk_return_statement(self, it);
     }
 
     fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2014,3 +2014,40 @@ fn does_not_report_no_function_declaration_in_block_for_function_expression() {
     let diagnostics = scan("no-function-declaration-in-block", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_inconsistent_returns_for_mixed_returns() {
+    let source = "function f(x) { if (!x) return; return x.value; }";
+    let diagnostics = scan("no-inconsistent-returns", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-inconsistent-returns");
+    assert_eq!(diagnostics[0].message_id, "inconsistentReturns");
+}
+
+#[test]
+fn reports_no_inconsistent_returns_for_mixed_returns_in_arrow() {
+    let source = "const f = (x) => { if (!x) return; return 1; };";
+    let diagnostics = scan("no-inconsistent-returns", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_inconsistent_returns_when_all_returns_have_values() {
+    let source = "function f(x) { if (!x) return 0; return x.value; }";
+    let diagnostics = scan("no-inconsistent-returns", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_inconsistent_returns_when_all_returns_are_bare() {
+    let source = "function f(x) { if (!x) return; doWork(); return; }";
+    let diagnostics = scan("no-inconsistent-returns", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_no_inconsistent_returns_only_for_inner_scope() {
+    let source = "function outer() { return 1; function inner() { if (a) return; return 2; } }";
+    let diagnostics = scan("no-inconsistent-returns", source);
+    assert_eq!(diagnostics.len(), 1);
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -167,6 +167,10 @@ const messages = Object.freeze({
     noFunctionDeclarationInBlock:
       'Move this function declaration out of the block, or use a function expression instead.',
   },
+  'no-inconsistent-returns': {
+    inconsistentReturns:
+      'Refactor this function to use "return" consistently, either always with a value or always without.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -248,6 +252,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow the Array constructor in favor of array literals, except for the single-argument length form',
   'no-function-declaration-in-block':
     'Disallow function declarations nested directly inside a block; use a function expression or move it to the top level',
+  'no-inconsistent-returns':
+    'Disallow mixing value returns and bare returns in the same function; return a value on all paths or none',
 });
 
 const ruleTypes = Object.freeze({
@@ -294,6 +300,7 @@ const ruleTypes = Object.freeze({
   'no-sonar-comments': 'suggestion',
   'array-constructor': 'suggestion',
   'no-function-declaration-in-block': 'suggestion',
+  'no-inconsistent-returns': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -340,6 +347,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-sonar-comments': 'error',
   'array-constructor': 'error',
   'no-function-declaration-in-block': 'error',
+  'no-inconsistent-returns': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -46,6 +46,7 @@ const expectedRuleNames = [
   'no-sonar-comments',
   'array-constructor',
   'no-function-declaration-in-block',
+  'no-inconsistent-returns',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1637,5 +1638,40 @@ describe('sonarjs native API', () => {
     const source = 'if (cond) {\n  const f = function () {};\n}';
     const diagnostics = scan('no-function-declaration-in-block', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-inconsistent-returns for a function mixing value and bare returns', () => {
+    const source = 'function f(x) {\n  if (!x) return;\n  return x.value;\n}';
+    const diagnostics = scan('no-inconsistent-returns', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-inconsistent-returns');
+    expect(diagnostics[0].messageId).toBe('inconsistentReturns');
+  });
+
+  it('reports no-inconsistent-returns for an arrow mixing value and bare returns', () => {
+    const source = 'const f = (x) => {\n  if (!x) return;\n  return 1;\n};';
+    const diagnostics = scan('no-inconsistent-returns', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report no-inconsistent-returns when all returns yield a value', () => {
+    const source = 'function f(x) {\n  if (!x) return 0;\n  return x.value;\n}';
+    const diagnostics = scan('no-inconsistent-returns', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-inconsistent-returns when all returns are bare', () => {
+    const source = 'function f(x) {\n  if (!x) return;\n  doWork();\n  return;\n}';
+    const diagnostics = scan('no-inconsistent-returns', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-inconsistent-returns only for the inconsistent nested function', () => {
+    // outer returns only a value; inner mixes value and bare returns. Only inner
+    // is flagged, proving each scope tracks its own returns on a separate frame.
+    const source =
+      'function outer() {\n  return 1;\n  function inner() {\n    if (a) return;\n    return 2;\n  }\n}';
+    const diagnostics = scan('no-inconsistent-returns', source);
+    expect(diagnostics).toHaveLength(1);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -137,6 +137,7 @@ describe('sonarjs plugin shape', () => {
       'no-sonar-comments',
       'array-constructor',
       'no-function-declaration-in-block',
+      'no-inconsistent-returns',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -181,6 +182,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-sonar-comments']).toBe('object');
     expect(typeof plugin.rules['array-constructor']).toBe('object');
     expect(typeof plugin.rules['no-function-declaration-in-block']).toBe('object');
+    expect(typeof plugin.rules['no-inconsistent-returns']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -227,6 +229,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-function-declaration-in-block']).toBe(
       'error',
     );
+    expect(plugin.configs.recommended.rules['sonarjs/no-inconsistent-returns']).toBe('error');
   });
 });
 
@@ -963,5 +966,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-function-declaration-in-block)');
+  });
+
+  it('reports no-inconsistent-returns through the adapter', () => {
+    const source = 'function f(x) {\n  if (!x) return;\n  return x.value;\n}';
+    const reports = runRule('no-inconsistent-returns', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('inconsistentReturns');
+  });
+
+  it('reports no-inconsistent-returns through the CLI', () => {
+    const source = 'function f(x) {\n  if (!x) return;\n  return x.value;\n}';
+    const result = runOxlint('no-inconsistent-returns', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-inconsistent-returns)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12398,19 +12398,19 @@
       },
       {
         "name": "no-inconsistent-returns",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-inconsistent-returns (Sonar key S3801). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S3801). A per-function/arrow frame stack (return_kind_stack) pushed in visit_function/visit_arrow_function_expression records, per scope, whether an explicit value `return x;` and an explicit bare `return;` were seen (visit_return_statement); on leave the scope is reported when both are present. Returns bind to the nearest scope frame so nested functions are isolated. Narrow form: an explicit value return mixed with an implicit fall-through (no trailing return) is a documented follow-up. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-incorrect-string-concat",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-inconsistent-returns` rule (Sonar key S3801).

Flags a function or arrow whose body mixes an explicit value `return x;` with an explicit bare `return;`.

- **Flagged:** `function f(x) { if (!x) return; return x.value; }`
- **Not flagged:** scopes that only ever return values, or only ever return nothing; returns belonging to a nested function/arrow (tracked on their own frame).

Implemented with a per-scope frame stack (`return_kind_stack`) pushed in `visit_function`/`visit_arrow_function_expression` and updated by `visit_return_statement`; each `return` binds to the nearest enclosing scope, so nested functions are isolated.

**Narrow form:** an explicit value return combined with an implicit fall-through (no trailing `return`) is a documented follow-up; only the mix of two explicit returns is reported, which is a strict subset of the upstream behaviour (no false positives). No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784003928&installation_id=136613492&pr_number=228&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F228&signature=13b21f98f1aad40b13dc861496a72d0de97b84b187fb7d66f2806688cfe60936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->