### PR TITLE
test(eslint-markdown): sync upstream RuleTester suite + parity harness

### DIFF
--- a/npm/eslint-markdown/test/fixtures/fenced-code-language.json
+++ b/npm/eslint-markdown/test/fixtures/fenced-code-language.json
@@ -1,0 +1,557 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/fenced-code-language.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "```js\nconsole.log(\"Hello, world!\");\n```"
+    },
+    {
+      "code": "```javascript\nconsole.log(\"Hello, world!\");\n```"
+    },
+    {
+      "code": "~~~js\nconsole.log(\"Hello, world!\");\n~~~"
+    },
+    {
+      "code": "~~~javascript\nconsole.log(\"Hello, world!\");\n~~~"
+    },
+    {
+      "code": "\n    console.log(\"Hello, world!\");\n        "
+    },
+    {
+      "code": "```js\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ]
+    },
+    {
+      "code": "```js foo\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ]
+    },
+    {
+      "code": "``` js\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ]
+    },
+    {
+      "code": "```JS\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["JS"]
+        }
+      ]
+    },
+    {
+      "code": "~~~js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ]
+    },
+    {
+      "code": "~~~js foo\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ]
+    },
+    {
+      "code": "~~~ js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ]
+    },
+    {
+      "code": "~~~JS\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["JS"]
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "```\nconsole.log(\"Hello, world!\");\n```",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": " ```\nconsole.log(\"Hello, world!\");\n```",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "  ```\nconsole.log(\"Hello, world!\");\n```",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "   ```\nconsole.log(\"Hello, world!\");\n```",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "```     \nconsole.log('Hello, world!');\n```",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "```\t\t\nconsole.log('Hello, world!');\n```",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "~~~\nconsole.log(\"Hello, world!\");\n~~~",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": " ~~~\nconsole.log(\"Hello, world!\");\n~~~",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "  ~~~\nconsole.log(\"Hello, world!\");\n~~~",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "   ~~~\nconsole.log(\"Hello, world!\");\n~~~",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "~~~     \nconsole.log('Hello, world!');\n~~~",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "~~~\t\t\nconsole.log('Hello, world!');\n~~~",
+      "errors": [
+        {
+          "messageId": "missingLanguage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "```javascript\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": " ```javascript\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "  ```javascript\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "   ```javascript\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ]
+    },
+    {
+      "code": "````javascript\nconsole.log(\"Hello, world!\");\n````",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": " ````javascript\nconsole.log(\"Hello, world!\");\n````",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "  ````javascript\nconsole.log(\"Hello, world!\");\n````",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ]
+    },
+    {
+      "code": "   ````javascript\nconsole.log(\"Hello, world!\");\n````",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "```js\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["JS"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "js"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "``` js\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["JS"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "js"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "```js foo\nconsole.log(\"Hello, world!\");\n```",
+      "options": [
+        {
+          "required": ["foo"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "js"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "~~~javascript\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "~~~~javascript\nconsole.log(\"Hello, world!\");\n~~~~",
+      "options": [
+        {
+          "required": ["js"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "javascript"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "~~~js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["JS"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "js"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "~~~ js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["JS"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "js"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "~~~js foo\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": [
+        {
+          "required": ["foo"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedLanguage",
+          "data": {
+            "lang": "js"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/fenced-code-meta.json
+++ b/npm/eslint-markdown/test/fixtures/fenced-code-meta.json
@@ -1,0 +1,298 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/fenced-code-meta.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "```\nconsole.log(\"Hello, world!\");\n```"
+    },
+    {
+      "code": "```js foo\nconsole.log(\"Hello, world!\");\n```"
+    },
+    {
+      "code": "``` js   foo\nconsole.log(\"Hello, world!\");\n```"
+    },
+    {
+      "code": "```\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"]
+    },
+    {
+      "code": "```js\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"]
+    },
+    {
+      "code": "``` js\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"]
+    },
+    {
+      "code": "~~~\nconsole.log(\"Hello, world!\");\n~~~"
+    },
+    {
+      "code": "~~~js foo\nconsole.log(\"Hello, world!\");\n~~~"
+    },
+    {
+      "code": "~~~ js   foo\nconsole.log(\"Hello, world!\");\n~~~"
+    },
+    {
+      "code": "~~~\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"]
+    },
+    {
+      "code": "~~~js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"]
+    },
+    {
+      "code": "~~~ js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"]
+    },
+    {
+      "code": "\tconsole.log(\"Hello, world!\");"
+    },
+    {
+      "code": "\tconsole.log(\"Hello, world!\");",
+      "options": ["never"]
+    },
+    {
+      "code": "\n    console.log(\"Hello, world!\")\n"
+    },
+    {
+      "code": "\n    console.log(\"Hello, world!\")\n",
+      "options": ["never"]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "```javascript\nconsole.log(\"Hello, world!\");\n```",
+      "errors": [
+        {
+          "messageId": "missingMetadata",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "~~~javascript\nconsole.log(\"Hello, world!\");\n~~~",
+      "errors": [
+        {
+          "messageId": "missingMetadata",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "``` js  \nconsole.log(\"Hello, world!\");\n```",
+      "errors": [
+        {
+          "messageId": "missingMetadata",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "~~~ js  \nconsole.log(\"Hello, world!\");\n~~~",
+      "errors": [
+        {
+          "messageId": "missingMetadata",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "  ```javascript\nconsole.log('Hello, world!');\n```",
+      "errors": [
+        {
+          "messageId": "missingMetadata",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "  ~~~javascript\nconsole.log('Hello, world!');\n~~~",
+      "errors": [
+        {
+          "messageId": "missingMetadata",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "```js title=\"example.js\"\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "~~~js title=\"example.js\"\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "  ```js title='example.js'\nconsole.log('Hello, world!');\n```",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ]
+    },
+    {
+      "code": "  ~~~js title='example.js'\nconsole.log('Hello, world!');\n~~~",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ]
+    },
+    {
+      "code": "```js foo bar\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "~~~js foo bar\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "``` js foo\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "~~~ js foo\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "```js js\nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "~~~js js\nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "``` js   foo   \nconsole.log(\"Hello, world!\");\n```",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "~~~ js   foo   \nconsole.log(\"Hello, world!\");\n~~~",
+      "options": ["never"],
+      "errors": [
+        {
+          "messageId": "disallowedMetadata",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/heading-increment.json
+++ b/npm/eslint-markdown/test/fixtures/heading-increment.json
@@ -1,0 +1,915 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/heading-increment.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "# Heading 1"
+    },
+    {
+      "code": "## Heading 2"
+    },
+    {
+      "code": "# Heading 1\n      ## Heading 2"
+    },
+    {
+      "code": "# Heading 1\n      # Heading 2"
+    },
+    {
+      "code": "Only one h1\n==========="
+    },
+    {
+      "code": "Heading 1\n==========\nHeading 2\n----------"
+    },
+    {
+      "code": "# Heading 1\n```markdown\n### Heading 3\n```"
+    },
+    {
+      "code": "<p>\n# Not heading\n### Not heading\n</p>"
+    },
+    {
+      "code": "---\n[ \"title\" ]\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title\"\n]\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title:\"\n]\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title=\"\n]\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "---\ntitle: \"My Title\"\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title\"\n]\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n# title: My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\n# title = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\nauthor: xbinaryx # title: My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\nauthor = \"xbinaryx\" # title = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\nheading: My Title\n---\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "---\nheading: \"My Title\"\n---\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\nheading = \"My Title\"\n+++\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*="
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"heading\": \"My Title\"\n}\n---\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*\"heading\"\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"heading\"\n]\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*\"heading\"\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\nauthor: xbinaryx\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\nauthor = \"xbinaryx\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"author\": \"xbinaryx\"\n}\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"author\"\n]\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "---\ntitle: \"My Title\"\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "code": "# Heading 1\n\n### Heading 3",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "## Heading 2\n\n##### Heading 5",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 2,
+            "toLevel": 5
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "Heading 1\n=========\n\n### Heading 3",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n### Heading 3\n###### Heading 6",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 14
+        },
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 3,
+            "toLevel": 6
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 17
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n> ### Quoted heading",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 2,
+          "column": 3,
+          "endLine": 2,
+          "endColumn": 21
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n> > ### Double-quoted heading",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 2,
+          "column": 5,
+          "endLine": 2,
+          "endColumn": 30
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n- Item\n  item\n  > ### Quoted heading in list",
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 5,
+          "endLine": 4,
+          "endColumn": 31
+        }
+      ]
+    },
+    {
+      "code": "---\n---\n# Heading 1\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: \"My Title\"\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n\"title\": My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n\"title\": \"My Title\"\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\n\"title\" = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n{ \"title\": \"My Title\" }\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n   {    \"title\": \"My Title\" }\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n'title': My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n'title': \"My Title\"\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\n'title' = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\nauthor: xbinaryx\ntitle: My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\nauthor = \"xbinaryx\"\ntitle = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"author\": \"xbinaryx\",\n\t\"title\": \"My Title\"\n}\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 7,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\nTITLE: My Title\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\nTITLE = \"My Title\"\n+++\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"TITLE\": \"My Title\"\n}\n---\n### Heading 3",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\nheading: My Title\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\nheading: \"My Title\"\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\nheading = \"My Title\"\n+++\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*="
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"heading\": \"My Title\"\n}\n---\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*\"heading\"\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n# Heading 1\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: \"My Title\"\n---\n# Heading 1\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n# Heading 1\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n# Heading 1\n### Heading 3",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "skippedHeading",
+          "data": {
+            "fromLevel": 1,
+            "toLevel": 3
+          },
+          "line": 7,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 14
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-bare-urls.json
+++ b/npm/eslint-markdown/test/fixtures/no-bare-urls.json
@@ -1,0 +1,406 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-bare-urls.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "<https://www.google.com/>"
+    },
+    {
+      "code": "<user@example.com>"
+    },
+    {
+      "code": "[text [undefined] text](https://example.com)."
+    },
+    {
+      "code": "[is-a-valid]: https://example.com"
+    },
+    {
+      "code": "<a href=\"https://example.com\">link</a>."
+    },
+    {
+      "code": "<a href=\"https://example.com\">https://example.com</a>"
+    },
+    {
+      "code": "<a href=\"https://example.com\">Text https://example.com</a>"
+    },
+    {
+      "code": "This is not a bare [link]( https://example.com )"
+    },
+    {
+      "code": "Nor is [link](https://example.com/path-with(parens))."
+    },
+    {
+      "code": "Or <https://example.com/path-with(parens)>."
+    },
+    {
+      "code": "<element-name first-attribute=\" https://example.com/first \" second-attribute=\" https://example.com/second \">\n    Text\n</element-name>"
+    },
+    {
+      "code": "<element-name\n    first-attribute=\" https://example.com/first \"\n    second-attribute=\" https://example.com/second \"></element-name>"
+    },
+    {
+      "code": "Not <code>https://example.com</code> bare."
+    },
+    {
+      "code": "Not <pre>https://example.com</pre> bare."
+    },
+    {
+      "code": "<p>\nNot bare due to being in an HTML block:\nhttps://example.com\n<code>https://example.com</code>\n<pre>https://example.com</pre>\n</p>"
+    },
+    {
+      "code": "<div>\nhttps://example.com\n</div>"
+    },
+    {
+      "code": "<div>\nhttps://example.com\n\n</div>"
+    },
+    {
+      "code": "Text [link to https://example.com site](https://example.com) text."
+    },
+    {
+      "code": "Image ![for https://example.com site](https://example.com) text."
+    },
+    {
+      "code": "Links with spaces inside angle brackets are okay: [blue jay](<https://en.wikipedia.org/wiki/Blue jay>)"
+    },
+    {
+      "code": "[link \\[is-not-a-valid\\] link](https://example.com)"
+    },
+    {
+      "code": "text <https://example.com/dir/dir>"
+    },
+    {
+      "code": "```text\nCode https://example.com/code?type=fence code\n```"
+    },
+    {
+      "code": "       Code https://example.com/code?type=indent code"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "https://www.example.com/",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ],
+      "output": "<https://www.example.com/>"
+    },
+    {
+      "code": "user@example.com",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ],
+      "output": "<user@example.com>"
+    },
+    {
+      "code": "text https://www.google.com/",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "output": "text <https://www.google.com/>"
+    },
+    {
+      "code": "hTtPs://gOoGlE.cOm/",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "<hTtPs://gOoGlE.cOm/>"
+    },
+    {
+      "code": "(https://example.com)",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "(<https://example.com>)"
+    },
+    {
+      "code": "# https://www.example.com/",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "# <https://www.example.com/>"
+    },
+    {
+      "code": "| Link                 |\n|----------------------|\n| https://example.com/ |",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 3,
+          "column": 3,
+          "endLine": 3,
+          "endColumn": 23
+        }
+      ],
+      "output": "| Link                 |\n|----------------------|\n| <https://example.com/> |"
+    },
+    {
+      "code": "[link that [is-a-valid] link](https://example.com)\n\n[is-a-valid]: https://example.com",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 31,
+          "endLine": 1,
+          "endColumn": 50
+        }
+      ],
+      "output": "[link that [is-a-valid] link](<https://example.com>)\n\n[is-a-valid]: https://example.com"
+    },
+    {
+      "code": "Text <https://example.com/brackets> text https://example.com/bare text",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 42,
+          "endLine": 1,
+          "endColumn": 66
+        }
+      ],
+      "output": "Text <https://example.com/brackets> text <https://example.com/bare> text"
+    },
+    {
+      "code": "> https://example.com/",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "> <https://example.com/>"
+    },
+    {
+      "code": "Text https://example.com/first more text https://example.com/second",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 31
+        },
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 42,
+          "endLine": 1,
+          "endColumn": 68
+        }
+      ],
+      "output": "Text <https://example.com/first> more text <https://example.com/second>"
+    },
+    {
+      "code": "Text https://example.com/first\nmore text https://example.com/second",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 31
+        },
+        {
+          "messageId": "bareUrl",
+          "line": 2,
+          "column": 11,
+          "endLine": 2,
+          "endColumn": 37
+        }
+      ],
+      "output": "Text <https://example.com/first>\nmore text <https://example.com/second>"
+    },
+    {
+      "code": "Text <a>https://example.com</a> https://example.com",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 33,
+          "endLine": 1,
+          "endColumn": 52
+        }
+      ],
+      "output": "Text <a>https://example.com</a> <https://example.com>"
+    },
+    {
+      "code": "<br> Another violation: https://example.com. <br>",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "<br> Another violation: <https://example.com>. <br>"
+    },
+    {
+      "code": "<br> Another violation: https://example.com. <br />",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "<br> Another violation: <https://example.com>. <br />"
+    },
+    {
+      "code": "<br /> Another violation: https://example.com. <br />",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 27,
+          "endLine": 1,
+          "endColumn": 46
+        }
+      ],
+      "output": "<br /> Another violation: <https://example.com>. <br />"
+    },
+    {
+      "code": "<div>\n\nhttps://example.com\n</div>",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 20
+        }
+      ],
+      "output": "<div>\n\n<https://example.com>\n</div>"
+    },
+    {
+      "code": "<div>\n\nhttps://example.com\n\n</div>",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 20
+        }
+      ],
+      "output": "<div>\n\n<https://example.com>\n\n</div>"
+    },
+    {
+      "code": "text **<a>https://example.com</a>** *https://example.com*",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 38,
+          "endLine": 1,
+          "endColumn": 57
+        }
+      ],
+      "output": "text **<a>https://example.com</a>** *<https://example.com>*"
+    },
+    {
+      "code": "text <>https://example.com</> https://example.com",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 27
+        },
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 31,
+          "endLine": 1,
+          "endColumn": 50
+        }
+      ],
+      "output": "text <><https://example.com></> <https://example.com>"
+    },
+    {
+      "code": "<!DOCTYPE html>\nhttps://example.com",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 20
+        }
+      ],
+      "output": "<!DOCTYPE html>\n<https://example.com>"
+    },
+    {
+      "code": "hi <!-- comment --> https://example.com <!-- comment -->",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 21,
+          "endLine": 1,
+          "endColumn": 40
+        }
+      ],
+      "output": "hi <!-- comment --> <https://example.com> <!-- comment -->"
+    },
+    {
+      "code": "hi <!-- comment --> https://example.com <!-- comment --> <a>https://example.com</a>",
+      "errors": [
+        {
+          "messageId": "bareUrl",
+          "line": 1,
+          "column": 21,
+          "endLine": 1,
+          "endColumn": 40
+        }
+      ],
+      "output": "hi <!-- comment --> <https://example.com> <!-- comment --> <a>https://example.com</a>"
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-duplicate-definitions.json
+++ b/npm/eslint-markdown/test/fixtures/no-duplicate-definitions.json
@@ -1,0 +1,404 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-duplicate-definitions.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n"
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[venus]: https://example.com/venus/\n"
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n"
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^venus]: Hello, Venus!\n"
+    },
+    {
+      "code": "\n[alpha]: bravo\n\n[^alpha]: bravo\n"
+    },
+    {
+      "code": "\n[//]: # (This is a comment 1)\n[//]: <> (This is a comment 2)\n"
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n[MERCURY]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["MERCURY"]
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[MERCURY]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n[   mercury   ]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[   mercury   ]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["   mercury   "]
+        }
+      ]
+    },
+    {
+      "code": "\n[foo bar]: https://example.com/foo-bar/\n[foo bar]: https://example.com/foo-bar/\n",
+      "options": [
+        {
+          "allowDefinitions": ["foo\t\r\nbar"]
+        }
+      ]
+    },
+    {
+      "code": "\n[^MERCURY]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["MERCURY"]
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^MERCURY]: Hello, Venus!\n",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "checkFootnoteDefinitions": false
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "checkFootnoteDefinitions": true,
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t\t\t[Grüsse]: https://example.com/\n\t\t\t\t\t\t[Grüsse]: https://example.com/\n\t\t\t\t\t\t",
+      "options": [
+        {
+          "allowDefinitions": ["GRÜẞE"]
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t\t\t[^Grüsse]: Grüsse\n\t\t\t\t\t\t[^Grüsse]: Grüsse\n\t\t\t\t\t\t",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["GRÜẞE"]
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n",
+      "errors": [
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 38
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n[mercury]: https://example.com/earth/\n[mercury]: https://example.com/mars/\n",
+      "errors": [
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 38
+        },
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 38
+        },
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 37
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[Mercury]: https://example.com/venus/\n",
+      "errors": [
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "Mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 38
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury    ]: https://example.com/venus/\n",
+      "errors": [
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 42
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["venus"],
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 38
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "errors": [
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n[^mercury]: Hello, Earth!\n[^mercury]: Hello, Mars!\n",
+      "errors": [
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 26
+        },
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 26
+        },
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^Mercury]: Hello, Venus!\n",
+      "errors": [
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "Mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"],
+          "allowFootnoteDefinitions": ["venus"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "checkFootnoteDefinitions": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[earth]: https://example.com/earth/\n[mars]: https://example.com/mars/\n\n[//]: # (comment about mars)\n\n[jupiter]: https://example.com/jupiter/\n\n[//]: # (comment about jupiter)\n\n[mercury]: https://example.com/venus/\n",
+      "errors": [
+        {
+          "messageId": "duplicateDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury",
+            "firstLine": "2",
+            "firstLabel": "mercury"
+          },
+          "line": 12,
+          "column": 1,
+          "endLine": 12,
+          "endColumn": 38
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-duplicate-headings.json
+++ b/npm/eslint-markdown/test/fixtures/no-duplicate-headings.json
@@ -1,0 +1,448 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-duplicate-headings.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "# Heading 1\n\n# Heading *1*"
+    },
+    {
+      "code": "# ***Heading 1***\n\n# Heading 1"
+    },
+    {
+      "code": "# Heading 1\n\n## Heading 2"
+    },
+    {
+      "code": "# Heading 1\n\n# Heading 1#"
+    },
+    {
+      "code": "Heading 1\nHi\n===\n\nHeading 1\nBye\n==="
+    },
+    {
+      "code": "Heading 1\nText\nHi\n===\n\nHeading 1\nText\nBye\n==="
+    },
+    {
+      "code": "Heading 2\nHi\n---\n\nHeading 2\nBye\n---"
+    },
+    {
+      "code": "Heading 2\nText\nHi\n---\n\nHeading 2\nText\nBye\n---"
+    },
+    {
+      "code": "# Heading 1\n#  Heading 1"
+    },
+    {
+      "code": "# Heading 1\n# Heading 1 "
+    },
+    {
+      "code": "# Heading 1 #\n#  Heading 1 #"
+    },
+    {
+      "code": "# Heading 1 #\n# Heading 1  #"
+    },
+    {
+      "code": "# Heading 1 #\n# Heading 1 #"
+    },
+    {
+      "code": "#  Heading 1  #\n#  Heading 1 #"
+    },
+    {
+      "code": "#  Heading 1 #\n# Heading 1  #"
+    },
+    {
+      "code": "# foo \\###\n# foo ###"
+    },
+    {
+      "code": "# foo #\\##\n# foo ###"
+    },
+    {
+      "code": "# foo \\#"
+    },
+    {
+      "code": "Heading  \nHi\n===\n\nHeading\nHi\n==="
+    },
+    {
+      "code": "# Change log\n\n## 1.0.0\n\n### Features\n\n## 2.0.0\n\n### Features",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ]
+    },
+    {
+      "code": "# Change log\n\n## 1.0.0\n\n### Features\n\n## 2.0.0\n\n### Features ###",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ]
+    },
+    {
+      "code": "1.0.0\n=====\n\nFeatures\n--------\n\n2.0.0\n=====\n\nFeatures\n--------",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ]
+    },
+    {
+      "code": "1.0.0\n=====\n\nFeatures\n--------\n\n2.0.0\n=====\n\n## Features",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n# Heading 1\n\n# Heading 1\n            ",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\r\n# Heading 1",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "Heading \nHi\n===\n\nHeading\nHi\n===",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading\nHi"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n\n# Heading 1 ##",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n\n# Heading 1 ##########",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "\n# Heading 1\n\n## Heading 1\n            ",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "\n# Heading 1\n\nHeading 1\n---------\n            ",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "\n# Heading 1\n\nHeading 1\n=========\n            ",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "Heading 1\nHi\n===\n\nHeading 1\nHi\n===",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1\nHi"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "Heading *1*\nHi\n===\n\nHeading _1_\nHi\n===",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1\nHi"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "Heading <u>1</u>\nHi\n===\n\nHeading <u>1</u>\nHi\n===",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1\nHi"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "Heading 1\r\nHi\r\n===\r\n\r\nHeading 1\r\nHi\r\n===",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1\r\nHi"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "# Heading `1`\n\n# Heading `1`",
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n\n# Heading 1",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Heading 1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "# Section 1\n\n## Subsection A\n## Subsection A\n\n# Section 2\n\n## Subsection B",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "# Section 1\n\n## Subsection A\n## Subsection A ###\n\n# Section 2\n\n## Subsection B",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "# Section 1\n\n## Subsection A\n## Subsection B\n\n# Section 2\n\n## Subsection A\n## Subsection A",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 9,
+          "column": 1,
+          "endLine": 9,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "Section 1\n=========\n\nSubsection A\n------------\nSubsection A\n------------\n\nSection 2\n=========\n\nSubsection B\n------------",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 6,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "Section 1\n=========\n\nSubsection A\n------------\nSubsection B\n------------\n\nSection 2\n=========\n\nSubsection A\n------------\nSubsection A\n------------",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 14,
+          "column": 1,
+          "endLine": 15,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "# Section 1\n\n## Subsection A\n## Subsection B\n\n# Section 2\n\n## Subsection A\n## Subsection A\nSubsection A\n------------",
+      "options": [
+        {
+          "checkSiblingsOnly": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 9,
+          "column": 1,
+          "endLine": 9,
+          "endColumn": 16
+        },
+        {
+          "messageId": "duplicateHeading",
+          "data": {
+            "text": "Subsection A"
+          },
+          "line": 10,
+          "column": 1,
+          "endLine": 11,
+          "endColumn": 13
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-empty-definitions.json
+++ b/npm/eslint-markdown/test/fixtures/no-empty-definitions.json
@@ -1,0 +1,608 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-empty-definitions.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "[foo]: bar"
+    },
+    {
+      "code": "[foo]: #bar"
+    },
+    {
+      "code": "[foo]: http://bar.com"
+    },
+    {
+      "code": "[foo]: <https://bar.com>"
+    },
+    {
+      "code": "[//]: # (This is a comment 1)"
+    },
+    {
+      "code": "[//]: <> (This is a comment 2)"
+    },
+    {
+      "code": "[^note]: This is a footnote."
+    },
+    {
+      "code": "[^note]: ![]()"
+    },
+    {
+      "code": "[^note]: [text](url)"
+    },
+    {
+      "code": "[^note]:\n    Content"
+    },
+    {
+      "code": "[^note]:\n    > blockquote"
+    },
+    {
+      "code": "[^note]: <span></span>"
+    },
+    {
+      "code": "\\[^note]:"
+    },
+    {
+      "code": "[\\^note]:"
+    },
+    {
+      "code": "[^note\\]:"
+    },
+    {
+      "code": "[^note]\\:"
+    },
+    {
+      "code": "[^foo]: <span></span> <!-- comment -->"
+    },
+    {
+      "code": "[^foo]: content <!-- comment -->"
+    },
+    {
+      "code": "[^foo]: <!-- comment --> content"
+    },
+    {
+      "code": "[^foo]: <!-- comment --> content <!-- comment -->"
+    },
+    {
+      "code": "[^foo]: <!-- comm\n    ent --> content <!-- comment -->"
+    },
+    {
+      "code": "[foo]: #",
+      "options": [
+        {
+          "allowDefinitions": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[bar]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["bar"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #\n[bar]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["foo", "bar"]
+        }
+      ]
+    },
+    {
+      "code": "[^note]:",
+      "options": [
+        {
+          "checkFootnoteDefinitions": false
+        }
+      ]
+    },
+    {
+      "code": "[^note]:",
+      "options": [
+        {
+          "checkFootnoteDefinitions": true,
+          "allowFootnoteDefinitions": ["note"]
+        }
+      ]
+    },
+    {
+      "code": "[FOO]: #",
+      "options": [
+        {
+          "allowDefinitions": ["FOO"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #",
+      "options": [
+        {
+          "allowDefinitions": ["FOO"]
+        }
+      ]
+    },
+    {
+      "code": "[FOO]: #",
+      "options": [
+        {
+          "allowDefinitions": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[   foo   ]: #",
+      "options": [
+        {
+          "allowDefinitions": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #",
+      "options": [
+        {
+          "allowDefinitions": ["   foo   "]
+        }
+      ]
+    },
+    {
+      "code": "[foo bar]: #",
+      "options": [
+        {
+          "allowDefinitions": ["foo\t\r\nbar"]
+        }
+      ]
+    },
+    {
+      "code": "[FOO]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["FOO"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["FOO"]
+        }
+      ]
+    },
+    {
+      "code": "[FOO]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[   foo   ]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["   foo   "]
+        }
+      ]
+    },
+    {
+      "code": "[foo bar]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["foo\t\r\nbar"]
+        }
+      ]
+    },
+    {
+      "code": "[^NOTE]:",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["NOTE"]
+        }
+      ]
+    },
+    {
+      "code": "[^note]:",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["NOTE"]
+        }
+      ]
+    },
+    {
+      "code": "[^NOTE]:",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["note"]
+        }
+      ]
+    },
+    {
+      "code": "[^note]:",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["   note   "]
+        }
+      ]
+    },
+    {
+      "code": "[Grüsse]: #",
+      "options": [
+        {
+          "allowDefinitions": ["GRÜẞE"]
+        }
+      ]
+    },
+    {
+      "code": "[Grüsse]: <>",
+      "options": [
+        {
+          "allowDefinitions": ["GRÜẞE"]
+        }
+      ]
+    },
+    {
+      "code": "[^Grüsse]:",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["GRÜẞE"]
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "[foo]: #",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[Foo]: #",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "Foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[  Foo  ]: #",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "Foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "[foo]: <>",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #\n[bar]: <>",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "bar",
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "[^note]:",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "note",
+            "label": "note"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[^Note]:",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "note",
+            "label": "Note"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[^note]:   ",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "note",
+            "label": "note"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "[^note]:\n",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "note",
+            "label": "note"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[^a]:\n[^b]:",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "a",
+            "label": "a"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        },
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "b",
+            "label": "b"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #\n[^note]:",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "note",
+            "label": "note"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #\n[^note]:",
+      "options": [
+        {
+          "checkFootnoteDefinitions": false
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[^foo]: <!-- comment -->",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "[^foo]: <!-- comment\n    -->",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 8
+        }
+      ]
+    },
+    {
+      "code": "[^foo]: <!-- comment -->\n    <!-- another comment -->",
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 29
+        }
+      ]
+    },
+    {
+      "code": "[//]: #\n[foo]: #",
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[foo]: #",
+      "options": [
+        {
+          "allowDefinitions": ["bar"],
+          "allowFootnoteDefinitions": ["foo"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "emptyDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[^foo]:",
+      "options": [
+        {
+          "allowDefinitions": ["foo"],
+          "allowFootnoteDefinitions": ["bar"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "emptyFootnoteDefinition",
+          "data": {
+            "identifier": "foo",
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-empty-images.json
+++ b/npm/eslint-markdown/test/fixtures/no-empty-images.json
@@ -1,0 +1,83 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-empty-images.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "![foo](bar)"
+    },
+    {
+      "code": "![foo](#bar)"
+    },
+    {
+      "code": "![foo](http://bar.com/image.png)"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "![]()",
+      "errors": [
+        {
+          "messageId": "emptyImage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "![](#)",
+      "errors": [
+        {
+          "messageId": "emptyImage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "![foo]()",
+      "errors": [
+        {
+          "messageId": "emptyImage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "![foo](#)",
+      "errors": [
+        {
+          "messageId": "emptyImage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "![foo]( )",
+      "errors": [
+        {
+          "messageId": "emptyImage",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-empty-links.json
+++ b/npm/eslint-markdown/test/fixtures/no-empty-links.json
@@ -1,0 +1,59 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-empty-links.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "[foo](bar)"
+    },
+    {
+      "code": "[foo](#bar)"
+    },
+    {
+      "code": "[foo](http://bar.com)"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "[foo]()",
+      "errors": [
+        {
+          "messageId": "emptyLink",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ]
+    },
+    {
+      "code": "[foo](#)",
+      "errors": [
+        {
+          "messageId": "emptyLink",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[foo]( )",
+      "errors": [
+        {
+          "messageId": "emptyLink",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-html.json
+++ b/npm/eslint-markdown/test/fixtures/no-html.json
@@ -1,0 +1,684 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-html.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "Hello world!"
+    },
+    {
+      "code": " 1 < 5"
+    },
+    {
+      "code": "<!-- comment -->"
+    },
+    {
+      "code": "<!-- <h1> -->"
+    },
+    {
+      "code": "<!-- <div id=\"foo\"> -->"
+    },
+    {
+      "code": "<!-- abcdefg <abcdefg> -->"
+    },
+    {
+      "code": "```html\n<b>Hello world!</b>\n```"
+    },
+    {
+      "code": "<b>Hello world!</b>",
+      "options": [
+        {
+          "allowed": ["b"]
+        }
+      ]
+    },
+    {
+      "code": "<custom-element>Hello world!</custom-element>",
+      "options": [
+        {
+          "allowed": ["custom-element"]
+        }
+      ]
+    },
+    {
+      "code": "<div>Hello world!</div>",
+      "options": [
+        {
+          "allowed": ["div"]
+        }
+      ]
+    },
+    {
+      "code": "<DIV>Hello world!</DIV>",
+      "options": [
+        {
+          "allowed": ["DIV"]
+        }
+      ]
+    },
+    {
+      "code": "<div>Hello world!</div>",
+      "options": [
+        {
+          "allowed": ["DIV"],
+          "allowedIgnoreCase": true
+        }
+      ]
+    },
+    {
+      "code": "<DIV>Hello world!</DIV>",
+      "options": [
+        {
+          "allowed": ["div"],
+          "allowedIgnoreCase": true
+        }
+      ]
+    },
+    {
+      "code": "<DiV>Hello world!</DiV>",
+      "options": [
+        {
+          "allowed": ["div"],
+          "allowedIgnoreCase": true
+        }
+      ]
+    },
+    {
+      "code": "<custom-element>Hello world!</custom-element>",
+      "options": [
+        {
+          "allowed": ["CUSTOM-ELEMENT"],
+          "allowedIgnoreCase": true
+        }
+      ]
+    },
+    {
+      "code": "<CUSTOM-ELEMENT>Hello world!</CUSTOM-ELEMENT>",
+      "options": [
+        {
+          "allowed": ["custom-element"],
+          "allowedIgnoreCase": true
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "<img>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "img"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<img >",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "img"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<img/>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "img"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<img />",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "img"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ]
+    },
+    {
+      "code": "<hr>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "hr"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "<hr >",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "hr"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<hr/>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "hr"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<hr />",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "hr"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<br>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "br"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "<br >",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "br"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<br/>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "br"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<br />",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "br"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<b>Hello world!</b>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "b"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "<b>Hello world!</b>",
+      "options": [
+        {
+          "allowed": ["em"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "b"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ]
+    },
+    {
+      "code": "<b>Hello world!</b><i>Goodbye world!</i>",
+      "options": [
+        {
+          "allowed": ["em"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "b"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        },
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "i"
+          },
+          "line": 1,
+          "column": 20,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "<!-- hi --><b>Hello world!</b>",
+      "options": [
+        {
+          "allowed": ["em"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "b"
+          },
+          "line": 1,
+          "column": 12,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "<custom-element>Hello world!</custom-element>",
+      "options": [
+        {
+          "allowed": ["em"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "custom-element"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ]
+    },
+    {
+      "code": "<div>Hello world!</div>",
+      "options": [
+        {
+          "allowed": ["DIV"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "div"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<DIV>Hello world!</DIV>",
+      "options": [
+        {
+          "allowed": ["div"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "DIV"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<div>Hello world!</div>",
+      "options": [
+        {
+          "allowed": ["span"],
+          "allowedIgnoreCase": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "div"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<DIV>Hello world!</DIV>",
+      "options": [
+        {
+          "allowed": ["span"],
+          "allowedIgnoreCase": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "DIV"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<span >Content</span>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "span"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ]
+    },
+    {
+      "code": "<div id=\"foo\">Some content</div>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "div"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "<p class=\"text-center\" data-attr=\"value\">Content</p>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "p"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 42
+        }
+      ]
+    },
+    {
+      "code": "<span\nclass=\"highlight\"\ndata-id=\"123\">Text</span>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "span"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<span\rclass=\"highlight\"\rdata-id=\"123\">Text</span>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "span"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<span\r\nclass=\"highlight\"\r\ndata-id=\"123\">Text</span>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "span"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<div   class=\"test\"   >Content</div>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "div"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<input type=\"text\" placeholder=\"Enter text\" />",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "input"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 47
+        }
+      ]
+    },
+    {
+      "code": "<a href=\"#\"><span class=\"highlight\">Link</span></a>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "a"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 13
+        },
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "span"
+          },
+          "line": 1,
+          "column": 13,
+          "endLine": 1,
+          "endColumn": 37
+        }
+      ]
+    },
+    {
+      "code": "<input placeholder=\">\" />",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "input"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "<input placeholder='>'></input>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "input"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<input\nplaceholder=\">\" />",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "input"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<!-- comment -->\n<input\n\tplaceholder=\"Enter name\"\n      \t\tname=\"First Name\"\n\t/>",
+      "errors": [
+        {
+          "messageId": "disallowedElement",
+          "data": {
+            "name": "input"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 7
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-invalid-label-refs.json
+++ b/npm/eslint-markdown/test/fixtures/no-invalid-label-refs.json
@@ -1,0 +1,256 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-invalid-label-refs.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "[*foo*]"
+    },
+    {
+      "code": "[foo]\n\n[foo]: http://bar.com"
+    },
+    {
+      "code": "[foo][ foo ]\n\n[foo]: http://bar.com"
+    },
+    {
+      "code": "![foo][foo]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[foo][]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "![foo][]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[  foo ][]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[eslint][\n\n]"
+    },
+    {
+      "code": "[*eslint*][]\n\n[*eslint*]: http://bar.com"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "[foo][ ]\n\n[foo]: http://bar.com/image.jpg",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "![foo][ ]\n\n[foo]: http://bar.com/image.jpg",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "[\nfoo\n][\n]\n\n[foo]: http://bar.com/image.jpg",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 3,
+          "column": 2,
+          "endLine": 4,
+          "endColumn": 2
+        }
+      ]
+    },
+    {
+      "code": "[\nfoo\n][\n ]\n\n[foo]: http://bar.com/image.jpg",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 3,
+          "column": 2,
+          "endLine": 4,
+          "endColumn": 3
+        }
+      ]
+    },
+    {
+      "code": "[foo][ ]\n[bar][ ]\n\n[foo]: http://foo.com\n[bar]: http://bar.com",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 6,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[foo][ ]\n![bar][ ]\n\n[foo]: http://foo.com\n[bar]: http://bar.com",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 7,
+          "endLine": 2,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "- - - [foo][ ]\n\n[foo]: http://foo.com",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 12,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "eslint [eslint][ ]",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "eslint"
+          },
+          "line": 1,
+          "column": 16,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ]
+    },
+    {
+      "code": "\\\\eslint [eslint][ ]",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "eslint"
+          },
+          "line": 1,
+          "column": 18,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ]
+    },
+    {
+      "code": "es\\\\lint\\\\ [eslint][ ]",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "eslint"
+          },
+          "line": 1,
+          "column": 20,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "[eslint][ ]",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "eslint"
+          },
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "[eslint][\n]",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "eslint"
+          },
+          "line": 1,
+          "column": 9,
+          "endLine": 2,
+          "endColumn": 2
+        }
+      ]
+    },
+    {
+      "code": "[*eslint*][ ]",
+      "errors": [
+        {
+          "messageId": "invalidLabelRef",
+          "data": {
+            "label": "*eslint*"
+          },
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-missing-atx-heading-space.json
+++ b/npm/eslint-markdown/test/fixtures/no-missing-atx-heading-space.json
@@ -1,0 +1,1454 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-missing-atx-heading-space.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "# Heading 1"
+    },
+    {
+      "code": "## Heading 2"
+    },
+    {
+      "code": "### Heading 3"
+    },
+    {
+      "code": "#### Heading 4"
+    },
+    {
+      "code": "##### Heading 5"
+    },
+    {
+      "code": "###### Heading 6"
+    },
+    {
+      "code": "####### Heading 7 (not a valid heading)"
+    },
+    {
+      "code": "#######Heading 7 (not a valid heading)"
+    },
+    {
+      "code": "# Heading 1\n\n## Heading 2\n\n### Heading 3"
+    },
+    {
+      "code": "#  Heading with extra space"
+    },
+    {
+      "code": "#\tHeading with tab"
+    },
+    {
+      "code": "#"
+    },
+    {
+      "code": "Heading 1\n========="
+    },
+    {
+      "code": "Heading 2\n---------"
+    },
+    {
+      "code": "Not a heading"
+    },
+    {
+      "code": "This is a paragraph with a #hashtag"
+    },
+    {
+      "code": "Text with # in the middle"
+    },
+    {
+      "code": "foo  #Bar  #Baz"
+    },
+    {
+      "code": "```js\n#Not a heading in a code block\nconsole.log(\"#Not a heading\");\n```"
+    },
+    {
+      "code": "```"
+    },
+    {
+      "code": "``` #followed #by text"
+    },
+    {
+      "code": "~~~ #followed #by more text"
+    },
+    {
+      "code": "This is a paragraph followed by code.\n\n```\n#This is in a code block\n```"
+    },
+    {
+      "code": "This paragraph has `#inline-code` which is not a heading"
+    },
+    {
+      "code": "Here's a code span with a hash: `const tag = '#heading'`"
+    },
+    {
+      "code": "[#370](https://github.com/eslint/markdown/issues/370)"
+    },
+    {
+      "code": "![#370](https://github.com/eslint/markdown/image.png)"
+    },
+    {
+      "code": "<h1>Heading 1</h1>"
+    },
+    {
+      "code": "<h2>Heading 2</h2>"
+    },
+    {
+      "code": "<h3>Heading 3</h3>"
+    },
+    {
+      "code": "<h4>Heading 4</h4>"
+    },
+    {
+      "code": "<h5>Heading 5</h5>"
+    },
+    {
+      "code": "<h6>Heading 6</h6>"
+    },
+    {
+      "code": "<h1>#valid heading</h1>"
+    },
+    {
+      "code": "<!-- #valid heading -->"
+    },
+    {
+      "code": "'#something'"
+    },
+    {
+      "code": "\"#something\""
+    },
+    {
+      "code": "\"<h1>#valid heading</h1>\""
+    },
+    {
+      "code": "    #Heading 1"
+    },
+    {
+      "code": "##  Normal outer non-breaking inner space"
+    },
+    {
+      "code": "## Normal space (both) ##"
+    },
+    {
+      "code": "##  Normal outer non-breaking inner space (both)  ##"
+    },
+    {
+      "code": "##\tTab"
+    },
+    {
+      "code": "##\tTab (left) ##"
+    },
+    {
+      "code": "## Tab (right)\t##"
+    },
+    {
+      "code": "# Heading 1 #",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "## Heading 2 ##",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "### Heading 3 ###",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "#### Heading 4 ####",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "##### Heading 5 #####",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "###### Heading 6 ######",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "####### Heading 7 (not a valid heading)#######",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "Not a heading#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "```js\n#Not a heading in a code block#\nconsole.log(\"#Not a heading#\");\n```",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1 #\n\n## Heading 2 ##\n\n### Heading 3 ###",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "This paragraph has `#inline-code#` which is not a heading",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "[#370#](https://github.com/eslint/markdown/issues/370)",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "<h1>#valid heading#</h1>",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "\"#something#\"",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "    #Heading 1#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Regular heading\n## Closed heading ##\n### Another regular heading",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Heading with extra spaces  #",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "#Setext Heading\n===",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "Setext Heading#\n===",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "#Setext Heading#\n===",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "#Setext Heading\n---",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "Setext Heading#\n---",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "#Setext Heading#\n---",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Backslash Escaping\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Backslash Escaping\\\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Backslash Escaping\\\\\\\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    },
+    {
+      "code": "# Backslash Escaping\\\\\\\\\\\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "#Heading 1",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Heading 1"
+    },
+    {
+      "code": "##Heading 2",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ],
+      "output": "## Heading 2"
+    },
+    {
+      "code": "###Heading 3",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ],
+      "output": "### Heading 3"
+    },
+    {
+      "code": "####Heading 4",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ],
+      "output": "#### Heading 4"
+    },
+    {
+      "code": "#####Heading 5",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ],
+      "output": "##### Heading 5"
+    },
+    {
+      "code": "######Heading 6",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ],
+      "output": "###### Heading 6"
+    },
+    {
+      "code": "# Heading 1\n\n##Heading 2\n\n### Heading 3",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 4
+        }
+      ],
+      "output": "# Heading 1\n\n## Heading 2\n\n### Heading 3"
+    },
+    {
+      "code": "#Text",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Text"
+    },
+    {
+      "code": "#Heading with trailing space ",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Heading with trailing space "
+    },
+    {
+      "code": "#Something with ``` backticks",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Something with ``` backticks"
+    },
+    {
+      "code": "#Heading with ``` in the middle and more text after",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Heading with ``` in the middle and more text after"
+    },
+    {
+      "code": "#Heading with `inline code`",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Heading with `inline code`"
+    },
+    {
+      "code": "#Title with ~~~ tildes in it",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Title with ~~~ tildes in it"
+    },
+    {
+      "code": "Text before\n#Heading with ``` code markers\nText after",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 3
+        }
+      ],
+      "output": "Text before\n# Heading with ``` code markers\nText after"
+    },
+    {
+      "code": "Text before\r\n#Heading with ``` code markers\r\nText after",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 3
+        }
+      ],
+      "output": "Text before\r\n# Heading with ``` code markers\r\nText after"
+    },
+    {
+      "code": "Text before\r#Heading with ``` code markers\rText after",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 3
+        }
+      ],
+      "output": "Text before\r# Heading with ``` code markers\rText after"
+    },
+    {
+      "code": "   ##Heading 2",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ],
+      "output": "   ## Heading 2"
+    },
+    {
+      "code": "#First heading\n\nSome text\n\n##Second heading\n\n###Third heading",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        },
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 4
+        },
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 7,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 5
+        }
+      ],
+      "output": "# First heading\n\nSome text\n\n## Second heading\n\n### Third heading"
+    },
+    {
+      "code": "#*hi*",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# *hi*"
+    },
+    {
+      "code": "#~hi~",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# ~hi~"
+    },
+    {
+      "code": "#_hi_",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# _hi_"
+    },
+    {
+      "code": "#__hi__",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# __hi__"
+    },
+    {
+      "code": "> #Quoted heading",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ],
+      "output": "> # Quoted heading"
+    },
+    {
+      "code": "> ##Quoted heading",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ],
+      "output": "> ## Quoted heading"
+    },
+    {
+      "code": "- Item\n> #Quoted heading in list",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 2,
+          "column": 3,
+          "endLine": 2,
+          "endColumn": 5
+        }
+      ],
+      "output": "- Item\n> # Quoted heading in list"
+    },
+    {
+      "code": "## Non-breaking space",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ],
+      "output": "##  Non-breaking space"
+    },
+    {
+      "code": "##  Extra non-breaking space",
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ],
+      "output": "##   Extra non-breaking space"
+    },
+    {
+      "code": "# Heading 1#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "output": "# Heading 1 #"
+    },
+    {
+      "code": "## Heading 2##",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 12,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "output": "## Heading 2 ##"
+    },
+    {
+      "code": "### Heading 3###",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 13,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ],
+      "output": "### Heading 3 ###"
+    },
+    {
+      "code": "#### Heading 4####",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 14,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "#### Heading 4 ####"
+    },
+    {
+      "code": "##### Heading 5#####",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "##### Heading 5 #####"
+    },
+    {
+      "code": "###### Heading 6######",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 16,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "###### Heading 6 ######"
+    },
+    {
+      "code": "## Heading 2#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 12,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ],
+      "output": "## Heading 2 #"
+    },
+    {
+      "code": "# Heading 1\\##",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 13,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "output": "# Heading 1\\# #"
+    },
+    {
+      "code": "# Heading 1\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 13,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "output": "# Heading 1\\\\ #"
+    },
+    {
+      "code": "# Heading 1\\\\\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ],
+      "output": "# Heading 1\\\\\\\\ #"
+    },
+    {
+      "code": "# Heading 1\\\\\\\\\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 17,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "# Heading 1\\\\\\\\\\\\ #"
+    },
+    {
+      "code": "# Heading 1\\\\\\\\\\\\\\\\#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 19,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "# Heading 1\\\\\\\\\\\\\\\\ #"
+    },
+    {
+      "code": "#Heading 1#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "after"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 3
+        }
+      ],
+      "output": "# Heading 1#"
+    },
+    {
+      "code": "# Heading 1\n\n## Heading 2##\n\n### Heading 3 ###",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 3,
+          "column": 12,
+          "endLine": 3,
+          "endColumn": 15
+        }
+      ],
+      "output": "# Heading 1\n\n## Heading 2 ##\n\n### Heading 3 ###"
+    },
+    {
+      "code": "# Something with ``` backticks#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 30,
+          "endLine": 1,
+          "endColumn": 32
+        }
+      ],
+      "output": "# Something with ``` backticks #"
+    },
+    {
+      "code": "# Heading with ``` in the middle and more text after#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 52,
+          "endLine": 1,
+          "endColumn": 54
+        }
+      ],
+      "output": "# Heading with ``` in the middle and more text after #"
+    },
+    {
+      "code": "# Heading with `inline code`#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 28,
+          "endLine": 1,
+          "endColumn": 30
+        }
+      ],
+      "output": "# Heading with `inline code` #"
+    },
+    {
+      "code": "# Title with ~~~ tildes in it#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 29,
+          "endLine": 1,
+          "endColumn": 31
+        }
+      ],
+      "output": "# Title with ~~~ tildes in it #"
+    },
+    {
+      "code": "Text before\n# Heading with ``` code markers#\nText after",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 2,
+          "column": 31,
+          "endLine": 2,
+          "endColumn": 33
+        }
+      ],
+      "output": "Text before\n# Heading with ``` code markers #\nText after"
+    },
+    {
+      "code": "   ## Heading 2##",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ],
+      "output": "   ## Heading 2 ##"
+    },
+    {
+      "code": "# First heading#\n\nSome text\n\n## Second heading##\n\n### Third heading###",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 17
+        },
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 5,
+          "column": 17,
+          "endLine": 5,
+          "endColumn": 20
+        },
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 7,
+          "column": 17,
+          "endLine": 7,
+          "endColumn": 21
+        }
+      ],
+      "output": "# First heading #\n\nSome text\n\n## Second heading ##\n\n### Third heading ###"
+    },
+    {
+      "code": "# *hi*#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ],
+      "output": "# *hi* #"
+    },
+    {
+      "code": "# ~hi~#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ],
+      "output": "# ~hi~ #"
+    },
+    {
+      "code": "# _hi_#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ],
+      "output": "# _hi_ #"
+    },
+    {
+      "code": "# __hi__#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ],
+      "output": "# __hi__ #"
+    },
+    {
+      "code": "# Heading [#123](issue-link)#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 28,
+          "endLine": 1,
+          "endColumn": 30
+        }
+      ],
+      "output": "# Heading [#123](issue-link) #"
+    },
+    {
+      "code": "> # Quoted heading#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 18,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "> # Quoted heading #"
+    },
+    {
+      "code": "> ## Quoted heading##",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 1,
+          "column": 19,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "> ## Quoted heading ##"
+    },
+    {
+      "code": "- Item\n> # Quoted heading in list#",
+      "options": [
+        {
+          "checkClosedHeadings": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingSpace",
+          "data": {
+            "position": "before"
+          },
+          "line": 2,
+          "column": 26,
+          "endLine": 2,
+          "endColumn": 28
+        }
+      ],
+      "output": "- Item\n> # Quoted heading in list #"
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-missing-label-refs.json
+++ b/npm/eslint-markdown/test/fixtures/no-missing-label-refs.json
@@ -1,0 +1,949 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-missing-label-refs.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "[*foo*]"
+    },
+    {
+      "code": "[foo]\n\n[foo]: http://bar.com"
+    },
+    {
+      "code": "[foo][foo]\n\n[foo]: http://bar.com"
+    },
+    {
+      "code": "[foo][foo]\n\n[ foo ]: http://bar.com"
+    },
+    {
+      "code": "[foo][ foo ]\n\n[ foo ]: http://bar.com"
+    },
+    {
+      "code": "![foo][foo]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[foo][]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "![foo][]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[  foo ][]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[foo][ ]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[\nfoo\n][\n]\n\n[foo]: http://bar.com/image.jpg"
+    },
+    {
+      "code": "[]"
+    },
+    {
+      "code": "][]"
+    },
+    {
+      "code": "[][]"
+    },
+    {
+      "code": "[] []"
+    },
+    {
+      "code": "[foo"
+    },
+    {
+      "code": "foo]"
+    },
+    {
+      "code": "foo][bar]\n\n[bar]: http://bar.com"
+    },
+    {
+      "code": "foo][bar][baz]\n\n[baz]: http://baz.com"
+    },
+    {
+      "code": "[][foo]\n\n[foo]: http://foo.com"
+    },
+    {
+      "code": "[foo][bar\\]\n\n[foo]: http://foo.com"
+    },
+    {
+      "code": "\\[\\]"
+    },
+    {
+      "code": "\\\\\\[\\\\\\]"
+    },
+    {
+      "code": "\\\\\\\\\\[\\\\\\\\\\]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "[\\]"
+    },
+    {
+      "code": "[\\\\\\]"
+    },
+    {
+      "code": "[\\\\\\\\\\]"
+    },
+    {
+      "code": "[\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "\\[]"
+    },
+    {
+      "code": "\\\\\\[]"
+    },
+    {
+      "code": "\\\\\\\\\\[]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[]"
+    },
+    {
+      "code": "\\[escaped\\]"
+    },
+    {
+      "code": "\\\\\\[escaped\\\\\\]"
+    },
+    {
+      "code": "\\\\\\\\\\[escaped\\\\\\\\\\]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[escaped\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "\\[escaped]"
+    },
+    {
+      "code": "\\\\\\[escaped]"
+    },
+    {
+      "code": "\\\\\\\\\\[escaped]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[escaped]"
+    },
+    {
+      "code": "[escaped\\]"
+    },
+    {
+      "code": "[escaped\\\\\\]"
+    },
+    {
+      "code": "[escaped\\\\\\\\\\]"
+    },
+    {
+      "code": "[escaped\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "\\[escaped\\]\\[escaped\\]"
+    },
+    {
+      "code": "\\\\\\[escaped\\\\\\]\\\\\\[escaped\\\\\\]"
+    },
+    {
+      "code": "\\\\\\\\\\[escaped\\\\\\\\\\]\\\\\\\\\\[escaped\\\\\\\\\\]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[escaped\\\\\\\\\\\\\\]\\\\\\\\\\\\\\[escaped\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "\\[escaped\\]\\[escaped]"
+    },
+    {
+      "code": "\\\\\\[escaped\\\\\\]\\\\\\[escaped]"
+    },
+    {
+      "code": "\\\\\\\\\\[escaped\\\\\\\\\\]\\\\\\\\\\[escaped]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[escaped\\\\\\\\\\\\\\]\\\\\\\\\\\\\\[escaped]"
+    },
+    {
+      "code": "[escaped\\]\\[escaped\\]"
+    },
+    {
+      "code": "[escaped\\\\\\]\\\\\\[escaped\\\\\\]"
+    },
+    {
+      "code": "[escaped\\\\\\\\\\]\\\\\\\\\\[escaped\\\\\\\\\\]"
+    },
+    {
+      "code": "[escaped\\\\\\\\\\\\\\]\\\\\\\\\\\\\\[escaped\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "\\[escaped]\\[escaped]"
+    },
+    {
+      "code": "\\\\\\[escaped]\\\\\\[escaped]"
+    },
+    {
+      "code": "\\\\\\\\\\[escaped]\\\\\\\\\\[escaped]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[escaped]\\\\\\\\\\\\\\[escaped]"
+    },
+    {
+      "code": "[escaped\\][escaped\\]"
+    },
+    {
+      "code": "[escaped\\\\\\][escaped\\\\\\]"
+    },
+    {
+      "code": "[escaped\\\\\\\\\\][escaped\\\\\\\\\\]"
+    },
+    {
+      "code": "[escaped\\\\\\\\\\\\\\][escaped\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "[foo][bar]",
+      "options": [
+        {
+          "allowLabels": ["bar"]
+        }
+      ]
+    },
+    {
+      "code": "![foo][bar]",
+      "options": [
+        {
+          "allowLabels": ["bar"]
+        }
+      ]
+    },
+    {
+      "code": "[foo][]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "![foo][]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "![foo]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ]
+    },
+    {
+      "code": "[foo]\n[bar]",
+      "options": [
+        {
+          "allowLabels": ["foo", "bar"]
+        }
+      ]
+    },
+    {
+      "code": "[Foo][]\n[Bar][]",
+      "options": [
+        {
+          "allowLabels": ["Foo", "Bar"]
+        }
+      ]
+    },
+    {
+      "code": "- [x] Checked\n- [-] In progress",
+      "options": [
+        {
+          "allowLabels": ["-"]
+        }
+      ]
+    },
+    {
+      "code": "$(A \\\\cdot x)[i] = \\\\sum_{j=1}^{n} A[i][j] , x[j]$",
+      "languageOptions": {
+        "math": true
+      }
+    },
+    {
+      "code": "$[1, 2, 3, 4]$",
+      "languageOptions": {
+        "math": true
+      }
+    },
+    {
+      "code": "$$\n[1, 2, 3, 4]\n$$",
+      "languageOptions": {
+        "math": true
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "code": "[foo][bar]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "![foo][bar]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "[foo][]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "![foo][]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "[foo]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "![foo]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "[foo]\n[bar]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 2,
+          "endLine": 2,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "- - - [foo]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "foo][bar]\n\n[baz]: http://baz.com",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "foo][bar][baz]\n\n[bar]: http://bar.com",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "baz"
+          },
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ]
+    },
+    {
+      "code": "[foo]\n[foo][bar]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 7,
+          "endLine": 2,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "[Foo][foo]\n[Bar][]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "Bar"
+          },
+          "line": 2,
+          "column": 2,
+          "endLine": 2,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "[Foo][]\n[Bar][]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "Foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "Bar"
+          },
+          "line": 2,
+          "column": 2,
+          "endLine": 2,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "[Foo][foo]\n[Bar][bar]\n[Hoge][]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 7,
+          "endLine": 2,
+          "endColumn": 10
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "Hoge"
+          },
+          "line": 3,
+          "column": 2,
+          "endLine": 3,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "[Foo][]\n[Bar][bar]\n[Hoge][hoge]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "Foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 7,
+          "endLine": 2,
+          "endColumn": 10
+        },
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "hoge"
+          },
+          "line": 3,
+          "column": 8,
+          "endLine": 3,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "[][foo]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": " foo\n  [bar]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 4,
+          "endLine": 2,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "\\\\[foo]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "\\\\[foo\\\\][bar\\\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar\\\\"
+          },
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "\\\\\\\\[foo\\\\\\\\][bar\\\\\\\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar\\\\\\\\"
+          },
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "\\\\\\\\\\\\[foo\\\\\\\\\\\\][bar\\\\\\\\\\\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar\\\\\\\\\\\\"
+          },
+          "line": 1,
+          "column": 19,
+          "endLine": 1,
+          "endColumn": 28
+        }
+      ]
+    },
+    {
+      "code": "\\[[foo]\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "\\\\\\[[foo]\\\\\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "\\\\\\\\\\[[foo]\\\\\\\\\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[[foo]\\\\\\\\\\\\\\]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "[\\[foo\\]]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "\\[foo\\]"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ]
+    },
+    {
+      "code": "[\\\\\\[foo\\\\\\]]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "\\\\\\[foo\\\\\\]"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "[\\\\\\\\\\[foo\\\\\\\\\\]]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "\\\\\\\\\\[foo\\\\\\\\\\]"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ]
+    },
+    {
+      "code": "[\\\\\\\\\\\\\\[foo\\\\\\\\\\\\\\]]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "\\\\\\\\\\\\\\[foo\\\\\\\\\\\\\\]"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ]
+    },
+    {
+      "code": "[\\[\\[foo\\]\\]]",
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "\\[\\[foo\\]\\]"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "[foo][bar]",
+      "options": [
+        {
+          "allowLabels": ["baz"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "![foo][bar]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "[foo][]",
+      "options": [
+        {
+          "allowLabels": ["bar"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "[foo]\n[bar]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "bar"
+          },
+          "line": 2,
+          "column": 2,
+          "endLine": 2,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "[Foo][]",
+      "options": [
+        {
+          "allowLabels": ["foo"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "Foo"
+          },
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ]
+    },
+    {
+      "code": "[Foo][foo]\n[Bar][]",
+      "options": [
+        {
+          "allowLabels": ["Bar"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "notFound",
+          "data": {
+            "label": "foo"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-missing-link-fragments.json
+++ b/npm/eslint-markdown/test/fixtures/no-missing-link-fragments.json
@@ -1,0 +1,930 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-missing-link-fragments.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "# Heading Name\n[Link](#heading-name)"
+    },
+    {
+      "code": "# Heading Name\n[Link][reference]\n\n[reference]: #heading-name"
+    },
+    {
+      "code": "# Heading Name $E=mc^2$\n[Link](#heading-name-emc2)",
+      "languageOptions": {
+        "math": true
+      }
+    },
+    {
+      "code": "# Heading Name $(A \\\\cdot x)[i] = \\\\sum_{j=1}^{n} A[i][j] , x[j]$\n[Link](#heading-name-a-cdot-xi--sum_j1n-aij--xj)",
+      "languageOptions": {
+        "math": true
+      }
+    },
+    {
+      "code": "# Heading Name {#custom-name}\n[Link](#custom-name)"
+    },
+    {
+      "code": "<h1>heading 1</h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1</h1 >\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1</h1  >\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1</h1   >\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1</h1\n>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<H1>heading 1</H1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>HEADING 1</h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>HeAdInG 1</h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>{ } scss-to-css</h1>\n\n[Link](#--scss-to-css)"
+    },
+    {
+      "code": "<h1>scss-to-css</h1>\n\n[Link](#scss-to-css)"
+    },
+    {
+      "code": "<h1>heading <strong>1</strong></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <strong><em>1</em></strong></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading  <strong><em>1</em></strong></h1>\n\n[Link](#heading--1)"
+    },
+    {
+      "code": "<h1>heading  <strong><em> 1 </em></strong></h1>\n\n[Link](#heading---1-)"
+    },
+    {
+      "code": "<h1>heading <em>1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em >1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em  >1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em>1</em ></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em>1</em  ></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em>1< /em></h1>\n\n[Link](#heading-1-em)"
+    },
+    {
+      "code": "<h1>heading < em>1</em></h1>\n\n[Link](#heading--em1)"
+    },
+    {
+      "code": "<h1>heading <  em>1</em></h1>\n\n[Link](#heading---em1)"
+    },
+    {
+      "code": "<h1>heading <EM>1</EM></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test=\"test\">1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test=\"test >\">1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test='test >'>1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test=\"test <>\">1</em></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em>1</em data-test=\"test\"></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em>1</em data-test=\"test >\"></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em>1</em data-test=\"test <>\"></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test=\"test\">1</em data-test=\"test\"></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test=\"test >\">1</em data-test=\"test >\"></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading <em data-test=\"test <>\">1</em data-test=\"test <>\"></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1< br></h1>\n\n[Link](#heading-1-br)"
+    },
+    {
+      "code": "<h1>heading 1<  br></h1>\n\n[Link](#heading-1--br)"
+    },
+    {
+      "code": "<h1>heading 1<   br></h1>\n\n[Link](#heading-1---br)"
+    },
+    {
+      "code": "<h1>heading 1<br ></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br  ></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br/></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br /></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br  /></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br/ ></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1>heading 1<br/  ></h1>\n\n[Link](#heading-1)"
+    },
+    {
+      "code": "<h1 id=\"foo\">bar</h1>\n\n[Link](#foo)\n[Link](#bar)"
+    },
+    {
+      "code": "<h1 name=\"foo\">bar</h1>\n\n[Link](#foo)\n[Link](#bar)"
+    },
+    {
+      "code": "<h2>heading 2</h2>\n\n[Link](#heading-2)"
+    },
+    {
+      "code": "<H2>heading 2</H2>\n\n[Link](#heading-2)"
+    },
+    {
+      "code": "<h3>heading 3</h3>\n\n[Link](#heading-3)"
+    },
+    {
+      "code": "<H3>heading 3</H3>\n\n[Link](#heading-3)"
+    },
+    {
+      "code": "<h4>heading 4</h4>\n\n[Link](#heading-4)"
+    },
+    {
+      "code": "<H4>heading 4</H4>\n\n[Link](#heading-4)"
+    },
+    {
+      "code": "<h5>heading 5</h5>\n\n[Link](#heading-5)"
+    },
+    {
+      "code": "<H5>heading 5</H5>\n\n[Link](#heading-5)"
+    },
+    {
+      "code": "<h6>heading 6</h6>\n\n[Link](#heading-6)"
+    },
+    {
+      "code": "<H6>heading 6</H6>\n\n[Link](#heading-6)"
+    },
+    {
+      "code": "<a id=\"bookmark\"></a>\n[Link](#bookmark)"
+    },
+    {
+      "code": "<a ID=\"bookmark\"></a>\n[Link](#bookmark)"
+    },
+    {
+      "code": "<a Id=\"bookmark\"></a>\n[Link](#bookmark)"
+    },
+    {
+      "code": "<a name=\"old-style\"></a>\n[Link](#old-style)"
+    },
+    {
+      "code": "<a NAME=\"old-style\"></a>\n[Link](#old-style)"
+    },
+    {
+      "code": "<a NaMe=\"old-style\"></a>\n[Link](#old-style)"
+    },
+    {
+      "code": "<h1 id=\"bookmark\">Bookmark</h1>\n<h1 name=\"old-style\">Old Style</h1>\n<h2 id=\"bookmark-2\">Bookmark 2</h2>\n<h2 name=\"old-style-2\">Old Style 2</h2>\n<h3 id=\"bookmark-3\">Bookmark 3</h3>\n<h3 name=\"old-style-3\">Old Style 3</h3>\n<h4 id=\"bookmark-4\">Bookmark 4</h4>\n<h4 name=\"old-style-4\">Old Style 4</h4>\n<h5 id=\"bookmark-5\">Bookmark 5</h5>\n<h5 name=\"old-style-5\">Old Style 5</h5>\n<h6 id=\"bookmark-6\">Bookmark 6</h6>\n<h6 name=\"old-style-6\">Old Style 6</h6>\n\n[Link](#bookmark)\n[Link](#old-style)\n[Link](#bookmark-2)\n[Link](#old-style-2)\n[Link](#bookmark-3)\n[Link](#old-style-3)\n[Link](#bookmark-4)\n[Link](#old-style-4)\n[Link](#bookmark-5)\n[Link](#old-style-5)\n[Link](#bookmark-6)\n[Link](#old-style-6)"
+    },
+    {
+      "code": "<h1 id=bookmark>Bookmark</h1>\n<h1 name=old-style>Old Style</h1>\n<h2 id = bookmark-2>Bookmark 2</h2>\n<h2 name = old-style-2>Old Style 2</h2>\n<h3 id= bookmark-3>Bookmark 3</h3>\n<h3 name= old-style-3>Old Style 3</h3>\n<h4 id =bookmark-4>Bookmark 4</h4>\n<h4 name =old-style-4>Old Style 4</h4>\n<h5 id='bookmark-5'>Bookmark 5</h5>\n<h5 name='old-style-5'>Old Style 5</h5>\n<h6 id = 'bookmark-6'>Bookmark 6</h6>\n<h6 name = 'old-style-6'>Old Style 6</h6>\n<h6 id= 'bookmark-7'>Bookmark 7</h6>\n<h6 name= 'old-style-7'>Old Style 7</h6>\n<h6 id ='bookmark-8'>Bookmark 8</h6>\n<h6 name ='old-style-8'>Old Style 8</h6>\n<h6 id=\"bookmark-9\">Bookmark 9</h6>\n<h6 name=\"old-style-9\">Old Style 9</h6>\n<h6 id = \"bookmark-10\">Bookmark 10</h6>\n<h6 name = \"old-style-10\">Old Style 10</h6>\n<h6 id= \"bookmark-11\">Bookmark 11</h6>\n<h6 name= \"old-style-11\">Old Style 11</h6>\n<h6 id =\"bookmark-12\">Bookmark 12</h6>\n<h6 name =\"old-style-12\">Old Style 12</h6>\n\n[Link](#bookmark)\n[Link](#old-style)\n[Link](#bookmark-2)\n[Link](#old-style-2)\n[Link](#bookmark-3)\n[Link](#old-style-3)\n[Link](#bookmark-4)\n[Link](#old-style-4)\n[Link](#bookmark-5)\n[Link](#old-style-5)\n[Link](#bookmark-6)\n[Link](#old-style-6)\n[Link](#bookmark-7)\n[Link](#old-style-7)\n[Link](#bookmark-8)\n[Link](#old-style-8)\n[Link](#bookmark-9)\n[Link](#old-style-9)\n[Link](#bookmark-10)\n[Link](#old-style-10)\n[Link](#bookmark-11)\n[Link](#old-style-11)\n[Link](#bookmark-12)\n[Link](#old-style-12)"
+    },
+    {
+      "code": "# foo bar baz\n# foo-bar-baz\n\n[Link](#foo-bar-baz)\n[Link](#foo-bar-baz-1)"
+    },
+    {
+      "code": "[Link](#top)"
+    },
+    {
+      "code": "# Sample Code Section\n\n```js\n// Line 1: Function declaration\nfunction add(a, b) {\n\t// Line 2: Add numbers\n\treturn a + b;\n}\n\n// Line 3: Function call\nconst result = add(1, 2);\n\n// Line 4: Log result\nconsole.log(result);\n```\n\n[Reference Line 2](#L6)\n[Reference Lines 2-4](#L6-L12)\n[Reference Line with Column](#L6C13)\n[Reference Line Range with Columns](#L6C13-L8C1)"
+    },
+    {
+      "code": "# Heading Name\n[Link](#HEADING-NAME)"
+    },
+    {
+      "code": "# Heading Name\n[Link](#HeAdInG-nAmE)"
+    },
+    {
+      "code": "# Heading Name\n[Link](#Heading-Name)"
+    },
+    {
+      "code": "[Link](#figure-1)\n[Link](#figure-2)",
+      "options": [
+        {
+          "allowPattern": "^figure-"
+        }
+      ]
+    },
+    {
+      "code": "# Duplicate\n[Link](#duplicate)\n# Duplicate\n[Link to second Duplicate](#duplicate-1)\n# Duplicate {#custom-dup}\n[Link to custom Duplicate](#custom-dup)\n# Duplicate\n[Link to third Duplicate](#duplicate-2)"
+    },
+    {
+      "code": "# Special & < > Characters!\n[Link](#special----characters)"
+    },
+    {
+      "code": "[External](https://example.com)"
+    },
+    {
+      "code": "[Root](/)"
+    },
+    {
+      "code": "[Empty]()"
+    },
+    {
+      "code": "[Link](#)"
+    },
+    {
+      "code": "# First Heading\n## Second Heading\n### Third Heading\n\n[Link 1](#first-heading)\n[Link 2](#second-heading)\n[Link 3](#third-heading)"
+    },
+    {
+      "code": "<div id=\"section1\">Content</div>\n[Link](#section1)"
+    },
+    {
+      "code": "# Heading with `inline code`\n[Link](#heading-with-inline-code)\n\n# Heading with *italic text*\n[Link](#heading-with-italic-text)\n\n# Heading with _italic too_\n[Link](#heading-with-italic-too)\n\n# Heading with **bold text**\n[Link](#heading-with-bold-text)\n\n# Heading with __bold too__\n[Link](#heading-with-bold-too)\n\n# Heading with ~strikethrough~\n[Link](#heading-with-strikethrough)"
+    },
+    {
+      "code": "# Heading with 🚀 emoji\n[Link](#heading-with--emoji)\n\n# Héading with àccènt chàrâctérs\n[Link](#héading-with-àccènt-chàrâctérs)\n\n# Mix: _Héading_ with 🚀 & `code`\n[Link](#mix-héading-with---code)"
+    },
+    {
+      "code": "<h1>👍 scss-to-css</h1>\n\n[Link](#-scss-to-css)"
+    },
+    {
+      "code": "# Hèading\n[Link](#h%C3%A8ading)\n\n# Hèading with `inline code`\n[Link](#h%C3%A8ading-with-inline-code)\n\n# Héading with _italic_\n[Link](#h%C3%A9ading-with-italic)\n\n# Héading with **bold**\n[Link](#h%C3%A9ading-with-bold)\n\n# Heading Name {#custom-namé}\n[Link](#custom-nam%C3%A9)\n\n<div id=\"réal-id\"></div>\n\n[Link](#r%C3%A9al-id)"
+    },
+    {
+      "code": "# Héading Name\n[Link](#H%C3%89ADING-NAME)",
+      "options": [
+        {
+          "ignoreCase": true
+        }
+      ]
+    },
+    {
+      "code": "[Link](#figur%C3%A9-1)\n[Link](#figur%C3%A9-2)",
+      "options": [
+        {
+          "allowPattern": "^figuré-"
+        }
+      ]
+    },
+    {
+      "code": "<div id=\"HtmlCaseCheck\"></div>\n[Link](#htmlcasecheck)",
+      "options": [
+        {
+          "ignoreCase": true
+        }
+      ]
+    },
+    {
+      "code": "<!-- <div id=\"commented-out\"></div> -->\n<div id=\"real-id\"></div>\n[Link](#real-id)"
+    },
+    {
+      "code": "# Heading with _italic_\n[Link](#heading-with-italic)\n\n# Heading with **bold**\n[Link](#heading-with-bold)\n\n# foo_\n[Link](#foo_)"
+    },
+    {
+      "code": "# <picture></picture> Heading Name\n[Link](#-heading-name)"
+    },
+    {
+      "code": "# Heading Name <picture></picture>\n[Link](#heading-name-)"
+    },
+    {
+      "code": "# Heading <picture></picture> Name\n[Link](#heading--name)"
+    },
+    {
+      "code": "# <span>Text</span> Heading Name\n[Link](#text-heading-name)"
+    },
+    {
+      "code": "# ![alt text](img.png) Heading Name\n[Link](#-heading-name)"
+    },
+    {
+      "code": "# Heading Name ![alt text](img.png)\n[Link](#heading-name-)"
+    },
+    {
+      "code": "# <picture></picture> Heading Name\n[Link](#-HEADING-NAME)",
+      "options": [
+        {
+          "ignoreCase": true
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "[Invalid](#non-existent)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "non-existent"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "[Invalid][reference]\n\n[reference]: #non-existent",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "non-existent"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 27
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading 1</h1>\n\n[Invalid](#non-existent)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "non-existent"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "< h1>heading 1</h1>\n\n         ^^^----------------\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<  h1>heading 1</h1>\n\n         ^^^^----------------\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading 1</ h1>\n\n      --------------^^^--\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading 1</  h1>\n\n      --------------^^^^--\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading 1</   h1>\n\n      --------------^^^^^--\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading 1</\n      h1>\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading <em>1</ em></h1>\n\n      ------------------^^^-------\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading <em>1</  em></h1>\n\n      ------------------^^^^------\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h7>heading 1</h7>\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h8>heading 1</h8>\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h1>heading 1</h2>\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<h3>heading 1</h6>\n\n[Invalid](#heading-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-1"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "# Heading Name\n[Invalid](#HEADING-NAME)",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "HEADING-NAME"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "# Heading\n[Invalid](#wrong-heading)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "wrong-heading"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "# Heading\n[Invalid 1](#wrong1)\n[Invalid 2](#wrong2)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "wrong1"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 21
+        },
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "wrong2"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 21
+        }
+      ]
+    },
+    {
+      "code": "# Heading {#Invalid-ID-With-Caps}\n[Link](#Invalid-ID-With-Caps)",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "Invalid-ID-With-Caps"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 30
+        }
+      ]
+    },
+    {
+      "code": "# Heading\n[Invalid](#heading@#$%)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading@#$%"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "```js\n// Some code\n```\n[Invalid Format](#L2O)  // Using O instead of 0",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "L2O"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "[Invalid Format](#l20)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "l20"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "[Invalid Format](#l20-l30)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "l20-l30"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ]
+    },
+    {
+      "code": "# Only One Like This\n[Invalid Link](#only-one-like-this-1)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "only-one-like-this-1"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 38
+        }
+      ]
+    },
+    {
+      "code": "<!-- <div id=\"only-in-comment\"></div> -->\n[Link](#only-in-comment)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "only-in-comment"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "<h1 id=bookmark>Bookmark</h1>\n\n[Link](#notfound)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "notfound"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "<h2 id = bookmark-2>Bookmark 2</h2>\n\n[Link](#notfound)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "notfound"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "<h3 name=old-style-3>Old Style 3</h3>\n\n[Link](#notfound)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "notfound"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "<h4 id=\"bookmark-4\">Bookmark 4</h4>\n\n[Link](#notfound)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "notfound"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "<h5 id = \"bookmark-5\">Bookmark 5</h5>\n\n[Link](#notfound)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "notfound"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "<h1 id=\"one\">\n<!-- comment <h1 id=\"two\"> </h1> -->\n</h1>\n\n[Link](#two)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "two"
+          },
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "# foo\n\n## foo\n\n[Link](#foo)\n\n[Link](#foo-1)\n\n[Link](#foo-2)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "foo-2"
+          },
+          "line": 9,
+          "column": 1,
+          "endLine": 9,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "# foo\n\n## foo-1\n\n### foo-1\n\n[Link](#foo)\n\n[Link](#foo-1)\n\n[Link](#foo-1-1)\n\n[Link](#foo-2)\n\n[Link](#foo-1-2)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "foo-2"
+          },
+          "line": 13,
+          "column": 1,
+          "endLine": 13,
+          "endColumn": 15
+        },
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "foo-1-2"
+          },
+          "line": 15,
+          "column": 1,
+          "endLine": 15,
+          "endColumn": 17
+        }
+      ]
+    },
+    {
+      "code": "# Heading With Space\n[Invalid](#heading%20with%20space)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading%20with%20space"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 35
+        }
+      ]
+    },
+    {
+      "code": "# fóo\n\n## fóo\n\n[Link](#f%C3%B3o)\n\n[Link](#f%C3%B3o-1)\n\n[Link](#f%C3%B3o-2)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "f%C3%B3o-2"
+          },
+          "line": 9,
+          "column": 1,
+          "endLine": 9,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "# <picture></picture> Heading Name\n[Link](#heading-name)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-name"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "# ![alt text](img.png) Heading Name\n[Link](#heading-name)",
+      "errors": [
+        {
+          "messageId": "invalidFragment",
+          "data": {
+            "fragment": "heading-name"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 22
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-multiple-h1.json
+++ b/npm/eslint-markdown/test/fixtures/no-multiple-h1.json
@@ -1,0 +1,1016 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-multiple-h1.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "# Only one h1"
+    },
+    {
+      "code": "# Heading 1\nText"
+    },
+    {
+      "code": "# Heading 1 #\nText"
+    },
+    {
+      "code": "# Heading 1\n## Heading 2"
+    },
+    {
+      "code": "Only one h1\n==========="
+    },
+    {
+      "code": "Heading 1\n==========\nText"
+    },
+    {
+      "code": "Heading 1\n==========\nHeading 2\n----------"
+    },
+    {
+      "code": "# Heading 1\n```markdown\n# Heading 1-2\n```"
+    },
+    {
+      "code": "<p>\n# Not heading\n</p>"
+    },
+    {
+      "code": "---\n[ \"title\" ]\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title\"\n]\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title:\"\n]\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title=\"\n]\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"title\"\n]\n---\n## Heading 2",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n# title: My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\n# title = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\nauthor: Pixel998 # title: My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\nauthor = \"Pixel998\" # title = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\nheading: My Title\n---\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\nheading = \"My Title\"\n+++\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*="
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"heading\": \"My Title\"\n}\n---\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*\"heading\"\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"heading\"\n]\n---\n## Heading 2",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*\"heading\"\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\nauthor: Pixel998\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\nauthor = \"Pixel998\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"author\": \"name\"\n}\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\n[\n\t\"author\"\n]\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n# Heading 1",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      }
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n# Heading 1",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      }
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n# Heading 1",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      }
+    },
+    {
+      "code": "<h1 class=\"title\">Heading</h1>"
+    },
+    {
+      "code": "< h1>Heading</h1>\n\n         -^---------------\n\n# Another H1"
+    },
+    {
+      "code": "<  h1>Heading</h1>\n\n         -^^---------------\n\n# Another H1"
+    },
+    {
+      "code": "<\n         h1>Heading</h1>\n\n# Another H1"
+    },
+    {
+      "code": "<h1>Heading</ h1>\n\n         -------------^---\n\n# Another H1"
+    },
+    {
+      "code": "<h1>Heading</  h1>\n\n         -------------^^---\n\n# Another H1"
+    },
+    {
+      "code": "<h1>Heading</   h1>\n\n         -------------^^^---\n\n# Another H1"
+    },
+    {
+      "code": "<h1>Heading</\n         h1>\n\n# Another H1"
+    },
+    {
+      "code": "<h1>Heading</ h1 >\n\n         -------------^--^-\n\n# Another H1"
+    },
+    {
+      "code": "# Heading 1\n\n<!-- <h1>Commented Heading</h1> -->\n<!-- <h1>Commented Heading</h1> -->"
+    },
+    {
+      "code": "# Heading 1\n\n<!--\n<h1>Commented Heading</h1>\n<p>Some text</p>\n-->"
+    },
+    {
+      "code": "# Heading 1\nSome text <!-- <h1>Commented</h1> --> more text."
+    },
+    {
+      "code": "# Heading 1\n<!-- <h1>Comment with --- extra dashes</h1> -->"
+    },
+    {
+      "code": "# Heading 1\n<!--<h1>No spaces</h1>-->\n<!--    <h1>Extra spaces</h1>    -->"
+    },
+    {
+      "code": "# Heading 1\n```html\n<!-- <h1>Commented in code</h1> -->\n```"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "# Heading 1\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n# Heading 2\n# Heading 3",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 12
+        },
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n> # Quoted heading",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 3,
+          "endLine": 2,
+          "endColumn": 19
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n> > # Double-quoted heading",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 5,
+          "endLine": 2,
+          "endColumn": 28
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n- Item\n  item\n  > # Quoted heading in list",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 5,
+          "endLine": 4,
+          "endColumn": 29
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\nAnother H1\n==========",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "Another H1\n==========\n# Heading 1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n---\n# Heading 1\n# Another H1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n\"title\": My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "+++\n\"title\" = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n{ \"title\": \"My Title\" }\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n   {    \"title\": \"My Title\" }\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n'title': My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "+++\n'title' = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\nauthor: Pixel998\ntitle: My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "+++\nauthor = \"Pixel998\"\ntitle = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"author\": \"name\",\n\t\"title\": \"My Title\"\n}\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 7,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\nTITLE: My Title\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "+++\nTITLE = \"My Title\"\n+++\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"TITLE\": \"My Title\"\n}\n---\n# Heading 1",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\nheading: My Title\n---\n# Heading 1",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "+++\nheading = \"My Title\"\n+++\n# Heading 1",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*heading\\s*="
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"heading\": \"My Title\"\n}\n---\n# Heading 1",
+      "options": [
+        {
+          "frontmatterTitle": "^\\s*\"heading\"\\s*:"
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 12
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n# Heading 1\n# Another H1",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n# Heading 1\n# Another H1",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n# Heading 1\n# Another H1",
+      "options": [
+        {
+          "frontmatterTitle": ""
+        }
+      ],
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 7,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading</h1>\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1 >Heading</h1>\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1  >Heading</h1>\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1   >Heading</h1>\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1\n            >Heading</h1>\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading</h1 >\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading</h1  >\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading</h1   >\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading</h1\n            >\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "<H1>Heading</H1>\n\n# Another H1",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n\n<h1\nclass=\"title\">\nAnother H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "# Heading\n<h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "<h1>First H1</h1>\n\n<h1>Second H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ]
+    },
+    {
+      "code": "<h1>First H1</h1>\n<p>Text</p>\n<h1>Second H1</h1>\n<p>Text</p>\n<h1>Third H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 19
+        },
+        {
+          "messageId": "multipleH1",
+          "line": 5,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "---\ntitle: My Title\n---\n<h1>Another H1</h1>",
+      "languageOptions": {
+        "frontmatter": "yaml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "+++\ntitle = \"My Title\"\n+++\n# Heading 1\n\n<h1>Another H1</h1>",
+      "languageOptions": {
+        "frontmatter": "toml"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 12
+        },
+        {
+          "messageId": "multipleH1",
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "---\n{\n\t\"title\": \"My Title\"\n}\n---\n# Heading 1\n\n<h1>Another H1</h1>",
+      "languageOptions": {
+        "frontmatter": "json"
+      },
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 6,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 12
+        },
+        {
+          "messageId": "multipleH1",
+          "line": 8,
+          "column": 1,
+          "endLine": 8,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "<!-- <h1>Commented</h1> -->\n<h1>Heading 1</h1>\n<h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n<!-- <h1>Commented</h1> -->\n<h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n<!- Not a valid comment ->\n<h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "# Heading 1\n<!-- comment --> <h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 37
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading 1</h1>\n<!-- comment --> <h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 37
+        }
+      ]
+    },
+    {
+      "code": "<h1>Heading 1</h1>\n<!-- comment with surrogate pairs: 👍🚀 --> <h1>Another H1</h1>",
+      "errors": [
+        {
+          "messageId": "multipleH1",
+          "line": 2,
+          "column": 45,
+          "endLine": 2,
+          "endColumn": 64
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-reference-like-urls.json
+++ b/npm/eslint-markdown/test/fixtures/no-reference-like-urls.json
@@ -1,0 +1,1090 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-reference-like-urls.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "[Mercury](https://example.com/mercury/)"
+    },
+    {
+      "code": "[Mercury](https://example.com/mercury/ \"Go to Mercury\")"
+    },
+    {
+      "code": "![Venus](https://example.com/venus/)"
+    },
+    {
+      "code": "![Venus](https://example.com/venus/ \"Go to Venus\")"
+    },
+    {
+      "code": "[text][mercury]"
+    },
+    {
+      "code": "[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "[Mercury](mercury) is the first planet.\n\n[venus]: https://example.com/venus/"
+    },
+    {
+      "code": "[Planet 1](https://example.com/planet1/)\n[Planet 2](https://example.com/planet2/)\n\n[planet1]: https://example.com/planet1/\n[planet2]: https://example.com/planet2/"
+    },
+    {
+      "code": "`[Mercury](mercury) is the first planet.`\n`![Mercury](mercury) is the first planet.`\n\n[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "```markdown\n[Mercury](mercury)\n![Mercury](mercury)\n\n[mercury]: https://example.com/mercury/\n```"
+    },
+    {
+      "code": "<div>[Mercury](mercury)</div>\n\n<div>![Mercury](mercury)</div>\n\n[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "\\[Mercury](mercury)\n[Mercury\\](mercury)\n![Mercury\\](mercury)\n[Mercury]\\(mercury)\n![Mercury]\\(mercury)\n\n[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "[foo bar](foo bar)\n![foo bar](foo bar)\n\n[foo bar]: https://example.com/foo-bar"
+    },
+    {
+      "code": "[link](<uri>)\n\n   [uri]: https://example.com/uri"
+    },
+    {
+      "code": "![image](<uri>)\n\n[uri]: https://example.com/uri"
+    },
+    {
+      "code": "<http://foo>\n\n[http://foo]: hi"
+    },
+    {
+      "code": "http://foo\n\n[http://foo]: hi"
+    },
+    {
+      "code": "# Heading with [Mercury](mercury)\n# Heading with ![Mercury](mercury)\n\n[venus]: https://example.com/venus/"
+    },
+    {
+      "code": "# Heading with [Mercury][mercury]\n# Heading with ![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "Heading with [Mercury](mercury)\n===============================\nHeading with ![Mercury](mercury)\n================================\n\n[venus]: https://example.com/venus/"
+    },
+    {
+      "code": "Heading with [Mercury][mercury]\n===============================\nHeading with ![Mercury][mercury]\n================================\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury](mercury)  |\n| Mercury | ![Mercury](mercury) |\n\n[venus]: https://example.com/venus/"
+    },
+    {
+      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury][mercury]  |\n| Mercury | ![Mercury][mercury] |\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "[Mercury](  mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "[Mercury][  mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](\tmercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "[Mercury][\tmercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](\nmercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "[Mercury][\nmercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](\r\nmercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "[Mercury][\r\nmercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](\rmercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "[Mercury][\rmercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "![Mercury](\nmercury)\n\n[mercury]: https://example.com/mercury.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "![Mercury][\nmercury]\n\n[mercury]: https://example.com/mercury.jpg"
+    },
+    {
+      "code": "![Mercury](\r\nmercury)\n\n[mercury]: https://example.com/mercury.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "![Mercury][\r\nmercury]\n\n[mercury]: https://example.com/mercury.jpg"
+    },
+    {
+      "code": "![Mercury](\rmercury)\n\n[mercury]: https://example.com/mercury.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "![Mercury][\rmercury]\n\n[mercury]: https://example.com/mercury.jpg"
+    },
+    {
+      "code": "![Mercury](  mercury)\n\n[mercury]: https://example.com/mercury.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "![Mercury][  mercury]\n\n[mercury]: https://example.com/mercury.jpg"
+    },
+    {
+      "code": "![Mercury](\tmercury)\n\n[mercury]: https://example.com/mercury.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "![Mercury][\tmercury]\n\n[mercury]: https://example.com/mercury.jpg"
+    },
+    {
+      "code": "[Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[**Mercury**](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "[**Mercury**][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](MERCURY)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "[Mercury][MERCURY]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](MeRcUrY)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "[Mercury][MeRcUrY]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[Mercury](<mercury>)\n\n[<mercury>]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "[Mercury][<mercury>]\n\n[<mercury>]: https://example.com/mercury"
+    },
+    {
+      "code": "![Venus](venus)\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "output": "![Venus][venus]\n\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "![Venus](VENUS)\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "output": "![Venus][VENUS]\n\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "![Venus](VeNuS)\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "output": "![Venus][VeNuS]\n\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "![Venus](<venus>)\n\n[<venus>]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ],
+      "output": "![Venus][<venus>]\n\n[<venus>]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "![**Mercury** is a planet](mercury)\n\n[mercury]: https://example.com/mercury.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 36
+        }
+      ],
+      "output": "![**Mercury** is a planet][mercury]\n\n[mercury]: https://example.com/mercury.jpg"
+    },
+    {
+      "code": "![Mercury](mercury) is the first planet from the sun.\n\n[mercury]: https://example.com/mercury/",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "![Mercury][mercury] is the first planet from the sun.\n\n[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "[Mercury](mercury) is the first planet from the sun.\n\n[mercury]: https://example.com/mercury/",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "[Mercury][mercury] is the first planet from the sun.\n\n[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "[Planet 1](planet1) and [Planet 2](planet2) are neighbors.\n\n[planet1]: https://example.com/planet1/\n[planet2]: https://example.com/planet2/",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 20
+        },
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "[Planet 1][planet1] and [Planet 2][planet2] are neighbors.\n\n[planet1]: https://example.com/planet1/\n[planet2]: https://example.com/planet2/"
+    },
+    {
+      "code": "[Mercury](mercury) is the first planet and ![Venus](venus) is the second.\n\n[mercury]: https://example.com/mercury\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        },
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 44,
+          "endLine": 1,
+          "endColumn": 59
+        }
+      ],
+      "output": "[Mercury][mercury] is the first planet and ![Venus][venus] is the second.\n\n[mercury]: https://example.com/mercury\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "[Mercury](mercury \"\")\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "![Venus](venus \"\")\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "![Venus][venus]\n\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "[Mercury](mercury '')\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "![Venus](venus '')\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "![Venus][venus]\n\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "[Mercury](mercury ())\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "![Venus](venus ())\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "![Venus][venus]\n\n[venus]: https://example.com/venus.jpg"
+    },
+    {
+      "code": "[Mercury](mercury \"Go to Mercury\")\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ]
+    },
+    {
+      "code": "![Venus](venus \"Venus Image\")\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 30
+        }
+      ]
+    },
+    {
+      "code": "[Mercury](mercury 'Go to Mercury')\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ]
+    },
+    {
+      "code": "![Venus](venus 'Venus Image')\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 30
+        }
+      ]
+    },
+    {
+      "code": "[Mercury](mercury (Go to Mercury))\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ]
+    },
+    {
+      "code": "![Venus](venus (Venus Image))\n\n[venus]: https://example.com/venus.jpg",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 30
+        }
+      ]
+    },
+    {
+      "code": "\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury/",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "\\\\[Mercury][mercury]\n\n[mercury]: https://example.com/mercury/"
+    },
+    {
+      "code": "\\\\![Venus](venus)\n\n[venus]: https://example.com/venus/",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ],
+      "output": "\\\\![Venus][venus]\n\n[venus]: https://example.com/venus/"
+    },
+    {
+      "code": "[Click Me\n](test)\n\n[test]: https://abc.com",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 8
+        }
+      ],
+      "output": "[Click Me\n][test]\n\n[test]: https://abc.com"
+    },
+    {
+      "code": "![Click Me\n](test)\n\n[test]: https://abc.com",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 8
+        }
+      ],
+      "output": "![Click Me\n][test]\n\n[test]: https://abc.com"
+    },
+    {
+      "code": "[Mercury](@mercury)\n![Mercury](@mercury)\n\n[@mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 20
+        },
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 21
+        }
+      ],
+      "output": "[Mercury][@mercury]\n![Mercury][@mercury]\n\n[@mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "# Heading with [Mercury](mercury)\n# Heading with ![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 16,
+          "endLine": 1,
+          "endColumn": 34
+        },
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 2,
+          "column": 16,
+          "endLine": 2,
+          "endColumn": 35
+        }
+      ],
+      "output": "# Heading with [Mercury][mercury]\n# Heading with ![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "Heading with [Mercury](mercury)\n===============================\nHeading with ![Mercury](mercury)\n================================\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 14,
+          "endLine": 1,
+          "endColumn": 32
+        },
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 3,
+          "column": 14,
+          "endLine": 3,
+          "endColumn": 33
+        }
+      ],
+      "output": "Heading with [Mercury][mercury]\n===============================\nHeading with ![Mercury][mercury]\n================================\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury](mercury)  |\n| Mercury | ![Mercury](mercury) |\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 3,
+          "column": 13,
+          "endLine": 3,
+          "endColumn": 31
+        },
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 4,
+          "column": 13,
+          "endLine": 4,
+          "endColumn": 32
+        }
+      ],
+      "output": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury][mercury]  |\n| Mercury | ![Mercury][mercury] |\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 5,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "\\\\\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ],
+      "output": "\\\\\\\\\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "\\\\\\\\\\\\\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "\\\\[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 5,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "\\\\\\\\[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\\\\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ],
+      "output": "\\\\\\\\\\\\[Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "\\\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 5,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "output": "\\\\\\\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "\\\\\\\\\\\\![Mercury](mercury)\n\n[mercury]: https://example.com/mercury",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "image",
+            "prefix": "!"
+          },
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 26
+        }
+      ],
+      "output": "\\\\\\\\\\\\![Mercury][mercury]\n\n[mercury]: https://example.com/mercury"
+    },
+    {
+      "code": "[link](GRÜẞE)\n\n[Grüsse]: https://example.com/",
+      "errors": [
+        {
+          "messageId": "referenceLikeUrl",
+          "data": {
+            "type": "link",
+            "prefix": ""
+          },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ],
+      "output": "[link][GRÜẞE]\n\n[Grüsse]: https://example.com/"
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-reversed-media-syntax.json
+++ b/npm/eslint-markdown/test/fixtures/no-reversed-media-syntax.json
@@ -1,0 +1,677 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-reversed-media-syntax.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": "[foo](bar)"
+    },
+    {
+      "code": "[foo](#bar)"
+    },
+    {
+      "code": "[foo](http://bar.com)"
+    },
+    {
+      "code": "![foo](bar)"
+    },
+    {
+      "code": "![foo](#bar)"
+    },
+    {
+      "code": "![foo](http://bar.com)"
+    },
+    {
+      "code": "(foo)[bar\r\n]"
+    },
+    {
+      "code": "(foo)[bar\r]"
+    },
+    {
+      "code": "(foo)[bar\n]"
+    },
+    {
+      "code": "(foo)[bar](http://bar.com)"
+    },
+    {
+      "code": "\t\tmyObj.getFiles(test)[0]"
+    },
+    {
+      "code": "```js\nmyObj.getFiles(test)[0];\n```"
+    },
+    {
+      "code": "`myobj.getFiles(test)[0]`"
+    },
+    {
+      "code": "Some long text about foo\n# Split,\n`myobj.getFiles(test)[0]`"
+    },
+    {
+      "code": "&lpar;reversed&rpar;[link]"
+    },
+    {
+      "code": "a &rpar; a &lpar; a &rpar;[a]~"
+    },
+    {
+      "code": "a<pre>&rpar; a &lpar; a &rpar;[a]~</pre>"
+    },
+    {
+      "code": "\\(foo)[bar]"
+    },
+    {
+      "code": "\\\\\\(foo)[bar]"
+    },
+    {
+      "code": "\\\\\\\\\\(foo)[bar]"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\(foo)[bar]"
+    },
+    {
+      "code": "(foo\\)[bar]"
+    },
+    {
+      "code": "(foo\\\\\\)[bar]"
+    },
+    {
+      "code": "(foo\\\\\\\\\\)[bar]"
+    },
+    {
+      "code": "(foo\\\\\\\\\\\\\\)[bar]"
+    },
+    {
+      "code": "(foo)\\[bar]"
+    },
+    {
+      "code": "(foo)\\\\\\[bar]"
+    },
+    {
+      "code": "(foo)\\\\\\\\\\[bar]"
+    },
+    {
+      "code": "(foo)\\\\\\\\\\\\\\[bar]"
+    },
+    {
+      "code": "(foo)[bar\\]"
+    },
+    {
+      "code": "(foo)[bar\\\\\\]"
+    },
+    {
+      "code": "(foo)[bar\\\\\\\\\\]"
+    },
+    {
+      "code": "(foo)[bar\\\\\\\\\\\\\\]"
+    },
+    {
+      "code": "text [foo](bar) text [foo](bar) text"
+    },
+    {
+      "code": "text [foo](bar)[foo](bar) text"
+    },
+    {
+      "code": "🎉 [foo](bar)"
+    },
+    {
+      "code": "text 🎉🎉 [foo](bar) text"
+    },
+    {
+      "code": "🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 `(foo)[bar]`"
+    },
+    {
+      "code": "text [foo](bar)[foo](bar)[foo](bar) text"
+    },
+    {
+      "code": "text (text `func()[index]`) text"
+    },
+    {
+      "code": "hi <span class=\"foo(bar)[baz]\">hi</span>"
+    },
+    {
+      "code": "( <!-- hi)[ --> ]"
+    },
+    {
+      "code": "( <img data-custom = \")[\" alt=\"alt\"> ]"
+    },
+    {
+      "code": "( ![image)[]]()"
+    },
+    {
+      "code": "(`)[`]"
+    },
+    {
+      "code": "(`)[]`"
+    },
+    {
+      "code": "# [ESLint](https://eslint.org/)"
+    },
+    {
+      "code": "# ![A beautiful sunset](sunset.png)"
+    },
+    {
+      "code": "![()[]](hi)"
+    },
+    {
+      "code": "![(hi)[something]](hi)"
+    },
+    {
+      "code": "![()[]](https://example.com)"
+    },
+    {
+      "code": "![()[]][ref]\n\n[ref]: https://example.com"
+    },
+    {
+      "code": "![(hi)[something]][ref]\n\n[ref]: https://example.com"
+    },
+    {
+      "code": "[()[]][ref]\n\n[ref]: https://example.com"
+    },
+    {
+      "code": "[(hi)[something]][ref]\n\n[ref]: https://example.com"
+    },
+    {
+      "code": "| ESLint                        | Sunset                            |\n| ----------------------------- | --------------------------------- |\n| [ESLint](https://eslint.org/) | ![A beautiful sunset](sunset.png) |"
+    },
+    {
+      "code": "$(A \\cdot x)[i] = \\sum_{j=1}^{n} A[i][j] , x[j]$",
+      "languageOptions": {
+        "math": true
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "code": "()[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ],
+      "output": "[]()"
+    },
+    {
+      "code": "(foo)[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ],
+      "output": "[foo]()"
+    },
+    {
+      "code": "!()[foo]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ],
+      "output": "![](foo)"
+    },
+    {
+      "code": "(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ],
+      "output": "[foo](bar)"
+    },
+    {
+      "code": "(foo)[#bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "[foo](#bar)"
+    },
+    {
+      "code": "(foo)[http://bar.com]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "[foo](http://bar.com)"
+    },
+    {
+      "code": "!(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "![foo](bar)"
+    },
+    {
+      "code": "!(foo)[#bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "output": "![foo](#bar)"
+    },
+    {
+      "code": "!(foo)[http://bar.com]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "![foo](http://bar.com)"
+    },
+    {
+      "code": "(*foo*)[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ],
+      "output": "[*foo*]()"
+    },
+    {
+      "code": "(**foo**)[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "[**foo**]()"
+    },
+    {
+      "code": "(~~foo~~)[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "[~~foo~~]()"
+    },
+    {
+      "code": "(`foo`)[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 10
+        }
+      ],
+      "output": "[`foo`]()"
+    },
+    {
+      "code": "[^1]: !(Footnote alt)[https://example.com]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 43
+        }
+      ],
+      "output": "[^1]: ![Footnote alt](https://example.com)"
+    },
+    {
+      "code": "[^1]: (Footnote text)[https://example.com]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 43
+        }
+      ],
+      "output": "[^1]: [Footnote text](https://example.com)"
+    },
+    {
+      "code": "(fo\no)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 8
+        }
+      ],
+      "output": "[fo\no](bar)"
+    },
+    {
+      "code": "(foo\n)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 7
+        }
+      ],
+      "output": "[foo\n](bar)"
+    },
+    {
+      "code": "(foo)[bar]\n!(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 11
+        },
+        {
+          "messageId": "reversedSyntax",
+          "line": 2,
+          "column": 2,
+          "endLine": 2,
+          "endColumn": 12
+        }
+      ],
+      "output": "[foo](bar)\n![foo](bar)"
+    },
+    {
+      "code": "`code code\ncode`\n(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 11
+        }
+      ],
+      "output": "`code code\ncode`\n[foo](bar)"
+    },
+    {
+      "code": "text\ntext `code\ncode code\ncode` text\ntext (foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 5,
+          "column": 6,
+          "endLine": 5,
+          "endColumn": 16
+        }
+      ],
+      "output": "text\ntext `code\ncode code\ncode` text\ntext [foo](bar)"
+    },
+    {
+      "code": "text (text(foo)[bar] text",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "text (text[foo](bar) text"
+    },
+    {
+      "code": "(text foo())[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ],
+      "output": "[text foo()](bar)"
+    },
+    {
+      "code": "text (foo)[bar] text !(baz)[qux] text",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 16
+        },
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 33
+        }
+      ],
+      "output": "text [foo](bar) text ![baz](qux) text"
+    },
+    {
+      "code": "abcd\n  \\a()[]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 2,
+          "column": 5,
+          "endLine": 2,
+          "endColumn": 9
+        }
+      ],
+      "output": "abcd\n  \\a[]()"
+    },
+    {
+      "code": "🎉 (foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ],
+      "output": "🎉 [foo](bar)"
+    },
+    {
+      "code": "text 🎉🎉 (foo)[bar] text",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "output": "text 🎉🎉 [foo](bar) text"
+    },
+    {
+      "code": "🎉🎉🎉🎉🎉🎉🎉🎉 `a` (foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 22,
+          "endLine": 1,
+          "endColumn": 32
+        }
+      ],
+      "output": "🎉🎉🎉🎉🎉🎉🎉🎉 `a` [foo](bar)"
+    },
+    {
+      "code": "[link1](#link \"`\") ()[] [link2](#link \"`\")",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 20,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "output": "[link1](#link \"`\") []() [link2](#link \"`\")"
+    },
+    {
+      "code": "\\\\(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "output": "\\\\[foo](bar)"
+    },
+    {
+      "code": "\\\\\\\\(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 5,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "output": "\\\\\\\\[foo](bar)"
+    },
+    {
+      "code": "\\\\\\\\\\\\(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ],
+      "output": "\\\\\\\\\\\\[foo](bar)"
+    },
+    {
+      "code": "\\\\\\\\\\\\\\\\(foo)[bar]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "\\\\\\\\\\\\\\\\[foo](bar)"
+    },
+    {
+      "code": "# (ESLint)[https://eslint.org/]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 3,
+          "endLine": 1,
+          "endColumn": 32
+        }
+      ],
+      "output": "# [ESLint](https://eslint.org/)"
+    },
+    {
+      "code": "# !(A beautiful sunset)[sunset.png]",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 1,
+          "column": 4,
+          "endLine": 1,
+          "endColumn": 36
+        }
+      ],
+      "output": "# ![A beautiful sunset](sunset.png)"
+    },
+    {
+      "code": "Setext Heading\n  (ESLint)[https://eslint.org/]\n===",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 2,
+          "column": 3,
+          "endLine": 2,
+          "endColumn": 32
+        }
+      ],
+      "output": "Setext Heading\n  [ESLint](https://eslint.org/)\n==="
+    },
+    {
+      "code": "| ESLint                        | Sunset                            |\n| ----------------------------- | --------------------------------- |\n| (ESLint)[https://eslint.org/] | !(A beautiful sunset)[sunset.png] |",
+      "errors": [
+        {
+          "messageId": "reversedSyntax",
+          "line": 3,
+          "column": 3,
+          "endLine": 3,
+          "endColumn": 32
+        },
+        {
+          "messageId": "reversedSyntax",
+          "line": 3,
+          "column": 36,
+          "endLine": 3,
+          "endColumn": 68
+        }
+      ],
+      "output": "| ESLint                        | Sunset                            |\n| ----------------------------- | --------------------------------- |\n| [ESLint](https://eslint.org/) | ![A beautiful sunset](sunset.png) |"
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-space-in-emphasis.json
+++ b/npm/eslint-markdown/test/fixtures/no-space-in-emphasis.json
@@ -1,0 +1,1626 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-space-in-emphasis.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "Line with *Normal emphasis*"
+    },
+    {
+      "code": "Line with **Normal strong**"
+    },
+    {
+      "code": "Line with ***Normal strong and emphasis***"
+    },
+    {
+      "code": "Line with _Normal emphasis_"
+    },
+    {
+      "code": "Line with __Normal strong__"
+    },
+    {
+      "code": "Line with ___Normal strong and emphasis___"
+    },
+    {
+      "code": "Line with ~Normal strikethrough~"
+    },
+    {
+      "code": "Line with ~~Normal strikethrough~~"
+    },
+    {
+      "code": "Line with ~~*strikethrough and emphasis*~~"
+    },
+    {
+      "code": "But not with escaped\\* asterisks\\* \\_and \\_underscores."
+    },
+    {
+      "code": "But not with escaped\\~ tildes\\~ either."
+    },
+    {
+      "code": "* Emphasis* with left space is recognized as a list"
+    },
+    {
+      "code": "* List item *with emphasis* on the\n  first and *second lines*."
+    },
+    {
+      "code": "* List item with\n  *hanging* emphasis"
+    },
+    {
+      "code": "***strong emph***"
+    },
+    {
+      "code": "***strong** in emph*"
+    },
+    {
+      "code": "***emph* in strong**"
+    },
+    {
+      "code": "**in strong *emph***"
+    },
+    {
+      "code": "*in emph **strong***"
+    },
+    {
+      "code": "**in strong * emph*** (internal spaces are not detected)"
+    },
+    {
+      "code": "*in emph ** strong*** (internal spaces are not detected)"
+    },
+    {
+      "code": "***strong ** in emph* (internal spaces are not detected)"
+    },
+    {
+      "code": "***emph * in strong** (internal spaces are not detected)"
+    },
+    {
+      "code": "Text *emph***strong** text"
+    },
+    {
+      "code": "```markdown\n      Violations * are * allowed in code blocks where emphasis does not apply.\n      ```"
+    },
+    {
+      "code": "```markdown\n      Violations ~~ are ~~ allowed in code blocks where strikethrough does not apply.\n      ```"
+    },
+    {
+      "code": "Emphasis `inside * code * blocks` is okay."
+    },
+    {
+      "code": "Emphasis `* inside` code `blocks *` is okay."
+    },
+    {
+      "code": "Emphasis `inside *` code `* blocks` is okay."
+    },
+    {
+      "code": "Emphasis `inside _ code _ blocks` is okay."
+    },
+    {
+      "code": "Emphasis `_ inside` code `blocks _` is okay."
+    },
+    {
+      "code": "Emphasis `inside _` code `_ blocks` is okay."
+    },
+    {
+      "code": "Mixed `code_span` scenarios are _also_ okay."
+    },
+    {
+      "code": "Mixed `code*span` scenarios are *also* okay."
+    },
+    {
+      "code": "Mixed `code*span` scenarios are _also_ okay."
+    },
+    {
+      "code": "Mixed `code_span` scenarios are *also* okay."
+    },
+    {
+      "code": "Text ~ strikethrough ~ with spaces"
+    },
+    {
+      "code": "Text ~~ strikethrough ~~ with spaces"
+    },
+    {
+      "code": "[Link](under_score) followed by _underscore_"
+    },
+    {
+      "code": "[Link](un_der_score) followed by _underscore_"
+    },
+    {
+      "code": "[Link](un_der_sco_re) followed by _underscore_"
+    },
+    {
+      "code": "[Link](star*star) followed by *star*"
+    },
+    {
+      "code": "* [Link](star*star) followed by *star*"
+    },
+    {
+      "code": "Text [Link](under_score) text _underscore_ text [Link](st*ar) text *star* text"
+    },
+    {
+      "code": "[Link [link] link](under_score) followed by _underscore_"
+    },
+    {
+      "code": "**under_score** text *under_score*"
+    },
+    {
+      "code": "*under_score* text **under_score**"
+    },
+    {
+      "code": "__star*star__ text _star*star_"
+    },
+    {
+      "code": "_star*star_ text __star*star__"
+    },
+    {
+      "code": "*_emphasis* text *emphasis*"
+    },
+    {
+      "code": "*emphasis_* text *emphasis*"
+    },
+    {
+      "code": "*emphasis* text *_emphasis*"
+    },
+    {
+      "code": "*emphasis* text *emphasis_*"
+    },
+    {
+      "code": "text \\*emphasis* text *emphasis* text"
+    },
+    {
+      "code": "text *emphasis\\* text *emphasis* text"
+    },
+    {
+      "code": "text *emphasis* text \\*emphasis* text"
+    },
+    {
+      "code": "text *emphasis* text *emphasis\\* text"
+    },
+    {
+      "code": "text *star*_underscore_ text **star**_underscore_ text"
+    },
+    {
+      "code": "text **star**_underscore_ text *star*_underscore_ text"
+    },
+    {
+      "code": "text **star**_underscore_ text **star**_underscore_ text"
+    },
+    {
+      "code": "text *star*_underscore_ text *star*__underscore__ text"
+    },
+    {
+      "code": "text *star*__underscore__ text *star*_underscore_ text"
+    },
+    {
+      "code": "text *star*__underscore__ text *star*__underscore__ text"
+    },
+    {
+      "code": "text _underscore_*star* text __underscore__*star* text"
+    },
+    {
+      "code": "text __underscore__*star* text _underscore_*star* text"
+    },
+    {
+      "code": "text __underscore__*star* text __underscore__*star* text"
+    },
+    {
+      "code": "text _underscore_*star* text _underscore_**star** text"
+    },
+    {
+      "code": "text _underscore_**star** text _underscore_*star* text"
+    },
+    {
+      "code": "text _underscore_**star** text _underscore_**star** text"
+    },
+    {
+      "code": "text ~~strike~~*star* text ~strike~**star** text"
+    },
+    {
+      "code": "text ~~strike~~_underscore_ text ~strike~__underscore__ text"
+    },
+    {
+      "code": "> * List with *emphasis* in blockquote\n>\n> > * List with *emphasis* in blockquote"
+    },
+    {
+      "code": "`* text *`"
+    },
+    {
+      "code": "`** text **`"
+    },
+    {
+      "code": "`*** text ***`"
+    },
+    {
+      "code": "`**** text ****`"
+    },
+    {
+      "code": "`***** text *****`"
+    },
+    {
+      "code": "`****** text ******`"
+    },
+    {
+      "code": "`******* text *******`"
+    },
+    {
+      "code": "under_score\n_underscore_"
+    },
+    {
+      "code": "st*ar\n*star*"
+    },
+    {
+      "code": "under_score\n*star*"
+    },
+    {
+      "code": "st*ar\n_underscore_"
+    },
+    {
+      "code": "*star*\n_underscore_"
+    },
+    {
+      "code": "_underscore_\n*star*"
+    },
+    {
+      "code": "[reference_link]\n_first_ and _second_\n\n[reference_link]: https://example.com"
+    },
+    {
+      "code": "[reference_link]\n*first* and *second*\n\n[reference_link]: https://example.com"
+    },
+    {
+      "code": "[reference*link]\n_first_ and _second_\n\n[reference*link]: https://example.com"
+    },
+    {
+      "code": "[reference*link]\n*first* and *second*\n\n[reference*link]: https://example.com"
+    },
+    {
+      "code": "text [reference_link] under _ score text\n\n[reference_link]: https://example.com"
+    },
+    {
+      "code": "text [reference*link] star * star text\n\n[reference*link]: https://example.com"
+    },
+    {
+      "code": "***text\n*text*\n***"
+    },
+    {
+      "code": "*** text\n*text*\n***"
+    },
+    {
+      "code": "*** text\n\\*text\\*\n***"
+    },
+    {
+      "code": "*** text\n**text**\n***"
+    },
+    {
+      "code": "| Table | Table |\n| ----- | ----- |\n| star  | x * y |\n| under | x _ y |"
+    },
+    {
+      "code": "| Table | Table |\n| ----- | ----- |\n| star  | x * y |\n| star  | x * y |\n| under | x _ y |\n| under | x _ y |"
+    },
+    {
+      "code": "| Table | Table                     |\n| ----- | ------------------------- |\n| star  | text *text* text          |\n| under | text _text_ text          |\n| strike| text ~text~ text          |"
+    },
+    {
+      "code": "| Table | Table |\n| ----- | ----- |\n| x * y | x * y |\n| x** y | x** y |\n| x _ y | x _ y |\n| x__ y | x__ y |"
+    },
+    {
+      "code": "```yaml /* autogenerated */\n# YAML...\n```"
+    },
+    {
+      "code": "new_value from *old_value* and *older_value*."
+    },
+    {
+      "code": ":ballot_box_with_check: _Emoji syntax_"
+    },
+    {
+      "code": "some_snake_case_function() is _called_"
+    },
+    {
+      "code": "_~/.ssh/id_rsa_ and _emphasis_"
+    },
+    {
+      "code": "Partial *em*phasis of a *wo*rd."
+    },
+    {
+      "code": "<p>\nEmphasis inside * HTML * content\n</p>"
+    },
+    {
+      "code": "Emphasis <p data=\"inside * attribute * content\"></p>"
+    },
+    {
+      "code": "Embedded underscore is okay:\nText _emphas_i_s_ text _emphasis_"
+    },
+    {
+      "code": "Text *emphasis\nemphasis* text"
+    },
+    {
+      "code": "Text *emphasis* *emphasis\nemphasis* *emphasis* text"
+    },
+    {
+      "code": "Text *emphasis* text *emphasis\nemphasis* text *emphasis* text"
+    },
+    {
+      "code": "Text *emphasis* *emphasis\nemphasis* *emphasis* *emphasis\nemphasis* text *emphasis\nemphasis* text *emphasis* text"
+    },
+    {
+      "code": "Text text\ntext *emphasis\nemphasis emphasis\nemphasis* text\ntext text"
+    },
+    {
+      "code": "Text * asterisk"
+    },
+    {
+      "code": "* Item *emphasis* item\n* Item *emphasis* item\n* Item *emphasis\n  emphasis* item\n* Item *emphasis* item"
+    },
+    {
+      "code": "* Item * asterisk\n* Item * asterisk"
+    },
+    {
+      "code": "Emphasis `inside\nof * code *\nblocks` is okay."
+    },
+    {
+      "code": "Emphasis `* inside`\ncode\n`blocks *` is okay."
+    },
+    {
+      "code": "Emphasis `inside *`\ncode\n`* blocks` is okay."
+    },
+    {
+      "code": "Emphasis `inside\n_ code _\nblocks` is okay."
+    },
+    {
+      "code": "Emphasis `_ inside`\ncode\n`blocks _` is okay."
+    },
+    {
+      "code": "Emphasis `inside _`\ncode\n`_ blocks` is okay."
+    },
+    {
+      "code": "Mixed `code_span`\nscenarios\nare _also_ okay."
+    },
+    {
+      "code": "Mixed `code*span`\nscenarios\nare *also* okay."
+    },
+    {
+      "code": "This paragraph\ncontains *a* mix\nof `*` emphasis\nscenarios and *should*\nnot trigger `*` any\nviolations at *all*."
+    },
+    {
+      "code": "This paragraph\ncontains `a * slightly\nmore complicated\nmulti-line emphasis\nscenario * that\nshould * not trigger\nviolations * either`."
+    },
+    {
+      "code": "Escaped asterisks \\* should \\* be ignored."
+    },
+    {
+      "code": "Escaped asterisks \\* should * be ignored."
+    },
+    {
+      "code": "Escaped asterisks * should \\* be ignored."
+    },
+    {
+      "code": "Escaped underscores \\_ should \\_ be ignored."
+    },
+    {
+      "code": "Escaped underscores \\_ should _ be ignored."
+    },
+    {
+      "code": "Escaped underscores _ should \\_ be ignored."
+    },
+    {
+      "code": "Escaped asterisks \\** should ** be ignored."
+    },
+    {
+      "code": "Escaped asterisks *\\* should ** be ignored."
+    },
+    {
+      "code": "Escaped underscores \\__ should __ be ignored."
+    },
+    {
+      "code": "Escaped underscores _\\_ should __ be ignored."
+    },
+    {
+      "code": "Escaped asterisks ** should \\** be ignored."
+    },
+    {
+      "code": "Escaped asterisks ** should *\\* be ignored."
+    },
+    {
+      "code": "Escaped underscores __ should \\__ be ignored."
+    },
+    {
+      "code": "Escaped underscores __ should _\\_ be ignored."
+    },
+    {
+      "code": "Escaped tildes \\~ should \\~ be ignored."
+    },
+    {
+      "code": "Escaped tildes \\~~ should ~~ be ignored."
+    },
+    {
+      "code": "This is * some * text"
+    },
+    {
+      "code": "$(f * g)(x) + (h * k)(x)$",
+      "languageOptions": {
+        "math": true
+      }
+    },
+    {
+      "code": "$$\n(f * g)(x) + (h * k)(x)\n$$",
+      "languageOptions": {
+        "math": true
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "code": "Broken * emphasis * with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 17,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "Broken *emphasis* with spaces"
+    },
+    {
+      "code": "Broken ** strong ** with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 12
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 16,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "Broken **strong** with spaces"
+    },
+    {
+      "code": "Broken *** strong and emphasis *** with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 13
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 30,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ],
+      "output": "Broken ***strong and emphasis*** with spaces"
+    },
+    {
+      "code": "Broken _ emphasis _ with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 17,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "Broken _emphasis_ with spaces"
+    },
+    {
+      "code": "Broken __ strong __ with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 12
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 16,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "Broken __strong__ with spaces"
+    },
+    {
+      "code": "Broken ___ strong and emphasis ___ with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 13
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 30,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ],
+      "output": "Broken ___strong and emphasis___ with spaces"
+    },
+    {
+      "code": "Mixed *ok emphasis* and * broken emphasis *",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 28
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 41,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "Mixed *ok emphasis* and *broken emphasis*"
+    },
+    {
+      "code": "Mixed **ok strong** and ** broken strong **",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 29
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 40,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "Mixed **ok strong** and **broken strong**"
+    },
+    {
+      "code": "Mixed ***ok strong and emphasis*** and *** broken strong and emphasis ***",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 40,
+          "endLine": 1,
+          "endColumn": 45
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 69,
+          "endLine": 1,
+          "endColumn": 74
+        }
+      ],
+      "output": "Mixed ***ok strong and emphasis*** and ***broken strong and emphasis***"
+    },
+    {
+      "code": "Mixed _ok emphasis_ and _ broken emphasis _",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 28
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 41,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "Mixed _ok emphasis_ and _broken emphasis_"
+    },
+    {
+      "code": "Mixed __ok strong__ and __ broken strong __",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 29
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 40,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "Mixed __ok strong__ and __broken strong__"
+    },
+    {
+      "code": "Mixed ___ok strong and emphasis___ and ___ broken strong and emphasis ___",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 40,
+          "endLine": 1,
+          "endColumn": 45
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 69,
+          "endLine": 1,
+          "endColumn": 74
+        }
+      ],
+      "output": "Mixed ___ok strong and emphasis___ and ___broken strong and emphasis___"
+    },
+    {
+      "code": "Mixed *ok emphasis* **ok strong** * broken emphasis *",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 35,
+          "endLine": 1,
+          "endColumn": 38
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 51,
+          "endLine": 1,
+          "endColumn": 54
+        }
+      ],
+      "output": "Mixed *ok emphasis* **ok strong** *broken emphasis*"
+    },
+    {
+      "code": "Multiple * broken emphasis * _ broken emphasis _",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 26,
+          "endLine": 1,
+          "endColumn": 29
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 30,
+          "endLine": 1,
+          "endColumn": 33
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 46,
+          "endLine": 1,
+          "endColumn": 49
+        }
+      ],
+      "output": "Multiple *broken emphasis* _broken emphasis_"
+    },
+    {
+      "code": "One-sided *broken emphasis *",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 26,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "output": "One-sided *broken emphasis*"
+    },
+    {
+      "code": "One-sided * broken emphasis*",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 11,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ],
+      "output": "One-sided *broken emphasis*"
+    },
+    {
+      "code": "Will _flag on _words with underscores before them.",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 13,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "output": "Will _flag on_words with underscores before them."
+    },
+    {
+      "code": "The same goes for words* with asterisks* after them.",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 24,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "The same goes for words*with asterisks* after them."
+    },
+    {
+      "code": "** Strong** with left space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ],
+      "output": "**Strong** with left space"
+    },
+    {
+      "code": "*** Strong and emphasis*** with left space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ],
+      "output": "***Strong and emphasis*** with left space"
+    },
+    {
+      "code": "_ Emphasis_ with left space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 4
+        }
+      ],
+      "output": "_Emphasis_ with left space"
+    },
+    {
+      "code": "__ Strong__ with left space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 5
+        }
+      ],
+      "output": "__Strong__ with left space"
+    },
+    {
+      "code": "___ Strong and emphasis___ with left space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ],
+      "output": "___Strong and emphasis___ with left space"
+    },
+    {
+      "code": "*Emphasis * with right space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "*Emphasis* with right space"
+    },
+    {
+      "code": "**Strong ** with right space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "**Strong** with right space"
+    },
+    {
+      "code": "***Strong and emphasis *** with right space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 22,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "***Strong and emphasis*** with right space"
+    },
+    {
+      "code": "_Emphasis _ with right space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "_Emphasis_ with right space"
+    },
+    {
+      "code": "__Strong __ with right space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 12
+        }
+      ],
+      "output": "__Strong__ with right space"
+    },
+    {
+      "code": "___Strong and emphasis ___ with right space",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 22,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "___Strong and emphasis___ with right space"
+    },
+    {
+      "code": "**Multiple ** spaces **in ** emphasis **at ** once.",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 14
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 29
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 42,
+          "endLine": 1,
+          "endColumn": 46
+        }
+      ],
+      "output": "**Multiple** spaces **in** emphasis **at** once."
+    },
+    {
+      "code": "This is * an ambiguous * scenario",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 12
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 22,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ],
+      "output": "This is *an ambiguous* scenario"
+    },
+    {
+      "code": "* List * item*",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ],
+      "output": "* List *item*"
+    },
+    {
+      "code": "* List *item *",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 12,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "output": "* List *item*"
+    },
+    {
+      "code": "* List * item *",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 13,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "output": "* List *item*"
+    },
+    {
+      "code": "*** strong emph***",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ],
+      "output": "***strong emph***"
+    },
+    {
+      "code": "***strong emph ***",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 14,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "output": "***strong emph***"
+    },
+    {
+      "code": "Text * emph***strong** text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ],
+      "output": "Text *emph***strong** text"
+    },
+    {
+      "code": "Text *emph ***strong** text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "output": "Text *emph***strong** text"
+    },
+    {
+      "code": "Text *emph*** strong** text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 12,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "output": "Text *emph***strong** text"
+    },
+    {
+      "code": "Text *emph***strong ** text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 19,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "Text *emph***strong** text"
+    },
+    {
+      "code": "Emphasis <b>inside * HTML * content</b>",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 20,
+          "endLine": 1,
+          "endColumn": 23
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 25,
+          "endLine": 1,
+          "endColumn": 28
+        }
+      ],
+      "output": "Emphasis <b>inside *HTML* content</b>"
+    },
+    {
+      "code": "Emphasis <p data=\"* attribute *\">* HTML *</p>",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 34,
+          "endLine": 1,
+          "endColumn": 37
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 39,
+          "endLine": 1,
+          "endColumn": 42
+        }
+      ],
+      "output": "Emphasis <p data=\"* attribute *\">*HTML*</p>"
+    },
+    {
+      "code": "Text * emphasis\nemphasis* text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        }
+      ],
+      "output": "Text *emphasis\nemphasis* text"
+    },
+    {
+      "code": "Text *emphasis\nemphasis * text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 8,
+          "endLine": 2,
+          "endColumn": 11
+        }
+      ],
+      "output": "Text *emphasis\nemphasis* text"
+    },
+    {
+      "code": "Text * emphasis\nemphasis * text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 8,
+          "endLine": 2,
+          "endColumn": 11
+        }
+      ],
+      "output": "Text *emphasis\nemphasis* text"
+    },
+    {
+      "code": "Text * emphasis * * emphasis\nemphasis * * emphasis * text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 18
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 19,
+          "endLine": 1,
+          "endColumn": 22
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 8,
+          "endLine": 2,
+          "endColumn": 11
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 12,
+          "endLine": 2,
+          "endColumn": 15
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 21,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ],
+      "output": "Text *emphasis* *emphasis\nemphasis* *emphasis* text"
+    },
+    {
+      "code": "Text text\ntext * emphasis\nemphasis emphasis\nemphasis * text\ntext text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 6,
+          "endLine": 2,
+          "endColumn": 9
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 4,
+          "column": 8,
+          "endLine": 4,
+          "endColumn": 11
+        }
+      ],
+      "output": "Text text\ntext *emphasis\nemphasis emphasis\nemphasis* text\ntext text"
+    },
+    {
+      "code": "Text ** bold\nbold ** text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 10
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 2,
+          "column": 4,
+          "endLine": 2,
+          "endColumn": 8
+        }
+      ],
+      "output": "Text **bold\nbold** text"
+    },
+    {
+      "code": "Text _ **bold** _",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 6,
+          "endLine": 1,
+          "endColumn": 9
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 15,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ],
+      "output": "Text _**bold**_"
+    },
+    {
+      "code": "This is * italic with __ bold __ markdown *",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 12
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 27
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 29,
+          "endLine": 1,
+          "endColumn": 33
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 41,
+          "endLine": 1,
+          "endColumn": 44
+        }
+      ],
+      "output": "This is *italic with __bold__ markdown*"
+    },
+    {
+      "code": "This is _\temphasized\t_ text",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 9,
+          "endLine": 1,
+          "endColumn": 12
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 20,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "output": "This is _emphasized_ text"
+    },
+    {
+      "code": "# Broken * emphasis * with spaces",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 19,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "output": "# Broken *emphasis* with spaces"
+    },
+    {
+      "code": "Broken * emphasis * with spaces\n===============",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 17,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "output": "Broken *emphasis* with spaces\n==============="
+    },
+    {
+      "code": "| Table | Table                     |\n| ----- | ------------------------- |\n| star  | text * text* text          |\n| star  | text *text * text          |\n| under | text _ text_ text          |\n| under | text _text _ text          |",
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 3,
+          "column": 16,
+          "endLine": 3,
+          "endColumn": 19
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 4,
+          "column": 20,
+          "endLine": 4,
+          "endColumn": 23
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 5,
+          "column": 16,
+          "endLine": 5,
+          "endColumn": 19
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 6,
+          "column": 20,
+          "endLine": 6,
+          "endColumn": 23
+        }
+      ],
+      "output": "| Table | Table                     |\n| ----- | ------------------------- |\n| star  | text *text* text          |\n| star  | text *text* text          |\n| under | text _text_ text          |\n| under | text _text_ text          |"
+    },
+    {
+      "code": "Broken ~ strikethrough ~ with spaces",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 11
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 22,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ],
+      "output": "Broken ~strikethrough~ with spaces"
+    },
+    {
+      "code": "Broken ~~ strikethrough ~~ with spaces",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 8,
+          "endLine": 1,
+          "endColumn": 12
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "Broken ~~strikethrough~~ with spaces"
+    },
+    {
+      "code": "Mixed ~~ok strikethrough~~ and ~~ broken strikethrough ~~",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 32,
+          "endLine": 1,
+          "endColumn": 36
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 54,
+          "endLine": 1,
+          "endColumn": 58
+        }
+      ],
+      "output": "Mixed ~~ok strikethrough~~ and ~~broken strikethrough~~"
+    },
+    {
+      "code": "Mixed ~ strikethrough ~ and * emphasis * with spaces",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 7,
+          "endLine": 1,
+          "endColumn": 10
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 21,
+          "endLine": 1,
+          "endColumn": 24
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 29,
+          "endLine": 1,
+          "endColumn": 32
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 38,
+          "endLine": 1,
+          "endColumn": 41
+        }
+      ],
+      "output": "Mixed ~strikethrough~ and *emphasis* with spaces"
+    },
+    {
+      "code": "Mixed ~ok strikethrough~ and ~ broken strikethrough ~",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 30,
+          "endLine": 1,
+          "endColumn": 33
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 51,
+          "endLine": 1,
+          "endColumn": 54
+        }
+      ],
+      "output": "Mixed ~ok strikethrough~ and ~broken strikethrough~"
+    },
+    {
+      "code": "# Broken ~ strikethrough ~ with spaces",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 10,
+          "endLine": 1,
+          "endColumn": 13
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 1,
+          "column": 24,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "output": "# Broken ~strikethrough~ with spaces"
+    },
+    {
+      "code": "| Table | Table                     |\n| ----- | ------------------------- |\n| strike | text ~ text~ text          |\n| strike | text ~text ~ text          |",
+      "options": [
+        {
+          "checkStrikethrough": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 3,
+          "column": 17,
+          "endLine": 3,
+          "endColumn": 20
+        },
+        {
+          "messageId": "spaceInEmphasis",
+          "line": 4,
+          "column": 21,
+          "endLine": 4,
+          "endColumn": 24
+        }
+      ],
+      "output": "| Table | Table                     |\n| ----- | ------------------------- |\n| strike | text ~text~ text          |\n| strike | text ~text~ text          |"
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/no-unused-definitions.json
+++ b/npm/eslint-markdown/test/fixtures/no-unused-definitions.json
@@ -1,0 +1,425 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/no-unused-definitions.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": ""
+    },
+    {
+      "code": "   "
+    },
+    {
+      "code": "\n[Mercury][mercury]\n\n[mercury]: https://example.com/mercury/\n"
+    },
+    {
+      "code": "\n[mercury][]\n\n[mercury]: https://example.com/mercury/\n"
+    },
+    {
+      "code": "\n[mercury]\n\n[mercury]: https://example.com/mercury/\n"
+    },
+    {
+      "code": "\n[Mercury][mercury]\n\n[mercury]: https://example.com/mercury/\n[Mercury]: https://example.com/venus/\n"
+    },
+    {
+      "code": "\n[Mercury][mercury]        \n\n[mercury]: https://example.com/mercury/\n[   mercury       ]: https://example.com/venus/\n"
+    },
+    {
+      "code": "\n![Venus Image][venus]\n\n[venus]: https://example.com/venus.jpg        \n"
+    },
+    {
+      "code": "\n![venus][]\n\n[venus]: https://example.com/venus.jpg\n"
+    },
+    {
+      "code": "\n![venus]\n\n[venus]: https://example.com/venus.jpg\n"
+    },
+    {
+      "code": "\nMercury[^mercury]\n\n[^mercury]: Hello, Mercury!\n"
+    },
+    {
+      "code": "\nMercury[^mercury]\n\n[^mercury]: Hello, Mercury!\n[^Mercury]: Hello, Venus!\n"
+    },
+    {
+      "code": "\nMercury[^mercury]\n\n[^mercury]: https://example.com/mercury/\n[    ^mercury       ]: https://example.com/venus/\n"
+    },
+    {
+      "code": "\n[//]: # (This is a comment 1)\n[//]: <> (This is a comment 2)\n"
+    },
+    {
+      "code": "\n[Alpha][alpha] and [Alpha][^alpha]\n\n[alpha]: bravo\n\n[^alpha]: bravo\n"
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "[MERCURY]: https://example.com/mercury/",
+      "options": [
+        {
+          "allowDefinitions": ["MERCURY"]
+        }
+      ]
+    },
+    {
+      "code": "[mercury]: https://example.com/mercury/",
+      "options": [
+        {
+          "allowDefinitions": ["MERCURY"]
+        }
+      ]
+    },
+    {
+      "code": "[MERCURY]: https://example.com/mercury/",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "[   mercury   ]: https://example.com/mercury/",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "[mercury]: https://example.com/mercury/",
+      "options": [
+        {
+          "allowDefinitions": ["   mercury   "]
+        }
+      ]
+    },
+    {
+      "code": "[foo bar]: https://example.com/foo-bar/",
+      "options": [
+        {
+          "allowDefinitions": ["foo\t\r\nbar"]
+        }
+      ]
+    },
+    {
+      "code": "[^MERCURY]: Hello, Mercury!",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["MERCURY"]
+        }
+      ]
+    },
+    {
+      "code": "[^mercury]: Hello, Mercury!",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["MERCURY"]
+        }
+      ]
+    },
+    {
+      "code": "[^MERCURY]: Hello, Mercury!",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "[^mercury]: Hello, Mercury!",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["   mercury   "]
+        }
+      ]
+    },
+    {
+      "code": "[^mercury]: Hello, Mercury!",
+      "options": [
+        {
+          "checkFootnoteDefinitions": false
+        }
+      ]
+    },
+    {
+      "code": "[^mercury]: Hello, Mercury!",
+      "options": [
+        {
+          "checkFootnoteDefinitions": true,
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ]
+    },
+    {
+      "code": "[Grüsse]: https://example.com/",
+      "options": [
+        {
+          "allowDefinitions": ["GRÜẞE"]
+        }
+      ]
+    },
+    {
+      "code": "[^Grüsse]: Grüsse",
+      "options": [
+        {
+          "allowFootnoteDefinitions": ["GRÜẞE"]
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n",
+      "errors": [
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 40
+        }
+      ]
+    },
+    {
+      "code": "\n[Mercury]: https://example.com/mercury/\n",
+      "errors": [
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "Mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 40
+        }
+      ]
+    },
+    {
+      "code": "\n[  Mercury  ]: https://example.com/mercury/\n",
+      "errors": [
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "Mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 44
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n[mercury]: https://example.com/venus/\n[mercury]: https://example.com/earth/\n",
+      "errors": [
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 40
+        },
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 38
+        },
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 38
+        }
+      ]
+    },
+    {
+      "code": "\n[mercury]: https://example.com/mercury/\n",
+      "options": [
+        {
+          "allowDefinitions": ["venus"],
+          "allowFootnoteDefinitions": ["mercury"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 40
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n",
+      "errors": [
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 28
+        }
+      ]
+    },
+    {
+      "code": "\n[^Mercury]: Hello, Mercury!\n",
+      "errors": [
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "Mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 28
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n[^mercury]: Hello, Venus!\n[^mercury]: Hello, Earth!\n",
+      "errors": [
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 28
+        },
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 26
+        },
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n",
+      "options": [
+        {
+          "allowDefinitions": ["mercury"],
+          "allowFootnoteDefinitions": ["venus"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 28
+        }
+      ]
+    },
+    {
+      "code": "\n[^mercury]: Hello, Mercury!\n",
+      "options": [
+        {
+          "checkFootnoteDefinitions": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "unusedFootnoteDefinition",
+          "data": {
+            "identifier": "mercury",
+            "label": "mercury"
+          },
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 28
+        }
+      ]
+    },
+    {
+      "code": "\nHello, [Mercury][mercury]! \nI am living on [Earth][earth] and I am going to [Mars][mars].\n\n[mercury]: https://example.com/mercury/\n[earth]: https://example.com/earth/\n[mars]: https://example.com/mars/\n\n[//]: # (comment about mars)\n\n[jupiter]: https://example.com/jupiter/\n\n[//]: # (comment about jupiter)\n\n[mercury]: https://example.com/venus/\n",
+      "errors": [
+        {
+          "messageId": "unusedDefinition",
+          "data": {
+            "identifier": "jupiter",
+            "label": "jupiter"
+          },
+          "line": 11,
+          "column": 1,
+          "endLine": 11,
+          "endColumn": 40
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/require-alt-text.json
+++ b/npm/eslint-markdown/test/fixtures/require-alt-text.json
@@ -1,0 +1,512 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/require-alt-text.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/commonmark"
+  },
+  "valid": [
+    {
+      "code": ""
+    },
+    {
+      "code": "  "
+    },
+    {
+      "code": "![Alternative text](image.jpg)"
+    },
+    {
+      "code": "![Alternative text](image.jpg \"Title\")"
+    },
+    {
+      "code": "![Alternative text][notitle]\n\n[notitle]: image.jpg"
+    },
+    {
+      "code": "![Alternative text][title]\n\n[title]: image.jpg \"Title\""
+    },
+    {
+      "code": "[![Alternative text](image.jpg)](image.jpg)"
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\"Descriptive text\">"
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\"Descriptive text\" >"
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\"Descriptive text\"/>"
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\"Descriptive text\" />"
+    },
+    {
+      "code": "<img src=\"image.png\" alt>"
+    },
+    {
+      "code": "<img src=\"image.png\" alt >"
+    },
+    {
+      "code": "<img src=\"image.png\" alt/>"
+    },
+    {
+      "code": "<img src=\"image.png\" alt />"
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\"\" />"
+    },
+    {
+      "code": "<img src=\"image.png>\" alt=\"alt text\">"
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\"alt text\" data-custom=\"custom>\">"
+    },
+    {
+      "code": "<img src=\"image.png\" data-custom=\"custom>\" alt=\"alt text\">"
+    },
+    {
+      "code": "<img src=\"image.png>\" data-custom=\"custom\" alt=\"alt text\">"
+    },
+    {
+      "code": "<img src=\"image.png>\" alt='alt text'>"
+    },
+    {
+      "code": "<img\r\nsrc=\"image.png>\" alt=\"alt text\">"
+    },
+    {
+      "code": "<img\r\nsrc=\"image.png>\" alt='alt text'>"
+    },
+    {
+      "code": "<img\rsrc=\"image.png>\" alt=\"alt text\">"
+    },
+    {
+      "code": "<img\rsrc=\"image.png>\" alt='alt text'>"
+    },
+    {
+      "code": "<img\nsrc=\"image.png>\" alt=\"alt text\">"
+    },
+    {
+      "code": "<img\nsrc=\"image.png>\" alt='alt text'>"
+    },
+    {
+      "code": "<img src=\"image.png\" alt='' />"
+    },
+    {
+      "code": "<IMG SRC=\"image.png\" ALT=\"Descriptive text\"/>"
+    },
+    {
+      "code": "<img src=\"image.png\" aria-hidden alt=\"alt\">"
+    },
+    {
+      "code": "<img src=\"image.png\" aria-hidden=\"true\"/>"
+    },
+    {
+      "code": "<img src=\"image.png\" ARIA-HIDDEN=\"TRUE\" />"
+    },
+    {
+      "code": "<p><img src=\"image.png\" alt=\"Descriptive text\" /></p>"
+    },
+    {
+      "code": "<!-- <img src=\"image.png\" /> -->"
+    },
+    {
+      "code": "Some text <!-- <img src=\"image.png\" /> --> more text."
+    },
+    {
+      "code": "<div>\n    <img src=\"https://example.com/image.jpg\" alt=\"alt text\">\"\n</div>"
+    },
+    {
+      "code": "<!--\n<img src=\"image.png\" />\n<p>Some text</p>\n-->"
+    },
+    {
+      "code": "<!--<img src=\"image.png\" />-->\n<!--    <img src=\"image.png\" />    -->"
+    },
+    {
+      "code": "```html\n<img src=\"image.png\" />\n```"
+    }
+  ],
+  "invalid": [
+    {
+      "code": "![ ](image.jpg)",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "![](image.jpg)",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ]
+    },
+    {
+      "code": "![](image.jpg \"Title\")",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "Image without an alternative text ![](image.jpg) in a sentence.",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 35,
+          "endLine": 1,
+          "endColumn": 49
+        }
+      ]
+    },
+    {
+      "code": "![][notitle]\n\n[notitle]: image.jpg",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ]
+    },
+    {
+      "code": "![][title]\n\n[title]: image.jpg \"Title\"",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 11
+        }
+      ]
+    },
+    {
+      "code": "[![](image.jpg)](image.jpg)",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 2,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "<img>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 6
+        }
+      ]
+    },
+    {
+      "code": "<img >",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<img/>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 7
+        }
+      ]
+    },
+    {
+      "code": "<img />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 8
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\">",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\" >",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\"/>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<IMG SRC=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\" alt=\" \" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 32
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\" data-custom1=\"custom>\" data-custom2=\"custom\">",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 67
+        }
+      ]
+    },
+    {
+      "code": "<p>\n<img src=\"image.png\" />\n</p>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<p>\n<img src=\"image.png\" />\n<img src=\"image2.png\" />\n</p>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        },
+        {
+          "messageId": "altTextRequired",
+          "line": 3,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "<div>\n<img src=\"image.png\" />\n<a href=\"#\">Link</a><br>\n<img src=\"image2.png\" />\n</div>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        },
+        {
+          "messageId": "altTextRequired",
+          "line": 4,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 25
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\" aria-hidden=\"false\"/>",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 43
+        }
+      ]
+    },
+    {
+      "code": "<img\nsrc=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 19
+        }
+      ]
+    },
+    {
+      "code": "<img\n src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "<img\n  src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 21
+        }
+      ]
+    },
+    {
+      "code": "<img\n   src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "<!-- <img src=\"image.png\" /> -->\n<img src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<!- Not a valid comment ->\n<img src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 2,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ]
+    },
+    {
+      "code": "<img src=\"image.png\" />\n<!-- comment --> <img src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 24
+        },
+        {
+          "messageId": "altTextRequired",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 41
+        }
+      ]
+    },
+    {
+      "code": "<!-- comment with surrogate pairs: 👍🚀 --> <img src=\"image.png\" />",
+      "errors": [
+        {
+          "messageId": "altTextRequired",
+          "line": 1,
+          "column": 45,
+          "endLine": 1,
+          "endColumn": 68
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/fixtures/table-column-count.json
+++ b/npm/eslint-markdown/test/fixtures/table-column-count.json
@@ -1,0 +1,386 @@
+{
+  "__generated": {
+    "source": "@eslint/markdown",
+    "ref": "v8.0.2",
+    "sourceFile": "tests/rules/table-column-count.test.js",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-eslint-markdown-tests.ts",
+    "language": "markdown/gfm"
+  },
+  "valid": [
+    {
+      "code": "| Header | Header |\n| ------ | ------ |\n| Cell   | Cell   |\n| Cell   | Cell   |"
+    },
+    {
+      "code": "| Header | Header | Header |\n| ------ | ------ | ------ |\n| Cell   | Cell   |\n| Cell   |        |"
+    },
+    {
+      "code": "| A | B |\n|---|---|\n|   |   |\n| C |   |"
+    },
+    {
+      "code": "Just some text. | not a table |"
+    },
+    {
+      "code": "| Header | Header |\n| ------ | ------ | ----- |\n| Cell   | Cell   |"
+    },
+    {
+      "code": "| Header | Header |\n| ------ | ------ |"
+    },
+    {
+      "code": "Some text before.\n\n| H1 | H2 |\n|----|----|\n| D1 | D2 |\n\nSome text after."
+    },
+    {
+      "code": "| Valid | Table |\n| ----- | ----- |\n| Row   | Here  |"
+    },
+    {
+      "code": "| abc | defghi |\n:-: | -----------:\nbar | baz"
+    },
+    {
+      "code": "| f|oo  |\n| ------ |\n| b `|` az |\n| b **|** im |"
+    },
+    {
+      "code": "| abc | def |\n| --- | --- |\n| bar | baz |\n> bar"
+    },
+    {
+      "code": "| abc | def |\n| --- | --- |"
+    },
+    {
+      "code": "| Header | Header |\n| ------ | ------ |\n| Cell   | Cell   |\n| Cell   | Cell   |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ]
+    },
+    {
+      "code": "| Header | Header |\n| ------ | ------ |\n| Cell   |        |\n| Cell   | Cell   |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "| Head1 | Head2 |\n| ----- | ----- |\n| R1C1  | R1C2  | R2C3  |",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 3,
+          "column": 17,
+          "endLine": 3,
+          "endColumn": 26
+        }
+      ]
+    },
+    {
+      "code": "| Head1 | Head2 |\n| ----- | ----- |\n| R1C1  | R1C2  | R2C3  | R3C4 |",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "4",
+            "expectedCells": "2"
+          },
+          "line": 3,
+          "column": 17,
+          "endLine": 3,
+          "endColumn": 33
+        }
+      ]
+    },
+    {
+      "code": "| A |\n| - |\n| 1 | 2 |",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "2",
+            "expectedCells": "1"
+          },
+          "line": 3,
+          "column": 5,
+          "endLine": 3,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "Some introductory text.\n\n| Header1 | Header2 |\n| ------- | ------- |\n| Data1   | Data2   | Data3 |\n| D4      | D5      |\n\nSome concluding text.",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 5,
+          "column": 21,
+          "endLine": 5,
+          "endColumn": 30
+        }
+      ]
+    },
+    {
+      "code": "| abc | defghi |\n:-: | -----------:\nbar | baz\nbar | baz | bad",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 4,
+          "column": 11,
+          "endLine": 4,
+          "endColumn": 16
+        }
+      ]
+    },
+    {
+      "code": "| abc | def |\n| --- | --- |\n| bar | baz | Extra |\n> This is a blockquote after",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 3,
+          "column": 13,
+          "endLine": 3,
+          "endColumn": 22
+        }
+      ]
+    },
+    {
+      "code": "| abc | def |\n| --- | --- |\n| bar | baz | Extra1 |\n| bar | baz | Extra2 |",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 3,
+          "column": 13,
+          "endLine": 3,
+          "endColumn": 23
+        },
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 4,
+          "column": 13,
+          "endLine": 4,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "| abc | def |\n| --- | --- |\n| bar | baz | Extra1 |\n   | bar | baz |\n| bar | baz | Extra2 |",
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 3,
+          "column": 13,
+          "endLine": 3,
+          "endColumn": 23
+        },
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 5,
+          "column": 13,
+          "endLine": 5,
+          "endColumn": 23
+        }
+      ]
+    },
+    {
+      "code": "| Header | Header | Header |\n| ------ | ------ | ------ |\n| Cell   | Cell   |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingCells",
+          "data": {
+            "actualCells": "2",
+            "expectedCells": "3"
+          },
+          "line": 3,
+          "column": 19,
+          "endLine": 3,
+          "endColumn": 20
+        }
+      ]
+    },
+    {
+      "code": "| Col A | Col B | Col C |\n| ----- | ----- | ----- |\n| Cell  |       | Cell  |\n| Cell  | Cell  |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingCells",
+          "data": {
+            "actualCells": "2",
+            "expectedCells": "3"
+          },
+          "line": 4,
+          "column": 17,
+          "endLine": 4,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "| Col A | Col B | Col C |\n| ----- | ----- | ----- |\n| Cell  |\n| Cell  | Cell  |\n| Cell  | Cell  | Cell  |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "missingCells",
+          "data": {
+            "actualCells": "1",
+            "expectedCells": "3"
+          },
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 10
+        },
+        {
+          "messageId": "missingCells",
+          "data": {
+            "actualCells": "2",
+            "expectedCells": "3"
+          },
+          "line": 4,
+          "column": 17,
+          "endLine": 4,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "| Table |\n| ----- |\n| Cell  | Cell  |\n| Cell  |\n| Cell  | Cell  |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "2",
+            "expectedCells": "1"
+          },
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 18
+        },
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "2",
+            "expectedCells": "1"
+          },
+          "line": 5,
+          "column": 9,
+          "endLine": 5,
+          "endColumn": 18
+        }
+      ]
+    },
+    {
+      "code": "| Table | Header |\n| ----- | ------ |\n| Cell  | Cell   | Cell   |\n| Cell  |\n| Cell  | Cell   |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "3",
+            "expectedCells": "2"
+          },
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 28
+        },
+        {
+          "messageId": "missingCells",
+          "data": {
+            "actualCells": "1",
+            "expectedCells": "2"
+          },
+          "line": 4,
+          "column": 9,
+          "endLine": 4,
+          "endColumn": 10
+        }
+      ]
+    },
+    {
+      "code": "| Table | Header | Header |\n| ----- | ------ | ------ |\n| Cell  | Cell   | Cell   |\n| Cell  | Cell   | Cell   | Cell   |\n| Cell  |",
+      "options": [
+        {
+          "checkMissingCells": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "extraCells",
+          "data": {
+            "actualCells": "4",
+            "expectedCells": "3"
+          },
+          "line": 4,
+          "column": 27,
+          "endLine": 4,
+          "endColumn": 37
+        },
+        {
+          "messageId": "missingCells",
+          "data": {
+            "actualCells": "1",
+            "expectedCells": "3"
+          },
+          "line": 5,
+          "column": 9,
+          "endLine": 5,
+          "endColumn": 10
+        }
+      ]
+    }
+  ]
+}

--- a/npm/eslint-markdown/test/harness.mjs
+++ b/npm/eslint-markdown/test/harness.mjs
@@ -1,0 +1,162 @@
+// Replay harness for upstream @eslint/markdown RuleTester cases.
+//
+// Each case's `code` is run through the ported rule's `createOnce`/`Program`
+// adapter (the same path the Oxlint runtime drives), and the reported
+// diagnostics are formatted into ESLint's reported error shape for comparison
+// against the case's declared `errors`. Cases that declare `output` have all
+// reported fixes applied in a single ESLint-compatible pass and compared.
+//
+// The port's descriptor `loc` carries 1-indexed lines and 0-indexed columns
+// (the Markdown scanner counts Unicode scalar columns from 0); RuleTester asserts
+// 1-indexed columns, so the harness adds 1 to every column. Rule options are
+// passed through untouched — the real adapter maps them onto the native scan
+// options, so the harness exercises the shipping option-handling code.
+
+import plugin from '../index.js';
+
+function interpolate(template, data) {
+  if (!data || template == null) {
+    return template;
+  }
+  return template.replace(/\{\{\s*([^}\s]+)\s*\}\}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(data, key) ? String(data[key]) : match,
+  );
+}
+
+// Turn a `context.report` descriptor into ESLint's reported error shape.
+function formatReport(rule, descriptor) {
+  const messages = rule.meta.messages ?? {};
+  const message = descriptor.messageId
+    ? interpolate(messages[descriptor.messageId], descriptor.data)
+    : descriptor.message;
+
+  const result = { message };
+  if (descriptor.messageId) {
+    result.messageId = descriptor.messageId;
+  }
+  if (descriptor.data) {
+    result.data = descriptor.data;
+  }
+
+  const loc = descriptor.loc;
+  if (loc) {
+    if (loc.start) {
+      result.line = loc.start.line;
+      result.column = loc.start.column + 1;
+    }
+    if (loc.end) {
+      result.endLine = loc.end.line;
+      result.endColumn = loc.end.column + 1;
+    }
+  }
+
+  return result;
+}
+
+// Extract a `{ range, text }` fix from a report descriptor, if any.
+function extractFix(descriptor) {
+  if (typeof descriptor.fix !== 'function') {
+    return null;
+  }
+  const fix = descriptor.fix({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return fix && Array.isArray(fix.range) ? fix : null;
+}
+
+// Apply all reported fixes in a single ESLint-compatible pass: sort by range,
+// skip any fix overlapping an already-applied one (matching SourceCodeFixer).
+function applyFixes(code, descriptors) {
+  const fixes = descriptors
+    .map(extractFix)
+    .filter(Boolean)
+    .sort((a, b) => a.range[0] - b.range[0] || a.range[1] - b.range[1]);
+
+  let output = '';
+  let cursor = 0;
+  for (const fix of fixes) {
+    const [start, end] = fix.range;
+    if (start < cursor) {
+      continue;
+    }
+    output += code.slice(cursor, start) + fix.text;
+    cursor = end;
+  }
+  output += code.slice(cursor);
+  return output;
+}
+
+// Run a rule over one case and return both the formatted reports and the raw
+// descriptors (the latter needed to apply fixes for `output` assertions).
+export function runRule(ruleName, testCase) {
+  const rule = plugin.rules[ruleName];
+  if (!rule) {
+    throw new Error(`Unknown rule: ${ruleName}`);
+  }
+
+  const code = testCase.code;
+  const sourceCode = {
+    text: code,
+    getText() {
+      return code;
+    },
+  };
+
+  const descriptors = [];
+  const context = {
+    id: ruleName,
+    options: testCase.options ?? [],
+    sourceCode,
+    filename: testCase.filename ?? 'file.md',
+    report(descriptor) {
+      descriptors.push(descriptor);
+    },
+  };
+
+  const visitor = rule.createOnce(context);
+  visitor.Program?.({ type: 'Program', range: [0, code.length] });
+
+  return {
+    reports: descriptors.map((descriptor) => formatReport(rule, descriptor)),
+    output: applyFixes(code, descriptors),
+  };
+}
+
+// Compare two `data` objects by key/value, independent of insertion order
+// (ESLint's RuleTester compares data with a deep equality that ignores order).
+function sameData(actual, expected) {
+  const actualKeys = Object.keys(actual);
+  const expectedKeys = Object.keys(expected);
+  if (actualKeys.length !== expectedKeys.length) {
+    return false;
+  }
+  return expectedKeys.every((key) => String(actual[key]) === String(expected[key]));
+}
+
+// Assert one reported error matches one declared expectation. A string
+// expectation checks only the message; an object checks each declared field
+// (ignoring `type`/`suggestions`, which the Markdown port does not model).
+export function matchError(actual, expected) {
+  if (typeof expected === 'string') {
+    return { ok: actual.message === expected, field: 'message', actualValue: actual.message };
+  }
+
+  for (const key of Object.keys(expected)) {
+    if (key === 'type' || key === 'suggestions') {
+      continue;
+    }
+    if (key === 'data') {
+      if (!sameData(actual.data ?? {}, expected.data ?? {})) {
+        return { ok: false, field: 'data', actualValue: actual.data };
+      }
+      continue;
+    }
+    if (actual[key] !== expected[key]) {
+      return { ok: false, field: key, actualValue: actual[key] };
+    }
+  }
+
+  return { ok: true, field: null };
+}

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -1,0 +1,81 @@
+{
+  "_doc": "Per-rule upstream-parity enforcement level for the synced @eslint/markdown fixtures (see test/upstream.test.mjs). Levels: 'full' (the default for any rule not listed here) = exact parity is enforced for every valid and invalid case — each reported error's messageId, data, and 1-indexed location must match upstream, and cases declaring `output` must autofix to the same text. 'off' = quarantined; the Rust core still diverges from upstream for this rule, so its valid and invalid cases are registered as skipped (coverage stays visible) until the divergence is fixed and the rule is promoted to 'full'. The end state is zero 'off' entries. Each quarantined rule carries a `note` summarising the known divergence to guide the follow-up fix PR. Regenerate fixtures with `pnpm run port:tests:eslint-markdown`.",
+  "rules": {
+    "fenced-code-language": {
+      "level": "off",
+      "note": "Diagnostic span points at the language token; upstream reports the opening code-fence span (node.position.start, line through the info string)."
+    },
+    "fenced-code-meta": {
+      "level": "off",
+      "note": "Diagnostic span points at the meta token; upstream reports the opening code-fence span."
+    },
+    "heading-increment": {
+      "level": "off",
+      "note": "Diverges on headings inside HTML blocks / blockquotes and on TOML (+++) and JSON frontmatter title detection."
+    },
+    "no-bare-urls": {
+      "level": "off",
+      "note": "False positives on URLs inside link/definition labels, HTML attributes, and existing autolinks."
+    },
+    "no-duplicate-definitions": {
+      "level": "off",
+      "note": "Treats deeply-indented (code-block) lines as definitions; upstream parses them as indented code."
+    },
+    "no-duplicate-headings": {
+      "level": "off",
+      "note": "Heading-text normalisation differs (closed ATX trailing '#', collapsed inner spaces)."
+    },
+    "no-empty-definitions": {
+      "level": "off",
+      "note": "Footnote multi-line content and escaped-caret labels classified differently from upstream."
+    },
+    "no-html": {
+      "level": "off",
+      "note": "Flags HTML tags inside `<!-- -->` comments; upstream ignores comment contents."
+    },
+    "no-invalid-label-refs": {
+      "level": "off",
+      "note": "False positives on collapsed `[foo][]` / `![foo][]` references with a matching definition."
+    },
+    "no-missing-atx-heading-space": {
+      "level": "off",
+      "note": "PANICS on non-ASCII input (char-boundary slice at lib.rs position_for_offset); span/column divergences."
+    },
+    "no-missing-label-refs": {
+      "level": "off",
+      "note": "Broad divergence in shortcut/collapsed reference resolution."
+    },
+    "no-missing-link-fragments": {
+      "level": "off",
+      "note": "Broad divergence in heading-anchor slugging and fragment matching."
+    },
+    "no-multiple-h1": {
+      "level": "off",
+      "note": "Frontmatter-title (YAML/TOML/JSON) interaction with the first H1 differs from upstream."
+    },
+    "no-reference-like-urls": {
+      "level": "off",
+      "note": "Broad divergence detecting inline URLs that collide with definition identifiers."
+    },
+    "no-reversed-media-syntax": {
+      "level": "off",
+      "note": "Broad divergence detecting reversed `(text)[url]` link/image syntax."
+    },
+    "no-space-in-emphasis": {
+      "level": "off",
+      "note": "Fundamentally different emphasis-marker scan; large divergence in spans and counts."
+    },
+    "no-unused-definitions": {
+      "level": "off",
+      "note": "Reference-usage tracking differs for footnotes and collapsed references."
+    },
+    "require-alt-text": {
+      "level": "off",
+      "note": "Divergence detecting images nested in HTML and reference-style images without alt text."
+    },
+    "table-column-count": {
+      "level": "off",
+      "note": "GFM table cell counting and diagnostic span diverge from upstream."
+    }
+  }
+}

--- a/npm/eslint-markdown/test/upstream.test.mjs
+++ b/npm/eslint-markdown/test/upstream.test.mjs
@@ -1,0 +1,138 @@
+// Replays the upstream @eslint/markdown test suite (captured verbatim into
+// test/fixtures/*.json by `pnpm run port:tests:eslint-markdown`) against this
+// plugin, so behavior stays faithful to upstream as the submodule is bumped.
+//
+// Design note — exact parity, ratcheted per rule:
+//   The harness drives each case through the ported rule's createOnce/Program
+//   adapter and asserts EXACT upstream parity: every reported error's
+//   messageId, data, and 1-indexed location must match, and cases that declare
+//   `output` must autofix to the same text. Enforcement is per rule via
+//   parity.json (see its `_doc`). Levels:
+//     - 'full' (the default for any rule not listed) — exact parity is enforced
+//       for every valid and invalid case.
+//     - 'off' — quarantined: the rule still diverges from upstream, so its
+//       cases are registered as skipped (coverage stays visible) until the Rust
+//       core is fixed and the rule is promoted to 'full'. The end state is zero
+//       'off' entries.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { matchError, runRule } from './harness.mjs';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const PARITY_FILE = join(dirname(fileURLToPath(import.meta.url)), 'parity.json');
+
+const fixtureFiles = readdirSync(FIXTURES_DIR)
+  .filter((name) => name.endsWith('.json'))
+  .sort();
+const parityRules = JSON.parse(readFileSync(PARITY_FILE, 'utf8')).rules ?? {};
+
+// Resolve the enforcement level for a rule (default 'full' when unlisted).
+function levelFor(rule) {
+  return parityRules[rule]?.level ?? 'full';
+}
+
+// Defensive: a `code` carrying a lone surrogate is not well-formed UTF-8 and
+// cannot survive the plugin's UTF-8 source-text boundary (it becomes U+FFFD).
+// Such a string also cannot occur in a real on-disk Markdown file. None are
+// expected in the markdown suite, but skip-and-count keeps any gap visible.
+function isReplayable(testCase) {
+  return typeof testCase.code !== 'string' || testCase.code.isWellFormed();
+}
+
+function label(testCase, index) {
+  const code = JSON.stringify(testCase.code);
+  const options =
+    testCase.options && testCase.options.length > 0
+      ? ` options=${JSON.stringify(testCase.options)}`
+      : '';
+  const languageOptions = testCase.languageOptions
+    ? ` languageOptions=${JSON.stringify(testCase.languageOptions)}`
+    : '';
+  return `#${index} ${code}${options}${languageOptions}`;
+}
+
+// Match a list of actual reports against declared expectations. `errors` may be
+// a count (number) or a list of string/object expectations.
+function assertErrors(actual, expectedErrors) {
+  if (typeof expectedErrors === 'number') {
+    expect(actual.length).toBe(expectedErrors);
+    return;
+  }
+
+  expect(
+    actual.length,
+    `error count mismatch\n  actual:   ${JSON.stringify(actual)}\n  expected: ${JSON.stringify(
+      expectedErrors,
+    )}`,
+  ).toBe(expectedErrors.length);
+
+  expectedErrors.forEach((expected, index) => {
+    const result = matchError(actual[index], expected);
+    expect(
+      result.ok,
+      `error #${index} mismatch on "${result.field}"\n  actual:   ${JSON.stringify(
+        actual[index],
+      )}\n  expected: ${JSON.stringify(expected)}`,
+    ).toBe(true);
+  });
+}
+
+// Summary logged at startup so CI output makes coverage visible.
+const counts = { full: 0, off: 0 };
+let nonUtf8 = 0;
+for (const file of fixtureFiles) {
+  counts[levelFor(file.replace(/\.json$/, '')) === 'off' ? 'off' : 'full']++;
+  const fixture = JSON.parse(readFileSync(join(FIXTURES_DIR, file), 'utf8'));
+  for (const testCase of [...fixture.valid, ...fixture.invalid]) {
+    if (!isReplayable(testCase)) {
+      nonUtf8 += 1;
+    }
+  }
+}
+console.log(
+  `eslint-markdown upstream parity: ${counts.full} full (exact) | ${counts.off} quarantined (off)` +
+    `${nonUtf8 > 0 ? ` | ${nonUtf8} non-UTF-8 case(s) skipped` : ''}`,
+);
+
+describe('eslint-markdown upstream parity', () => {
+  expect(fixtureFiles.length).toBeGreaterThan(0);
+
+  for (const file of fixtureFiles) {
+    const ruleName = file.replace(/\.json$/, '');
+    const fixture = JSON.parse(readFileSync(join(FIXTURES_DIR, file), 'utf8'));
+    const quarantined = levelFor(ruleName) === 'off';
+
+    describe(ruleName, () => {
+      describe('valid', () => {
+        fixture.valid.forEach((testCase, index) => {
+          const run = quarantined || !isReplayable(testCase) ? it.skip : it;
+          run(label(testCase, index), () => {
+            expect(runRule(ruleName, testCase).reports).toEqual([]);
+          });
+        });
+      });
+
+      describe('invalid', () => {
+        fixture.invalid.forEach((testCase, index) => {
+          if (quarantined || !isReplayable(testCase)) {
+            it.skip(label(testCase, index), () => {});
+            return;
+          }
+          it(label(testCase, index), () => {
+            const { reports, output } = runRule(ruleName, testCase);
+            assertErrors(reports, testCase.errors);
+            if ('output' in testCase) {
+              const expectedOutput = testCase.output === null ? testCase.code : testCase.output;
+              expect(output).toBe(expectedOutput);
+            }
+          });
+        });
+      });
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "port:status": "node tools/tasks/sync-status-from-port-targets.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
     "port:tests:eslint-json": "node tools/tasks/sync-eslint-json-tests.ts",
+    "port:tests:eslint-markdown": "node tools/tasks/sync-eslint-markdown-tests.ts",
     "port:tests:functional": "node tools/tasks/sync-functional-tests.ts",
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",

--- a/tools/tasks/markdown-sync-dedent.mjs
+++ b/tools/tasks/markdown-sync-dedent.mjs
@@ -1,0 +1,73 @@
+// Verbatim reimplementation of dedent v1.7.1 (MIT, https://github.com/dmnd/dedent),
+// used only by tools/tasks/sync-eslint-markdown-tests.ts: the shallow upstream
+// submodule does not install dev dependencies, so the sync registers this module
+// in place of the real `dedent` package when importing the upstream test files.
+//
+// The upstream @eslint/markdown tests author multi-line Markdown with the
+// `dedent` tagged template, so the captured `code`/`output` fixture strings must
+// match the real package byte-for-byte. The algorithm below mirrors the published
+// source exactly (the Bun-only Unicode workaround is intentionally omitted — it
+// never runs under Node). For tagged-template callers `escapeSpecialCharacters`
+// defaults to `Array.isArray(strings)` (true), enabling the escaped-newline,
+// escaped-backtick/dollar/brace handling and the trailing `\n` -> newline pass.
+
+function createDedent(options) {
+  dedent.withOptions = (newOptions) => createDedent({ ...options, ...newOptions });
+  return dedent;
+
+  function dedent(strings, ...values) {
+    const raw = typeof strings === 'string' ? [strings] : strings.raw;
+    const { escapeSpecialCharacters = Array.isArray(strings), trimWhitespace = true } = options;
+
+    // 1. Interpolate, optionally unescaping special characters.
+    let result = '';
+    for (let i = 0; i < raw.length; i++) {
+      let next = raw[i];
+      if (escapeSpecialCharacters) {
+        next = next
+          .replace(/\\\n[ \t]*/g, '')
+          .replace(/\\`/g, '`')
+          .replace(/\\\$/g, '$')
+          .replace(/\\\{/g, '{');
+      }
+      result += next;
+      if (i < values.length) {
+        result += values[i];
+      }
+    }
+
+    // 2. Find the minimum indentation across all non-blank lines.
+    const lines = result.split('\n');
+    let mindent = null;
+    for (const l of lines) {
+      const m = l.match(/^(\s+)\S+/);
+      if (m) {
+        const indent = m[1].length;
+        if (!mindent) {
+          mindent = indent;
+        } else {
+          mindent = Math.min(mindent, indent);
+        }
+      }
+    }
+
+    // 3. Strip the common indentation from every indented line.
+    if (mindent !== null) {
+      const m = mindent;
+      result = lines.map((l) => (l[0] === ' ' || l[0] === '\t' ? l.slice(m) : l)).join('\n');
+    }
+
+    // 4. Trim surrounding whitespace, then restore escaped newlines.
+    if (trimWhitespace) {
+      result = result.trim();
+    }
+    if (escapeSpecialCharacters) {
+      result = result.replace(/\\n/g, '\n');
+    }
+
+    return result;
+  }
+}
+
+const dedent = createDedent({});
+export default dedent;

--- a/tools/tasks/sync-eslint-markdown-tests.ts
+++ b/tools/tasks/sync-eslint-markdown-tests.ts
@@ -1,0 +1,373 @@
+// Captures the upstream @eslint/markdown test suite straight from the vendored
+// submodule and writes it to committed JSON fixtures, so our Vitest suite
+// replays the real upstream cases and tracks behaviour as the submodule is
+// bumped (oxc-style test syncing). Mirrors tools/tasks/sync-storybook-tests.ts
+// and tools/tasks/sync-eslint-json-tests.ts.
+//
+// Upstream drives cases through ESLint's *declarative* `RuleTester`: each
+// `tests/rules/<rule>.test.js` calls `ruleTester.run('<rule>', rule, { valid,
+// invalid })` once at module top level. The files are ESM (`import`), use the
+// `dedent` tagged template to author multi-line Markdown, and configure the
+// RuleTester with a Markdown `language` (`markdown/commonmark` or
+// `markdown/gfm`). A handful also `import { Linter }` for an ad-hoc perf check
+// wrapped in a top-level mocha `it()`.
+//
+// We register synchronous module hooks (`module.registerHooks`) and stub:
+//   - `eslint`                -> a capturing `RuleTester` whose `run(name, _rule,
+//                                tests)` records the `valid`/`invalid` arrays
+//                                (plus the constructor's `language`) instead of
+//                                executing ESLint, and a no-op `Linter`.
+//   - `dedent`                -> a verbatim reimplementation of dedent v1.7.1
+//                                (the shallow submodule does not install it).
+//   - `../../src/index.js` and `../../src/rules/<rule>.js` -> `export default
+//                                {}`; the real modules pull deps the submodule
+//                                has not installed, and we only need the cases.
+// Global mocha hooks (`it`/`describe`/...) are stubbed as no-ops so the trailing
+// `it()` perf blocks in a few files do not throw at import time.
+//
+// The upstream `.js` test files are ESM, so we drive them with dynamic
+// `import()`; the stubs are emitted as real `.mjs` files in a temp dir and the
+// resolve hook points bare/relative specifiers at them (cleaner than escaping
+// dedent's regex-heavy source into an inline string).
+//
+// Cases carrying non-serialisable values (functions) are dropped and counted
+// (no silent truncation). Re-run with `pnpm run port:tests:eslint-markdown`, then
+// `vp fmt` the generated fixtures (the JSON is emitted with `JSON.stringify`,
+// which always expands short arrays the formatter collapses onto one line).
+
+import { registerHooks } from 'node:module';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type RawCase =
+  | string
+  | {
+      code?: string;
+      output?: string | null;
+      options?: unknown[];
+      filename?: string;
+      only?: boolean;
+      languageOptions?: Record<string, unknown>;
+      errors?: unknown;
+    };
+type Capture = { language?: string; valid: RawCase[]; invalid: RawCase[] };
+
+type NormError = {
+  messageId?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+};
+type NormCase = {
+  code: string;
+  options?: unknown[];
+  filename?: string;
+  languageOptions?: Record<string, unknown>;
+  output?: string | null;
+  errors?: NormError[] | number;
+};
+type NormalizedCapture = { valid: NormCase[]; invalid: NormCase[] };
+
+type SyncGlobal = { captures: Record<string, Capture> };
+
+const ROOT = process.cwd();
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SYNC_KEY = '__eslintMarkdownSyncState__';
+const DEDENT_STUB = pathToFileURL(join(HERE, 'markdown-sync-dedent.mjs')).href;
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-markdown');
+if (!plugin) {
+  throw new Error('eslint-markdown is not registered in tools/port-targets.json');
+}
+
+const SUBMODULE = join(ROOT, plugin.submodule);
+const TESTS_DIR = join(SUBMODULE, 'tests', 'rules');
+const FIXTURES_DIR = join(ROOT, 'npm', 'eslint-markdown', 'test', 'fixtures');
+const REF = plugin.pinnedRef ?? `v${plugin.baselineVersion}`;
+
+if (!existsSync(TESTS_DIR)) {
+  throw new Error(
+    `Upstream tests not found at ${TESTS_DIR}. Run: git submodule update --init --depth 1 ${plugin.submodule}`,
+  );
+}
+
+// Only generate fixtures for rules we actually ship, so the replay harness never
+// references a rule that is not ported.
+const ruleNames = getPortedRules();
+
+mkdirSync(FIXTURES_DIR, { recursive: true });
+
+const state: SyncGlobal = { captures: {} };
+(globalThis as Record<string, unknown>)[SYNC_KEY] = state;
+
+// Mocha globals used at the top level by a few perf-check `it()` blocks. No-op
+// them so importing the test module never throws.
+for (const name of ['describe', 'it', 'before', 'after', 'beforeEach', 'afterEach']) {
+  (globalThis as Record<string, unknown>)[name] = () => {};
+}
+
+const tempDir = mkdtempSync(join(tmpdir(), 'eslint-markdown-sync-'));
+const stubUrls = writeStubs(tempDir);
+registerStubHooks(stubUrls);
+
+const summary: string[] = [];
+for (const rule of ruleNames) {
+  const testFile = join(TESTS_DIR, `${rule}.test.js`);
+  if (!existsSync(testFile)) {
+    throw new Error(`Upstream test file missing for rule "${rule}": ${testFile}`);
+  }
+
+  await import(pathToFileURL(testFile).href);
+
+  const captured = state.captures[rule];
+  if (!captured) {
+    throw new Error(`No RuleTester.run("${rule}") call captured from ${testFile}`);
+  }
+
+  const { cases, dropped } = normalizeCapture(captured);
+  writeFixture(rule, `tests/rules/${rule}.test.js`, captured.language, cases);
+  summary.push(
+    `${rule}: ${cases.valid.length} valid, ${cases.invalid.length} invalid` +
+      `${dropped > 0 ? `, ${dropped} dropped` : ''}`,
+  );
+}
+
+rmSync(tempDir, { recursive: true, force: true });
+
+console.log(`Synced @eslint/markdown fixtures from upstream ${REF}:`);
+for (const line of summary) {
+  console.log(`- ${line}`);
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function getPortedRules(): string[] {
+  const lib = readFileSync(join(ROOT, 'crates', 'eslint_markdown', 'src', 'lib.rs'), 'utf8');
+  const block = /pub const RULE_NAMES:[^=]*=\s*\[([\s\S]*?)\]/.exec(lib);
+  if (!block) {
+    throw new Error('Could not read RULE_NAMES from crates/eslint_markdown/src/lib.rs');
+  }
+  const rules = [...block[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  if (rules.length === 0) {
+    throw new Error('No rules found in RULE_NAMES.');
+  }
+  return rules.sort();
+}
+
+function writeFixture(
+  rule: string,
+  sourceFile: string,
+  language: string | undefined,
+  cases: NormalizedCapture,
+): void {
+  const fixture = {
+    __generated: {
+      source: plugin!.npm,
+      ref: REF,
+      sourceFile,
+      license: plugin!.license,
+      tool: 'tools/tasks/sync-eslint-markdown-tests.ts',
+      language: language ?? null,
+    },
+    valid: cases.valid,
+    invalid: cases.invalid,
+  };
+  writeFileSync(join(FIXTURES_DIR, `${rule}.json`), `${JSON.stringify(fixture, null, 2)}\n`);
+}
+
+function normalizeCapture(capture: Capture): { cases: NormalizedCapture; dropped: number } {
+  let dropped = 0;
+  const valid: NormCase[] = [];
+  const invalid: NormCase[] = [];
+
+  for (const raw of capture.valid) {
+    const normalized = normalizeCase(raw, false);
+    if (normalized) {
+      valid.push(normalized);
+    } else {
+      dropped += 1;
+    }
+  }
+  for (const raw of capture.invalid) {
+    const normalized = normalizeCase(raw, true);
+    if (normalized) {
+      invalid.push(normalized);
+    } else {
+      dropped += 1;
+    }
+  }
+
+  return { cases: { valid, invalid }, dropped };
+}
+
+// Keep only JSON-serialisable cases with a string `code`. A case carrying a
+// function (e.g. a custom parser) does not survive the round-trip and is dropped.
+function normalizeCase(raw: RawCase, isInvalid: boolean): NormCase | null {
+  const value = typeof raw === 'string' ? { code: raw } : raw;
+  if (value == null || typeof value !== 'object' || typeof value.code !== 'string') {
+    return null;
+  }
+
+  const out: NormCase = { code: value.code };
+
+  if (Array.isArray(value.options) && value.options.length > 0) {
+    const options = safeClone(value.options);
+    if (options === undefined) {
+      return null;
+    }
+    out.options = options as unknown[];
+  }
+  if (typeof value.filename === 'string') {
+    out.filename = value.filename;
+  }
+  if (value.languageOptions && typeof value.languageOptions === 'object') {
+    const languageOptions = safeClone(value.languageOptions);
+    if (languageOptions !== undefined) {
+      out.languageOptions = languageOptions as Record<string, unknown>;
+    }
+  }
+
+  if (isInvalid) {
+    const errors = normalizeErrors(value.errors);
+    if (errors !== undefined) {
+      out.errors = errors;
+    }
+    if (typeof value.output === 'string' || value.output === null) {
+      out.output = value.output;
+    }
+  }
+
+  return out;
+}
+
+// Reduce each declared error to the fields we replay against: messageId (or
+// message), the asserted `data` placeholders, and the 1-indexed location. A
+// numeric `errors` is an expected count; a string error is a message assertion.
+function normalizeErrors(errors: unknown): NormError[] | number | undefined {
+  if (typeof errors === 'number') {
+    return errors;
+  }
+  if (!Array.isArray(errors)) {
+    return undefined;
+  }
+  const out: NormError[] = [];
+  for (const error of errors) {
+    if (typeof error === 'string') {
+      out.push({ message: error });
+      continue;
+    }
+    if (!error || typeof error !== 'object') {
+      continue;
+    }
+    const e = error as Record<string, unknown>;
+    const norm: NormError = {};
+    if (typeof e.messageId === 'string') {
+      norm.messageId = e.messageId;
+    }
+    if (typeof e.message === 'string') {
+      norm.message = e.message;
+    }
+    if (e.data && typeof e.data === 'object') {
+      const data = safeClone(e.data);
+      if (data !== undefined) {
+        norm.data = data as Record<string, unknown>;
+      }
+    }
+    for (const key of ['line', 'column', 'endLine', 'endColumn'] as const) {
+      if (typeof e[key] === 'number') {
+        norm[key] = e[key] as number;
+      }
+    }
+    out.push(norm);
+  }
+  return out;
+}
+
+function safeClone(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
+// --- stubs -----------------------------------------------------------------
+
+function writeStubs(dir: string): { eslint: string; noop: string } {
+  const eslintFile = join(dir, 'eslint.mjs');
+  const noopFile = join(dir, 'noop.mjs');
+  writeFileSync(eslintFile, eslintStub());
+  writeFileSync(noopFile, 'export default {};\n');
+  return {
+    eslint: pathToFileURL(eslintFile).href,
+    noop: pathToFileURL(noopFile).href,
+  };
+}
+
+function registerStubHooks(stubs: { eslint: string; noop: string }): void {
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (specifier === 'eslint') {
+        return { url: stubs.eslint, shortCircuit: true };
+      }
+      if (specifier === 'dedent') {
+        return { url: DEDENT_STUB, shortCircuit: true };
+      }
+      // The Markdown plugin entry and the rule-under-test modules: stub both.
+      if (
+        /(^|\/)src\/index\.js$/.test(specifier) ||
+        /(^|\/)src\/rules\/[^/]+\.js$/.test(specifier)
+      ) {
+        return { url: stubs.noop, shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+  });
+}
+
+// Capturing RuleTester: records the `valid`/`invalid` arrays and the configured
+// Markdown `language` keyed on the rule name, on the shared global so the value
+// crosses the hook-loaded module boundary. `Linter` is a no-op (a few files use
+// it for an ad-hoc perf check we do not replay).
+function eslintStub(): string {
+  return [
+    `const KEY = ${JSON.stringify(SYNC_KEY)};`,
+    'export class RuleTester {',
+    '  constructor(config) {',
+    '    this.language = config && config.language;',
+    '  }',
+    '  run(name, _rule, tests) {',
+    '    const valid = (tests && tests.valid) || [];',
+    '    const invalid = (tests && tests.invalid) || [];',
+    '    const prev = globalThis[KEY].captures[name];',
+    '    globalThis[KEY].captures[name] = prev',
+    '      ? { language: prev.language, valid: prev.valid.concat(valid), invalid: prev.invalid.concat(invalid) }',
+    '      : { language: this.language, valid, invalid };',
+    '  }',
+    '}',
+    'export class Linter {',
+    '  verify() { return []; }',
+    '  verifyAndFix(code) { return { output: code, fixed: false, messages: [] }; }',
+    '}',
+    'export default { RuleTester, Linter };',
+  ].join('\n');
+}


### PR DESCRIPTION
## What

Builds the upstream test-sync infrastructure for the `@eslint/markdown` port (issue #13), the same oxc-style harness used by the regexp / eslint-json / storybook ports. The 21 rules were already ported (PR #59) but only exercised by a handful of hand-written cases; this replays the **real upstream RuleTester suite** (v8.0.2) and enforces exact parity, ratcheted per rule.

## How

- **`tools/tasks/sync-eslint-markdown-tests.ts`** — ESM module-hook capture of each `tests/rules/<rule>.test.js`. Stubs `eslint` (capturing `RuleTester` + the configured Markdown `language`; no-op `Linter`), `dedent` (verbatim v1.7.1 reimpl in `tools/tasks/markdown-sync-dedent.mjs`), and the plugin/rule modules; no-ops mocha globals. Emits JSON fixtures with `code`, `options`, `output`, `errors` (`messageId`/`data`/`line`/`column`/`endLine`/`endColumn`), and `languageOptions`. Run via `pnpm run port:tests:eslint-markdown`.
- **`npm/eslint-markdown/test/{harness,upstream.test}.mjs`** — drive every case through the shipping `createOnce`/`Program` adapter and assert **exact** parity: messageId, data, 1-indexed location, and autofix `output`.
- **`npm/eslint-markdown/test/parity.json`** — per-rule ratchet. `full` (enforced) is the default; `off` quarantines a still-diverging rule (its cases run as skipped so coverage stays visible). End state: zero `off`.

## Parity baseline

Replaying the real suite surfaced broad gaps the prior hand-written tests missed (and a **panic** on non-ASCII input in `no-missing-atx-heading-space`). Current state:

- **Full parity, enforced:** `no-empty-images`, `no-empty-links`
- **Quarantined (`off`), to be fixed one PR at a time:** the remaining 19 rules, each annotated in `parity.json` with the known divergence.

Follow-up PRs will fix the Rust core rule-by-rule and promote each to `full` until `parity.json` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784008660&installation_id=136613492&pr_number=242&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F242&signature=f4bd4713299ade34a0e219cfdef193da00854d3933cfc32f6a89d951ef56ed12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->