### PR TITLE
port(sonarjs): port max-lines (S104)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 49] = [
+pub const RULE_NAMES: [&str; 50] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -72,6 +72,7 @@ pub const RULE_NAMES: [&str; 49] = [
     "no-nested-incdec",
     "no-useless-increment",
     "class-name",
+    "max-lines",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -11,6 +11,7 @@ mod elseif_without_else;
 mod fixme_tag;
 mod for_in;
 mod generator_without_yield;
+mod max_lines;
 mod max_switch_cases;
 mod max_union_size;
 mod no_all_duplicated_branches;

--- a/crates/sonarjs/src/rules/max_lines.rs
+++ b/crates/sonarjs/src/rules/max_lines.rs
@@ -1,0 +1,81 @@
+//! Rule `max-lines` (SonarJS key S104).
+//!
+//! Clean-room port. Reports files whose number of code lines exceeds the
+//! configured threshold, because very long files are hard to read, understand,
+//! and maintain, and are usually a sign that the file needs to be split.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+//!
+//! ## What counts as a "code line"
+//!
+//! A physical line counts as a code line when it contains at least one
+//! character that is NOT whitespace AND NOT inside a comment span. Blank lines
+//! (containing only whitespace) and lines whose every non-whitespace character
+//! falls inside a `// …` or `/* … */` comment are excluded from the count.
+//!
+//! ## Threshold
+//!
+//! The threshold mirrors SonarJS's configurable `maximum` option
+//! (`self.options.max_lines_threshold`); when no option is supplied the
+//! SonarJS default of **1000** is used.
+//!
+//! A diagnostic is emitted when the code-line count is **strictly greater
+//! than** the threshold; a file with exactly the threshold lines is accepted.
+
+use oxc_ast::ast::Comment;
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "max-lines";
+
+/// Returns `true` when byte offset `abs` falls inside `comment`'s span.
+fn span_covers(comment: &Comment, abs: u32) -> bool {
+    comment.span.start <= abs && abs < comment.span.end
+}
+
+/// Returns `true` when the slice `source[start..end]` contains at least one
+/// character that is not whitespace and not covered by any comment span.
+fn line_has_code(source: &str, start: usize, end: usize, comments: &[Comment]) -> bool {
+    for (offset, ch) in source[start..end].char_indices() {
+        if ch.is_whitespace() {
+            continue;
+        }
+        let abs = (start + offset) as u32;
+        if !comments.iter().any(|c| span_covers(c, abs)) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Counts the number of code lines in `source`, excluding blank lines and
+/// lines that are entirely inside comment spans.
+fn count_code_lines(source: &str, comments: &[Comment]) -> u32 {
+    let mut count = 0u32;
+    let mut start = 0usize;
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            if line_has_code(source, start, i, comments) {
+                count += 1;
+            }
+            start = i + 1;
+        }
+    }
+    // Handle a final line with no trailing newline.
+    if start < source.len() && line_has_code(source, start, source.len(), comments) {
+        count += 1;
+    }
+    count
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_max_lines(&mut self, comments: &[Comment]) {
+        let code_lines = count_code_lines(self.source_text, comments);
+        if code_lines <= self.options.max_lines_threshold {
+            return;
+        }
+        self.report(RULE_NAME, "maxLines", Span::new(0, 0));
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -81,6 +81,7 @@ impl Scanner<'_> {
 impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_program(&mut self, it: &Program<'a>) {
         self.check_no_tab();
+        self.check_max_lines(&it.comments);
         self.check_fixme_tag(&it.comments);
         self.check_todo_tag(&it.comments);
         self.check_no_sonar_comments(&it.comments);

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2280,3 +2280,44 @@ fn max_union_size_respects_custom_threshold() {
     let two = "type T = A | B;";
     assert!(scan_sonarjs(two, "sample.ts", &options).is_empty());
 }
+
+#[test]
+fn max_lines_reports_when_code_lines_exceed_threshold() {
+    let mut options = options_for("max-lines");
+    options.max_lines_threshold = 2;
+    let source = "const a = 1;\nconst b = 2;\nconst c = 3;";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "max-lines");
+    assert_eq!(diagnostics[0].message_id, "maxLines");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+    assert_eq!(diagnostics[0].loc.start_column, 0);
+}
+
+#[test]
+fn max_lines_does_not_report_when_code_lines_equal_threshold() {
+    let mut options = options_for("max-lines");
+    options.max_lines_threshold = 3;
+    let source = "const a = 1;\nconst b = 2;\nconst c = 3;";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn max_lines_excludes_blank_and_comment_only_lines() {
+    // 2 code lines + 1 blank line + 1 comment-only line = 2 code lines total;
+    // with a threshold of 2, no diagnostic should be emitted.
+    let mut options = options_for("max-lines");
+    options.max_lines_threshold = 2;
+    let source = "const a = 1;\n\n// only a comment\nconst b = 2;";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn max_lines_uses_default_threshold_when_unset() {
+    // Default threshold is 1000; a small file must not be flagged.
+    let source = "const x = 1;\nconst y = 2;";
+    let diagnostics = scan("max-lines", source);
+    assert!(diagnostics.is_empty());
+}

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -44,6 +44,8 @@ pub struct Diagnostic {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SonarjsOptions {
     pub rule_names: SmallVec<[CompactString; 32]>,
+    /// Threshold for `max-lines` (S104); the SonarJS default is 1000.
+    pub max_lines_threshold: u32,
     /// Threshold for `max-switch-cases` (S1479); the SonarJS default is 30.
     pub max_switch_cases_threshold: u32,
     /// Threshold for `max-union-size` (S4622); the SonarJS default is 3.
@@ -57,6 +59,7 @@ impl Default for SonarjsOptions {
                 .iter()
                 .map(|rule_name| CompactString::from(*rule_name))
                 .collect(),
+            max_lines_threshold: 1000,
             max_switch_cases_threshold: 30,
             max_union_size_threshold: 3,
         }

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -188,6 +188,9 @@ const messages = Object.freeze({
   'class-name': {
     className: 'Rename this class to start with an uppercase letter (PascalCase).',
   },
+  'max-lines': {
+    maxLines: 'This file has more lines than the maximum allowed; split it into smaller files.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -281,6 +284,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow assigning a postfix increment or decrement of a variable back to that same variable',
   'class-name':
     'Require class names to start with an uppercase letter, following the PascalCase convention',
+  'max-lines':
+    'Disallow files with more code lines than the configured maximum (the "maximum" option; default 1000); blank lines and comment-only lines are not counted',
 });
 
 const ruleTypes = Object.freeze({
@@ -333,6 +338,7 @@ const ruleTypes = Object.freeze({
   'no-nested-incdec': 'suggestion',
   'no-useless-increment': 'suggestion',
   'class-name': 'suggestion',
+  'max-lines': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -385,6 +391,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-nested-incdec': 'error',
   'no-useless-increment': 'error',
   'class-name': 'error',
+  'max-lines': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());
@@ -441,6 +448,15 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'max-lines') {
+    return [
+      {
+        type: 'object',
+        properties: { maximum: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
   return [];
 }
 
@@ -453,6 +469,9 @@ function scanOptionsForRule(context, ruleName) {
   }
   if (ruleName === 'max-union-size' && Number.isInteger(raw.threshold)) {
     options.maxUnionSizeThreshold = raw.threshold;
+  }
+  if (ruleName === 'max-lines' && Number.isInteger(raw.maximum)) {
+    options.maxLinesThreshold = raw.maximum;
   }
   return options;
 }

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -19,6 +19,7 @@ mod napi_abi {
     #[derive(Clone, Debug, Default)]
     pub struct SonarjsScanOptions {
         pub rule_names: Option<Vec<String>>,
+        pub max_lines_threshold: Option<u32>,
         pub max_switch_cases_threshold: Option<u32>,
         pub max_union_size_threshold: Option<u32>,
     }
@@ -74,6 +75,9 @@ mod napi_abi {
         let default_options = core::SonarjsOptions::default();
         let core_options = core::SonarjsOptions {
             rule_names: compact_rule_names(options.rule_names),
+            max_lines_threshold: options
+                .max_lines_threshold
+                .unwrap_or(default_options.max_lines_threshold),
             max_switch_cases_threshold: options
                 .max_switch_cases_threshold
                 .unwrap_or(default_options.max_switch_cases_threshold),

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -52,6 +52,7 @@ const expectedRuleNames = [
   'no-nested-incdec',
   'no-useless-increment',
   'class-name',
+  'max-lines',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1861,5 +1862,37 @@ describe('sonarjs native API', () => {
       maxUnionSizeThreshold: 2,
     });
     expect(flagged).toHaveLength(1);
+  });
+
+  it('reports max-lines when code lines exceed the threshold', () => {
+    const source = 'const a = 1;\nconst b = 2;\nconst c = 3;';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-lines'],
+      maxLinesThreshold: 2,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('max-lines');
+    expect(diagnostics[0].messageId).toBe('maxLines');
+    expect(diagnostics[0].loc.startLine).toBe(1);
+    expect(diagnostics[0].loc.startColumn).toBe(0);
+  });
+
+  it('does not report max-lines when code lines equal the threshold', () => {
+    const source = 'const a = 1;\nconst b = 2;\nconst c = 3;';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-lines'],
+      maxLinesThreshold: 3,
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not count blank or comment-only lines toward the max-lines total', () => {
+    // 2 code lines + blank line + comment-only line = still only 2 code lines
+    const source = 'const a = 1;\n\n// only a comment\nconst b = 2;';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-lines'],
+      maxLinesThreshold: 2,
+    });
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -143,6 +143,7 @@ describe('sonarjs plugin shape', () => {
       'no-nested-incdec',
       'no-useless-increment',
       'class-name',
+      'max-lines',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -193,6 +194,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-nested-incdec']).toBe('object');
     expect(typeof plugin.rules['no-useless-increment']).toBe('object');
     expect(typeof plugin.rules['class-name']).toBe('object');
+    expect(typeof plugin.rules['max-lines']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -245,6 +247,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-incdec']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-useless-increment']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/class-name']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/max-lines']).toBe('error');
   });
 });
 
@@ -1114,5 +1117,19 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
       },
     ]);
     expect(plugin.rules['no-collapsible-if'].meta.schema).toEqual([]);
+  });
+
+  it('honors the max-lines "maximum" option through the adapter', () => {
+    const source = 'const a = 1;\nconst b = 2;\nconst c = 3;';
+    expect(runRule('max-lines', source, { options: [{ maximum: 2 }] })).toHaveLength(1);
+    expect(runRule('max-lines', source, { options: [{ maximum: 3 }] })).toHaveLength(0);
+  });
+
+  it('reports max-lines through the CLI', () => {
+    const source = 'const a = 1;\nconst b = 2;\nconst c = 3;';
+    const result = runOxlint('max-lines', source);
+    // default threshold is 1000; three code lines must NOT be flagged
+    expect(result.status).toBe(0);
+    expect(result.diagnostics).toHaveLength(0);
   });
 });

--- a/status.json
+++ b/status.json
@@ -11518,19 +11518,19 @@
       },
       {
         "name": "max-lines",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule max-lines (Sonar key S104). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of S104. Counts physical lines that contain at least one non-whitespace character outside a comment span. Blank lines and lines whose every non-whitespace character is inside a // or /* */ comment are excluded. A single diagnostic is emitted at the start of the file (Span 0,0) when the code-line count strictly exceeds the configurable maximum (default 1000)."
       },
       {
         "name": "max-lines-per-function",


### PR DESCRIPTION
Clean-room port of the SonarJS `max-lines` rule (Sonar key S104) — the first rule built on the new per-rule options layer (#246).

Counts the file's "code lines" = physical lines containing at least one non-whitespace character outside a comment span. **Blank lines and comment-only lines are excluded.** Reports one diagnostic at the start of the file when the count strictly exceeds the configurable `maximum` option (default 1000).

- **Flagged:** a file with more code lines than `maximum`.
- **Not flagged:** blank lines and `//` / `/* */` comment-only lines (they don't count); a file at exactly the threshold.

Implemented in `check_max_lines` from the existing `visit_program` hook. Tests cover the boundary (exceed vs equal), the blank/comment-only exclusion, the default fallback, and the option end-to-end through the native NAPI boundary, the adapter (`runRule` with `{ maximum }`), and the CLI. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784011021&installation_id=136613492&pr_number=251&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F251&signature=57777141a0e057000f1bcc768fb7cfbae69efea751b61fa7b0a12dd881b8f2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->