### PR TITLE
fix(unocss): collect object-property keys in uno-function calls (parity ratchet)

### DIFF
--- a/crates/unocss/src/tests.rs
+++ b/crates/unocss/src/tests.rs
@@ -214,3 +214,31 @@ fn blocklist_span_covers_only_the_token() {
         "blocklist span should cover only `border`, not the whole class string"
     );
 }
+
+/// A UnoCSS-function object argument has its property KEYS checked for order
+/// (upstream `handleObjectExpression`), e.g. `clsx({ 'mr-1 ml-1': cond })`.
+#[test]
+fn object_key_in_uno_call_is_order_checked() {
+    let source = r#"clsx({ "mr-1 ml-1": cond });"#;
+    let diagnostics = scan_unocss(source, "fixture.tsx", &UnocssOptions::default());
+    let order = diagnostics
+        .iter()
+        .filter(|d| d.rule_name == "order")
+        .count();
+    assert_eq!(
+        order, 1,
+        "expected the object key to be order-checked: {diagnostics:?}"
+    );
+}
+
+/// A UnoCSS-VARIABLE initialiser object does NOT have its keys checked — upstream
+/// only collects object keys in the call path, not the variable path.
+#[test]
+fn object_key_in_uno_variable_is_not_checked() {
+    let source = r#"const clsButton = { "mr-1 ml-1": cond };"#;
+    let diagnostics = scan_unocss(source, "fixture.tsx", &UnocssOptions::default());
+    assert!(
+        diagnostics.iter().all(|d| d.rule_name != "order"),
+        "variable-init object keys must not be order-checked: {diagnostics:?}"
+    );
+}

--- a/crates/unocss/src/visitor.rs
+++ b/crates/unocss/src/visitor.rs
@@ -13,7 +13,8 @@
 
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Expression, JSXAttributeItem, JSXAttributeName,
-    JSXAttributeValue, JSXOpeningElement, ObjectPropertyKind, TemplateLiteral, VariableDeclarator,
+    JSXAttributeValue, JSXOpeningElement, ObjectExpression, ObjectPropertyKind, TemplateLiteral,
+    VariableDeclarator,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -203,6 +204,35 @@ impl<'src, 'a> UnocssVisitor<'src, 'a> {
         }
     }
 
+    /// Collect literals from an object passed as a UnoCSS-function argument,
+    /// mirroring upstream `handleObjectExpression` in the CallExpression visitor:
+    /// property VALUES (recursing into nested objects) AND property KEYS that are
+    /// string / template / `String.raw` literals (e.g. `{ 'a b': x }`,
+    /// `` { [`a b`]: x } ``). Upstream collects keys ONLY for call-argument
+    /// objects, not variable-initialiser objects, so this is reached only from
+    /// the call path; `collect_expression_literals` keeps the value-only behavior.
+    fn collect_object_with_keys(
+        &self,
+        obj: &ObjectExpression<'_>,
+        out: &mut SmallVec<[LiteralSpan<'src>; 16]>,
+    ) {
+        for prop in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(op) = prop else {
+                continue;
+            };
+            if let Expression::ObjectExpression(inner) = &op.value {
+                self.collect_object_with_keys(inner, out);
+            } else {
+                self.collect_expression_literals(&op.value, out);
+            }
+            // Non-identifier keys (string/template/`String.raw`) expose an inner
+            // expression; identifier keys (`small:`) return `None` and are skipped.
+            if let Some(key_expr) = op.key.as_expression() {
+                self.collect_expression_literals(key_expr, out);
+            }
+        }
+    }
+
     /// Return the simple identifier callee name of a call expression, if any.
     fn callee_name<'x>(call: &'x CallExpression<'_>) -> Option<&'x str> {
         match &call.callee {
@@ -339,7 +369,13 @@ impl<'src, 'a> Visit<'src> for UnocssVisitor<'src, 'a> {
                 }
                 if let Some(expr) = arg.as_expression() {
                     let mut tmp: SmallVec<[LiteralSpan<'src>; 16]> = SmallVec::new();
-                    self.collect_expression_literals(expr, &mut tmp);
+                    // A direct object argument also has its keys checked (upstream
+                    // `handleObjectExpression`); other args collect values only.
+                    if let Expression::ObjectExpression(obj) = expr {
+                        self.collect_object_with_keys(obj, &mut tmp);
+                    } else {
+                        self.collect_expression_literals(expr, &mut tmp);
+                    }
                     for ls in tmp {
                         if !ls.content.trim().is_empty() {
                             self.call_literals.push(ls);

--- a/npm/unocss/test/parity.json
+++ b/npm/unocss/test/parity.json
@@ -10,26 +10,6 @@
       ],
       "invalid": [
         {
-          "index": 1,
-          "reason": "object-property key class string (`{ 'top-1 bottom-1': test }`) — upstream sorts object keys; the port collects property values only."
-        },
-        {
-          "index": 2,
-          "reason": "computed object key (`{ [`top-1 bottom-1`]: test }`) — not collected by the port."
-        },
-        {
-          "index": 3,
-          "reason": "computed `String.raw` object key — not collected by the port."
-        },
-        {
-          "index": 4,
-          "reason": "object-property key class string — not collected by the port."
-        },
-        {
-          "index": 8,
-          "reason": "computed object key with interpolation — not collected by the port."
-        },
-        {
           "index": 9,
           "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens; the heuristic only sorts when every token is recognized, while the engine sorts the recognized subset in place."
         }


### PR DESCRIPTION
## What

Ratchets up upstream parity for the `order` rule: collects object-property **keys** inside UnoCSS-function arguments, matching upstream `handleObjectExpression`.

Upstream's `order` checks the keys of objects passed to uno functions — `clsx({ 'top-1 bottom-1': cond })`, computed `` { [`top-1 bottom-1`]: cond } ``, and `String.raw` keys. The port previously collected property **values** only, so PR #241 quarantined those cases. This adds `collect_object_with_keys`, reached **only from the call-argument path**, faithfully mirroring upstream's asymmetry (variable-initialiser objects do *not* collect keys).

## Parity impact

Un-quarantines `order-unoFunctions` invalid cases **1, 2, 3, 4, 8** in `npm/unocss/test/parity.json` (string keys, computed template keys, `String.raw` keys, interpolated keys) — now asserted by `upstream.test.mjs`. Remaining quarantine entries (mixed UnoCSS/non-UnoCSS token strings; the `bg-[var]` engine ordering) stay — genuinely engine-dependent.

## Tests

Rust unit tests: key collection fires in the call path; does **not** fire in the variable path (upstream parity). `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` (14 passed) green locally; the upstream parity replay runs in CI (JS Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784009592&installation_id=136613492&pr_number=245&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F245&signature=961570403481a891a9ece7c7de109a89c1432dfddeb623bf7e1ac54c7670193f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->