### PR TITLE
test(unocss): sync upstream test suite and replay achievable parity

### DIFF
--- a/docs/guides/testing-strategy.md
+++ b/docs/guides/testing-strategy.md
@@ -32,6 +32,11 @@ upstream as the submodule is bumped (oxc-style test syncing):
   TypeScript type information the syntax-only Rust port does not have, so the
   replay harness skips and counts them (no silent truncation) and asserts full
   parity per rule via a `FULL_PARITY` allowlist that grows one entry per rule PR.
+- `pnpm run port:tests:unocss` — `eslint-vitest-rule-tester` declarative `run()`
+  suites. Cases are grouped by block name (each `run()` call) and tagged with the
+  detected parser (`vue`, `svelte`, `jsx`, `js`). Vue/svelte-parser blocks are
+  always skipped (template languages); js/jsx-parser blocks are asserted and
+  individual divergences are quarantined in `test/parity.json`.
 
 Re-run the relevant sync script after bumping a submodule and commit the
 regenerated fixtures.

--- a/npm/unocss/test/fixtures/blocklist.json
+++ b/npm/unocss/test/fixtures/blocklist.json
@@ -1,0 +1,74 @@
+{
+  "__generated": {
+    "source": "@unocss/eslint-plugin",
+    "ref": "v66.7.0",
+    "sourceFiles": ["src/rules/blocklist.test.ts"],
+    "license": "MIT",
+    "tool": "tools/tasks/sync-unocss-tests.ts"
+  },
+  "blocks": {
+    "blocklist": {
+      "parser": "vue",
+      "valid": [
+        {
+          "code": "<template>\n  <div class=\"m1 mx1 mr-1\"></div>\n</template>",
+          "parser": "vue"
+        }
+      ],
+      "invalid": [
+        {
+          "code": "<template>\n  <div class=\"border\"></div>\n</template>",
+          "parser": "vue",
+          "errors": [
+            {
+              "messageId": "in-blocklist",
+              "data": {
+                "name": "border",
+                "reason": ""
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div class=\"bg-red-500\"></div>\n</template>",
+          "parser": "vue",
+          "errors": [
+            {
+              "messageId": "in-blocklist",
+              "data": {
+                "name": "bg-red-500",
+                "reason": ": Use bg-red-600 instead"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div class=\"text-red\"></div>\n</template>",
+          "parser": "vue",
+          "errors": [
+            {
+              "messageId": "in-blocklist",
+              "data": {
+                "name": "text-red",
+                "reason": ": Use color-* instead"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div class=\"h-auto\"></div>\n</template>",
+          "parser": "vue",
+          "errors": [
+            {
+              "messageId": "in-blocklist",
+              "data": {
+                "name": "h-auto",
+                "reason": ": Use h-a instead"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/npm/unocss/test/fixtures/enforce-class-compile.json
+++ b/npm/unocss/test/fixtures/enforce-class-compile.json
@@ -1,0 +1,220 @@
+{
+  "__generated": {
+    "source": "@unocss/eslint-plugin",
+    "ref": "v66.7.0",
+    "sourceFiles": ["src/rules/enforce-class-compile.test.ts"],
+    "license": "MIT",
+    "tool": "tools/tasks/sync-unocss-tests.ts"
+  },
+  "blocks": {
+    "enforce-class-compile": {
+      "parser": "vue",
+      "valid": [
+        {
+          "code": "<template>\n  <div class=\":uno: mr-1\"></div>\n</template>",
+          "parser": "vue"
+        },
+        {
+          "code": "<template>\n  <div :class=\"':uno: mr-1'\"></div>\n</template>",
+          "parser": "vue"
+        },
+        {
+          "code": "<template>\n  <div :class=\"condition ? ':uno: mr-1' : ':uno: ml-1'\"></div>\n</template>",
+          "parser": "vue"
+        },
+        {
+          "code": "<template>\n  <div :class=\"{':uno: mr-1': condition}\"></div>\n</template>",
+          "parser": "vue"
+        },
+        {
+          "code": "<template>\n  <div :class=\"`:uno: mr-1`\"></div>\n</template>",
+          "parser": "vue"
+        },
+        {
+          "code": "<template>\n  <div class=\":some: mr-1\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "prefix": ":some:"
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"':some: mr-1'\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "prefix": ":some:"
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"condition ? ':some: mr-1' : ':some: ml-1'\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "prefix": ":some:"
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"{':some: mr-1': condition}\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "prefix": ":some:"
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"`:some: mr-1`\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "prefix": ":some:"
+            }
+          ]
+        }
+      ],
+      "invalid": [
+        {
+          "code": "<template>\n  <div class=\"mr-1\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div class=\":uno: mr-1\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "line": 2,
+              "column": 14,
+              "endLine": 2,
+              "endColumn": 20,
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"'mr-1'\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div :class=\"':uno: mr-1'\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"condition ? 'mr-1' : 'ml-1'\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div :class=\"condition ? ':uno: mr-1' : ':uno: ml-1'\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            },
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"{'mr-1': condition}\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div :class=\"{':uno: mr-1': condition}\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"{flex}\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div :class=\"{':uno: flex': flex}\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"{flex: condition}\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div :class=\"{':uno: flex': condition}\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"`mr-1`\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n  <div :class=\"`:uno: mr-1`\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div :class=\"`mr-1`\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "prefix": ":some:"
+            }
+          ],
+          "output": "<template>\n  <div :class=\"`:some: mr-1`\"></div>\n</template>",
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":some:"
+              }
+            }
+          ]
+        },
+        {
+          "code": "<template>\n  <div class=\"mr-1\"></div>\n</template>",
+          "parser": "vue",
+          "options": [
+            {
+              "enableFix": false
+            }
+          ],
+          "output": null,
+          "errors": [
+            {
+              "messageId": "missing",
+              "data": {
+                "prefix": ":uno:"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/npm/unocss/test/fixtures/order-attributify.json
+++ b/npm/unocss/test/fixtures/order-attributify.json
@@ -1,0 +1,11 @@
+{
+  "__generated": {
+    "source": "@unocss/eslint-plugin",
+    "ref": "v66.7.0",
+    "sourceFiles": [],
+    "license": "MIT",
+    "tool": "tools/tasks/sync-unocss-tests.ts",
+    "noUpstreamTests": true
+  },
+  "blocks": {}
+}

--- a/npm/unocss/test/fixtures/order.json
+++ b/npm/unocss/test/fixtures/order.json
@@ -1,0 +1,596 @@
+{
+  "__generated": {
+    "source": "@unocss/eslint-plugin",
+    "ref": "v66.7.0",
+    "sourceFiles": ["src/rules/order.test.ts"],
+    "license": "MIT",
+    "tool": "tools/tasks/sync-unocss-tests.ts"
+  },
+  "blocks": {
+    "order": {
+      "parser": "vue",
+      "valid": [
+        {
+          "code": "<template>\n  <div class=\"m1 mx1 mr-1\"></div>\n</template>",
+          "parser": "vue"
+        },
+        {
+          "code": "<template>\n  <div class=\"m-class f-class\"></div>\n</template>",
+          "parser": "vue"
+        }
+      ],
+      "invalid": [
+        {
+          "code": "<template>\n  <div class=\"mx1 m1 mr-1\"></div>\n</template>",
+          "parser": "vue",
+          "output": "<template>\n          <div class=\"m1 mx1 mr-1\"></div>\n        </template>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        }
+      ]
+    },
+    "order-jsx": {
+      "parser": "jsx",
+      "valid": [
+        {
+          "code": "<div className=\"m1 mx1 mr-1\"></div>",
+          "parser": "jsx"
+        },
+        {
+          "code": "<div className=\"m-class f-class\"></div>",
+          "parser": "jsx"
+        },
+        {
+          "code": "<div className={\"m1 mx1 mr-1\"}></div>",
+          "parser": "jsx"
+        },
+        {
+          "code": "<div className={`m1 mx1 mr-1`}></div>",
+          "parser": "jsx"
+        },
+        {
+          "code": "<div className={`m1 mx1 mr-1 ${more}`}></div>",
+          "parser": "jsx"
+        }
+      ],
+      "invalid": [
+        {
+          "code": "<div className=\"mx1 m1 mr-1\"></div>",
+          "parser": "jsx",
+          "output": "<div className=\"m1 mx1 mr-1\"></div>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "<div className={\"mx1 m1 mr-1\"}></div>",
+          "parser": "jsx",
+          "output": "<div className={\"m1 mx1 mr-1\"}></div>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "<div className={`mx1 m1 mr-1`}></div>",
+          "parser": "jsx",
+          "output": "<div className={`m1 mx1 mr-1`}></div>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "<div className={`mx1 m1 mr-1 ${more}`}></div>",
+          "parser": "jsx",
+          "output": "<div className={`m1 mx1 mr-1 ${more}`}></div>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        }
+      ]
+    },
+    "order-svelte": {
+      "parser": "svelte",
+      "valid": [
+        {
+          "code": "<div class=\"ml-1 mr-1\"></div>",
+          "parser": "svelte"
+        },
+        {
+          "code": "<div class=\"pl1 pr1 {test ? 'ml-1 mr-1' : 'left-1 right-1'}\"></div>",
+          "parser": "svelte"
+        }
+      ],
+      "invalid": [
+        {
+          "code": "<div class=\"mr-1 ml-1\"></div>",
+          "parser": "svelte",
+          "output": "<div class=\"ml-1 mr-1\"></div>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "<div class=\"pr1 pl1{test ? 'mr-1 ml-1' : 'right-1 left-1'}top-1 bottom-1\"></div>",
+          "parser": "svelte",
+          "output": "<div class=\"pl1 pr1 {test ? 'ml-1 mr-1' : 'left-1 right-1'} bottom-1 top-1\"></div>",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        }
+      ]
+    },
+    "order-unoFunctions": {
+      "parser": "js",
+      "valid": [
+        {
+          "code": "clsx('ml-1 mr-1')",
+          "parser": "js"
+        },
+        {
+          "code": "clsx('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', 'bottom-1 top-1')",
+          "parser": "js"
+        },
+        {
+          "code": "clsx('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', test && 'bottom-1 top-1', { 'bottom-1 top-1': test })",
+          "parser": "js"
+        },
+        {
+          "code": "clsx(`pl1 pr1`, test ? `ml-1 mr-1` : `left-1 right-1`, test && `bottom-1 top-1`, { [`bottom-1 top-1`]: test })",
+          "parser": "js"
+        },
+        {
+          "code": "clsx(String.raw`pl1 pr1`, test ? String.raw`ml-1 mr-1` : String.raw`left-1 right-1`, test && String.raw`bottom-1 top-1`, { [String.raw`bottom-1 top-1`]: test })",
+          "parser": "js"
+        },
+        {
+          "code": "clsx(String.raw`bg-[var(--some_variable_with_underscore)] pl1 pr1`)",
+          "parser": "js"
+        },
+        {
+          "code": "superclass('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', 'bottom-1 top-1')",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["superclass"]
+            }
+          ]
+        },
+        {
+          "code": "abc('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', test && 'bottom-1 top-1', { 'bottom-1 top-1': test })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["abc"]
+            }
+          ]
+        },
+        {
+          "code": "cva({ variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["cva"]
+            }
+          ]
+        },
+        {
+          "code": "cva('bottom-1 top-1', { variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["cva"]
+            }
+          ]
+        },
+        {
+          "code": "tv({ base: 'bottom-1 top-1', variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["tv"]
+            }
+          ]
+        },
+        {
+          "code": "clsx(`pl1 pr1 ${more}`, test ? `ml-1 mr-1 ${more}` : `left-1 right-1 ${more}`, test && `bottom-1 top-1 ${more}`, { [`bottom-1 top-1 ${more}`]: test })",
+          "parser": "js"
+        },
+        {
+          "code": "clsx(['ml-1 mr-1'])",
+          "parser": "js"
+        },
+        {
+          "code": "clsx(['flex flex-col'], ['bottom-1 top-1'])",
+          "parser": "js"
+        },
+        {
+          "code": "notSorted('mr-1 ml-1')",
+          "parser": "js"
+        }
+      ],
+      "invalid": [
+        {
+          "code": "clsx('mr-1 ml-1')",
+          "parser": "js",
+          "output": "clsx('ml-1 mr-1')",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx('pr1 pl1', test ? 'mr-1 ml-1' : 'right-1 left-1', test && 'top-1 bottom-1', { 'top-1 bottom-1': test })",
+          "parser": "js",
+          "output": "clsx('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', test && 'bottom-1 top-1', { 'bottom-1 top-1': test })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(`pr1 pl1`, test ? `mr-1 ml-1` : `right-1 left-1`, test && `top-1 bottom-1`, { [`top-1 bottom-1`]: test })",
+          "parser": "js",
+          "output": "clsx(`pl1 pr1`, test ? `ml-1 mr-1` : `left-1 right-1`, test && `bottom-1 top-1`, { [`bottom-1 top-1`]: test })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(String.raw`pr1 pl1`, test ? String.raw`mr-1 ml-1` : String.raw`right-1 left-1`, test && String.raw`top-1 bottom-1`, { [String.raw`top-1 bottom-1`]: test })",
+          "parser": "js",
+          "output": "clsx(String.raw`pl1 pr1`, test ? String.raw`ml-1 mr-1` : String.raw`left-1 right-1`, test && String.raw`bottom-1 top-1`, { [String.raw`bottom-1 top-1`]: test })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "superclass('pr1 pl1', test ? 'mr-1 ml-1' : 'right-1 left-1', test && 'top-1 bottom-1', { 'top-1 bottom-1': test })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["superclass"]
+            }
+          ],
+          "output": "superclass('pl1 pr1', test ? 'ml-1 mr-1' : 'left-1 right-1', test && 'bottom-1 top-1', { 'bottom-1 top-1': test })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "cva({ variants: { size: { small: 'px-2 text-sm py-1', medium: 'px-4 text-base py-2' } } })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["cva"]
+            }
+          ],
+          "output": "cva({ variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "cva('top-1 bottom-1', { variants: { size: { small: 'px-2 text-sm py-1', medium: 'px-4 text-base py-2' } } })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["cva"]
+            }
+          ],
+          "output": "cva('bottom-1 top-1', { variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "tv({ base: 'top-1 bottom-1', variants: { size: { small: 'px-2 text-sm py-1', medium: 'px-4 text-base py-2' } } })",
+          "parser": "js",
+          "options": [
+            {
+              "unoFunctions": ["tv"]
+            }
+          ],
+          "output": "tv({ base: 'bottom-1 top-1', variants: { size: { small: 'text-sm px-2 py-1', medium: 'text-base px-4 py-2' } } })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(`pr1 pl1 ${more}`, test ? `mr-1 ml-1 ${more}` : `right-1 left-1 ${more}`, test && `top-1 bottom-1 ${more}`, { [`top-1 bottom-1 ${more}`]: test })",
+          "parser": "js",
+          "output": "clsx(`pl1 pr1 ${more}`, test ? `ml-1 mr-1 ${more}` : `left-1 right-1 ${more}`, test && `bottom-1 top-1 ${more}`, { [`bottom-1 top-1 ${more}`]: test })",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(`pr1 pl1 ${more} none-uno-class mr-1 ml-1 ${more} none-uno-class2`)",
+          "parser": "js",
+          "output": "clsx(`pl1 pr1 ${more} none-uno-class ml-1 mr-1 ${more} none-uno-class2`)",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(['mr-1 ml-1'])",
+          "parser": "js",
+          "output": "clsx(['ml-1 mr-1'])",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(['mr-1 ml-1'], ['top-1 bottom-1'])",
+          "parser": "js",
+          "output": "clsx(['ml-1 mr-1'], ['bottom-1 top-1'])",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "clsx(['flex-col flex'], className)",
+          "parser": "js",
+          "output": "clsx(['flex flex-col'], className)",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        }
+      ]
+    },
+    "order-unoVariables": {
+      "parser": "js",
+      "valid": [
+        {
+          "code": "const clsButton = 'ml-1 mr-1'",
+          "parser": "js"
+        },
+        {
+          "code": "const clsButton = `ml-1 mr-1 ${more}`",
+          "parser": "js"
+        },
+        {
+          "code": "const notSorted = 'mr-1 ml-1'",
+          "parser": "js"
+        },
+        {
+          "code": "const buttonClassNames = { default: 'pl1 pr1', variants: { light: 'ml-1 mr-1', dark: 'left-1 right-1' } }",
+          "parser": "js"
+        },
+        {
+          "code": "const CLS_BUTTON = 'ml-1 mr-1'",
+          "parser": "js",
+          "options": [
+            {
+              "unoVariables": ["^CLS_"]
+            }
+          ]
+        },
+        {
+          "code": "const CLS_BUTTON = { default: 'pl1 pr1', variants: { light: 'ml-1 mr-1', dark: 'left-1 right-1' } }",
+          "parser": "js",
+          "options": [
+            {
+              "unoVariables": ["^CLS_"]
+            }
+          ]
+        }
+      ],
+      "invalid": [
+        {
+          "code": "const clsButton = 'mr-1 ml-1'",
+          "parser": "js",
+          "output": "const clsButton = 'ml-1 mr-1'",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "const clsButton = `mr-1 ml-1 ${more}`",
+          "parser": "js",
+          "output": "const clsButton = `ml-1 mr-1 ${more}`",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "const clsButton = `pr1 pl1 ${more} none-uno-class mr-1 ml-1 ${more} none-uno-class2`",
+          "parser": "js",
+          "output": "const clsButton = `pl1 pr1 ${more} none-uno-class ml-1 mr-1 ${more} none-uno-class2`",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "const buttonClassNames = { default: 'pr1 pl1', variants: { light: 'mr-1 ml-1', dark: 'right-1 left-1' } }",
+          "parser": "js",
+          "output": "const buttonClassNames = { default: 'pl1 pr1', variants: { light: 'ml-1 mr-1', dark: 'left-1 right-1' } }",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "const CLS_BUTTON = 'mr-1 ml-1'",
+          "parser": "js",
+          "options": [
+            {
+              "unoVariables": ["^CLS_"]
+            }
+          ],
+          "output": "const CLS_BUTTON = 'ml-1 mr-1'",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        },
+        {
+          "code": "const CLS_BUTTON = { default: 'pr1 pl1', variants: { light: 'mr-1 ml-1', dark: 'right-1 left-1' } }",
+          "parser": "js",
+          "options": [
+            {
+              "unoVariables": ["^CLS_"]
+            }
+          ],
+          "output": "const CLS_BUTTON = { default: 'pl1 pr1', variants: { light: 'ml-1 mr-1', dark: 'left-1 right-1' } }",
+          "errors": [
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            },
+            {
+              "messageId": "invalid-order"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/npm/unocss/test/parity.json
+++ b/npm/unocss/test/parity.json
@@ -1,0 +1,47 @@
+{
+  "$comment": "Upstream parity ratchet for the @unocss/eslint-plugin port. Fixtures under test/fixtures/*.json are captured verbatim from upstream by `pnpm run port:tests:unocss`; upstream.test.mjs replays them. Vue- and Svelte-parser blocks are quarantined structurally by the harness (oxc parses JS/TS/JSX only). This file additionally quarantines individual js/jsx cases the syntax-only port cannot reproduce without the live UnoCSS engine. Each quarantine is a tracked ratchet item: a future PR that closes the gap removes the entry. quarantine[blockName][valid|invalid] is an array of { index, reason }.",
+  "quarantine": {
+    "order-unoFunctions": {
+      "valid": [
+        {
+          "index": 5,
+          "reason": "`bg-[var(--x)] pl1 pr1`: the heuristic ranks `bg-` after spacing utilities and would reorder, but presetUno treats this order as already valid. Engine-dependent."
+        }
+      ],
+      "invalid": [
+        {
+          "index": 1,
+          "reason": "object-property key class string (`{ 'top-1 bottom-1': test }`) — upstream sorts object keys; the port collects property values only."
+        },
+        {
+          "index": 2,
+          "reason": "computed object key (`{ [`top-1 bottom-1`]: test }`) — not collected by the port."
+        },
+        {
+          "index": 3,
+          "reason": "computed `String.raw` object key — not collected by the port."
+        },
+        {
+          "index": 4,
+          "reason": "object-property key class string — not collected by the port."
+        },
+        {
+          "index": 8,
+          "reason": "computed object key with interpolation — not collected by the port."
+        },
+        {
+          "index": 9,
+          "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens; the heuristic only sorts when every token is recognized, while the engine sorts the recognized subset in place."
+        }
+      ]
+    },
+    "order-unoVariables": {
+      "invalid": [
+        {
+          "index": 2,
+          "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens; the heuristic only sorts when every token is recognized."
+        }
+      ]
+    }
+  }
+}

--- a/npm/unocss/test/upstream.test.mjs
+++ b/npm/unocss/test/upstream.test.mjs
@@ -1,0 +1,184 @@
+// Replays the upstream @unocss/eslint-plugin test suite (captured verbatim into
+// test/fixtures/*.json by `pnpm run port:tests:unocss`) against this plugin's
+// native scanner, so behaviour stays faithful to upstream as the submodule is
+// bumped. This is the guarantee that the port reproduces @unocss/eslint-plugin's
+// own tests.
+//
+// Fixture structure: each JSON file has a top-level `blocks` object whose keys
+// are the `name` passed to the upstream `run()` call (e.g. 'order', 'order-jsx',
+// 'order-unoFunctions'). Each block carries:
+//   `parser`  — 'vue' | 'svelte' | 'jsx' | 'js'
+//   `valid`   — array of cases: { code, options?, filename?, parser }
+//   `invalid` — array of cases: { code, options?, filename?, output?, errors?, parser }
+//
+// Parser policy:
+//   vue / svelte → always quarantined (Oxlint / the Rust port operates on
+//     JS/TS only; Vue and Svelte template scanning is not yet wired through
+//     the same NAPI interface).
+//   jsx / js → asserted, unless listed in parity.json.
+//
+// For every asserted case:
+//   valid   → the port must report zero diagnostics (soundness).
+//   invalid → the multiset of reported messageIds must equal the upstream
+//             `errors[].messageId`; where `output` is a non-null string,
+//             applying the port's fixes must reproduce it exactly.
+//
+// Known divergences are quarantined per-case in test/parity.json (with a
+// reason); each is a tracked bug whose fix PR removes the entry.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(TEST_DIR, 'fixtures');
+const parity = JSON.parse(readFileSync(join(TEST_DIR, 'parity.json'), 'utf8'));
+
+// Rule name derived from the block name (strip leading 'order-*' qualifier
+// suffixes that are not part of the rule name, e.g. 'order-jsx' → 'order').
+function ruleNameForBlock(blockName) {
+  if (blockName === 'order' || blockName.startsWith('order-')) {
+    return 'order';
+  }
+  return blockName;
+}
+
+function runRule(ruleName, testCase) {
+  const sourceText = testCase.code;
+  const filename = testCase.filename ?? (testCase.parser === 'jsx' ? 'fixture.jsx' : 'fixture.js');
+  const options = testCase.options ?? [];
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return sourceText;
+    },
+  };
+  const rule = plugin.rules[ruleName];
+  const visitor = rule.createOnce({
+    filename,
+    options,
+    settings: {},
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.before?.();
+  visitor.Program?.({ type: 'Program', range: [0, sourceText.length] });
+  visitor.after?.();
+  return reports;
+}
+
+function applyFixes(code, reports) {
+  const fixes = [];
+  for (const report of reports) {
+    if (typeof report.fix === 'function') {
+      report.fix({
+        replaceTextRange(range, replacement) {
+          fixes.push({ start: range[0], end: range[1], replacement });
+        },
+      });
+    }
+  }
+  fixes.sort((a, b) => b.start - a.start);
+  return fixes.reduce(
+    (text, fix) => text.slice(0, fix.start) + fix.replacement + text.slice(fix.end),
+    code,
+  );
+}
+
+function label(testCase, index) {
+  const code = JSON.stringify(testCase.code);
+  const truncated = code.length > 70 ? `${code.slice(0, 70)}…"` : code;
+  const options =
+    testCase.options && testCase.options.length > 0
+      ? ` options=${JSON.stringify(testCase.options)}`
+      : '';
+  return `#${index} ${truncated}${options}`;
+}
+
+// Returns a Set of indices to skip from parity.json for a given block and kind.
+function skipSet(blockName, kind) {
+  const entry = parity.quarantine[blockName];
+  if (!entry || !Array.isArray(entry[kind])) {
+    return new Set();
+  }
+  return new Set(entry[kind].map((q) => q.index));
+}
+
+const fixtureFiles = readdirSync(FIXTURES_DIR)
+  .filter((name) => name.endsWith('.json'))
+  .sort();
+
+describe('@unocss/eslint-plugin upstream parity', () => {
+  for (const file of fixtureFiles) {
+    const ruleName = file.replace(/\.json$/, '');
+    const fixture = JSON.parse(readFileSync(join(FIXTURES_DIR, file), 'utf8'));
+
+    describe(ruleName, () => {
+      it('carries upstream provenance', () => {
+        expect(fixture.__generated.source).toBe('@unocss/eslint-plugin');
+        expect(fixture.__generated.ref).toBeTruthy();
+      });
+
+      if (fixture.__generated.noUpstreamTests) {
+        return;
+      }
+
+      for (const [blockName, block] of Object.entries(fixture.blocks)) {
+        const blockRuleName = ruleNameForBlock(blockName);
+        const parser = block.parser;
+        // Vue and Svelte cases are always quarantined — the Rust port does not
+        // process template-based languages through the same NAPI interface.
+        const parserQuarantined = parser === 'vue' || parser === 'svelte';
+
+        const skipValid = skipSet(blockName, 'valid');
+        const skipInvalid = skipSet(blockName, 'invalid');
+
+        describe(blockName, () => {
+          if (block.valid.length > 0) {
+            describe('valid', () => {
+              block.valid.forEach((testCase, index) => {
+                const quarantined = parserQuarantined || skipValid.has(index);
+                const run = quarantined ? it.skip : it;
+                run(label(testCase, index), () => {
+                  const reports = runRule(blockRuleName, testCase);
+                  expect(reports).toEqual([]);
+                });
+              });
+            });
+          }
+
+          if (block.invalid.length > 0) {
+            describe('invalid', () => {
+              block.invalid.forEach((testCase, index) => {
+                const quarantined = parserQuarantined || skipInvalid.has(index);
+                const run = quarantined ? it.skip : it;
+                run(label(testCase, index), () => {
+                  const reports = runRule(blockRuleName, testCase);
+
+                  const expectedErrors = testCase.errors ?? [];
+                  const actualIds = reports.map((r) => r.messageId).sort();
+                  const expectedIds = expectedErrors.map((e) => e.messageId).sort();
+                  expect(actualIds).toEqual(expectedIds);
+
+                  if (typeof testCase.output === 'string') {
+                    expect(applyFixes(testCase.code, reports)).toBe(testCase.output);
+                  } else if (testCase.output === null) {
+                    // Upstream asserts no fix; we assert no fix was applied.
+                    expect(applyFixes(testCase.code, reports)).toBe(testCase.code);
+                  }
+                });
+              });
+            });
+          }
+        });
+      }
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",
     "port:tests:simple-import-sort": "node tools/tasks/sync-simple-import-sort-tests.ts",
     "port:tests:storybook": "node tools/tasks/sync-storybook-tests.ts",
+    "port:tests:unocss": "node tools/tasks/sync-unocss-tests.ts",
     "profile": "node tools/tasks/profile.ts",
     "release": "node tools/tasks/release.ts",
     "security:audit": "node tools/tasks/security-audit.ts",

--- a/tools/tasks/sync-unocss-tests.ts
+++ b/tools/tasks/sync-unocss-tests.ts
@@ -1,0 +1,503 @@
+// Captures the upstream @unocss/eslint-plugin test suite straight from the
+// vendored submodule and writes it to committed JSON fixtures, so our Vitest
+// suite replays the real upstream cases and tracks behaviour as the submodule
+// is bumped (oxc-style test syncing).
+//
+// Upstream drives cases through a *declarative* `run()` API from
+// `eslint-vitest-rule-tester`. Each test file calls `run({ name, rule,
+// languageOptions?, settings?, valid, invalid })` once or more at module top
+// level. We register synchronous module hooks (`module.registerHooks`) that:
+//
+//   - stub `eslint-vitest-rule-tester` → a capturing `run()` that records each
+//     block keyed by `name`, plus a faithful `$` / `html` unindent tag and a
+//     no-op `RuleTester` class.
+//   - stub `vue-eslint-parser`          → marker object (default export).
+//   - stub `svelte-eslint-parser`       → marker object (default export).
+//   - stub `vitest`                     → `{ expect }` that captures inline
+//     snapshots passed to `toMatchInlineSnapshot`.
+//   - stub rule modules (`./order`, etc.)      → `{ default: {} }`.
+//   - stub `@typescript-eslint/types`   → `{ AST_TOKEN_TYPES: {} }`.
+//   - pass through `node:url`           → real module.
+//
+// Parser detection per block:
+//   `languageOptions.parser === vueMarker`                → 'vue'
+//   `languageOptions.parser === svelteMarker` or `.default` → 'svelte'
+//   `languageOptions.parserOptions?.ecmaFeatures?.jsx`    → 'jsx'
+//   otherwise                                             → 'js'
+//
+// Snapshot capture: `toMatchInlineSnapshot` is called inside the `output`
+// function of invalid cases. The vitest stub writes the snapshot argument to
+// `globalThis[SYNC_KEY].lastSnapshot` before returning; the normalise pass
+// reads it immediately after calling the output function.
+//
+// Snapshot parsing: after trim, if the value starts and ends with `"` we
+// strip those outer quotes and unescape `\"` → `"` inside to recover the
+// actual fixed output string (vitest serialises strings that way).
+//
+// enforce-class-compile uses the `$` tag for BOTH `code` and `output`
+// fields of invalid cases — `output` is a plain string there, not a function.
+//
+// Re-run with `pnpm run port:tests:unocss`, then `vp fmt` the generated
+// fixtures (the JSON is emitted with `JSON.stringify`, which always expands
+// short arrays the formatter collapses onto one line).
+
+import { registerHooks } from 'node:module';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    packageSubdir?: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type Parser = 'vue' | 'svelte' | 'jsx' | 'js';
+
+type RawCase = {
+  code: string;
+  options?: unknown[];
+  filename?: string;
+  output?: string | null | ((o: unknown) => unknown);
+  errors?: unknown[];
+  parser: Parser;
+};
+
+type NormCase = {
+  code: string;
+  options?: unknown[];
+  filename?: string;
+  output?: string | null;
+  errors?: unknown[];
+  parser: Parser;
+};
+
+type Capture = { valid: RawCase[]; invalid: RawCase[] };
+
+type BlockCapture = {
+  parser: Parser;
+  valid: NormCase[];
+  invalid: NormCase[];
+};
+
+type FixtureBlocks = Record<string, BlockCapture>;
+
+type SyncGlobal = {
+  captures: Record<string, Capture>;
+  vueMarker: object;
+  svelteMarker: object;
+  lastSnapshot: string | undefined;
+};
+
+const ROOT = process.cwd();
+const SYNC_KEY = '__unocssSyncState__';
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'unocss-eslint-plugin');
+if (!plugin) {
+  throw new Error('unocss-eslint-plugin is not registered in tools/port-targets.json');
+}
+
+const PKG = join(ROOT, plugin.submodule, plugin.packageSubdir ?? '.');
+const SRC_RULES_DIR = join(PKG, 'src', 'rules');
+const FIXTURES_DIR = join(ROOT, 'npm', 'unocss', 'test', 'fixtures');
+const REF = plugin.pinnedRef ?? `v${plugin.baselineVersion}`;
+
+if (!existsSync(SRC_RULES_DIR)) {
+  throw new Error(
+    `Upstream sources not found under ${PKG}. Run: git submodule update --init ${plugin.submodule}`,
+  );
+}
+
+mkdirSync(FIXTURES_DIR, { recursive: true });
+
+// Shared markers for parser detection — the stubs export these same objects.
+const vueMarker: object = { __parser: 'vue' };
+const svelteMarker: object = { __parser: 'svelte' };
+
+const state: SyncGlobal = {
+  captures: {},
+  vueMarker,
+  svelteMarker,
+  lastSnapshot: undefined,
+};
+(globalThis as Record<string, unknown>)[SYNC_KEY] = state;
+
+registerStubHooks();
+
+// Rule files that have a corresponding .test.ts in src/rules/.
+const TEST_RULES: Array<{ rule: string; testFile: string }> = [
+  { rule: 'order', testFile: 'order.test.ts' },
+  { rule: 'blocklist', testFile: 'blocklist.test.ts' },
+  { rule: 'enforce-class-compile', testFile: 'enforce-class-compile.test.ts' },
+];
+
+// order-attributify has no test file in the upstream submodule.
+const NO_TEST_RULES: string[] = ['order-attributify'];
+
+const summary: string[] = [];
+
+for (const { rule, testFile } of TEST_RULES) {
+  const testFilePath = join(SRC_RULES_DIR, testFile);
+  if (!existsSync(testFilePath)) {
+    writeFixture(rule, [], {}, true);
+    summary.push(`${rule}: no upstream test file (empty fixture written)`);
+    continue;
+  }
+
+  // Reset captures for this file import.
+  state.captures = {};
+
+  await import(pathToFileURL(testFilePath).href);
+
+  const blocks: Record<string, Capture> = { ...state.captures };
+  const { cases, dropped } = normalizeBlocks(blocks);
+  writeFixture(rule, Object.keys(blocks), cases, false);
+
+  let total = 0;
+  for (const blk of Object.values(cases.blocks)) {
+    total += blk.valid.length + blk.invalid.length;
+  }
+  summary.push(
+    `${rule}: ${total} cases across ${Object.keys(blocks).length} block(s)` +
+      `${dropped > 0 ? `, ${dropped} dropped` : ''}`,
+  );
+}
+
+for (const rule of NO_TEST_RULES) {
+  writeFixture(rule, [], {}, true);
+  summary.push(`${rule}: no upstream test file (empty fixture written)`);
+}
+
+console.log(`Synced @unocss/eslint-plugin fixtures from upstream ${REF}:`);
+for (const line of summary) {
+  console.log(`- ${line}`);
+}
+
+// --- helpers ----------------------------------------------------------------
+
+function normalizeBlocks(blocks: Record<string, Capture>): {
+  cases: { blocks: FixtureBlocks };
+  dropped: number;
+} {
+  let dropped = 0;
+  const result: FixtureBlocks = {};
+
+  for (const [name, capture] of Object.entries(blocks)) {
+    const valid: NormCase[] = [];
+    const invalid: NormCase[] = [];
+
+    // Determine the parser from the first case in the block (all cases in a
+    // single run() call share the same languageOptions).
+    const allCases = [...capture.valid, ...capture.invalid];
+    const parser: Parser = allCases.length > 0 ? allCases[0].parser : 'js';
+
+    for (const raw of capture.valid) {
+      const norm = normalizeCase(raw, false);
+      if (norm) {
+        valid.push(norm);
+      } else {
+        dropped++;
+      }
+    }
+    for (const raw of capture.invalid) {
+      const norm = normalizeCase(raw, true);
+      if (norm) {
+        invalid.push(norm);
+      } else {
+        dropped++;
+      }
+    }
+
+    result[name] = { parser, valid, invalid };
+  }
+
+  return { cases: { blocks: result }, dropped };
+}
+
+function normalizeCase(raw: RawCase, isInvalid: boolean): NormCase | null {
+  if (!raw || typeof raw.code !== 'string') {
+    return null;
+  }
+
+  const out: NormCase = { code: raw.code, parser: raw.parser };
+
+  if (Array.isArray(raw.options) && raw.options.length > 0) {
+    const opts = safeClone(raw.options);
+    if (opts === undefined) {
+      return null;
+    }
+    out.options = opts as unknown[];
+  }
+
+  if (typeof raw.filename === 'string') {
+    out.filename = raw.filename;
+  }
+
+  if (isInvalid) {
+    // `output` can be:
+    //   - a string  → direct output (enforce-class-compile uses `$` tagged strings)
+    //   - null      → explicitly no output
+    //   - a function → calls expect(output).toMatchInlineSnapshot(snap);
+    //     the vitest stub captures the `snap` argument into state.lastSnapshot.
+    if (typeof raw.output === 'function') {
+      state.lastSnapshot = undefined;
+      // Call with a dummy value; the function body is:
+      //   output => expect(output).toMatchInlineSnapshot(`"..."`)
+      // Our vitest stub's expect().toMatchInlineSnapshot captures the snap argument.
+      raw.output('__sentinel__');
+      const snap = state.lastSnapshot;
+      state.lastSnapshot = undefined;
+      if (typeof snap === 'string') {
+        out.output = parseSnapshot(snap);
+      }
+      // If no snapshot was captured, leave output undefined.
+    } else if (typeof raw.output === 'string') {
+      out.output = raw.output;
+    } else if (raw.output === null) {
+      out.output = null;
+    }
+
+    if (Array.isArray(raw.errors)) {
+      const errors = normalizeErrors(raw.errors);
+      if (errors.length > 0) {
+        out.errors = errors;
+      }
+    }
+  }
+
+  return out;
+}
+
+// Parse a vitest inline snapshot string to the actual expected output.
+// Template literal form: "\n  \"<div>...</div>\"\n" → trim → "\"...\"" → strip quotes → unescape
+// String literal form:   "   \"...\"   " → trim → "\"...\"" → strip quotes → unescape
+// If no outer quotes: return trimmed value as-is.
+function parseSnapshot(snap: string): string {
+  const trimmed = snap.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    // Strip outer double-quote delimiters and unescape \" → "
+    return trimmed.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return trimmed;
+}
+
+function normalizeErrors(errors: unknown[]): unknown[] {
+  return errors
+    .map((error) => {
+      if (typeof error === 'string') {
+        return { messageId: error };
+      }
+      if (!error || typeof error !== 'object') {
+        return null;
+      }
+      const e = error as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const key of ['messageId', 'message', 'line', 'column', 'endLine', 'endColumn']) {
+        if (key in e) {
+          out[key] = e[key];
+        }
+      }
+      if (e.data && typeof e.data === 'object') {
+        const data = safeClone(e.data);
+        if (data !== undefined) {
+          out.data = data;
+        }
+      }
+      if (Object.keys(out).length === 0) {
+        return null;
+      }
+      return out;
+    })
+    .filter(Boolean);
+}
+
+function writeFixture(
+  rule: string,
+  blockNames: string[],
+  cases: { blocks?: FixtureBlocks },
+  noUpstreamTests: boolean,
+): void {
+  const sourceFiles =
+    blockNames.length > 0 ? [...new Set(blockNames.map(() => `src/rules/${rule}.test.ts`))] : [];
+  const fixture: Record<string, unknown> = {
+    __generated: {
+      source: plugin!.npm,
+      ref: REF,
+      sourceFiles,
+      license: plugin!.license,
+      tool: 'tools/tasks/sync-unocss-tests.ts',
+      noUpstreamTests: noUpstreamTests || undefined,
+    },
+    blocks: cases.blocks ?? {},
+  };
+  writeFileSync(join(FIXTURES_DIR, `${rule}.json`), `${JSON.stringify(fixture, null, 2)}\n`);
+}
+
+function safeClone(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
+// --- stubs ------------------------------------------------------------------
+
+function registerStubHooks(): void {
+  const stubSource: Record<string, string> = {
+    'eslint-vitest-rule-tester': ruleTesterStub(),
+    'vue-eslint-parser': vueParserStub(),
+    'svelte-eslint-parser': svelteParserStub(),
+    vitest: vitestStub(),
+    rule: 'export default {};',
+    'ts-types': 'export const AST_TOKEN_TYPES = {};',
+  };
+
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (specifier === 'eslint-vitest-rule-tester') {
+        return { url: 'stub:///eslint-vitest-rule-tester', shortCircuit: true };
+      }
+      if (specifier === 'vue-eslint-parser') {
+        return { url: 'stub:///vue-eslint-parser', shortCircuit: true };
+      }
+      if (specifier === 'svelte-eslint-parser') {
+        return { url: 'stub:///svelte-eslint-parser', shortCircuit: true };
+      }
+      if (specifier === 'vitest') {
+        return { url: 'stub:///vitest', shortCircuit: true };
+      }
+      if (specifier === '@typescript-eslint/types') {
+        return { url: 'stub:///ts-types', shortCircuit: true };
+      }
+      // Relative rule imports (e.g. './order', './blocklist', './enforce-class-compile')
+      if (
+        /^\.\//.test(specifier) &&
+        !specifier.endsWith('.test.ts') &&
+        !specifier.endsWith('.test.js')
+      ) {
+        return { url: 'stub:///rule', shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+    load(url, context, nextLoad) {
+      if (url.startsWith('stub:///')) {
+        const key = url.slice('stub:///'.length);
+        const source = stubSource[key];
+        if (source !== undefined) {
+          return { format: 'module', source, shortCircuit: true };
+        }
+      }
+      return nextLoad(url, context);
+    },
+  });
+}
+
+// The capturing `run()` stub plus the `$` / `html` unindent tag.
+// `$` is exported as `unindent` in eslint-vitest-rule-tester, and its real
+// implementation uses the COOKED string value (str[0], not strings.raw[0]).
+// Using .raw would incorrectly keep `\`` as `\\`` instead of the literal backtick.
+// See: eslint-vitest-rule-tester/dist/index.mjs:
+//   const lines = (typeof str === "string" ? str : str[0]).split("\n");
+function ruleTesterStub(): string {
+  return [
+    `const KEY = ${JSON.stringify(SYNC_KEY)};`,
+    'function state() { return globalThis[KEY]; }',
+    'export function $(strings, ...values) {',
+    // Use cooked strings[0] (the TemplateStringsArray object), NOT strings.raw[0].
+    // This preserves literal backticks (from \` in template literals) correctly.
+    '  const str = typeof strings === "string" ? strings : strings[0];',
+    '  const lines = str.split("\\n");',
+    '  const nonBlank = lines.filter((l) => l.trim().length > 0);',
+    '  const commonIndent = nonBlank.reduce((min, l) => {',
+    '    const m = l.match(/^(\\s*)/);',
+    '    return Math.min(min, m ? m[1].length : 0);',
+    '  }, Infinity);',
+    '  const indent = Number.isFinite(commonIndent) ? commonIndent : 0;',
+    '  let head = 0;',
+    '  while (head < lines.length && lines[head].trim() === "") head++;',
+    '  let tail = lines.length;',
+    '  while (tail > head && lines[tail - 1].trim() === "") tail--;',
+    '  return lines.slice(head, tail).map((l) => l.slice(indent)).join("\\n");',
+    '}',
+    'export { $ as html };',
+    'export class RuleTester {}',
+    'export function run(config) {',
+    '  const captures = state().captures;',
+    '  const name = config && config.name ? config.name : "unknown";',
+    '  const lang = config && config.languageOptions;',
+    '  const vue = state().vueMarker;',
+    '  const svelte = state().svelteMarker;',
+    '  let parser = "js";',
+    '  if (lang && lang.parser) {',
+    '    if (lang.parser === vue || (lang.parser && lang.parser.default === vue)) parser = "vue";',
+    '    else if (lang.parser === svelte || (lang.parser && lang.parser.default === svelte)) parser = "svelte";',
+    '  } else if (lang && lang.parserOptions && lang.parserOptions.ecmaFeatures && lang.parserOptions.ecmaFeatures.jsx) {',
+    '    parser = "jsx";',
+    '  }',
+    '  function toCase(input) {',
+    '    if (typeof input === "string") return { code: input, parser };',
+    '    return { ...(input || {}), parser };',
+    '  }',
+    '  const valid = (config && config.valid ? config.valid : []).map(toCase);',
+    '  const invalid = (config && config.invalid ? config.invalid : []).map(toCase);',
+    '  captures[name] = { valid, invalid };',
+    '}',
+    'export default { run, $, html: $, RuleTester };',
+  ].join('\n');
+}
+
+function vueParserStub(): string {
+  return [
+    `const KEY = ${JSON.stringify(SYNC_KEY)};`,
+    'const marker = globalThis[KEY].vueMarker;',
+    'export default marker;',
+    'export { marker as parse };',
+  ].join('\n');
+}
+
+function svelteParserStub(): string {
+  return [
+    `const KEY = ${JSON.stringify(SYNC_KEY)};`,
+    'const marker = globalThis[KEY].svelteMarker;',
+    'export default marker;',
+    'export { marker as parse };',
+  ].join('\n');
+}
+
+// The vitest stub captures the snapshot argument passed to toMatchInlineSnapshot
+// by writing it to `globalThis[SYNC_KEY].lastSnapshot`. The normalise pass reads
+// this immediately after calling the output function.
+function vitestStub(): string {
+  return [
+    `const KEY = ${JSON.stringify(SYNC_KEY)};`,
+    'function state() { return globalThis[KEY]; }',
+    'function chain() {',
+    '  return new Proxy(function () {}, {',
+    '    get(_t, prop) {',
+    '      if (prop === "toMatchInlineSnapshot") {',
+    '        return function (snap) { state().lastSnapshot = snap; };',
+    '      }',
+    '      return function () { return chain(); };',
+    '    },',
+    '    apply() { return chain(); },',
+    '  });',
+    '}',
+    'export function expect(_value) { return chain(); }',
+    'export function describe(_n, fn) { if (typeof fn === "function") fn(); }',
+    'export function it() {}',
+    'export const test = it;',
+    'export function beforeAll() {} export function afterAll() {}',
+    'export function beforeEach() {} export function afterEach() {}',
+    'export default { expect, describe, it, test };',
+  ].join('\n');
+}


### PR DESCRIPTION
## What

Adds **upstream test syncing** for `@unocss/eslint-plugin` — the oxc-style pattern already used by the `functional`/`regexp` ports — so the port's behavior is verified against (and tracks) the upstream test corpus. This is the "guarantee the ESLint plugin's own tests are replayed" deliverable from issue #11.

## How

- **`tools/tasks/sync-unocss-tests.ts`** (`pnpm run port:tests:unocss`) imports the three upstream `*.test.ts` files with stubbed `eslint-vitest-rule-tester` / `vue-eslint-parser` / `svelte-eslint-parser` / `vitest`, captures **every** `run()` block (tagged by parser: `vue`/`svelte`/`jsx`/`js`), resolves the inline-snapshot `output` expectations, and writes verbatim JSON fixtures under `npm/unocss/test/fixtures/`.
- **`npm/unocss/test/upstream.test.mjs`** replays them: valid → zero diagnostics; invalid → messageId multiset **and exact fix output** match upstream.
- **`npm/unocss/test/parity.json`** quarantines, with a reason each, the cases the syntax-only port can't reproduce without the live UnoCSS engine.

## Honest parity ledger (no silent truncation)

| Category | Disposition |
|---|---|
| Vue / Svelte blocks (`order`, `order-svelte`, all of `blocklist` + `enforce-class-compile`) | Quarantined structurally — oxc parses JS/TS/JSX only |
| `order-jsx` (9 cases) | **Asserted & passing** |
| `order-unoFunctions` / `order-unoVariables` JS subset (single strings, templates, `String.raw`, arrays, `cva`/`tv` object values, uno variables) | **Asserted & passing** |
| Object-key sorting + partial in-place sort of mixed UnoCSS/non-UnoCSS token strings | Quarantined (needs the engine) — each a ratchet item a future PR removes |

So the engine/template-dependent majority is honestly quarantined and **counted**, while the achievable JS/JSX `order` subset is replayed against upstream's own expected outputs — exactly the heuristic the port was built around.

## Verification

`node tools/tasks/sync-unocss-tests.ts` regenerates the fixtures deterministically; `prettier --check` clean on all new files. The Vitest replay runs in CI (JS Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784008566&installation_id=136613492&pr_number=241&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F241&signature=958bbe311a4c78f29b95aaaeee6f9ba84264695f8173403ca820babb784f2974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->