### PR TITLE
port(sonarjs): port class-name (S101)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 48] = [
+pub const RULE_NAMES: [&str; 49] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -71,6 +71,7 @@ pub const RULE_NAMES: [&str; 48] = [
     "no-nested-assignment",
     "no-nested-incdec",
     "no-useless-increment",
+    "class-name",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -3,6 +3,7 @@
 
 mod arguments_usage;
 mod array_constructor;
+mod class_name;
 mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;

--- a/crates/sonarjs/src/rules/class_name.rs
+++ b/crates/sonarjs/src/rules/class_name.rs
@@ -1,0 +1,48 @@
+//! Rule `class-name` (SonarJS key S101).
+//!
+//! Clean-room port. Class names should follow the conventional PascalCase
+//! style, which (among other things) requires the name to begin with an
+//! uppercase letter. A class whose name starts with anything else reads like a
+//! variable or function and obscures that it is a constructor.
+//!
+//! ## Narrow form
+//!
+//! The default SonarJS convention is the regular expression
+//! `^[A-Z][a-zA-Z0-9]*$`. This port enforces the unambiguous, configuration-
+//! independent part of that convention — the name must start with an uppercase
+//! ASCII letter:
+//!
+//! ```js
+//! class myClass {}   // Noncompliant: starts with a lowercase letter
+//! class _Helper {}   // Noncompliant: starts with an underscore
+//! class MyClass {}   // Compliant
+//! ```
+//!
+//! Restricting the check to the first character guarantees no false positives
+//! regardless of the exact configured format. Violations only in the remainder
+//! of the name (for example an embedded underscore, `My_Class`) are a documented
+//! follow-up. Anonymous classes (`export default class {}`) have no name and are
+//! never reported.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S101) only; no
+//! upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::Class;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "class-name";
+
+impl Scanner<'_> {
+    pub(crate) fn check_class_name(&mut self, class: &Class<'_>) {
+        let Some(id) = &class.id else {
+            return;
+        };
+        let name = id.name.as_str();
+        if name.starts_with(|c: char| c.is_ascii_uppercase()) {
+            return;
+        }
+        self.report(RULE_NAME, "className", id.span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -4,7 +4,7 @@
 
 use oxc_ast::ast::{
     ArrowFunctionExpression, AssignmentExpression, BinaryExpression, BindingIdentifier,
-    BlockStatement, CallExpression, CatchClause, ConditionalExpression, DoWhileStatement,
+    BlockStatement, CallExpression, CatchClause, Class, ConditionalExpression, DoWhileStatement,
     ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function, FunctionBody,
     IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, NewExpression, Program,
     RegExpLiteral, ReturnStatement, StaticMemberExpression, SwitchCase, SwitchStatement,
@@ -92,6 +92,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_function_declaration_in_block(it);
         self.check_no_same_line_conditional(&it.body);
         walk::walk_block_statement(self, it);
+    }
+
+    fn visit_class(&mut self, it: &Class<'a>) {
+        self.check_class_name(it);
+        walk::walk_class(self, it);
     }
 
     fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2206,3 +2206,40 @@ fn does_not_report_no_useless_increment_for_standalone_increment() {
     let diagnostics = scan("no-useless-increment", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_class_name_for_lowercase_class() {
+    let source = "class myClass {}";
+    let diagnostics = scan("class-name", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "class-name");
+    assert_eq!(diagnostics[0].message_id, "className");
+}
+
+#[test]
+fn reports_class_name_for_underscore_class() {
+    let source = "class _Helper {}";
+    let diagnostics = scan("class-name", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_class_name_for_pascal_case_class() {
+    let source = "class MyClass {}";
+    let diagnostics = scan("class-name", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_class_name_for_anonymous_class() {
+    let source = "export default class {}";
+    let diagnostics = scan("class-name", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_class_name_for_lowercase_class_expression() {
+    let source = "const C = class widget {};";
+    let diagnostics = scan("class-name", source);
+    assert_eq!(diagnostics.len(), 1);
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -185,6 +185,9 @@ const messages = Object.freeze({
     uselessIncrement:
       'Remove this useless increment or decrement; the updated value is immediately discarded.',
   },
+  'class-name': {
+    className: 'Rename this class to start with an uppercase letter (PascalCase).',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -276,6 +279,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow increment and decrement operators used as a function or constructor call argument',
   'no-useless-increment':
     'Disallow assigning a postfix increment or decrement of a variable back to that same variable',
+  'class-name':
+    'Require class names to start with an uppercase letter, following the PascalCase convention',
 });
 
 const ruleTypes = Object.freeze({
@@ -327,6 +332,7 @@ const ruleTypes = Object.freeze({
   'no-nested-assignment': 'suggestion',
   'no-nested-incdec': 'suggestion',
   'no-useless-increment': 'suggestion',
+  'class-name': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -378,6 +384,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-nested-assignment': 'error',
   'no-nested-incdec': 'error',
   'no-useless-increment': 'error',
+  'class-name': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -51,6 +51,7 @@ const expectedRuleNames = [
   'no-nested-assignment',
   'no-nested-incdec',
   'no-useless-increment',
+  'class-name',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1805,5 +1806,37 @@ describe('sonarjs native API', () => {
     const source = 'i++;';
     const diagnostics = scan('no-useless-increment', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports class-name for a class starting with a lowercase letter', () => {
+    const source = 'class myClass {}';
+    const diagnostics = scan('class-name', source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('class-name');
+    expect(diagnostics[0].messageId).toBe('className');
+  });
+
+  it('reports class-name for a class starting with an underscore', () => {
+    const source = 'class _Helper {}';
+    const diagnostics = scan('class-name', source);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('does not report class-name for a PascalCase class', () => {
+    const source = 'class MyClass {}';
+    const diagnostics = scan('class-name', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report class-name for an anonymous default-exported class', () => {
+    const source = 'export default class {}';
+    const diagnostics = scan('class-name', source);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports class-name for a lowercase named class expression', () => {
+    const source = 'const C = class widget {};';
+    const diagnostics = scan('class-name', source);
+    expect(diagnostics).toHaveLength(1);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -142,6 +142,7 @@ describe('sonarjs plugin shape', () => {
       'no-nested-assignment',
       'no-nested-incdec',
       'no-useless-increment',
+      'class-name',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -191,6 +192,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-nested-assignment']).toBe('object');
     expect(typeof plugin.rules['no-nested-incdec']).toBe('object');
     expect(typeof plugin.rules['no-useless-increment']).toBe('object');
+    expect(typeof plugin.rules['class-name']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -242,6 +244,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-assignment']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-incdec']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-useless-increment']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/class-name']).toBe('error');
   });
 });
 
@@ -1063,5 +1066,22 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-useless-increment)');
+  });
+
+  it('reports class-name through the adapter', () => {
+    const source = 'class myClass {}';
+    const reports = runRule('class-name', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('className');
+  });
+
+  it('reports class-name through the CLI', () => {
+    const source = 'class myClass {}';
+    const result = runOxlint('class-name', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(class-name)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10574,19 +10574,19 @@
       },
       {
         "name": "class-name",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule class-name (Sonar key S101). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room narrow port (Sonar key S101). Flags a named Class whose identifier does not start with an uppercase ASCII letter (check_class_name from a new visit_class hook; `name.starts_with(|c: char| c.is_ascii_uppercase())`). This is the configuration-independent core of the default `^[A-Z][a-zA-Z0-9]*$` convention; restricting to the first character guarantees no false positives regardless of the configured format. Anonymous classes are skipped. Violations only in the remainder of the name (e.g. `My_Class`) are a documented follow-up. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "class-prototype",


### PR DESCRIPTION
Clean-room narrow port of the SonarJS `class-name` rule (Sonar key S101).

Flags a named class whose identifier does not start with an uppercase ASCII letter — the configuration-independent core of the default `^[A-Z][a-zA-Z0-9]*$` PascalCase convention:

- **Flagged:** `class myClass {}`, `class _Helper {}`, `const C = class widget {}`
- **Not flagged:** `class MyClass {}`, an anonymous `export default class {}`.

Implemented in `check_class_name` from a new `visit_class` hook. Restricting the check to the first character guarantees no false positives regardless of the exact configured format; violations only in the remainder of the name (e.g. `My_Class`) are a documented follow-up. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784008430&installation_id=136613492&pr_number=240&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F240&signature=9d80d16d37cf7759e2a45f24de4cdfe298142bf2559ca5ba457fe5885641b7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->