### PR TITLE
port(sonarjs): port no-nested-assignment (S1121)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 45] = [
+pub const RULE_NAMES: [&str; 46] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -68,6 +68,7 @@ pub const RULE_NAMES: [&str; 45] = [
     "no-function-declaration-in-block",
     "no-inconsistent-returns",
     "no-same-line-conditional",
+    "no-nested-assignment",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -26,6 +26,7 @@ mod no_identical_expressions;
 mod no_inconsistent_returns;
 mod no_inverted_boolean_check;
 mod no_labels;
+mod no_nested_assignment;
 mod no_nested_conditional;
 mod no_nested_switch;
 mod no_nested_template_literals;

--- a/crates/sonarjs/src/rules/no_nested_assignment.rs
+++ b/crates/sonarjs/src/rules/no_nested_assignment.rs
@@ -1,0 +1,59 @@
+//! Rule `no-nested-assignment` (SonarJS key S1121).
+//!
+//! Clean-room port. An assignment buried inside a larger expression is easy to
+//! misread — `if (x = y)` looks like a comparison `if (x == y)`, and a chained
+//! `a = b = c` hides two assignments in one statement. Such assignments should
+//! be pulled out into their own statement.
+//!
+//! ## Narrow form
+//!
+//! This port reports the two unambiguous nested positions, both detected from
+//! the enclosing node so no parent pointers are needed:
+//!
+//! - an `=` assignment used as the condition of an `if`, `while`, `do…while`, or
+//!   `for` statement — `if (x = y) {}`, `while (node = node.next) {}`;
+//! - the right-hand side of a chained `=` assignment — the `b = c` in
+//!   `a = b = c`.
+//!
+//! Only the plain `=` operator is reported, which guarantees the flagged code is
+//! genuinely a hidden assignment. Other sub-expression positions (call
+//! arguments, declarator initializers, array/object literals) and compound
+//! assignment operators are a documented follow-up.
+//!
+//! **Not flagged**: an assignment that is its own expression statement
+//! (`x = y;`), or the `init`/`update` clauses of a `for` loop (`for (i = 0; …;
+//! i = i + 1)`), where an assignment is the expected form.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S1121) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{AssignmentExpression, Expression};
+use oxc_syntax::operator::AssignmentOperator;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-nested-assignment";
+
+impl Scanner<'_> {
+    /// Reports `expr` when it is an `=` assignment whose value is consumed as a
+    /// loop or branch condition.
+    pub(crate) fn check_no_nested_assignment_condition(&mut self, expr: &Expression<'_>) {
+        if let Expression::AssignmentExpression(assign) = expr.get_inner_expression() {
+            self.report_nested_assignment(assign);
+        }
+    }
+
+    /// Reports the right-hand side of a chained `=` assignment (`a = b = c`).
+    pub(crate) fn check_no_nested_assignment_chain(&mut self, assign: &AssignmentExpression<'_>) {
+        if let Expression::AssignmentExpression(inner) = assign.right.get_inner_expression() {
+            self.report_nested_assignment(inner);
+        }
+    }
+
+    fn report_nested_assignment(&mut self, assign: &AssignmentExpression<'_>) {
+        if assign.operator == AssignmentOperator::Assign {
+            self.report(RULE_NAME, "nestedAssignment", assign.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -151,6 +151,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_all_duplicated_branches_if(it);
         self.check_elseif_without_else(it);
         self.check_prefer_single_boolean_return(it);
+        self.check_no_nested_assignment_condition(&it.test);
         walk::walk_if_statement(self, it);
     }
 
@@ -163,16 +164,21 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
         self.check_prefer_while(it);
         self.check_redundant_continue(&it.body);
+        if let Some(test) = &it.test {
+            self.check_no_nested_assignment_condition(test);
+        }
         walk::walk_for_statement(self, it);
     }
 
     fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
         self.check_redundant_continue(&it.body);
+        self.check_no_nested_assignment_condition(&it.test);
         walk::walk_while_statement(self, it);
     }
 
     fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
         self.check_redundant_continue(&it.body);
+        self.check_no_nested_assignment_condition(&it.test);
         walk::walk_do_while_statement(self, it);
     }
 
@@ -190,6 +196,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_non_existent_operator(it);
         self.check_no_built_in_override_assignment(it);
         self.check_class_prototype(it);
+        self.check_no_nested_assignment_chain(it);
         walk::walk_assignment_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2081,3 +2081,54 @@ fn does_not_report_no_same_line_conditional_when_preceding_is_not_if() {
     let diagnostics = scan("no-same-line-conditional", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_nested_assignment_in_if_condition() {
+    let source = "if (x = compute()) { use(x); }";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-nested-assignment");
+    assert_eq!(diagnostics[0].message_id, "nestedAssignment");
+}
+
+#[test]
+fn reports_no_nested_assignment_in_while_condition() {
+    let source = "while (node = node.next) { visit(node); }";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn reports_no_nested_assignment_for_chained_assignment() {
+    let source = "a = b = c;";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_nested_assignment_for_plain_statement() {
+    let source = "x = compute();";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_nested_assignment_for_for_loop_init_and_update() {
+    let source = "for (i = 0; i < 10; i = i + 1) { use(i); }";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_nested_assignment_for_equality_in_condition() {
+    let source = "if (x === compute()) { use(x); }";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_nested_assignment_for_compound_assignment_in_condition() {
+    let source = "while (x += 1) { use(x); }";
+    let diagnostics = scan("no-nested-assignment", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -175,6 +175,9 @@ const messages = Object.freeze({
     sameLineConditional:
       'Move this "if" to a new line or add the missing "else" to clarify the intent.',
   },
+  'no-nested-assignment': {
+    nestedAssignment: 'Extract this assignment out of the expression into its own statement.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -260,6 +263,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow mixing value returns and bare returns in the same function; return a value on all paths or none',
   'no-same-line-conditional':
     'Disallow an "if" statement placed on the same line as the closing brace of a preceding sibling "if"',
+  'no-nested-assignment':
+    'Disallow assignments inside sub-expressions such as loop and branch conditions or chained assignments',
 });
 
 const ruleTypes = Object.freeze({
@@ -308,6 +313,7 @@ const ruleTypes = Object.freeze({
   'no-function-declaration-in-block': 'suggestion',
   'no-inconsistent-returns': 'suggestion',
   'no-same-line-conditional': 'suggestion',
+  'no-nested-assignment': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -356,6 +362,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-function-declaration-in-block': 'error',
   'no-inconsistent-returns': 'error',
   'no-same-line-conditional': 'error',
+  'no-nested-assignment': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -48,6 +48,7 @@ const expectedRuleNames = [
   'no-function-declaration-in-block',
   'no-inconsistent-returns',
   'no-same-line-conditional',
+  'no-nested-assignment',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1699,6 +1700,44 @@ describe('sonarjs native API', () => {
   it('does not report no-same-line-conditional when the preceding statement is not an if', () => {
     const source = 'doA(); if (b) {\n  doB();\n}';
     const diagnostics = scan('no-same-line-conditional', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-nested-assignment for an assignment in an if condition', () => {
+    const source = 'if (x = compute()) {\n  use(x);\n}';
+    const diagnostics = scan('no-nested-assignment', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-nested-assignment');
+    expect(diagnostics[0].messageId).toBe('nestedAssignment');
+  });
+
+  it('reports no-nested-assignment for an assignment in a while condition', () => {
+    const source = 'while (node = node.next) {\n  visit(node);\n}';
+    const diagnostics = scan('no-nested-assignment', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('reports no-nested-assignment for the inner part of a chained assignment', () => {
+    const source = 'a = b = c;';
+    const diagnostics = scan('no-nested-assignment', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report no-nested-assignment for a plain assignment statement', () => {
+    const source = 'x = compute();';
+    const diagnostics = scan('no-nested-assignment', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-nested-assignment for the init and update of a for loop', () => {
+    const source = 'for (i = 0; i < 10; i = i + 1) {\n  use(i);\n}';
+    const diagnostics = scan('no-nested-assignment', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-nested-assignment for an equality comparison in a condition', () => {
+    const source = 'if (x === compute()) {\n  use(x);\n}';
+    const diagnostics = scan('no-nested-assignment', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -139,6 +139,7 @@ describe('sonarjs plugin shape', () => {
       'no-function-declaration-in-block',
       'no-inconsistent-returns',
       'no-same-line-conditional',
+      'no-nested-assignment',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -185,6 +186,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-function-declaration-in-block']).toBe('object');
     expect(typeof plugin.rules['no-inconsistent-returns']).toBe('object');
     expect(typeof plugin.rules['no-same-line-conditional']).toBe('object');
+    expect(typeof plugin.rules['no-nested-assignment']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -233,6 +235,7 @@ describe('sonarjs plugin shape', () => {
     );
     expect(plugin.configs.recommended.rules['sonarjs/no-inconsistent-returns']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-same-line-conditional']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-nested-assignment']).toBe('error');
   });
 });
 
@@ -1003,5 +1006,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-same-line-conditional)');
+  });
+
+  it('reports no-nested-assignment through the adapter', () => {
+    const source = 'if (x = compute()) {\n  use(x);\n}';
+    const reports = runRule('no-nested-assignment', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('nestedAssignment');
+  });
+
+  it('reports no-nested-assignment through the CLI', () => {
+    const source = 'if (x = compute()) {\n  use(x);\n}';
+    const result = runOxlint('no-nested-assignment', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-assignment)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12622,19 +12622,19 @@
       },
       {
         "name": "no-nested-assignment",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-nested-assignment (Sonar key S1121). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room narrow port (Sonar key S1121). Flags an `=` assignment used as an if/while/do-while/for condition (check_no_nested_assignment_condition on the relevant `test`) and the right-hand side of a chained `=` assignment (check_no_nested_assignment_chain from visit_assignment_expression). Restricted to the AssignmentOperator::Assign operator for a zero-false-positive subset; other sub-expression positions (call args, declarator init, literals) and compound operators are a documented follow-up. for-loop init/update are intentionally not flagged. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-nested-conditional",


### PR DESCRIPTION
Clean-room narrow port of the SonarJS `no-nested-assignment` rule (Sonar key S1121).

Flags an `=` assignment hidden inside a larger expression, in the two unambiguous positions detected from the enclosing node (no parent pointers needed):

- an `=` assignment used as the condition of `if` / `while` / `do…while` / `for` — `if (x = y) {}`, `while (node = node.next) {}`
- the right-hand side of a chained `=` assignment — the `b = c` in `a = b = c`

- **Not flagged:** a plain `x = y;` statement, or the `init`/`update` clauses of a `for` loop.

Restricted to the plain `=` operator for a zero-false-positive subset; other sub-expression positions (call arguments, declarator initializers, array/object literals) and compound assignment operators are a documented follow-up. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784005305&installation_id=136613492&pr_number=235&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F235&signature=d8581609d0daa73cc4f582cbf49f5902aa0446425ae42f1aadff05f1f54f110a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->