### PR TITLE
fix(eslint-markdown): report opening-fence span for fenced-code rules

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -557,6 +557,38 @@ fn collect_html_tags(source_text: &str, facts: &mut MarkdownFacts<'_>) {
     }
 }
 
+// Span from the opening fence start through the end of the language token,
+// matching upstream's `start: node.position.start` + `column + langIndex +
+// lang.length` (where `langIndex` is the offset of the language within the
+// node's text, i.e. on the opening fence line).
+fn fence_lang_span(source_text: &str, fence: &FenceFact, lang: &str) -> ByteSpan {
+    let fence_start = fence.marker_span.start;
+    let fence_line = source_text
+        .get(fence_start..fence.info_span.end)
+        .unwrap_or("");
+    let lang_offset = fence_line.find(lang).unwrap_or(0);
+    ByteSpan {
+        start: fence_start,
+        end: fence_start + lang_offset + lang.len(),
+    }
+}
+
+// Span covering the metadata token on the opening fence line, matching upstream's
+// `start.column + metaIndex` .. `+ meta.trimEnd().length` (where `metaIndex` is
+// `fenceLineText.lastIndexOf(node.meta)`).
+fn fence_meta_span(source_text: &str, fence: &FenceFact, meta: &str) -> ByteSpan {
+    let fence_start = fence.marker_span.start;
+    let fence_line = source_text
+        .get(fence_start..fence.info_span.end)
+        .unwrap_or("");
+    let meta_offset = fence_line.rfind(meta).unwrap_or(0);
+    let start = fence_start + meta_offset;
+    ByteSpan {
+        start,
+        end: start + meta.trim_end().len(),
+    }
+}
+
 fn scan_fenced_code_language(
     source_text: &str,
     line_index: &LineIndex,
@@ -588,7 +620,8 @@ fn scan_fenced_code_language(
                     lang: Some(lang.clone()),
                     ..DiagnosticData::default()
                 },
-                loc: line_index.loc_for_span(source_text, fence.info_span),
+                loc: line_index
+                    .loc_for_span(source_text, fence_lang_span(source_text, fence, lang)),
                 fix: None,
             });
         }
@@ -605,32 +638,32 @@ fn scan_fenced_code_meta(
     for fence in &facts.fences {
         match options.fenced_code_meta_mode {
             MetaMode::Always => {
-                if fence.lang.is_some()
-                    && fence
-                        .meta
-                        .as_ref()
-                        .is_none_or(|meta| meta.trim().is_empty())
+                let Some(lang) = &fence.lang else {
+                    continue;
+                };
+                if fence
+                    .meta
+                    .as_ref()
+                    .is_none_or(|meta| meta.trim().is_empty())
                 {
                     diagnostics.push(Diagnostic {
                         rule_name: "fenced-code-meta",
                         message_id: "missingMetadata",
                         data: DiagnosticData::default(),
-                        loc: line_index.loc_for_span(source_text, fence.info_span),
+                        loc: line_index
+                            .loc_for_span(source_text, fence_lang_span(source_text, fence, lang)),
                         fix: None,
                     });
                 }
             }
             MetaMode::Never => {
-                if fence
-                    .meta
-                    .as_ref()
-                    .is_some_and(|meta| !meta.trim().is_empty())
-                {
+                if let Some(meta) = fence.meta.as_ref().filter(|meta| !meta.trim().is_empty()) {
                     diagnostics.push(Diagnostic {
                         rule_name: "fenced-code-meta",
                         message_id: "disallowedMetadata",
                         data: DiagnosticData::default(),
-                        loc: line_index.loc_for_span(source_text, fence.info_span),
+                        loc: line_index
+                            .loc_for_span(source_text, fence_meta_span(source_text, fence, meta)),
                         fix: None,
                     });
                 }

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -1,14 +1,6 @@
 {
   "_doc": "Per-rule upstream-parity enforcement level for the synced @eslint/markdown fixtures (see test/upstream.test.mjs). Levels: 'full' (the default for any rule not listed here) = exact parity is enforced for every valid and invalid case — each reported error's messageId, data, and 1-indexed location must match upstream, and cases declaring `output` must autofix to the same text. 'off' = quarantined; the Rust core still diverges from upstream for this rule, so its valid and invalid cases are registered as skipped (coverage stays visible) until the divergence is fixed and the rule is promoted to 'full'. The end state is zero 'off' entries. Each quarantined rule carries a `note` summarising the known divergence to guide the follow-up fix PR. Regenerate fixtures with `pnpm run port:tests:eslint-markdown`.",
   "rules": {
-    "fenced-code-language": {
-      "level": "off",
-      "note": "Diagnostic span points at the language token; upstream reports the opening code-fence span (node.position.start, line through the info string)."
-    },
-    "fenced-code-meta": {
-      "level": "off",
-      "note": "Diagnostic span points at the meta token; upstream reports the opening code-fence span."
-    },
     "heading-increment": {
       "level": "off",
       "note": "Diverges on headings inside HTML blocks / blockquotes and on TOML (+++) and JSON frontmatter title detection."


### PR DESCRIPTION
First parity fix following the test-sync infra (#242). Promotes **`fenced-code-language`** and **`fenced-code-meta`** to full upstream parity.

## Divergence
Both rules reported the diagnostic at the info-string token (e.g. column 4 of ` ```javascript`). Upstream anchors the span at the opening fence (`node.position.start`):
- `disallowedLanguage` / `missingMetadata`: fence start → end of the language token.
- `disallowedMetadata`: `metaIndex` → `+ meta.trimEnd().length`.

## Fix
Adds `fence_lang_span` / `fence_meta_span` helpers that compute these byte spans from the opening fence line, and uses them. No behavioural change to which fences are flagged — only the reported location.

Replaying the upstream suite locally: `fenced-code-language` 13 valid / 28 invalid and `fenced-code-meta` 16 valid / 18 invalid all pass. Their `parity.json` quarantine is removed (they are now enforced at `full`).

These two rules share the `fence_lang_span` helper (meta's `missingMetadata` reuses it), so they are fixed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784009341&installation_id=136613492&pr_number=243&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F243&signature=0f5aa9ed7c07fba000a01471692d7bc808f46da48e6873fe7f6c7970318fbfe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->