### PR TITLE
infra(sonarjs): per-rule options layer; configurable max-switch-cases & max-union-size

### DIFF
--- a/crates/sonarjs/src/rules/max_switch_cases.rs
+++ b/crates/sonarjs/src/rules/max_switch_cases.rs
@@ -10,16 +10,15 @@
 //!
 //! ## Threshold
 //!
-//! The threshold is fixed at **30** (`MAX_CASES`). SonarJS exposes a
-//! configurable `maximum` option, but this port has no per-rule options
-//! infrastructure yet. Configurability is a follow-up task; for now the
-//! default of 30 is hardcoded.
+//! The threshold mirrors SonarJS's configurable `maximum` option
+//! (`self.options.max_switch_cases_threshold`); when no option is supplied the
+//! SonarJS default of **30** is used.
 //!
 //! ## Counting
 //!
 //! All entries in `SwitchStatement.cases` are counted, including both `case`
 //! clauses and the optional `default` clause. A diagnostic is emitted when the
-//! count is **strictly greater than** `MAX_CASES`.
+//! count is **strictly greater than** the threshold.
 
 use oxc_ast::ast::SwitchStatement;
 use oxc_span::Span;
@@ -28,13 +27,9 @@ use crate::scanner::Scanner;
 
 pub(crate) const RULE_NAME: &str = "max-switch-cases";
 
-/// Maximum number of `case`/`default` clauses allowed in a single `switch`.
-/// A switch with more than this many clauses is flagged.
-const MAX_CASES: usize = 30;
-
 impl Scanner<'_> {
     pub(crate) fn check_max_switch_cases(&mut self, switch: &SwitchStatement<'_>) {
-        if switch.cases.len() <= MAX_CASES {
+        if switch.cases.len() <= self.options.max_switch_cases_threshold as usize {
             return;
         }
         let start = switch.span.start;

--- a/crates/sonarjs/src/rules/max_union_size.rs
+++ b/crates/sonarjs/src/rules/max_union_size.rs
@@ -10,10 +10,9 @@
 //!
 //! ## Threshold
 //!
-//! The threshold is fixed at **3** (`MAX_UNION_SIZE`). SonarJS exposes a
-//! configurable `threshold` option, but this port has no per-rule options
-//! infrastructure yet. Configurability is a follow-up task; for now the
-//! default of 3 is hardcoded.
+//! The threshold mirrors SonarJS's configurable `threshold` option
+//! (`self.options.max_union_size_threshold`); when no option is supplied the
+//! SonarJS default of **3** is used.
 //!
 //! ## Counting
 //!
@@ -28,13 +27,9 @@ use crate::scanner::Scanner;
 
 pub(crate) const RULE_NAME: &str = "max-union-size";
 
-/// Maximum number of members allowed in a single union type.
-/// A union with more than this many members is flagged.
-const MAX_UNION_SIZE: usize = 3;
-
 impl Scanner<'_> {
     pub(crate) fn check_max_union_size(&mut self, union: &TSUnionType<'_>) {
-        if union.types.len() <= MAX_UNION_SIZE {
+        if union.types.len() <= self.options.max_union_size_threshold as usize {
             return;
         }
         self.report(RULE_NAME, "maxUnionSize", union.span);

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -8,6 +8,7 @@ use crate::{Diagnostic, SonarjsOptions, scan_sonarjs};
 fn scan(rule_name: &str, source: &str) -> SmallVec<[Diagnostic; 32]> {
     let options = SonarjsOptions {
         rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+        ..SonarjsOptions::default()
     };
     scan_sonarjs(source, "sample.ts", &options)
 }
@@ -115,6 +116,7 @@ fn reports_two_diagnostics_for_doubly_nested_conditional() {
 fn disabled_rule_reports_nothing() {
     let options = SonarjsOptions {
         rule_names: SmallVec::new(),
+        ..SonarjsOptions::default()
     };
     let diagnostics = scan_sonarjs("const x = `outer ${`inner`}`;", "sample.ts", &options);
     assert!(diagnostics.is_empty());
@@ -935,7 +937,7 @@ fn does_not_report_class_prototype_for_read_expression() {
 
 #[test]
 fn reports_max_switch_cases_for_switch_with_31_cases() {
-    // 31 case clauses (indices 0..=30) — strictly greater than MAX_CASES (30) → 1 diagnostic
+    // 31 case clauses (indices 0..=30) — strictly greater than the default threshold (30) → 1 diagnostic
     let source = "switch (x) {case 0: break;case 1: break;case 2: break;case 3: break;case 4: break;case 5: break;case 6: break;case 7: break;case 8: break;case 9: break;case 10: break;case 11: break;case 12: break;case 13: break;case 14: break;case 15: break;case 16: break;case 17: break;case 18: break;case 19: break;case 20: break;case 21: break;case 22: break;case 23: break;case 24: break;case 25: break;case 26: break;case 27: break;case 28: break;case 29: break;case 30: break;}";
     let diagnostics = scan("max-switch-cases", source);
     assert_eq!(diagnostics.len(), 1);
@@ -953,7 +955,7 @@ fn does_not_report_max_switch_cases_for_small_switch() {
 
 #[test]
 fn does_not_report_max_switch_cases_for_exactly_30_cases() {
-    // 30 cases (indices 0..=29) — equal to MAX_CASES, not strictly greater → 0 diagnostics
+    // 30 cases (indices 0..=29) — equal to the default threshold, not strictly greater → 0 diagnostics
     let source = "switch (x) {case 0: break;case 1: break;case 2: break;case 3: break;case 4: break;case 5: break;case 6: break;case 7: break;case 8: break;case 9: break;case 10: break;case 11: break;case 12: break;case 13: break;case 14: break;case 15: break;case 16: break;case 17: break;case 18: break;case 19: break;case 20: break;case 21: break;case 22: break;case 23: break;case 24: break;case 25: break;case 26: break;case 27: break;case 28: break;case 29: break;}";
     let diagnostics = scan("max-switch-cases", source);
     assert!(diagnostics.is_empty());
@@ -2242,4 +2244,39 @@ fn reports_class_name_for_lowercase_class_expression() {
     let source = "const C = class widget {};";
     let diagnostics = scan("class-name", source);
     assert_eq!(diagnostics.len(), 1);
+}
+
+fn options_for(rule_name: &str) -> SonarjsOptions {
+    SonarjsOptions {
+        rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+        ..SonarjsOptions::default()
+    }
+}
+
+#[test]
+fn max_switch_cases_respects_custom_threshold() {
+    let mut options = options_for("max-switch-cases");
+    options.max_switch_cases_threshold = 2;
+    let three = "switch (x) { case 1: break; case 2: break; case 3: break; }";
+    assert_eq!(scan_sonarjs(three, "sample.ts", &options).len(), 1);
+    let two = "switch (x) { case 1: break; case 2: break; }";
+    assert!(scan_sonarjs(two, "sample.ts", &options).is_empty());
+}
+
+#[test]
+fn max_switch_cases_uses_default_threshold_when_unset() {
+    // The default threshold is 30, so a 3-case switch is not flagged by default.
+    let source = "switch (x) { case 1: break; case 2: break; case 3: break; }";
+    let diagnostics = scan("max-switch-cases", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn max_union_size_respects_custom_threshold() {
+    let mut options = options_for("max-union-size");
+    options.max_union_size_threshold = 2;
+    let three = "type T = A | B | C;";
+    assert_eq!(scan_sonarjs(three, "sample.ts", &options).len(), 1);
+    let two = "type T = A | B;";
+    assert!(scan_sonarjs(two, "sample.ts", &options).is_empty());
 }

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -39,10 +39,15 @@ pub struct Diagnostic {
     pub fix: Option<DiagnosticFix>,
 }
 
-/// Per-scan options: the set of enabled rule names.
+/// Per-scan options: the set of enabled rule names plus per-rule thresholds
+/// that mirror the configurable options of the corresponding SonarJS rules.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SonarjsOptions {
     pub rule_names: SmallVec<[CompactString; 32]>,
+    /// Threshold for `max-switch-cases` (S1479); the SonarJS default is 30.
+    pub max_switch_cases_threshold: u32,
+    /// Threshold for `max-union-size` (S4622); the SonarJS default is 3.
+    pub max_union_size_threshold: u32,
 }
 
 impl Default for SonarjsOptions {
@@ -52,6 +57,8 @@ impl Default for SonarjsOptions {
                 .iter()
                 .map(|rule_name| CompactString::from(*rule_name))
                 .collect(),
+            max_switch_cases_threshold: 30,
+            max_union_size_threshold: 3,
         }
     }
 }

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -224,9 +224,9 @@ const ruleDescriptions = Object.freeze({
   'class-prototype':
     'Disallow assigning methods or properties to a constructor prototype; use class syntax instead',
   'max-switch-cases':
-    'Disallow switch statements with more than 30 case/default clauses (threshold fixed at default 30; configurability is a follow-up)',
+    'Disallow switch statements with more than the configured number of case/default clauses (the "maximum" option; default 30)',
   'max-union-size':
-    'Disallow union types with more than 3 members (threshold fixed at default 3; configurability is a follow-up; each TSUnionType node is counted per-node)',
+    'Disallow union types with more than the configured number of members (the "threshold" option; default 3; each TSUnionType node is counted per-node)',
   'elseif-without-else':
     "Require a final 'else' clause when an 'if … else if' chain is present, to explicitly handle the remaining case",
   'no-case-label-in-switch':
@@ -422,6 +422,41 @@ function configFromRuleConfig(name, ruleConfig) {
   };
 }
 
+function schemaForRule(ruleName) {
+  if (ruleName === 'max-switch-cases') {
+    return [
+      {
+        type: 'object',
+        properties: { maximum: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'max-union-size') {
+    return [
+      {
+        type: 'object',
+        properties: { threshold: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
+  return [];
+}
+
+function scanOptionsForRule(context, ruleName) {
+  const raw =
+    context.options?.[0] && typeof context.options[0] === 'object' ? context.options[0] : {};
+  const options = { ruleNames: [ruleName] };
+  if (ruleName === 'max-switch-cases' && Number.isInteger(raw.maximum)) {
+    options.maxSwitchCasesThreshold = raw.maximum;
+  }
+  if (ruleName === 'max-union-size' && Number.isInteger(raw.threshold)) {
+    options.maxUnionSizeThreshold = raw.threshold;
+  }
+  return options;
+}
+
 function createSonarjsRule(ruleName) {
   return {
     meta: {
@@ -432,7 +467,7 @@ function createSonarjsRule(ruleName) {
         url: `${DOCS_BASE}#${ruleName}`,
       },
       messages: messages[ruleName],
-      schema: [],
+      schema: schemaForRule(ruleName),
     },
     createOnce(context) {
       return {
@@ -447,7 +482,7 @@ function createSonarjsRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
-  return diagnosticsForContext(context, { ruleNames: [ruleName] }).filter(
+  return diagnosticsForContext(context, scanOptionsForRule(context, ruleName)).filter(
     (diagnostic) => diagnostic.ruleName === ruleName,
   );
 }

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -19,6 +19,8 @@ mod napi_abi {
     #[derive(Clone, Debug, Default)]
     pub struct SonarjsScanOptions {
         pub rule_names: Option<Vec<String>>,
+        pub max_switch_cases_threshold: Option<u32>,
+        pub max_union_size_threshold: Option<u32>,
     }
 
     #[napi(object)]
@@ -69,8 +71,15 @@ mod napi_abi {
         options: Option<SonarjsScanOptions>,
     ) -> Vec<Diagnostic> {
         let options = options.unwrap_or_default();
+        let default_options = core::SonarjsOptions::default();
         let core_options = core::SonarjsOptions {
             rule_names: compact_rule_names(options.rule_names),
+            max_switch_cases_threshold: options
+                .max_switch_cases_threshold
+                .unwrap_or(default_options.max_switch_cases_threshold),
+            max_union_size_threshold: options
+                .max_union_size_threshold
+                .unwrap_or(default_options.max_union_size_threshold),
         };
 
         core::scan_sonarjs(&source_text, &filename, &core_options)

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -1839,4 +1839,27 @@ describe('sonarjs native API', () => {
     const diagnostics = scan('class-name', source);
     expect(diagnostics).toHaveLength(1);
   });
+
+  it('passes the max-switch-cases threshold through the native boundary', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; case 3: break; }';
+    const flagged = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-switch-cases'],
+      maxSwitchCasesThreshold: 2,
+    });
+    expect(flagged).toHaveLength(1);
+    const allowed = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-switch-cases'],
+      maxSwitchCasesThreshold: 3,
+    });
+    expect(allowed).toHaveLength(0);
+  });
+
+  it('passes the max-union-size threshold through the native boundary', () => {
+    const source = 'type T = A | B | C;';
+    const flagged = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-union-size'],
+      maxUnionSizeThreshold: 2,
+    });
+    expect(flagged).toHaveLength(1);
+  });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -1084,4 +1084,35 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(class-name)');
   });
+
+  it('honors the max-switch-cases "maximum" option', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; case 3: break; }';
+    expect(runRule('max-switch-cases', source, { options: [{ maximum: 2 }] })).toHaveLength(1);
+    expect(runRule('max-switch-cases', source, { options: [{ maximum: 3 }] })).toHaveLength(0);
+  });
+
+  it('uses the default max-switch-cases threshold when no option is given', () => {
+    const source = 'switch (x) { case 1: break; case 2: break; case 3: break; }';
+    expect(runRule('max-switch-cases', source)).toHaveLength(0);
+  });
+
+  it('honors the max-union-size "threshold" option', () => {
+    const source = 'type T = A | B | C;';
+    expect(runRule('max-union-size', source, { options: [{ threshold: 2 }] })).toHaveLength(1);
+    expect(runRule('max-union-size', source, { options: [{ threshold: 3 }] })).toHaveLength(0);
+  });
+
+  it('exposes the configurable options in each rule schema', () => {
+    expect(plugin.rules['max-switch-cases'].meta.schema).toEqual([
+      { type: 'object', properties: { maximum: { type: 'integer' } }, additionalProperties: false },
+    ]);
+    expect(plugin.rules['max-union-size'].meta.schema).toEqual([
+      {
+        type: 'object',
+        properties: { threshold: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ]);
+    expect(plugin.rules['no-collapsible-if'].meta.schema).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Infrastructure: per-rule options layer

Adds a per-rule options layer to the `sonarjs` plugin so rules can read ESLint-style configuration (`["error", { ... }]`), modeled on the existing `mocha` plugin precedent. This unblocks the family of threshold-configured SonarJS rules.

**Plumbing (end to end):**
- core `SonarjsOptions` (crates/sonarjs/src/types.rs) gains typed fields with SonarJS defaults baked into its `Default` impl;
- NAPI `SonarjsScanOptions` (npm/sonarjs/src/lib.rs) carries `Option<u32>` fields and applies the core default with `unwrap_or`;
- the JS adapter (npm/sonarjs/index.js) reads `context.options[0]` via new `scanOptionsForRule`/`schemaForRule` helpers and declares each configurable rule's option schema.

**First two rules migrated** from hardcoded thresholds to options:
- `max-switch-cases` (S1479) — `{ "maximum": <int> }`, default 30
- `max-union-size` (S4622) — `{ "threshold": <int> }`, default 3

Behavior is identical when no option is supplied (defaults equal the previous hardcoded constants); rules that take no options are unaffected.

**Tests:** Rust unit tests for the custom-threshold and default-fallback paths, plus JS tests through the adapter (`runRule` with `options`), the native NAPI boundary, and the exposed rule schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784009664&installation_id=136613492&pr_number=246&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F246&signature=9fb0036c0b7ef750a6ae0372b4a59753c6bcd864275248bf36ff843b45962c09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->