### PR TITLE
fix(eslint-markdown): ignore comments & quoted attrs in no-html

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -534,14 +534,21 @@ fn collect_inline_links(source_text: &str, facts: &mut MarkdownFacts<'_>) {
 }
 
 fn collect_html_tags(source_text: &str, facts: &mut MarkdownFacts<'_>) {
-    let Ok(tag_re) = Regex::new(r#"(?is)<[a-z][a-z0-9-]*(?:\s[^>]*)?/?>"#) else {
+    // Mirror upstream's `htmlTagPattern`: an attribute value may contain `>`
+    // when wrapped in quotes, so the tag does not end at the first raw `>`.
+    let Ok(tag_re) =
+        Regex::new(r#"(?i)<[a-z0-9]+(?:-[a-z0-9]+)*(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?/?>"#)
+    else {
         return;
     };
-    for mat in tag_re.find_iter(source_text) {
+    // Upstream strips HTML comments before scanning for tags; blank out comment
+    // interiors first (preserving byte length and newlines so offsets stay valid).
+    let stripped = strip_html_comments(source_text);
+    for mat in tag_re.find_iter(&stripped) {
         if in_fenced_range(facts, mat.start()) {
             continue;
         }
-        let raw = mat.as_str();
+        let raw = source_text.get(mat.start()..mat.end()).unwrap_or("");
         let name = html_tag_name(raw);
         if name.is_empty() {
             continue;
@@ -555,6 +562,26 @@ fn collect_html_tags(source_text: &str, facts: &mut MarkdownFacts<'_>) {
             raw: CompactString::from(raw),
         });
     }
+}
+
+// Replace the interior of every `<!-- ... -->` comment with spaces, keeping the
+// byte length and any newlines so byte offsets into the original text stay valid
+// (mirrors upstream `stripHtmlComments`, which replaces each non-newline unit).
+fn strip_html_comments(source_text: &str) -> CompactString {
+    let Ok(comment_re) = Regex::new(r"(?s)<!--.*?-->") else {
+        return CompactString::from(source_text);
+    };
+    let replaced = comment_re.replace_all(source_text, |caps: &regex::Captures| {
+        caps[0]
+            .bytes()
+            .map(|byte| match byte {
+                b'\n' => '\n',
+                b'\r' => '\r',
+                _ => ' ',
+            })
+            .collect::<CompactString>()
+    });
+    CompactString::from(replaced.as_ref())
 }
 
 // Span from the opening fence start through the end of the language token,
@@ -933,6 +960,12 @@ fn scan_no_html(
         }) {
             continue;
         }
+        // Upstream truncates the reported span at the first line ending inside
+        // the matched tag (`firstNewlineIndex`).
+        let raw = source_text.get(tag.span.start..tag.span.end).unwrap_or("");
+        let end = raw
+            .find(['\n', '\r'])
+            .map_or(tag.span.end, |idx| tag.span.start + idx);
         diagnostics.push(Diagnostic {
             rule_name: "no-html",
             message_id: "disallowedElement",
@@ -940,7 +973,13 @@ fn scan_no_html(
                 name: Some(tag.name.clone()),
                 ..DiagnosticData::default()
             },
-            loc: line_index.loc_for_span(source_text, tag.span),
+            loc: line_index.loc_for_span(
+                source_text,
+                ByteSpan {
+                    start: tag.span.start,
+                    end,
+                },
+            ),
             fix: None,
         });
     }

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -21,10 +21,6 @@
       "level": "off",
       "note": "Footnote multi-line content and escaped-caret labels classified differently from upstream."
     },
-    "no-html": {
-      "level": "off",
-      "note": "Flags HTML tags inside `<!-- -->` comments; upstream ignores comment contents."
-    },
     "no-invalid-label-refs": {
       "level": "off",
       "note": "False positives on collapsed `[foo][]` / `![foo][]` references with a matching definition."


### PR DESCRIPTION
Promotes **`no-html`** to full upstream parity (16 valid / 34 invalid).

## Divergences fixed
- **HTML in comments was flagged.** Upstream runs `stripHtmlComments` on the node text first, so `<!-- <h1> -->` is valid. We now blank out comment interiors before tag scanning, preserving byte length + newlines so offsets stay valid.
- **Tag ended at the first `>`.** Upstream's `htmlTagPattern` allows `>` inside quoted attribute values, so `<input placeholder=">" />` is one tag. Adopted that pattern.
- **Multi-line tag span.** Upstream truncates the reported span at the first line ending inside the matched tag (`firstNewlineIndex`); a `<span\nclass=…>` now reports only `<span` on line 1. The full span is kept in the fact for other rules.

Removes the `no-html` quarantine in `parity.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784009682&installation_id=136613492&pr_number=247&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F247&signature=129bb73413a3bd8606931ce5cb022528e13197466ca2ffa29af80c34c48bcc3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->