### PR TITLE
fix(eslint-json): suppress autofix for escaped JSON5 identifier keys + parity hardening

### DIFF
--- a/crates/eslint_json/src/lib.rs
+++ b/crates/eslint_json/src/lib.rs
@@ -1018,12 +1018,17 @@ impl<'a> Parser<'a> {
                 if ident.is_empty() {
                     return None;
                 }
+                // JSON5 identifier names may carry Unicode escapes (e.g.
+                // `foot`), which momoa decodes for the key's value while
+                // the raw key keeps the source text. Mirror that so duplicate
+                // and sort comparisons see the decoded name; when the decoded
+                // name differs from the source, the key has an escape and
+                // no-unnormalized-keys must not autofix it (upstream returns
+                // null when `key !== rawKey`).
+                let key = decode_identifier_escapes(ident);
+                let key_has_escape = key.as_str() != ident;
                 Some(MemberFact {
-                    // JSON5 identifier names may carry Unicode escapes (e.g.
-                    // `foot`), which momoa decodes for the key's value while
-                    // the raw key keeps the source text. Mirror that so duplicate
-                    // and sort comparisons see the decoded name.
-                    key: decode_identifier_escapes(ident),
+                    key,
                     raw_key: CompactString::from(ident),
                     name_span: ByteSpan {
                         start,
@@ -1034,7 +1039,7 @@ impl<'a> Parser<'a> {
                         end: self.pos,
                     },
                     member_span: ByteSpan { start, end: start },
-                    key_has_escape: false,
+                    key_has_escape,
                 })
             }
         }
@@ -1470,7 +1475,48 @@ impl LineIndex {
 
 #[cfg(test)]
 mod tests {
-    use super::{NormalizationForm, RULE_NAMES, ScanOptions, SortDirection, scan_eslint_json};
+    use super::{
+        NormalizationForm, RULE_NAMES, ScanOptions, SortDirection, natural_compare,
+        scan_eslint_json,
+    };
+    use core::cmp::Ordering;
+
+    // Locks in the `natural-compare` semantics, including digit runs that begin
+    // with `0` (which the package does NOT treat as a number, since its chunk
+    // trigger requires a unit > 66, i.e. `1`..`9`). Values verified against the
+    // upstream `natural-compare` v1.4.0 package.
+    #[test]
+    fn natural_compare_matches_upstream() {
+        assert_eq!(natural_compare("00", "9"), Ordering::Less);
+        assert_eq!(natural_compare("a0b", "a00b"), Ordering::Greater);
+        assert_eq!(natural_compare("0x", "00x"), Ordering::Greater);
+        assert_eq!(natural_compare("10", "9"), Ordering::Greater);
+        assert_eq!(natural_compare("1", "10"), Ordering::Less);
+        assert_eq!(natural_compare("11", "2"), Ordering::Greater);
+        // The remapping puts `_`/`$` before letters and keeps case order.
+        assert_eq!(natural_compare("_", "A"), Ordering::Less);
+        assert_eq!(natural_compare("$", "_"), Ordering::Less);
+        assert_eq!(natural_compare("A", "a"), Ordering::Less);
+        assert_eq!(natural_compare("abc", "abc"), Ordering::Equal);
+    }
+
+    // A JSON5 identifier key that is both escaped and unnormalized must be
+    // reported but NOT autofixed, mirroring upstream's `key !== rawKey` bail-out.
+    #[test]
+    fn unnormalized_escaped_identifier_key_has_no_fix() {
+        // A JSON5 identifier key written with Unicode escapes that decode
+        // to `e` + combining acute (the decomposed form, which NFC
+        // recomposes). Built from a backslash char so the escape token is
+        // not rewritten by tooling.
+        let source = "{\\u0065\\u0301: 1}";
+        let diagnostics = scan_eslint_json(source, &ScanOptions::default());
+        let unnormalized: oxlint_plugins_carton::SmallVec<[_; 4]> = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "no-unnormalized-keys")
+            .collect();
+        assert_eq!(unnormalized.len(), 1);
+        assert!(unnormalized[0].fix.is_none());
+    }
 
     #[test]
     fn exposes_all_rule_names() {

--- a/status.json
+++ b/status.json
@@ -2257,7 +2257,7 @@
           "lsp": true,
           "oxlintIntegration": false
         },
-        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-duplicate-keys; duplicate string and JSON5-style keys are covered through native API and direct adapter Vitest tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
+        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-duplicate-keys; duplicate string and JSON5-style keys are covered by the upstream @eslint/json RuleTester suite, replayed at exact parity (messageId, data, location, and autofix output) via synced fixtures (test/upstream.test.mjs), plus native API tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
       },
       {
         "name": "no-empty-keys",
@@ -2273,7 +2273,7 @@
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-empty-keys; empty quoted keys are covered through native API and direct adapter Vitest tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
+        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-empty-keys; empty quoted keys are covered by the upstream @eslint/json RuleTester suite, replayed at exact parity (messageId, data, location, and autofix output) via synced fixtures (test/upstream.test.mjs), plus native API tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
       },
       {
         "name": "no-unnormalized-keys",
@@ -2289,7 +2289,7 @@
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-unnormalized-keys; NFC/NFKD options and safe key fixes are covered through native API and direct adapter Vitest tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
+        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-unnormalized-keys; NFC/NFKD options and safe key fixes are covered by the upstream @eslint/json RuleTester suite, replayed at exact parity (messageId, data, location, and autofix output) via synced fixtures (test/upstream.test.mjs), plus native API tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
       },
       {
         "name": "no-unsafe-values",
@@ -2305,7 +2305,7 @@
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-unsafe-values; unsafe integers, infinity, underflow-to-zero, subnormal numbers, and lone surrogates are covered through native API and direct adapter Vitest tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
+        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/no-unsafe-values; unsafe integers, infinity, underflow-to-zero, subnormal numbers, and lone surrogates are covered by the upstream @eslint/json RuleTester suite, replayed at exact parity (messageId, data, location, and autofix output) via synced fixtures (test/upstream.test.mjs), plus native API tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
       },
       {
         "name": "sort-keys",
@@ -2321,7 +2321,7 @@
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/sort-keys; direction, case sensitivity, natural ordering, minKeys, and blank-line grouping are covered through native API and direct adapter Vitest tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
+        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/sort-keys; direction, case sensitivity, natural ordering, minKeys, and blank-line grouping are covered by the upstream @eslint/json RuleTester suite, replayed at exact parity (messageId, data, location, and autofix output) via synced fixtures (test/upstream.test.mjs), plus native API tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
       },
       {
         "name": "top-level-interop",
@@ -2337,7 +2337,7 @@
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/top-level-interop; scalar top-level values are covered through native API and direct adapter Vitest tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
+        "notes": "Rust JSON/JSONC/JSON5 parser port of @eslint/json/top-level-interop; scalar top-level values are covered by the upstream @eslint/json RuleTester suite, replayed at exact parity (messageId, data, location, and autofix output) via synced fixtures (test/upstream.test.mjs), plus native API tests. Oxlint 1.68 does not select .json files for jsPlugins, so CLI integration is not available yet."
       }
     ]
   },


### PR DESCRIPTION
Finalization pass after the four parity PRs (#220 → #226 → #231 → #233), addressing findings from a full multi-dimensional review.

## Correctness fix
**no-unnormalized-keys** must return a null fix when `key !== rawKey` — rewriting decoded text over an escaped source is wrong (upstream bails out for this). String keys already carried the escape flag, but JSON5 *identifier* keys were unconditionally marked escape-free, so an unnormalized identifier key written with Unicode escapes (e.g. `é`) would have been incorrectly autofixed. `key_has_escape` is now derived from whether decoding actually changed the identifier text. (Untested upstream path, but a real divergence introduced by the no-duplicate-keys decode work in #226.)

## Regression tests
- `natural_compare` is unit-tested against the upstream `natural-compare` v1.4.0 results, including digit runs that begin with `0` (`"00"` vs `"9"`, `"a0b"` vs `"a00b"`) — which the package does **not** treat numerically, since its chunk trigger requires a remapped unit `> 66` (`1`..`9`). This locks in that the port's `(67..76)` trigger is correct.
- The escaped-unnormalized-identifier no-fix case.

## Review notes (no code change needed)
- The natural-sort comparator, sort-keys swap autofix, `has_adjacent_comment`, and the harness's single-pass fix application were all verified correct against upstream.
- `top-level-interop` reports the value span vs upstream's document-node span; identical for every upstream case (none have surrounding whitespace) and unverifiable without the momoa runtime, so left as-is.

## Docs
- `status.json`: records that all six rules are verified by the upstream RuleTester suite replayed at exact parity, not just adapter smoke tests.

## Testing
- `cargo test -p oxlint-plugins-eslint-json` (5 unit tests), `cargo clippy`, `vp fmt`, `node tools/tasks/verify-status.ts`, and a full local replay of the upstream suite (304 enforced / 3 non-UTF-8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784006076&installation_id=136613492&pr_number=236&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F236&signature=b739c3cf88da2bb910af55ebe4ae815d797cf0453c04b6ea891620b8b595fb19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->