### PR TITLE
fix(regexp): no-misleading-unicode-character ignores single code points

### DIFF
--- a/crates/regexp/src/checks.rs
+++ b/crates/regexp/src/checks.rs
@@ -18,13 +18,13 @@ use crate::helpers::{
     first_strict_violation, first_surrogate_pair_escape, first_unicode_escape_as_hex,
     first_uppercase_hex_escape, first_useless_escape, first_useless_one_quantifier, group_prefix,
     has_assertion_contradiction, has_mergeable_quantifier_concatenation,
-    has_misleading_capturing_group, has_preferable_set_operation, has_simplifiable_set_operation,
-    has_standalone_backslash, has_super_linear_backtracking, has_super_linear_move,
-    has_unnecessary_general_category_key, has_useless_set_operand, has_useless_word_boundary,
-    mention_char, pattern_ends_with_lazy_quantifier,
-    pattern_has_capturing_group_and_no_backreference, pattern_has_empty_string_literal,
-    pattern_is_safe_to_add_i_flag, prefer_lookaround_groups, skip_escape, sorted_flags,
-    string_literal_value_with_span,
+    has_misleading_capturing_group, has_misleading_quantifier_unicode,
+    has_preferable_set_operation, has_simplifiable_set_operation, has_standalone_backslash,
+    has_super_linear_backtracking, has_super_linear_move, has_unnecessary_general_category_key,
+    has_useless_set_operand, has_useless_word_boundary, mention_char,
+    pattern_ends_with_lazy_quantifier, pattern_has_capturing_group_and_no_backreference,
+    pattern_has_empty_string_literal, pattern_is_safe_to_add_i_flag, prefer_lookaround_groups,
+    skip_escape, sorted_flags, string_literal_value_with_span,
 };
 use crate::pattern::PatternAnalysis;
 use crate::scanner::Scanner;
@@ -1053,7 +1053,11 @@ impl<'a> Scanner<'a> {
         used_as_whole: bool,
     ) {
         let mut analysis = PatternAnalysis::new();
-        analysis.scan(pattern, flags.contains('v'));
+        analysis.scan(
+            pattern,
+            flags.contains('v'),
+            flags.contains('u') || flags.contains('v'),
+        );
 
         // `strict` (narrow form): only fire on non-`u`/non-`v` patterns.
         // The `u`/`v` flags turn on strict parsing automatically, so those
@@ -1269,7 +1273,12 @@ impl<'a> Scanner<'a> {
         if analysis.has_useless_lazy {
             self.report("no-useless-lazy", "unexpected", span);
         }
-        if analysis.has_misleading_unicode_character {
+        if analysis.has_misleading_unicode_character
+            || has_misleading_quantifier_unicode(
+                pattern,
+                flags.contains('u') || flags.contains('v'),
+            )
+        {
             self.report("no-misleading-unicode-character", "unexpected", span);
         }
 

--- a/crates/regexp/src/helpers.rs
+++ b/crates/regexp/src/helpers.rs
@@ -1745,22 +1745,257 @@ pub(crate) fn class_negated_shorthand_letter(bytes: &[u8], open: usize) -> Optio
     }
 }
 
-/// Returns `true` when the character class at `open` contains a Zero
-/// Width Joiner (U+200D) in its raw UTF-8 form (bytes `0xE2 0x80 0x8D`).
+/// A combining mark or other code point that, in `Intl.Segmenter` terms,
+/// attaches to a preceding base code point to form one grapheme cluster
+/// instead of starting a new one. We approximate the (large) Unicode grapheme
+/// algorithm with the cases that matter for `no-misleading-unicode-character`:
+/// the joiners and modifiers that turn several code points into a single
+/// user-perceived character (combining marks, variation selectors, ZWJ, and
+/// emoji modifiers). This is intentionally conservative — when in doubt a code
+/// point is treated as its own grapheme, which can only *narrow* detection and
+/// therefore never produces a false positive.
+fn is_grapheme_extend(ch: char) -> bool {
+    matches!(ch as u32,
+        // Combining Diacritical Marks and related combining blocks.
+        0x0300..=0x036F   // Combining Diacritical Marks
+        | 0x0483..=0x0489 // Cyrillic combining
+        | 0x0591..=0x05BD | 0x05BF | 0x05C1 | 0x05C2 | 0x05C4 | 0x05C5 | 0x05C7 // Hebrew
+        | 0x0610..=0x061A | 0x064B..=0x065F | 0x0670 // Arabic combining
+        | 0x06D6..=0x06DC | 0x06DF..=0x06E4 | 0x06E7 | 0x06E8 | 0x06EA..=0x06ED
+        | 0x1AB0..=0x1AFF // Combining Diacritical Marks Extended
+        | 0x1DC0..=0x1DFF // Combining Diacritical Marks Supplement
+        | 0x20D0..=0x20FF // Combining Diacritical Marks for Symbols
+        | 0xFE00..=0xFE0F // Variation Selectors
+        | 0xFE20..=0xFE2F // Combining Half Marks
+        | 0x200D          // Zero Width Joiner
+        | 0xE0100..=0xE01EF // Variation Selectors Supplement
+        | 0x1F3FB..=0x1F3FF // Emoji modifiers (skin-tone)
+    )
+}
+
+/// Returns `true` for the regional-indicator symbols (U+1F1E6..=U+1F1FF) that
+/// combine in pairs to form flag emoji such as 🇯🇵.
+fn is_regional_indicator(ch: char) -> bool {
+    matches!(ch as u32, 0x1F1E6..=0x1F1FF)
+}
+
+/// Returns `true` when the character class at `open` contains an element that
+/// the regex engine actually matches as MULTIPLE code points — i.e. a genuine
+/// "misleading" character. This mirrors the upstream
+/// `no-misleading-unicode-character` rule, which flags a class element only
+/// when it is a multi-code-point grapheme (a combining / ZWJ / regional
+/// sequence, "Multi") or, in non-`u`/`v` mode, a single astral character that
+/// is seen as a surrogate pair ("Surrogate").
 ///
-/// A ZWJ inside a character class is always misleading: the class matches the
-/// ZWJ as a separate atom, so a grapheme such as a ZWJ-joined family emoji
-/// (man, ZWJ, woman, ZWJ, boy) cannot be matched as a single unit. The narrow
-/// form of `no-misleading-unicode-character` flags this raw-UTF-8 case; the
-/// equivalent `\\u200D`, `\\u{200D}`, or v-mode `\\q{}` forms are
-/// intentionally deferred because they need additional escape decoding.
-pub(crate) fn class_contains_zwj(bytes: &[u8], open: usize) -> bool {
+/// A class element consisting of a SINGLE code point — a lone ZWJ (U+200D),
+/// combining mark, variation selector, lone surrogate (only expressible via an
+/// escape, which we skip), or an astral character under the `u`/`v` flag — is
+/// never flagged.
+///
+/// Only LITERAL code points in the class body are considered. Escape sequences
+/// (`\uXXXX`, `\u{...}`, `\xHH`, etc.), v-mode string disjunctions (`\q{...}`),
+/// and nested classes (`[...]`/`[a--b]`) are skipped: their raw source text is
+/// ASCII and never forms a multi-code-point grapheme, exactly as upstream's
+/// segmentation of the raw class text behaves.
+pub(crate) fn class_has_misleading_unicode(
+    bytes: &[u8],
+    open: usize,
+    v_mode: bool,
+    unicode_mode: bool,
+) -> bool {
     debug_assert_eq!(bytes.get(open).copied(), Some(b'['));
-    let Some(end) = find_class_end(bytes, open) else {
+    let end = if v_mode {
+        find_class_end_nested(bytes, open)
+    } else {
+        find_class_end(bytes, open)
+    };
+    let Some(end) = end else {
         return false;
     };
-    let body = &bytes[open + 1..end];
-    body.windows(3).any(|w| w == [0xE2, 0x80, 0x8D])
+
+    // Body bytes, skipping a leading `^` for a negated class.
+    let mut index = open + 1;
+    if bytes.get(index).copied() == Some(b'^') {
+        index += 1;
+    }
+
+    // We walk the body grouping consecutive literal code points into grapheme
+    // clusters. The cluster is flushed (and inspected) whenever a non-literal
+    // boundary is hit (escape, nested class, end of body) or a new base code
+    // point begins. A cluster is a "problem" when it spans >= 2 code points
+    // (a multi-code-point grapheme, "Multi") or is a single astral code point
+    // in non-`u`/`v` mode (matched as a surrogate pair, "Surrogate").
+    let mut cluster_code_points: u32 = 0;
+    let mut cluster_base_astral = false;
+    let mut prev_char: Option<char> = None;
+
+    let cluster_is_problem = |code_points: u32, base_astral: bool| -> bool {
+        code_points >= 2 || (code_points == 1 && base_astral && !unicode_mode)
+    };
+
+    while index < end {
+        let byte = bytes[index];
+        if byte == b'\\' || (v_mode && byte == b'[') {
+            // Escape sequence (ASCII in the raw) or a nested-class operand
+            // (ignored upstream): both end the current cluster.
+            if cluster_is_problem(cluster_code_points, cluster_base_astral) {
+                return true;
+            }
+            cluster_code_points = 0;
+            cluster_base_astral = false;
+            prev_char = None;
+            if byte == b'\\' {
+                index = skip_escape(bytes, index);
+            } else {
+                match find_class_end_nested(bytes, index) {
+                    Some(inner_end) => index = inner_end + 1,
+                    None => index += 1,
+                }
+            }
+            continue;
+        }
+
+        // Decode one literal code point from the UTF-8 body.
+        let Some(ch) = std::str::from_utf8(&bytes[index..end])
+            .ok()
+            .and_then(|s| s.chars().next())
+        else {
+            // Invalid UTF-8 (should not happen for valid source); bail.
+            return false;
+        };
+
+        let extends = cluster_code_points > 0
+            && (is_grapheme_extend(ch)
+                || (is_regional_indicator(ch)
+                    && cluster_code_points == 1
+                    && prev_char.is_some_and(is_regional_indicator)));
+
+        if extends {
+            cluster_code_points += 1;
+        } else {
+            // A new base code point: flush the previous cluster, start a new
+            // one.
+            if cluster_is_problem(cluster_code_points, cluster_base_astral) {
+                return true;
+            }
+            cluster_code_points = 1;
+            cluster_base_astral = (ch as u32) > 0xFFFF;
+        }
+
+        prev_char = Some(ch);
+        index += ch.len_utf8();
+    }
+
+    cluster_is_problem(cluster_code_points, cluster_base_astral)
+}
+
+/// Returns `true` when the pattern applies a quantifier (`*`, `+`, `?`, or a
+/// `{...}` brace) to the trailing code point of a multi-code-point grapheme,
+/// so the quantifier silently repeats only the last code point instead of the
+/// whole user-perceived character. This is the quantifier arm of
+/// `no-misleading-unicode-character` (upstream `quantifierMulti` /
+/// `quantifierSurrogate`).
+///
+/// The grapheme immediately to the left of the quantifier is flagged when it
+/// spans >= 2 literal code points ("Multi"), or is a single astral code point
+/// in non-`u`/`v` mode ("Surrogate"). A quantifier on a single non-astral code
+/// point — or on any astral code point under the `u`/`v` flag — is fine. Only
+/// LITERAL code points are considered; a quantifier directly after an escape
+/// (e.g. `\u{1F44D}+`) is never misleading because the escaped atom is the
+/// whole code point.
+pub(crate) fn has_misleading_quantifier_unicode(pattern: &str, unicode_mode: bool) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index = skip_escape(bytes, index),
+            b'[' => match find_class_end(bytes, index) {
+                Some(end) => index = end + 1,
+                None => index += 1,
+            },
+            b'*' | b'+' | b'?' | b'{' => {
+                // A quantifier byte. (For `{` we conservatively treat it as a
+                // quantifier; a literal `{` only triggers a false *positive*
+                // when preceded by a multi-code-point grapheme, which is
+                // extremely unlikely and still describes a misleading intent.)
+                if quantifier_target_is_misleading(bytes, index, unicode_mode) {
+                    return true;
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    false
+}
+
+/// Given the byte index of a quantifier, returns `true` when the immediately
+/// preceding atom is the trailing code point of a multi-code-point grapheme
+/// (or, in non-`u`/`v` mode, a single astral code point). Walks backward over
+/// the run of literal code points ending just before the quantifier and
+/// inspects the last grapheme cluster of that run.
+fn quantifier_target_is_misleading(bytes: &[u8], quant: usize, unicode_mode: bool) -> bool {
+    if quant == 0 {
+        return false;
+    }
+    // The atom the quantifier applies to ends at `quant`. We walk the prefix
+    // text right-to-left, one code point at a time.
+    let Ok(prefix_str) = std::str::from_utf8(&bytes[..quant]) else {
+        return false;
+    };
+
+    // The last char before the quantifier is the quantifier's target atom.
+    let Some(last_char) = prefix_str.chars().next_back() else {
+        return false;
+    };
+    // If the target atom is the close of a group/class, the quantifier applies
+    // to the whole group/class, not a single code point — never misleading.
+    if matches!(last_char, ')' | ']') {
+        return false;
+    }
+
+    // Walk backward from the target atom, accumulating the grapheme cluster it
+    // belongs to: the target code point plus any preceding base + combining /
+    // ZWJ / regional members. Clustering stops at the first char that does not
+    // extend the cluster. We also count the contiguous backslash run that
+    // begins immediately left of the cluster: an odd run escapes the leftmost
+    // (base) code point, meaning the quantifier's atom is an escape sequence
+    // and is therefore never misleading.
+    let mut cluster_code_points: u32 = 1;
+    let mut base_char = last_char;
+    let mut chars_left = prefix_str[..prefix_str.len() - last_char.len_utf8()].chars();
+
+    while let Some(ch) = chars_left.next_back() {
+        // `ch` (to the left) joins the cluster when the code point to its right
+        // is a grapheme-extend, or when both are regional indicators.
+        let right_extends = is_grapheme_extend(base_char)
+            || (is_regional_indicator(base_char) && is_regional_indicator(ch));
+        let is_boundary = matches!(
+            ch,
+            '(' | ')' | '[' | ']' | '|' | '*' | '+' | '?' | '{' | '}' | '\\'
+        ) || !right_extends;
+        if is_boundary {
+            // Cluster boundary. If `ch` is a backslash, count its run to learn
+            // whether the base code point is escaped (odd run => escape => the
+            // quantifier atom is an escape sequence, never misleading).
+            if ch == '\\' {
+                let mut backslashes = 1u32;
+                while chars_left.next_back() == Some('\\') {
+                    backslashes += 1;
+                }
+                if backslashes % 2 == 1 {
+                    return false;
+                }
+            }
+            break;
+        }
+        cluster_code_points += 1;
+        base_char = ch;
+    }
+
+    cluster_code_points >= 2
+        || (cluster_code_points == 1 && (base_char as u32) > 0xFFFF && !unicode_mode)
 }
 
 /// Returns `true` when the pattern contains a standalone backslash — a `\c`

--- a/crates/regexp/src/pattern.rs
+++ b/crates/regexp/src/pattern.rs
@@ -4,8 +4,8 @@ use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{
     BraceQuantifierShape, class_bracket_changes_meaning, class_contains_backspace_escape,
-    class_contains_zwj, class_first_collapsible_run, class_first_duplicate_literal,
-    class_first_obscure_range, class_has_case_pair, class_has_unsorted_literal_elements,
+    class_first_collapsible_run, class_first_duplicate_literal, class_first_obscure_range,
+    class_has_case_pair, class_has_misleading_unicode, class_has_unsorted_literal_elements,
     class_has_useless_range, class_has_useless_string_literal, class_is_digit_range,
     class_is_useless_single_literal, class_is_word_char_set, class_matches_anything,
     class_negated_shorthand_letter, find_class_end, find_class_end_nested,
@@ -233,9 +233,14 @@ pub(crate) struct PatternAnalysis {
     /// modifier. The lazy modifier is a no-op because the engine always
     /// matches exactly `n` repetitions. `no-useless-lazy`.
     pub(crate) has_useless_lazy: bool,
-    /// Character class body contains a ZWJ (U+200D) in raw UTF-8, which
-    /// breaks the grapheme semantics of any ZWJ-joined sequence it might
-    /// have been intended to match. `no-misleading-unicode-character`.
+    /// A character class or quantifier element is a single *unit* that the
+    /// regex engine actually matches as MULTIPLE Unicode code points — either
+    /// a multi-code-point grapheme (combining / ZWJ / regional-indicator
+    /// sequence) placed literally in a class, or an astral character that is
+    /// seen as a surrogate pair (two UTF-16 code units) in non-`u`/`v` mode.
+    /// A class/quantifier element consisting of a *single* code point (a lone
+    /// ZWJ, combining mark, variation selector, or an astral char under the
+    /// `u`/`v` flag) is NOT flagged. `no-misleading-unicode-character`.
     pub(crate) has_misleading_unicode_character: bool,
     /// Bitmask of capturing-group indices (1-based, bits 1..=31) whose closing
     /// `)` is immediately followed by `?` or `*` — meaning the group's capture
@@ -260,7 +265,12 @@ impl PatternAnalysis {
     /// v-mode allows nested `[...]` classes (set-operation operands); in
     /// non-v mode every unescaped `[` inside a class is a literal character
     /// and must not be treated as opening a nested class.
-    pub(crate) fn scan(&mut self, pattern: &str, v_mode: bool) {
+    ///
+    /// `unicode_mode` must be `true` when the regex carries either the `u` or
+    /// `v` flag. Under those flags an astral character is a single code point,
+    /// so it is no longer "misleading"; without them the same astral character
+    /// is matched as a surrogate pair (two UTF-16 code units).
+    pub(crate) fn scan(&mut self, pattern: &str, v_mode: bool, unicode_mode: bool) {
         let bytes = pattern.as_bytes();
         let mut groups = SmallVec::<[GroupState; 8]>::new();
         groups.push(GroupState::top_level());
@@ -372,7 +382,7 @@ impl PatternAnalysis {
                             self.has_negation_shorthand = true;
                         }
                         if !self.has_misleading_unicode_character
-                            && class_contains_zwj(bytes, index)
+                            && class_has_misleading_unicode(bytes, index, v_mode, unicode_mode)
                         {
                             self.has_misleading_unicode_character = true;
                         }

--- a/crates/regexp/src/tests.rs
+++ b/crates/regexp/src/tests.rs
@@ -3791,30 +3791,91 @@ mod no_misleading_unicode_character {
     use super::*;
 
     #[test]
-    fn reports_classes_containing_zwj() {
-        // ZWJ-joined family emoji inside a character class. The U+200D bytes
-        // `0xE2 0x80 0x8D` appear inside the class body, so the engine
-        // matches the ZWJ as a separate atom and the grapheme cluster cannot
-        // be matched as a unit.
+    fn reports_multi_code_point_class_elements() {
+        // ZWJ-joined family emoji placed literally in a class: the class
+        // matches each code point separately, so the grapheme cannot be
+        // matched as a unit ("Multi").
         assert_eq!(
             rule_ids_for("const a = /[👨‍👩‍👦]/u;", "no-misleading-unicode-character").as_slice(),
             &["unexpected"]
         );
-        // Bare ZWJ in a class is also misleading.
+        // Combining sequence `❇` + U+FE0F variation selector — two code points.
         assert_eq!(
-            rule_ids_for("const a = /[‍]/u;", "no-misleading-unicode-character").as_slice(),
+            rule_ids_for("const a = /[❇️]/;", "no-misleading-unicode-character").as_slice(),
+            &["unexpected"]
+        );
+        // Astral char as a surrogate pair in a class without the `u` flag
+        // ("Surrogate").
+        assert_eq!(
+            rule_ids_for("const a = /[👍]foo/;", "no-misleading-unicode-character").as_slice(),
             &["unexpected"]
         );
     }
 
     #[test]
-    fn ignores_classes_without_zwj_bytes() {
+    fn reports_multi_code_point_quantifier_target() {
+        // Quantifier on a surrogate pair in non-`u` mode: the `+` applies only
+        // to the trailing surrogate.
+        assert_eq!(
+            rule_ids_for("const a = /👍+/;", "no-misleading-unicode-character").as_slice(),
+            &["unexpected"]
+        );
+    }
+
+    #[test]
+    fn ignores_single_code_point_elements() {
         // ASCII-only class.
         assert!(rule_ids_for("const a = /[abc]/u;", "no-misleading-unicode-character").is_empty());
-        // Single-codepoint emoji without ZWJ.
+        // Single-code-point astral emoji under the `u` flag.
         assert!(rule_ids_for("const a = /[😀]/u;", "no-misleading-unicode-character").is_empty());
-        // ZWJ outside any class — not flagged by the narrow port.
+        assert!(rule_ids_for("const a = /[👍]/u;", "no-misleading-unicode-character").is_empty());
+        // Lone ZWJ in a class is a single code point — valid.
+        assert!(rule_ids_for("const a = /[‍]/u;", "no-misleading-unicode-character").is_empty());
+        assert!(rule_ids_for("const a = /[‍]/;", "no-misleading-unicode-character").is_empty());
+        // Lone combining mark / variation selector — single code point.
+        assert!(rule_ids_for("const a = /[́]/;", "no-misleading-unicode-character").is_empty());
+        assert!(rule_ids_for("const a = /[️]/;", "no-misleading-unicode-character").is_empty());
+        // Escaped surrogate pair: the raw class text is ASCII, never a
+        // multi-code-point grapheme — valid even without the `u` flag.
+        assert!(
+            rule_ids_for(
+                "const a = /[\\uD83D\\uDC4D]/;",
+                "no-misleading-unicode-character"
+            )
+            .is_empty()
+        );
+        // Astral quantifier target under the `u` flag — single code point.
+        assert!(rule_ids_for("const a = /👍+/u;", "no-misleading-unicode-character").is_empty());
+        // ZWJ outside any class/quantifier — not flagged.
         assert!(rule_ids_for("const a = /a‍b/u;", "no-misleading-unicode-character").is_empty());
+        // Escaped surrogate pair with the `u` flag — single code point.
+        assert!(
+            rule_ids_for(
+                "const a = /[\\uD83D\\uDC4D]/u;",
+                "no-misleading-unicode-character"
+            )
+            .is_empty()
+        );
+        // v-mode: astral char (1 code point), `\q{}` string disjunction, and
+        // nested classes are all ignored / single-code-point.
+        assert!(rule_ids_for("const a = /[👍]/v;", "no-misleading-unicode-character").is_empty());
+        assert!(
+            rule_ids_for("const a = /[\\q{👶🏻}]/v;", "no-misleading-unicode-character").is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "const a = /[🇯\\q{abc}🇵]/v;",
+                "no-misleading-unicode-character"
+            )
+            .is_empty()
+        );
+        assert!(
+            rule_ids_for(
+                "const a = /[🇯[A--B]🇵]/v;",
+                "no-misleading-unicode-character"
+            )
+            .is_empty()
+        );
     }
 }
 

--- a/npm/regexp/test/parity.json
+++ b/npm/regexp/test/parity.json
@@ -1,9 +1,4 @@
 {
   "_doc": "Per-rule upstream-parity enforcement level for the synced eslint-plugin-regexp fixtures (see test/upstream.test.mjs). Levels: 'off' = quarantined; the rule's behavior diverges from upstream defaults, so its valid and invalid cases are skipped until the port is fixed (the reason is the parity-debt backlog entry). 'valid' (the default for any rule not listed here) = every upstream VALID case must emit zero diagnostics for the rule (soundness). 'full' = 'valid' plus invalid-case COUNT parity (same number of diagnostics per case as upstream). Diagnostic message text and span are intentionally NOT asserted: the port rewords messages and may flag a different span (e.g. the whole literal) than upstream by design; the recorded fixture locations are reference data for a future strict-location pass.",
-  "rules": {
-    "no-misleading-unicode-character": {
-      "level": "off",
-      "reason": "Over-reports multi-code-point characters such as ZWJ sequences (e.g. /[‍]/) — needs full grapheme/code-point analysis to match upstream."
-    }
-  }
+  "rules": {}
 }

--- a/npm/regexp/test/plugin.test.mjs
+++ b/npm/regexp/test/plugin.test.mjs
@@ -168,6 +168,9 @@ const validCases = [
   ['no-misleading-unicode-character', 'ascii class', 'const re = /[abc]/u;\n'],
   ['no-misleading-unicode-character', 'bmp emoji single', 'const re = /[😀]/u;\n'],
   ['no-misleading-unicode-character', 'zwj outside class', 'const re = /a‍b/u;\n'],
+  ['no-misleading-unicode-character', 'lone zwj in class', 'const re = /[‍]/u;\n'],
+  ['no-misleading-unicode-character', 'single astral in u class', 'const re = /[👍]/u;\n'],
+  ['no-misleading-unicode-character', 'quantifier on astral in u', 'const re = /👍+/u;\n'],
   // prefer-unicode-codepoint-escapes
   [
     'prefer-unicode-codepoint-escapes',
@@ -592,7 +595,18 @@ const invalidCases = [
     'const re = /[👨‍👩‍👦]/u;\n',
     ['unexpected'],
   ],
-  ['no-misleading-unicode-character', 'bare zwj in class', 'const re = /[‍]/u;\n', ['unexpected']],
+  [
+    'no-misleading-unicode-character',
+    'astral as surrogate pair in non-u class',
+    'const re = /[👍]foo/;\n',
+    ['unexpected'],
+  ],
+  [
+    'no-misleading-unicode-character',
+    'quantifier on surrogate pair in non-u',
+    'const re = /👍+/;\n',
+    ['unexpected'],
+  ],
   // no-standalone-backslash
   ['no-standalone-backslash', '\\c at end of pattern', 'const re = /\\c/;\n', ['unexpected']],
   ['no-standalone-backslash', '\\c followed by digit', 'const re = /\\c1/;\n', ['unexpected']],

--- a/status.json
+++ b/status.json
@@ -8887,7 +8887,7 @@
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Narrow byte-walker port that flags a character class whose body contains a raw-UTF-8 Zero Width Joiner (U+200D, bytes `0xE2 0x80 0x8D`). A ZWJ inside a class is always misleading: the engine matches it as a separate atom, so a grapheme like `\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66` (man + ZWJ + woman + ZWJ + boy) cannot be matched as a single unit. Equivalent `\\u200D`, `\\u{200D}`, regional-indicator flag pairs, and other multi-codepoint grapheme shapes are intentionally deferred."
+        "notes": "Byte-walker port that flags a character-class element or quantifier target only when the engine matches it as MULTIPLE code points: a multi-code-point grapheme placed literally in a class or after a quantifier (combining/variation-selector/ZWJ/regional-indicator/skin-tone sequence, upstream 'Multi'), or a single astral character seen as a surrogate pair in non-`u`/`v` mode (upstream 'Surrogate'). A single code point \u2014 a lone ZWJ (U+200D), combining mark, variation selector, lone surrogate, or an astral char under the `u`/`v` flag \u2014 never flags, matching upstream's per-grapheme `getProblem`. Only literal code points are inspected; escapes (`\\uXXXX`, `\\u{...}`), v-mode `\\q{...}` string disjunctions, and nested classes are skipped because their raw source is ASCII. Grapheme clustering is approximated with the joiner/modifier ranges that turn several code points into one user-perceived character; when uncertain a code point is its own grapheme, which can only narrow detection."
       },
       {
         "name": "no-missing-g-flag",


### PR DESCRIPTION
## Summary

Fixes the over-reporting bug in the ported `no-misleading-unicode-character` regexp rule and un-quarantines it.

The rule previously flagged any character class containing a Zero Width Joiner — including a **lone** ZWJ (`/[‍]/`). Upstream treats a single code point in a class as VALID: a lone ZWJ, combining mark, variation selector, lone surrogate, or an astral char under the `u`/`v` flag is not a "multi-code-point character". Only an element the engine actually matches as **multiple** code points is misleading.

## The fix

- Replaced `class_contains_zwj` (any-ZWJ byte match) with `class_has_misleading_unicode`, which groups the **literal** code points of a class body into grapheme clusters (base + combining / variation-selector / ZWJ / regional-indicator / skin-tone members) and flags a cluster only when it spans ≥ 2 code points (upstream "Multi") or is a single astral code point in non-`u`/`v` mode (upstream "Surrogate", a surrogate pair).
- Added the quantifier arm `has_misleading_quantifier_unicode`: a quantifier whose target atom is the trailing code point of a multi-code-point grapheme (or a lone astral char in non-`u`/`v` mode) is flagged; a quantifier on a single non-astral code point, an escaped atom, or a group/class is not.
- Escapes (`\uXXXX`, `\u{…}`), v-mode `\q{…}` string disjunctions, and nested classes are skipped — their raw source is ASCII and never forms a multi-code-point grapheme, matching upstream's segmentation of the raw class text.
- `scan` now also receives `unicode_mode` (`u` or `v` flag) to distinguish the Surrogate case.

## Un-quarantine

Removed `no-misleading-unicode-character` from `npm/regexp/test/parity.json` `rules` in the same commit — the object is now `{}`. The rule now runs at the default `valid` level, so the parity harness enforces that every upstream VALID case emits zero diagnostics.

## Verification

- `cargo test -p oxlint-plugins-regexp`: 223 passed.
- `cargo clippy -p oxlint-plugins-regexp --all-targets -- -D warnings`: clean.
- `cargo fmt -p oxlint-plugins-regexp --check`: clean.
- All 29 fixture `valid[]` cases produce zero diagnostics (verified against the Rust scan path, including U+FFFD substitution for the lone-surrogate cases that napi normalizes); the single `invalid[]` case `/[👍]foo/` is still caught.
- Decisive cases confirmed: `/[👍]/u` valid, `/[‍]/` (lone ZWJ) valid, `/[👍]foo/` (non-`u`) invalid, `/👍+/` (non-`u`) invalid, `/👍+/u` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784009369&installation_id=136613492&pr_number=244&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F244&signature=4e6cdd3e5aeddf9e828b5482a4a85553424732d908156a6c61305f47271071b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->