### PR TITLE
fix(eslint-markdown): rewrite no-invalid-label-refs to match upstream

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -995,19 +995,53 @@ fn scan_invalid_label_refs(
     facts: &MarkdownFacts<'_>,
     diagnostics: &mut SmallVec<[Diagnostic; 32]>,
 ) {
-    for label_ref in &facts.label_refs {
-        if label_ref.label.trim().is_empty() {
-            diagnostics.push(Diagnostic {
-                rule_name: "no-invalid-label-refs",
-                message_id: "invalidLabelRef",
-                data: DiagnosticData {
-                    label: Some(label_ref.label.clone()),
-                    ..DiagnosticData::default()
-                },
-                loc: line_index.loc_for_span(source_text, label_ref.span),
-                fix: None,
-            });
+    // Mirror upstream: scan for `][label]` (`labelPattern`), and flag it only
+    // when the trailing reference is whitespace-only (`illegalShorthandTailPattern`
+    // = `/\]\[\s+\]$/`). The reported label is the leading bracket's contents.
+    let Ok(label_re) = Regex::new(r"\]\[([^\]]+)\]") else {
+        return;
+    };
+    let Ok(first_re) = Regex::new(r"!?\[([^\]]+)\]") else {
+        return;
+    };
+    let mut search_from = 0;
+    while search_from < source_text.len() {
+        let Some(mat) = label_re.find_at(source_text, search_from) else {
+            break;
+        };
+        let inner = &mat.as_str()[2..mat.as_str().len() - 1];
+        // A blank line (>= 2 newlines in the whitespace) breaks the paragraph, so
+        // the `][ ]` would span two text nodes and upstream never matches it.
+        let whitespace_only = !inner.is_empty()
+            && inner.chars().all(char::is_whitespace)
+            && inner.bytes().filter(|byte| *byte == b'\n').count() <= 1;
+        if whitespace_only && !in_fenced_range(facts, mat.start()) {
+            // The leading `[` of the reference text, searched across the whole
+            // document like upstream's `lastIndexOf("[", startOffset)`.
+            if let Some(open) = source_text[..mat.start()].rfind('[') {
+                let label = first_re
+                    .captures(&source_text[open..mat.end()])
+                    .and_then(|caps| caps.get(1))
+                    .map_or("", |group| group.as_str().trim());
+                diagnostics.push(Diagnostic {
+                    rule_name: "no-invalid-label-refs",
+                    message_id: "invalidLabelRef",
+                    data: DiagnosticData {
+                        label: Some(CompactString::from(label)),
+                        ..DiagnosticData::default()
+                    },
+                    loc: line_index.loc_for_span(
+                        source_text,
+                        ByteSpan {
+                            start: mat.start() + 1,
+                            end: mat.end(),
+                        },
+                    ),
+                    fix: None,
+                });
+            }
         }
+        search_from = mat.end();
     }
 }
 

--- a/npm/eslint-markdown/test/api.test.mjs
+++ b/npm/eslint-markdown/test/api.test.mjs
@@ -67,7 +67,7 @@ describe('@eslint/markdown native API', () => {
       '(label)[https://example.com]',
       'https://example.com',
       '* spaced *',
-      '[ ][]',
+      '[foo][ ]',
       '<div><img src="x"></div>',
       '',
       '| a | b |',

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -17,10 +17,6 @@
       "level": "off",
       "note": "Footnote multi-line content and escaped-caret labels classified differently from upstream."
     },
-    "no-invalid-label-refs": {
-      "level": "off",
-      "note": "False positives on collapsed `[foo][]` / `![foo][]` references with a matching definition."
-    },
     "no-missing-atx-heading-space": {
       "level": "off",
       "note": "PANICS on non-ASCII input (char-boundary slice at lib.rs position_for_offset); span/column divergences."


### PR DESCRIPTION
Promotes **`no-invalid-label-refs`** to full upstream parity (9 valid / 13 invalid).

## Divergence
The port flagged any reference with an empty/whitespace second label — including valid collapsed references like `[foo][]` and `![foo][]`. Upstream only flags a reference whose **trailing** bracket is whitespace-only (`[text][ ]`), reports the **leading** bracket's label (e.g. `foo`), and spans the trailing `[...]`.

## Fix
Reimplement `scan_invalid_label_refs` directly on the source, mirroring upstream's `labelPattern` (`/\]\[([^\]]+)\]/`) and `illegalShorthandTailPattern` (`/\]\[\s+\]$/`): match `][label]`, require the inner label to be whitespace-only, take the reported label from the leading bracket (`/!?\[([^\]]+)\]/`), and report `[match.start+1, match.end]`. Whitespace that spans a blank line is excluded — the paragraph break splits the text node, so upstream never matches across it (e.g. `[eslint][\n\n]` is valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784010837&installation_id=136613492&pr_number=250&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F250&signature=17e8151ea080c6ea0ad9025bed47fada56d08a63cda3613033d7968cf02276e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->