### PR TITLE
port(sonarjs): port no-useless-increment (S2123)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 47] = [
+pub const RULE_NAMES: [&str; 48] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -70,6 +70,7 @@ pub const RULE_NAMES: [&str; 47] = [
     "no-same-line-conditional",
     "no-nested-assignment",
     "no-nested-incdec",
+    "no-useless-increment",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -42,6 +42,7 @@ mod no_sonar_comments;
 mod no_tab;
 mod no_unthrown_error;
 mod no_useless_catch;
+mod no_useless_increment;
 mod non_existent_operator;
 mod prefer_default_last;
 mod prefer_immediate_return;

--- a/crates/sonarjs/src/rules/no_useless_increment.rs
+++ b/crates/sonarjs/src/rules/no_useless_increment.rs
@@ -1,0 +1,56 @@
+//! Rule `no-useless-increment` (SonarJS key S2123).
+//!
+//! Clean-room port. Assigning a *postfix* increment or decrement of a variable
+//! back to that same variable wastes the operation: `i = i++` evaluates the old
+//! value of `i`, increments `i`, and then writes the old value back — so `i` is
+//! left unchanged and the `++` accomplishes nothing.
+//!
+//! ```js
+//! i = i++;   // Noncompliant: i is unchanged
+//! j = j--;   // Noncompliant
+//! ```
+//!
+//! **Not flagged**:
+//! - `i = ++i` — the *prefix* form returns the incremented value, so the
+//!   assignment does change `i` (though it is still redundant with `++i`).
+//! - `i = j++` — different variables; the assignment is meaningful.
+//! - `i++;` — a standalone update statement.
+//!
+//! Narrow form: only a plain identifier assigned its own postfix update is
+//! reported. The member-expression case (`a.b = a.b++`) requires full operand
+//! equivalence and is a documented follow-up; restricting to identifiers
+//! guarantees no false positives (e.g. `a.b = c.b++` is not flagged).
+//!
+//! Behaviour is reproduced from the public RSPEC description (S2123) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{AssignmentExpression, AssignmentTarget, Expression, SimpleAssignmentTarget};
+use oxc_syntax::operator::AssignmentOperator;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-useless-increment";
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_useless_increment(&mut self, assign: &AssignmentExpression<'_>) {
+        if assign.operator != AssignmentOperator::Assign {
+            return;
+        }
+        let AssignmentTarget::AssignmentTargetIdentifier(left) = &assign.left else {
+            return;
+        };
+        let Expression::UpdateExpression(update) = assign.right.get_inner_expression() else {
+            return;
+        };
+        if update.prefix {
+            return;
+        }
+        let SimpleAssignmentTarget::AssignmentTargetIdentifier(target) = &update.argument else {
+            return;
+        };
+        if left.name == target.name {
+            self.report(RULE_NAME, "uselessIncrement", assign.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -197,6 +197,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_built_in_override_assignment(it);
         self.check_class_prototype(it);
         self.check_no_nested_assignment_chain(it);
+        self.check_no_useless_increment(it);
         walk::walk_assignment_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2169,3 +2169,40 @@ fn does_not_report_no_nested_incdec_for_for_loop_update() {
     let diagnostics = scan("no-nested-incdec", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_useless_increment_for_postfix_self_increment() {
+    let source = "i = i++;";
+    let diagnostics = scan("no-useless-increment", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-useless-increment");
+    assert_eq!(diagnostics[0].message_id, "uselessIncrement");
+}
+
+#[test]
+fn reports_no_useless_increment_for_postfix_self_decrement() {
+    let source = "j = j--;";
+    let diagnostics = scan("no-useless-increment", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_useless_increment_for_prefix_increment() {
+    let source = "i = ++i;";
+    let diagnostics = scan("no-useless-increment", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_useless_increment_for_different_variable() {
+    let source = "i = j++;";
+    let diagnostics = scan("no-useless-increment", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_useless_increment_for_standalone_increment() {
+    let source = "i++;";
+    let diagnostics = scan("no-useless-increment", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -181,6 +181,10 @@ const messages = Object.freeze({
   'no-nested-incdec': {
     nestedIncDec: 'Extract this increment or decrement operator into a separate statement.',
   },
+  'no-useless-increment': {
+    uselessIncrement:
+      'Remove this useless increment or decrement; the updated value is immediately discarded.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -270,6 +274,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow assignments inside sub-expressions such as loop and branch conditions or chained assignments',
   'no-nested-incdec':
     'Disallow increment and decrement operators used as a function or constructor call argument',
+  'no-useless-increment':
+    'Disallow assigning a postfix increment or decrement of a variable back to that same variable',
 });
 
 const ruleTypes = Object.freeze({
@@ -320,6 +326,7 @@ const ruleTypes = Object.freeze({
   'no-same-line-conditional': 'suggestion',
   'no-nested-assignment': 'suggestion',
   'no-nested-incdec': 'suggestion',
+  'no-useless-increment': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -370,6 +377,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-same-line-conditional': 'error',
   'no-nested-assignment': 'error',
   'no-nested-incdec': 'error',
+  'no-useless-increment': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -50,6 +50,7 @@ const expectedRuleNames = [
   'no-same-line-conditional',
   'no-nested-assignment',
   'no-nested-incdec',
+  'no-useless-increment',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1771,6 +1772,38 @@ describe('sonarjs native API', () => {
   it('does not report no-nested-incdec for the update clause of a for loop', () => {
     const source = 'for (let i = 0; i < n; i++) {\n  use(i);\n}';
     const diagnostics = scan('no-nested-incdec', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-useless-increment for a postfix self-increment assignment', () => {
+    const source = 'i = i++;';
+    const diagnostics = scan('no-useless-increment', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-useless-increment');
+    expect(diagnostics[0].messageId).toBe('uselessIncrement');
+  });
+
+  it('reports no-useless-increment for a postfix self-decrement assignment', () => {
+    const source = 'j = j--;';
+    const diagnostics = scan('no-useless-increment', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report no-useless-increment for a prefix increment assignment', () => {
+    const source = 'i = ++i;';
+    const diagnostics = scan('no-useless-increment', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-useless-increment for an increment of a different variable', () => {
+    const source = 'i = j++;';
+    const diagnostics = scan('no-useless-increment', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report no-useless-increment for a standalone increment statement', () => {
+    const source = 'i++;';
+    const diagnostics = scan('no-useless-increment', source);
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -141,6 +141,7 @@ describe('sonarjs plugin shape', () => {
       'no-same-line-conditional',
       'no-nested-assignment',
       'no-nested-incdec',
+      'no-useless-increment',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -189,6 +190,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-same-line-conditional']).toBe('object');
     expect(typeof plugin.rules['no-nested-assignment']).toBe('object');
     expect(typeof plugin.rules['no-nested-incdec']).toBe('object');
+    expect(typeof plugin.rules['no-useless-increment']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -239,6 +241,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-same-line-conditional']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-assignment']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-incdec']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-useless-increment']).toBe('error');
   });
 });
 
@@ -1043,5 +1046,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-nested-incdec)');
+  });
+
+  it('reports no-useless-increment through the adapter', () => {
+    const source = 'i = i++;';
+    const reports = runRule('no-useless-increment', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('uselessIncrement');
+  });
+
+  it('reports no-useless-increment through the CLI', () => {
+    const source = 'i = i++;';
+    const result = runOxlint('no-useless-increment', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-useless-increment)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13262,19 +13262,19 @@
       },
       {
         "name": "no-useless-increment",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-useless-increment (Sonar key S2123). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room narrow port (Sonar key S2123). Flags `X = X++` / `X = X--` where both sides are the same plain identifier and the update is postfix: check_no_useless_increment from visit_assignment_expression matches AssignmentTarget::AssignmentTargetIdentifier on the left and a non-prefix Expression::UpdateExpression whose SimpleAssignmentTarget::AssignmentTargetIdentifier argument has the same name. Prefix form (`i = ++i`), different variables, and member targets (`a.b = a.b++`) are not flagged; the member case requires full operand equivalence and is a documented follow-up. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-useless-intersection",


### PR DESCRIPTION
Clean-room narrow port of the SonarJS `no-useless-increment` rule (Sonar key S2123).

Flags assigning a postfix increment/decrement of a variable back to that same variable, where the update is wasted:

- **Flagged:** `i = i++`, `j = j--` (post-increment yields the old value, so the variable is left unchanged)
- **Not flagged:** `i = ++i` (prefix form changes the variable), `i = j++` (different variables), `i++;` (standalone).

Implemented in `check_no_useless_increment` from the existing `visit_assignment_expression` hook: it matches a plain `AssignmentTargetIdentifier` on the left and a non-prefix `UpdateExpression` whose identifier argument has the same name.

The member-target case (`a.b = a.b++`) requires full operand equivalence and is a documented follow-up; restricting to identifiers guarantees no false positives. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784007401&installation_id=136613492&pr_number=239&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F239&signature=a21cada8c319a58037ba086cd29ed846a6d8f408ade802bcdf05780896a2a546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->