### PR TITLE
fix(unocss): full-code-review fixes (order false positives, blocklist span)

### DIFF
--- a/crates/unocss/src/ordering.rs
+++ b/crates/unocss/src/ordering.rs
@@ -97,30 +97,36 @@ fn class_rank(token: &str, index: usize) -> (u16, u16, usize) {
     if base.starts_with("bg-") {
         return (90, 0, index);
     }
-    if base.starts_with("h-") || base.starts_with("h") {
+    if base.starts_with("h-") {
         return (100, 0, index);
     }
-    if base.starts_with("w-") || base.starts_with("w") {
+    if base.starts_with("w-") {
         return (101, 0, index);
     }
     (10_000, 0, index)
 }
 
+/// Rank a margin (`family = 'm'`) or padding (`family = 'p'`) utility by axis.
+///
+/// Only matches genuine utilities (`m`, `m-1`, `p4`, `mx1`, `ml-2`); a bare word
+/// that merely starts with an axis letter (`my`, `prose`, `play`, `previous`) is
+/// rejected so the heuristic does not flag ordinary class names as orderable.
 fn spacing_axis_rank(base: &str, family: char) -> Option<u16> {
-    let mut chars = base.chars();
-    if chars.next()? != family {
-        return None;
-    }
-    let next = chars.next();
-    match next {
-        None => Some(0),
-        Some('-' | '0'..='9') => Some(0),
-        Some('x') => Some(1),
-        Some('y') => Some(2),
-        Some('l') => Some(3),
-        Some('r') => Some(4),
-        Some('b') => Some(5),
-        Some('t') => Some(6),
+    let mut chars = base.strip_prefix(family)?.chars();
+    let rank = match chars.next() {
+        // `m`/`p` alone, or directly followed by a value (`m-1`, `p4`).
+        None | Some('-' | '0'..='9') => return Some(0),
+        Some('x') => 1,
+        Some('y') => 2,
+        Some('l') => 3,
+        Some('r') => 4,
+        Some('b') => 5,
+        Some('t') => 6,
+        _ => return None,
+    };
+    // A real axis utility continues with a value (`mx1`, `ml-2`); reject `my`/`pr`.
+    match chars.next() {
+        Some('-' | '0'..='9') => Some(rank),
         _ => None,
     }
 }
@@ -159,7 +165,5 @@ pub(crate) fn is_unocss_token(token: &str) -> bool {
         || base.starts_with("border")
         || base.starts_with("bg-")
         || base.starts_with("h-")
-        || base.starts_with('h')
         || base.starts_with("w-")
-        || base.starts_with('w')
 }

--- a/crates/unocss/src/scanner.rs
+++ b/crates/unocss/src/scanner.rs
@@ -72,10 +72,12 @@ impl<'a> Scanner<'a> {
 
     fn check_blocklist(&mut self, literal: LiteralSpan<'_>) {
         for token in literal.content.split_whitespace() {
-            self.check_blocked_token(
-                token,
-                Span::new(literal.content_start as u32, literal.content_end as u32),
-            );
+            // `split_whitespace` yields subslices of `content`, so the token's
+            // byte offset within the literal is its pointer distance from the
+            // content start. Report the precise token span, not the whole string.
+            let offset = token.as_ptr() as usize - literal.content.as_ptr() as usize;
+            let start = literal.content_start + offset;
+            self.check_blocked_token(token, Span::new(start as u32, (start + token.len()) as u32));
         }
     }
 
@@ -181,10 +183,14 @@ impl<'a> Scanner<'a> {
             return;
         }
 
-        // Build a fix only when the attrs are contiguous in source.
+        // Build a fix only when the attrs are contiguous in source. `get`
+        // guards against any degenerate (reversed/out-of-range) span pair so a
+        // parser edge case can never panic at the NAPI boundary.
         let contiguous = uno_attrs.windows(2).all(|pair| {
-            let between = &self.source_text[pair[0].1.end as usize..pair[1].1.start as usize];
-            between.trim().is_empty()
+            let range = pair[0].1.end as usize..pair[1].1.start as usize;
+            self.source_text
+                .get(range)
+                .is_some_and(|between| between.trim().is_empty())
         });
         let fix = if contiguous {
             let start = uno_attrs[0].1.start;

--- a/crates/unocss/src/tests.rs
+++ b/crates/unocss/src/tests.rs
@@ -156,3 +156,61 @@ fn enforce_class_compile_utf8_fix_offsets() {
         "enforce-class-compile fix must start at the byte after the opening quote"
     );
 }
+
+// ── full-code-review fixes ──────────────────────────────────────────────────
+
+/// The ordering heuristic must not treat ordinary English class names that
+/// merely start with `h`/`w`/an axis letter (`hello`, `world`, `my`, `prose`)
+/// as UnoCSS utilities, or `order` would reorder non-UnoCSS class names.
+#[test]
+fn plain_words_do_not_trigger_order() {
+    for source in [
+        r#"const node = <div className="world hello flex" />;"#,
+        r#"const node = <div className="my prose flex" />;"#,
+        r#"const node = <div className="play previous block" />;"#,
+    ] {
+        let diagnostics = scan_unocss(source, "fixture.tsx", &UnocssOptions::default());
+        assert!(
+            diagnostics.iter().all(|d| d.rule_name != "order"),
+            "unexpected 'order' diagnostic for {source:?}: {diagnostics:?}"
+        );
+    }
+}
+
+/// Genuine bare `h-`/`w-`/axis utilities are still recognized after tightening.
+#[test]
+fn genuine_utilities_still_ordered() {
+    let source = r#"const node = <div className="w-1 h-1 mx1" />;"#;
+    let diagnostics = scan_unocss(source, "fixture.tsx", &UnocssOptions::default());
+    assert!(
+        diagnostics.iter().any(|d| d.rule_name == "order"),
+        "expected 'order' for real utilities, got: {diagnostics:?}"
+    );
+}
+
+/// A `blocklist` diagnostic must point at the offending token, not the whole
+/// class string, so editors underline only the blocked utility.
+#[test]
+fn blocklist_span_covers_only_the_token() {
+    let mut blocklist = SmallVec::new();
+    blocklist.push(BlocklistEntry {
+        name: CompactString::from("border"),
+        reason: CompactString::new(""),
+    });
+    let options = UnocssOptions {
+        blocklist,
+        ..UnocssOptions::default()
+    };
+    // `border` sits at bytes 21..27 of the source: `<div className="flex border">`.
+    let source = r#"<div className="flex border"></div>"#;
+    let diagnostics = scan_unocss(source, "fixture.tsx", &options);
+    let columns = diagnostics
+        .iter()
+        .find(|d| d.rule_name == "blocklist")
+        .map(|d| (d.loc.start_column, d.loc.end_column));
+    assert_eq!(
+        columns,
+        Some((21, 27)),
+        "blocklist span should cover only `border`, not the whole class string"
+    );
+}

--- a/npm/unocss/README.md
+++ b/npm/unocss/README.md
@@ -4,3 +4,19 @@ Rust-backed Oxlint plugin port of `@unocss/eslint-plugin`.
 
 The JavaScript layer is an Oxlint/NAPI adapter. Class token scanning, ordering,
 blocklist checks, and class-compile prefix checks run in Rust through Oxc.
+
+## Scope and divergence from `@unocss/eslint-plugin`
+
+This is a syntax-only port that does **not** load or invoke the UnoCSS engine,
+so behavior differs from upstream:
+
+- `order` / `order-attributify` sort classes with a built-in **heuristic bucket
+  order**, not the real `presetUno`-generated order; results may differ, and the
+  heuristic only recognizes common utility shapes (so it ignores, rather than
+  reorders, class strings it does not recognize).
+- `blocklist` matches utility **names supplied via rule options / `settings.unocss.blocklist`**
+  by exact token, instead of resolving them against your `uno.config` blocklist.
+- Only JS/TS/JSX is analyzed; `.vue` / `.svelte` templates (which Oxc cannot
+  parse) are out of scope.
+
+Full engine-backed parity is tracked upstream and intentionally deferred.

--- a/npm/unocss/api.d.ts
+++ b/npm/unocss/api.d.ts
@@ -16,7 +16,15 @@ export type UnocssDiagnostic = {
   messageId: string;
   loc: UnocssDiagnosticLoc;
   fix?: UnocssDiagnosticFix | null;
+  /** Blocklisted utility name (set for `blocklist` diagnostics). */
   name?: string | null;
+  /**
+   * Blocklist reason, echoed verbatim from the matched `blocklist` option
+   * entry's `reason` (empty string when none). The bundled plugin supplies it
+   * pre-formatted with a leading `": "` so it splices into the default
+   * `"{{name}}" is in blocklist{{reason}}` template; a direct API caller gets
+   * back exactly the string it passed.
+   */
   reason?: string | null;
   prefix?: string | null;
 };

--- a/npm/unocss/index.js
+++ b/npm/unocss/index.js
@@ -42,6 +42,8 @@ const ruleTypes = {
 
 const implementedRuleNames = Object.freeze(implementedUnocssRuleNames());
 const recommendedRuleNames = Object.freeze(['order', 'order-attributify']);
+// `blocklist` only reports; it never emits a fix, so it is not `fixable`.
+const fixableRuleNames = Object.freeze(['order', 'order-attributify', 'enforce-class-compile']);
 
 const rules = Object.freeze(
   Object.fromEntries(
@@ -94,7 +96,7 @@ function createUnocssRule(ruleName) {
         recommended: recommendedRuleNames.includes(ruleName),
         url: `${DOCS_BASE}#rules`,
       },
-      fixable: 'code',
+      fixable: fixableRuleNames.includes(ruleName) ? 'code' : undefined,
       messages: messages[ruleName],
       schema: schemaForRule(ruleName),
     },
@@ -156,7 +158,7 @@ function schemaForRule(ruleName) {
             type: 'array',
           },
         },
-        additionalProperties: true,
+        additionalProperties: false,
       },
     ];
   }


### PR DESCRIPTION
## What

Applies the fixes from a comprehensive full-code-review of the `@unocss/eslint-plugin` port (follow-up to #229). Scope stays within the achievable, syntax-only surface — engine-backed parity remains deferred (issue #11).

## Findings fixed

**MAJOR**
- **`order` false positives that corrupt code via autofix** — the ordering heuristic (`ordering.rs`) treated any token starting with `h`/`w`, or with a margin/padding axis letter, as a UnoCSS utility. So plain class names like `hello world`, `my prose`, `play previous` were "sorted" and **rewritten** by `--fix`. Tightened `h-`/`w-` and the `m`/`p` axis matchers to require a real value boundary (`h-1`, `mx1`, `mr-1`, `p4` still match; `hello`/`world`/`my`/`prose` no longer do). No existing test changes; added regression tests.
- **`blocklist` diagnostic span** covered the whole class string instead of the offending token — now reports the token's own span (the attributify path already did this).

**Minor**
- `blocklist` rule schema → `additionalProperties: false`; dropped the misleading `fixable: 'code'` from the fixer-less `blocklist` rule.
- Bounds-guarded the attributify contiguity slice so no degenerate span can panic at the NAPI boundary.
- Documented the syntax-only divergence (heuristic sort, options-based blocklist, JS/TS/JSX-only) in `README.md` and the `api.d.ts` `reason` field.

## Known/deferred (not fixed — by design)

The heuristic sort is not the real `presetUno` order, and bare keyword utilities that are also English words (`block`, `grid`, `flex`, `inline`, `hidden`) remain irreducibly ambiguous without the engine. This is the deferred parity limitation, now disclosed in the README.

## Verification

`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test -p oxlint-plugins-unocss` (12 passed), and `prettier --check` on the changed JS/TS/MD are all green locally. Full `pnpm verify` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784006420&installation_id=136613492&pr_number=237&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F237&signature=97019f34bf1de7ff9ee170b422f016251178b6125cec00bc0abe61ee88e8278b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->