### PR TITLE
port(sonarjs): port no-nested-incdec (S881)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 46] = [
+pub const RULE_NAMES: [&str; 47] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -69,6 +69,7 @@ pub const RULE_NAMES: [&str; 46] = [
     "no-inconsistent-returns",
     "no-same-line-conditional",
     "no-nested-assignment",
+    "no-nested-incdec",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -28,6 +28,7 @@ mod no_inverted_boolean_check;
 mod no_labels;
 mod no_nested_assignment;
 mod no_nested_conditional;
+mod no_nested_incdec;
 mod no_nested_switch;
 mod no_nested_template_literals;
 mod no_primitive_wrappers;

--- a/crates/sonarjs/src/rules/no_nested_incdec.rs
+++ b/crates/sonarjs/src/rules/no_nested_incdec.rs
@@ -1,0 +1,51 @@
+//! Rule `no-nested-incdec` (SonarJS key S881).
+//!
+//! Clean-room port. A `++` or `--` operator has a side effect (it mutates its
+//! operand) *and* evaluates to a value, so hiding one inside a larger
+//! expression makes the code hard to read: the reader has to remember both that
+//! the variable changed and what the surrounding expression evaluated to.
+//!
+//! ## Narrow form
+//!
+//! This port reports the unambiguous case named directly by the rule: an
+//! increment or decrement used as an argument of a function or constructor
+//! call, where the mutation is easily missed.
+//!
+//! ```js
+//! foo(i++);            // Noncompliant
+//! arr.push(--count);   // Noncompliant
+//! new Widget(n++);     // Noncompliant
+//! ```
+//!
+//! **Not flagged**:
+//! - `i++;` — a standalone update statement.
+//! - `for (let i = 0; i < n; i++)` — the update clause of a `for` loop.
+//!
+//! Increments mixed with other operators in an arithmetic or index expression
+//! (`a[i++]`, `x = i++ + 1`) are a documented follow-up. Behaviour is
+//! reproduced from the public RSPEC description (S881) only; no upstream source,
+//! tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Argument, CallExpression, NewExpression};
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-nested-incdec";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_nested_incdec_call(&mut self, call: &CallExpression<'_>) {
+        self.check_no_nested_incdec_arguments(&call.arguments);
+    }
+
+    pub(crate) fn check_no_nested_incdec_new(&mut self, new_expr: &NewExpression<'_>) {
+        self.check_no_nested_incdec_arguments(&new_expr.arguments);
+    }
+
+    fn check_no_nested_incdec_arguments(&mut self, arguments: &[Argument<'_>]) {
+        for argument in arguments {
+            if let Argument::UpdateExpression(update) = argument {
+                self.report(RULE_NAME, "nestedIncDec", update.span);
+            }
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -235,6 +235,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
         self.check_no_skipped_tests_call(it);
         self.check_array_constructor_call(it);
+        self.check_no_nested_incdec_call(it);
         walk::walk_call_expression(self, it);
     }
 
@@ -252,6 +253,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
         self.check_no_primitive_wrappers(it);
         self.check_array_constructor_new(it);
+        self.check_no_nested_incdec_new(it);
         walk::walk_new_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2132,3 +2132,40 @@ fn does_not_report_no_nested_assignment_for_compound_assignment_in_condition() {
     let diagnostics = scan("no-nested-assignment", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_nested_incdec_for_increment_call_argument() {
+    let source = "foo(i++);";
+    let diagnostics = scan("no-nested-incdec", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-nested-incdec");
+    assert_eq!(diagnostics[0].message_id, "nestedIncDec");
+}
+
+#[test]
+fn reports_no_nested_incdec_for_decrement_method_argument() {
+    let source = "arr.push(--count);";
+    let diagnostics = scan("no-nested-incdec", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn reports_no_nested_incdec_for_constructor_argument() {
+    let source = "new Widget(n++);";
+    let diagnostics = scan("no-nested-incdec", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_nested_incdec_for_standalone_statement() {
+    let source = "i++;";
+    let diagnostics = scan("no-nested-incdec", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_nested_incdec_for_for_loop_update() {
+    let source = "for (let i = 0; i < n; i++) { use(i); }";
+    let diagnostics = scan("no-nested-incdec", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -178,6 +178,9 @@ const messages = Object.freeze({
   'no-nested-assignment': {
     nestedAssignment: 'Extract this assignment out of the expression into its own statement.',
   },
+  'no-nested-incdec': {
+    nestedIncDec: 'Extract this increment or decrement operator into a separate statement.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -265,6 +268,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow an "if" statement placed on the same line as the closing brace of a preceding sibling "if"',
   'no-nested-assignment':
     'Disallow assignments inside sub-expressions such as loop and branch conditions or chained assignments',
+  'no-nested-incdec':
+    'Disallow increment and decrement operators used as a function or constructor call argument',
 });
 
 const ruleTypes = Object.freeze({
@@ -314,6 +319,7 @@ const ruleTypes = Object.freeze({
   'no-inconsistent-returns': 'suggestion',
   'no-same-line-conditional': 'suggestion',
   'no-nested-assignment': 'suggestion',
+  'no-nested-incdec': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -363,6 +369,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-inconsistent-returns': 'error',
   'no-same-line-conditional': 'error',
   'no-nested-assignment': 'error',
+  'no-nested-incdec': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -49,6 +49,7 @@ const expectedRuleNames = [
   'no-inconsistent-returns',
   'no-same-line-conditional',
   'no-nested-assignment',
+  'no-nested-incdec',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1738,6 +1739,38 @@ describe('sonarjs native API', () => {
   it('does not report no-nested-assignment for an equality comparison in a condition', () => {
     const source = 'if (x === compute()) {\n  use(x);\n}';
     const diagnostics = scan('no-nested-assignment', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-nested-incdec for an increment used as a call argument', () => {
+    const source = 'foo(i++);';
+    const diagnostics = scan('no-nested-incdec', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-nested-incdec');
+    expect(diagnostics[0].messageId).toBe('nestedIncDec');
+  });
+
+  it('reports no-nested-incdec for a decrement used as a method call argument', () => {
+    const source = 'arr.push(--count);';
+    const diagnostics = scan('no-nested-incdec', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('reports no-nested-incdec for an increment used as a constructor argument', () => {
+    const source = 'new Widget(n++);';
+    const diagnostics = scan('no-nested-incdec', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report no-nested-incdec for a standalone increment statement', () => {
+    const source = 'i++;';
+    const diagnostics = scan('no-nested-incdec', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-nested-incdec for the update clause of a for loop', () => {
+    const source = 'for (let i = 0; i < n; i++) {\n  use(i);\n}';
+    const diagnostics = scan('no-nested-incdec', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -140,6 +140,7 @@ describe('sonarjs plugin shape', () => {
       'no-inconsistent-returns',
       'no-same-line-conditional',
       'no-nested-assignment',
+      'no-nested-incdec',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -187,6 +188,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-inconsistent-returns']).toBe('object');
     expect(typeof plugin.rules['no-same-line-conditional']).toBe('object');
     expect(typeof plugin.rules['no-nested-assignment']).toBe('object');
+    expect(typeof plugin.rules['no-nested-incdec']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -236,6 +238,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-inconsistent-returns']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-same-line-conditional']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-assignment']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-nested-incdec']).toBe('error');
   });
 });
 
@@ -1023,5 +1026,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-assignment)');
+  });
+
+  it('reports no-nested-incdec through the adapter', () => {
+    const source = 'foo(i++);';
+    const reports = runRule('no-nested-incdec', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('nestedIncDec');
+  });
+
+  it('reports no-nested-incdec through the CLI', () => {
+    const source = 'foo(i++);';
+    const result = runOxlint('no-nested-incdec', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-incdec)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12670,19 +12670,19 @@
       },
       {
         "name": "no-nested-incdec",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-nested-incdec (Sonar key S881). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room narrow port (Sonar key S881). Flags an UpdateExpression (++/--) used directly as an argument of a CallExpression or NewExpression, matched as Argument::UpdateExpression in check_no_nested_incdec_call/check_no_nested_incdec_new from visit_call_expression/visit_new_expression. Standalone update statements and for-loop update clauses are not flagged. Increments mixed with other operators in arithmetic/index expressions are a documented follow-up. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-nested-switch",


### PR DESCRIPTION
Clean-room narrow port of the SonarJS `no-nested-incdec` rule (Sonar key S881).

Flags a `++`/`--` update expression used directly as an argument of a function or constructor call, where the side effect is easy to overlook:

- **Flagged:** `foo(i++)`, `arr.push(--count)`, `new Widget(n++)`
- **Not flagged:** a standalone `i++;` statement, or the update clause of a `for` loop (`for (…; i++)`).

Implemented by matching `Argument::UpdateExpression` over the arguments of `CallExpression`/`NewExpression` from the existing `visit_call_expression`/`visit_new_expression` hooks.

Increments mixed with other operators in arithmetic or index expressions (`a[i++]`, `x = i++ + 1`) are a documented follow-up. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784006654&installation_id=136613492&pr_number=238&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F238&signature=8eb59dcc59386d89e5221c8a9bdbf901a588bc11b64717748f94ce22aabe23e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->