### PR TITLE
fix(eslint-markdown): skip indented code blocks in no-duplicate-definitions

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -475,6 +475,10 @@ fn collect_definitions(facts: &mut MarkdownFacts<'_>) {
         if line.in_fence {
             continue;
         }
+        // Lines indented >= 4 columns are indented code blocks, not definitions.
+        if indent_columns(line.text) >= 4 {
+            continue;
+        }
         let trimmed = line.text.trim_start();
         let Some(rest) = trimmed.strip_prefix('[') else {
             continue;
@@ -1514,6 +1518,20 @@ fn is_allowed(values: &[CompactString], identifier: &CompactString) -> bool {
 fn split_indent(line: &str) -> (usize, &str) {
     let indent = line.bytes().take_while(|byte| *byte == b' ').count();
     (indent, &line[indent..])
+}
+
+// Leading-whitespace width in columns, expanding tabs to the next multiple of 4
+// (CommonMark tab stop). A width >= 4 marks an indented code block.
+fn indent_columns(line: &str) -> usize {
+    let mut columns = 0;
+    for byte in line.bytes() {
+        match byte {
+            b' ' => columns += 1,
+            b'\t' => columns += 4 - (columns % 4),
+            _ => break,
+        }
+    }
+    columns
 }
 
 fn split_fence_info(info: &str) -> (Option<CompactString>, Option<CompactString>) {

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -9,10 +9,6 @@
       "level": "off",
       "note": "False positives on URLs inside link/definition labels, HTML attributes, and existing autolinks."
     },
-    "no-duplicate-definitions": {
-      "level": "off",
-      "note": "Treats deeply-indented (code-block) lines as definitions; upstream parses them as indented code."
-    },
     "no-duplicate-headings": {
       "level": "off",
       "note": "Heading-text normalisation differs (closed ATX trailing '#', collapsed inner spaces)."


### PR DESCRIPTION
Promotes **`no-duplicate-definitions`** to full upstream parity (19 valid / 11 invalid).

## Divergence
Lines indented ≥ 4 columns are indented **code blocks**, not definitions. `collect_definitions` stripped leading whitespace unconditionally, so two tab-indented `[Grüsse]: …` lines were parsed as definitions and wrongly flagged as duplicates (upstream parses them as code → valid).

## Fix
Add a tab-aware `indent_columns` helper (tab → next multiple of 4) and skip lines whose leading width is ≥ 4 when collecting definitions. Removes the `no-duplicate-definitions` quarantine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784010126&installation_id=136613492&pr_number=248&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F248&signature=ebe0c2a20d49a73b32063c4b44dc512201afa1a130a12833299f5398da3ddfb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->