### PR TITLE
fix(eslint-markdown): prevent panic on non-ASCII offsets

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -1761,7 +1761,12 @@ fn count_table_cells(line: &str) -> usize {
 }
 
 fn utf16_offset(source_text: &str, byte_offset: usize) -> u32 {
-    source_text[..byte_offset.min(source_text.len())]
+    let mut byte_offset = byte_offset.min(source_text.len());
+    // Defensive: floor to a char boundary so slicing never panics on non-ASCII.
+    while byte_offset > 0 && !source_text.is_char_boundary(byte_offset) {
+        byte_offset -= 1;
+    }
+    source_text[..byte_offset]
         .chars()
         .map(char::len_utf16)
         .sum::<usize>() as u32
@@ -1795,7 +1800,13 @@ impl LineIndex {
     }
 
     fn position_for_offset(&self, source_text: &str, offset: usize) -> (u32, u32) {
-        let offset = offset.min(source_text.len());
+        let mut offset = offset.min(source_text.len());
+        // Defensive: a rule may hand us a byte offset that lands inside a
+        // multibyte char on non-ASCII input; floor it to the nearest char
+        // boundary so the slice below never panics.
+        while offset > 0 && !source_text.is_char_boundary(offset) {
+            offset -= 1;
+        }
         let line_index = self.line_starts.partition_point(|start| *start <= offset);
         let line_index = line_index.saturating_sub(1);
         let line_start = self.line_starts[line_index];


### PR DESCRIPTION
Safety fix surfaced by replaying the upstream suite (#242).

`position_for_offset` / `utf16_offset` sliced `source_text` at a byte offset that a rule can compute mid-multibyte-character — e.g. a heading whose `#`s are immediately followed by a non-breaking space (U+00A0). That panicked with *"byte index N is not a char boundary"*, crashing the scanner on otherwise-valid Markdown.

Both helpers now floor the offset to the nearest char boundary before slicing, so diagnostics never panic on non-ASCII input. Pure hardening — no behavioural change for inputs that were already handled (they never produced a mid-char offset). Verified the previously-crashing `no-missing-atx-heading-space` cases now run without panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784010407&installation_id=136613492&pr_number=249&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F249&signature=0060b2a8524a82fedc687716d9aa59b51cfb65a1e56abfee80aad290ad55a406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->