### PR TITLE
port(sonarjs): port no-same-line-conditional (S3972)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 44] = [
+pub const RULE_NAMES: [&str; 45] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -67,6 +67,7 @@ pub const RULE_NAMES: [&str; 44] = [
     "array-constructor",
     "no-function-declaration-in-block",
     "no-inconsistent-returns",
+    "no-same-line-conditional",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -33,6 +33,7 @@ mod no_primitive_wrappers;
 mod no_redundant_boolean;
 mod no_redundant_jump;
 mod no_redundant_optional;
+mod no_same_line_conditional;
 mod no_skipped_tests;
 mod no_small_switch;
 mod no_sonar_comments;

--- a/crates/sonarjs/src/rules/no_same_line_conditional.rs
+++ b/crates/sonarjs/src/rules/no_same_line_conditional.rs
@@ -1,0 +1,52 @@
+//! Rule `no-same-line-conditional` (SonarJS key S3972).
+//!
+//! Clean-room port. When an `if` statement begins on the same line as the
+//! closing `}` of an immediately preceding sibling `if` statement, the intent is
+//! ambiguous: the author may have meant `else if` (and forgotten the `else`), or
+//! the two conditionals are independent and should be on separate lines. Either
+//! way the layout invites a bug, so the second `if` is reported.
+//!
+//! ```js
+//! if (a) {
+//!   // ...
+//! } if (b) {       // Noncompliant: `if` on the same line as the preceding `}`
+//!   // ...
+//! }
+//! ```
+//!
+//! **Flagged**: a sibling `if` statement whose start line equals the end line of
+//! the directly preceding sibling `if` statement (within the same statement
+//! list: a program, block, function body, or switch case).
+//!
+//! **Not flagged**:
+//! - `} else if (b) {` — the `else if` is part of one `if` statement, not a
+//!   separate sibling.
+//! - a second `if` placed on its own line.
+//! - an `if` preceded by a non-`if` statement on the same line.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S3972) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::Statement;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-same-line-conditional";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_same_line_conditional(&mut self, statements: &[Statement<'_>]) {
+        let mut prev_if_end_line: Option<u32> = None;
+        for statement in statements {
+            let Statement::IfStatement(if_stmt) = statement else {
+                prev_if_end_line = None;
+                continue;
+            };
+            let loc = self.line_index.loc_for_span(self.source_text, if_stmt.span);
+            if prev_if_end_line == Some(loc.start_line) {
+                self.report(RULE_NAME, "sameLineConditional", if_stmt.span);
+            }
+            prev_if_end_line = Some(loc.end_line);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -84,11 +84,13 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_fixme_tag(&it.comments);
         self.check_todo_tag(&it.comments);
         self.check_no_sonar_comments(&it.comments);
+        self.check_no_same_line_conditional(&it.body);
         walk::walk_program(self, it);
     }
 
     fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
         self.check_no_function_declaration_in_block(it);
+        self.check_no_same_line_conditional(&it.body);
         walk::walk_block_statement(self, it);
     }
 
@@ -113,6 +115,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_switch_case(&mut self, it: &SwitchCase<'a>) {
         self.check_comma_or_logical_or_case(it);
+        self.check_no_same_line_conditional(&it.consequent);
         walk::walk_switch_case(self, it);
     }
 
@@ -277,6 +280,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_function_body(&mut self, it: &FunctionBody<'a>) {
         self.check_prefer_immediate_return(it);
         self.check_redundant_return(it);
+        self.check_no_same_line_conditional(&it.statements);
         walk::walk_function_body(self, it);
     }
 }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2051,3 +2051,33 @@ fn reports_no_inconsistent_returns_only_for_inner_scope() {
     let diagnostics = scan("no-inconsistent-returns", source);
     assert_eq!(diagnostics.len(), 1);
 }
+
+#[test]
+fn reports_no_same_line_conditional_for_if_on_closing_brace_line() {
+    let source = "if (a) {\n  doA();\n} if (b) {\n  doB();\n}";
+    let diagnostics = scan("no-same-line-conditional", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-same-line-conditional");
+    assert_eq!(diagnostics[0].message_id, "sameLineConditional");
+}
+
+#[test]
+fn does_not_report_no_same_line_conditional_for_if_on_new_line() {
+    let source = "if (a) {\n  doA();\n}\nif (b) {\n  doB();\n}";
+    let diagnostics = scan("no-same-line-conditional", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_same_line_conditional_for_else_if_chain() {
+    let source = "if (a) {\n  doA();\n} else if (b) {\n  doB();\n}";
+    let diagnostics = scan("no-same-line-conditional", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_same_line_conditional_when_preceding_is_not_if() {
+    let source = "doA(); if (b) {\n  doB();\n}";
+    let diagnostics = scan("no-same-line-conditional", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -171,6 +171,10 @@ const messages = Object.freeze({
     inconsistentReturns:
       'Refactor this function to use "return" consistently, either always with a value or always without.',
   },
+  'no-same-line-conditional': {
+    sameLineConditional:
+      'Move this "if" to a new line or add the missing "else" to clarify the intent.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -254,6 +258,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow function declarations nested directly inside a block; use a function expression or move it to the top level',
   'no-inconsistent-returns':
     'Disallow mixing value returns and bare returns in the same function; return a value on all paths or none',
+  'no-same-line-conditional':
+    'Disallow an "if" statement placed on the same line as the closing brace of a preceding sibling "if"',
 });
 
 const ruleTypes = Object.freeze({
@@ -301,6 +307,7 @@ const ruleTypes = Object.freeze({
   'array-constructor': 'suggestion',
   'no-function-declaration-in-block': 'suggestion',
   'no-inconsistent-returns': 'suggestion',
+  'no-same-line-conditional': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -348,6 +355,7 @@ const recommendedRuleConfig = Object.freeze({
   'array-constructor': 'error',
   'no-function-declaration-in-block': 'error',
   'no-inconsistent-returns': 'error',
+  'no-same-line-conditional': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -47,6 +47,7 @@ const expectedRuleNames = [
   'array-constructor',
   'no-function-declaration-in-block',
   'no-inconsistent-returns',
+  'no-same-line-conditional',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1673,5 +1674,31 @@ describe('sonarjs native API', () => {
       'function outer() {\n  return 1;\n  function inner() {\n    if (a) return;\n    return 2;\n  }\n}';
     const diagnostics = scan('no-inconsistent-returns', source);
     expect(diagnostics).toHaveLength(1);
+  });
+
+  it('reports no-same-line-conditional for an if on the closing brace line', () => {
+    const source = 'if (a) {\n  doA();\n} if (b) {\n  doB();\n}';
+    const diagnostics = scan('no-same-line-conditional', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-same-line-conditional');
+    expect(diagnostics[0].messageId).toBe('sameLineConditional');
+  });
+
+  it('does not report no-same-line-conditional for an if on a new line', () => {
+    const source = 'if (a) {\n  doA();\n}\nif (b) {\n  doB();\n}';
+    const diagnostics = scan('no-same-line-conditional', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-same-line-conditional for an else-if chain', () => {
+    const source = 'if (a) {\n  doA();\n} else if (b) {\n  doB();\n}';
+    const diagnostics = scan('no-same-line-conditional', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-same-line-conditional when the preceding statement is not an if', () => {
+    const source = 'doA(); if (b) {\n  doB();\n}';
+    const diagnostics = scan('no-same-line-conditional', source);
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -138,6 +138,7 @@ describe('sonarjs plugin shape', () => {
       'array-constructor',
       'no-function-declaration-in-block',
       'no-inconsistent-returns',
+      'no-same-line-conditional',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -183,6 +184,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['array-constructor']).toBe('object');
     expect(typeof plugin.rules['no-function-declaration-in-block']).toBe('object');
     expect(typeof plugin.rules['no-inconsistent-returns']).toBe('object');
+    expect(typeof plugin.rules['no-same-line-conditional']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -230,6 +232,7 @@ describe('sonarjs plugin shape', () => {
       'error',
     );
     expect(plugin.configs.recommended.rules['sonarjs/no-inconsistent-returns']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-same-line-conditional']).toBe('error');
   });
 });
 
@@ -983,5 +986,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-inconsistent-returns)');
+  });
+
+  it('reports no-same-line-conditional through the adapter', () => {
+    const source = 'if (a) {\n  doA();\n} if (b) {\n  doB();\n}';
+    const reports = runRule('no-same-line-conditional', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('sameLineConditional');
+  });
+
+  it('reports no-same-line-conditional through the CLI', () => {
+    const source = 'if (a) {\n  doA();\n} if (b) {\n  doB();\n}';
+    const result = runOxlint('no-same-line-conditional', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-same-line-conditional)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12942,19 +12942,19 @@
       },
       {
         "name": "no-same-line-conditional",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-same-line-conditional (Sonar key S3972). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S3972). Scans each statement list (program, block, function body, switch case) for an IfStatement whose start line equals the end line of the immediately preceding sibling IfStatement, via check_no_same_line_conditional using LineIndex::loc_for_span. `else if` is part of a single IfStatement (not a sibling) so it is not flagged. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-selector-parameter",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-same-line-conditional` rule (Sonar key S3972).

Flags an `if` statement that begins on the same line as the closing `}` of an immediately-preceding sibling `if` statement — a layout that usually means a missing `else` or two conditionals that should be on separate lines.

- **Flagged:** `if (a) { ... } if (b) { ... }` (second `if` on the closing-brace line)
- **Not flagged:** an `else if` chain (one statement, not siblings), a second `if` on its own line, or an `if` preceded by a non-`if` statement.

Implemented via `check_no_same_line_conditional`, invoked over every statement list (program / block / function body / switch case); sibling line positions are compared with `LineIndex::loc_for_span`. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784004602&installation_id=136613492&pr_number=234&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F234&signature=5d1cf0b24e51d394b4fdde20ed829fd54303a96c35dbb2ad7d8f7776be2811dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->