### PR TITLE
port(sonarjs): port nested-control-flow (S134)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 50] = [
+pub const RULE_NAMES: [&str; 51] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -73,6 +73,7 @@ pub const RULE_NAMES: [&str; 50] = [
     "no-useless-increment",
     "class-name",
     "max-lines",
+    "nested-control-flow",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -107,6 +108,8 @@ pub fn scan_sonarjs(
         if_chain_seen: SmallVec::new(),
         generator_yield_stack: SmallVec::new(),
         return_kind_stack: SmallVec::new(),
+        control_flow_depth: 0,
+        else_if_starts: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -14,6 +14,7 @@ mod generator_without_yield;
 mod max_lines;
 mod max_switch_cases;
 mod max_union_size;
+mod nested_control_flow;
 mod no_all_duplicated_branches;
 mod no_built_in_override;
 mod no_case_label_in_switch;

--- a/crates/sonarjs/src/rules/nested_control_flow.rs
+++ b/crates/sonarjs/src/rules/nested_control_flow.rs
@@ -1,0 +1,59 @@
+//! Rule `nested-control-flow` (SonarJS key S134).
+//!
+//! Clean-room port. Reports control-flow statements nested too deeply. The
+//! nesting depth counter increments for each of the eight statement types that
+//! are considered a level: `if`, `for`, `for…in`, `for…of`, `while`,
+//! `do…while`, `switch`, and `try`. A diagnostic fires on the statement that
+//! causes the depth to exceed the configured `maximumNestingLevel` option
+//! (default **3**).
+//!
+//! **`else if` chains do not add a level.** An `if` statement that is the
+//! `alternate` (the `else` branch) of a parent `if` is part of the same
+//! conditional chain and is not counted as an additional nesting level. Deeper
+//! statements inside an already-flagged one are NOT separately flagged.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{IfStatement, Statement};
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "nested-control-flow";
+
+impl Scanner<'_> {
+    /// Enters a control-flow statement that counts toward nesting depth. Reports
+    /// when the current depth already equals the threshold (i.e. this node would
+    /// exceed it), then increments. Returns `true` (the caller must pair it with
+    /// `leave_nested_control_flow(true)`).
+    pub(crate) fn enter_nested_control_flow(&mut self, span: Span) -> bool {
+        if self.control_flow_depth == self.options.nested_control_flow_threshold {
+            self.report(RULE_NAME, "nestedControlFlow", span);
+        }
+        self.control_flow_depth += 1;
+        true
+    }
+
+    /// Enters an `if` statement. An `else if` (an `if` that is the `alternate`
+    /// of a parent `if`) does not count toward depth and is not checked; its
+    /// own alternate-if is marked so the chain continues. Returns whether this
+    /// node was counted (pass it to `leave_nested_control_flow`).
+    pub(crate) fn enter_nested_control_flow_if(&mut self, it: &IfStatement<'_>) -> bool {
+        if let Some(Statement::IfStatement(alternate)) = &it.alternate {
+            self.else_if_starts.push(alternate.span.start);
+        }
+        if self.else_if_starts.contains(&it.span.start) {
+            return false;
+        }
+        self.enter_nested_control_flow(it.span)
+    }
+
+    /// Leaves a control-flow statement, decrementing the depth only if it was
+    /// counted.
+    pub(crate) fn leave_nested_control_flow(&mut self, counted: bool) {
+        if counted {
+            self.control_flow_depth -= 1;
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -8,8 +8,8 @@ use oxc_ast::ast::{
     ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function, FunctionBody,
     IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, NewExpression, Program,
     RegExpLiteral, ReturnStatement, StaticMemberExpression, SwitchCase, SwitchStatement,
-    TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral, UnaryExpression,
-    WhileStatement, YieldExpression,
+    TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral, TryStatement,
+    UnaryExpression, WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -44,6 +44,12 @@ pub(crate) struct Scanner<'a> {
     /// Pushed on entry to a function/arrow and popped on exit;
     /// `no-inconsistent-returns` reports a scope whose frame has both kinds set.
     pub(crate) return_kind_stack: SmallVec<[(Span, bool, bool); 8]>,
+    /// Current nesting depth of control-flow statements (if/for/while/switch/try),
+    /// used by `nested-control-flow`. `else if` branches do not add depth.
+    pub(crate) control_flow_depth: u32,
+    /// Span-start offsets of `if` statements that are the `else`-branch of a parent
+    /// `if` (an `else if`); these do not increment the nesting depth.
+    pub(crate) else_if_starts: SmallVec<[u32; 8]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -115,7 +121,9 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_small_switch(it);
         self.check_prefer_default_last(it);
         self.switch_depth += 1;
+        let counted = self.enter_nested_control_flow(it.span);
         walk::walk_switch_statement(self, it);
+        self.leave_nested_control_flow(counted);
         self.switch_depth -= 1;
     }
 
@@ -158,13 +166,17 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_elseif_without_else(it);
         self.check_prefer_single_boolean_return(it);
         self.check_no_nested_assignment_condition(&it.test);
+        let counted = self.enter_nested_control_flow_if(it);
         walk::walk_if_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
         self.check_for_in(it);
         self.check_redundant_continue(&it.body);
+        let counted = self.enter_nested_control_flow(it.span);
         walk::walk_for_in_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
@@ -173,24 +185,32 @@ impl<'a> Visit<'a> for Scanner<'a> {
         if let Some(test) = &it.test {
             self.check_no_nested_assignment_condition(test);
         }
+        let counted = self.enter_nested_control_flow(it.span);
         walk::walk_for_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
         self.check_redundant_continue(&it.body);
         self.check_no_nested_assignment_condition(&it.test);
+        let counted = self.enter_nested_control_flow(it.span);
         walk::walk_while_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
         self.check_redundant_continue(&it.body);
         self.check_no_nested_assignment_condition(&it.test);
+        let counted = self.enter_nested_control_flow(it.span);
         walk::walk_do_while_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
         self.check_redundant_continue(&it.body);
+        let counted = self.enter_nested_control_flow(it.span);
         walk::walk_for_of_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
@@ -291,6 +311,12 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
         self.check_no_useless_catch(it);
         walk::walk_catch_clause(self, it);
+    }
+
+    fn visit_try_statement(&mut self, it: &TryStatement<'a>) {
+        let counted = self.enter_nested_control_flow(it.span);
+        walk::walk_try_statement(self, it);
+        self.leave_nested_control_flow(counted);
     }
 
     fn visit_function_body(&mut self, it: &FunctionBody<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2321,3 +2321,51 @@ fn max_lines_uses_default_threshold_when_unset() {
     let diagnostics = scan("max-lines", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_nested_control_flow_for_four_levels_deep() {
+    // Default threshold is 3; a 4th-level statement is flagged.
+    let source = "if (a) { for (let i = 0; i < 10; i++) { while (b) { if (c) {} } } }";
+    let diagnostics = scan("nested-control-flow", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "nested-control-flow");
+    assert_eq!(diagnostics[0].message_id, "nestedControlFlow");
+}
+
+#[test]
+fn does_not_report_nested_control_flow_for_exactly_three_levels() {
+    // Exactly 3 levels: at the threshold, not exceeding it.
+    let source = "if (a) { for (let i = 0; i < 10; i++) { while (b) {} } }";
+    let diagnostics = scan("nested-control-flow", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_nested_control_flow_for_else_if_chain() {
+    // An else-if chain at the top level must not accumulate depth.
+    let source = "if (a) {} else if (b) {} else if (c) {} else if (d) {} else {}";
+    let diagnostics = scan("nested-control-flow", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn reports_nested_control_flow_when_try_counts_as_a_level() {
+    // try(1) + if(2) + for(3) + while(4) = 4 levels → 1 diagnostic
+    let source = "try { if (a) { for (let i = 0; i < 10; i++) { while (b) {} } } } catch (e) {}";
+    let diagnostics = scan("nested-control-flow", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "nested-control-flow");
+    assert_eq!(diagnostics[0].message_id, "nestedControlFlow");
+}
+
+#[test]
+fn nested_control_flow_respects_custom_threshold() {
+    // With threshold 2, a 3-level nest should fire exactly once.
+    let mut options = options_for("nested-control-flow");
+    options.nested_control_flow_threshold = 2;
+    let source = "if (a) { for (let i = 0; i < 10; i++) { while (b) {} } }";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "nested-control-flow");
+    assert_eq!(diagnostics[0].message_id, "nestedControlFlow");
+}

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -50,6 +50,8 @@ pub struct SonarjsOptions {
     pub max_switch_cases_threshold: u32,
     /// Threshold for `max-union-size` (S4622); the SonarJS default is 3.
     pub max_union_size_threshold: u32,
+    /// Maximum nesting level for `nested-control-flow` (S134); the SonarJS default is 3.
+    pub nested_control_flow_threshold: u32,
 }
 
 impl Default for SonarjsOptions {
@@ -62,6 +64,7 @@ impl Default for SonarjsOptions {
             max_lines_threshold: 1000,
             max_switch_cases_threshold: 30,
             max_union_size_threshold: 3,
+            nested_control_flow_threshold: 3,
         }
     }
 }

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -191,6 +191,9 @@ const messages = Object.freeze({
   'max-lines': {
     maxLines: 'This file has more lines than the maximum allowed; split it into smaller files.',
   },
+  'nested-control-flow': {
+    nestedControlFlow: 'Refactor this code to reduce the nesting of control flow statements.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -286,6 +289,8 @@ const ruleDescriptions = Object.freeze({
     'Require class names to start with an uppercase letter, following the PascalCase convention',
   'max-lines':
     'Disallow files with more code lines than the configured maximum (the "maximum" option; default 1000); blank lines and comment-only lines are not counted',
+  'nested-control-flow':
+    'Disallow control flow statements (if/for/for-in/for-of/while/do-while/switch/try) nested beyond the configured maximumNestingLevel (default 3); else-if chains do not add a level',
 });
 
 const ruleTypes = Object.freeze({
@@ -339,6 +344,7 @@ const ruleTypes = Object.freeze({
   'no-useless-increment': 'suggestion',
   'class-name': 'suggestion',
   'max-lines': 'suggestion',
+  'nested-control-flow': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -392,6 +398,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-useless-increment': 'error',
   'class-name': 'error',
   'max-lines': 'error',
+  'nested-control-flow': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());
@@ -457,6 +464,15 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'nested-control-flow') {
+    return [
+      {
+        type: 'object',
+        properties: { maximumNestingLevel: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
   return [];
 }
 
@@ -472,6 +488,9 @@ function scanOptionsForRule(context, ruleName) {
   }
   if (ruleName === 'max-lines' && Number.isInteger(raw.maximum)) {
     options.maxLinesThreshold = raw.maximum;
+  }
+  if (ruleName === 'nested-control-flow' && Number.isInteger(raw.maximumNestingLevel)) {
+    options.nestedControlFlowThreshold = raw.maximumNestingLevel;
   }
   return options;
 }

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -22,6 +22,7 @@ mod napi_abi {
         pub max_lines_threshold: Option<u32>,
         pub max_switch_cases_threshold: Option<u32>,
         pub max_union_size_threshold: Option<u32>,
+        pub nested_control_flow_threshold: Option<u32>,
     }
 
     #[napi(object)]
@@ -84,6 +85,9 @@ mod napi_abi {
             max_union_size_threshold: options
                 .max_union_size_threshold
                 .unwrap_or(default_options.max_union_size_threshold),
+            nested_control_flow_threshold: options
+                .nested_control_flow_threshold
+                .unwrap_or(default_options.nested_control_flow_threshold),
         };
 
         core::scan_sonarjs(&source_text, &filename, &core_options)

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -53,6 +53,7 @@ const expectedRuleNames = [
   'no-useless-increment',
   'class-name',
   'max-lines',
+  'nested-control-flow',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1894,5 +1895,16 @@ describe('sonarjs native API', () => {
       maxLinesThreshold: 2,
     });
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports nested-control-flow when threshold 2 is exceeded with a 3-level nest', () => {
+    const source = 'if (a) { for (let i = 0; i < 10; i++) { while (b) {} } }';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['nested-control-flow'],
+      nestedControlFlowThreshold: 2,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('nested-control-flow');
+    expect(diagnostics[0].messageId).toBe('nestedControlFlow');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -144,6 +144,7 @@ describe('sonarjs plugin shape', () => {
       'no-useless-increment',
       'class-name',
       'max-lines',
+      'nested-control-flow',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -195,6 +196,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-useless-increment']).toBe('object');
     expect(typeof plugin.rules['class-name']).toBe('object');
     expect(typeof plugin.rules['max-lines']).toBe('object');
+    expect(typeof plugin.rules['nested-control-flow']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -248,6 +250,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-useless-increment']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/class-name']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-lines']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/nested-control-flow']).toBe('error');
   });
 });
 
@@ -1131,5 +1134,25 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     // default threshold is 1000; three code lines must NOT be flagged
     expect(result.status).toBe(0);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('honors the nested-control-flow "maximumNestingLevel" option through the adapter', () => {
+    const source = 'if (a) { for (let i = 0; i < 10; i++) { while (b) {} } }';
+    expect(
+      runRule('nested-control-flow', source, { options: [{ maximumNestingLevel: 2 }] }),
+    ).toHaveLength(1);
+    expect(
+      runRule('nested-control-flow', source, { options: [{ maximumNestingLevel: 3 }] }),
+    ).toHaveLength(0);
+  });
+
+  it('reports nested-control-flow through the CLI', () => {
+    const source = 'if (a) { for (let i = 0; i < 10; i++) { while (b) { if (c) {} } } }';
+    const result = runOxlint('nested-control-flow', source);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(nested-control-flow)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11598,19 +11598,19 @@
       },
       {
         "name": "nested-control-flow",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule nested-control-flow (Sonar key S134). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of S134. Counts nesting depth for if/for/for-in/for-of/while/do-while/switch/try; else-if chains do not add a level; configurable maximumNestingLevel option (default 3); reports the statement that exceeds the limit."
       },
       {
         "name": "new-operator-misuse",


### PR DESCRIPTION
Clean-room port of the SonarJS `nested-control-flow` rule (Sonar key S134), built on the per-rule options layer (#246).

Reports control-flow statements nested too deeply. A depth counter increments for each of the eight statement types that count as a level — `if`, `for`, `for…in`, `for…of`, `while`, `do…while`, `switch`, `try` — and a diagnostic fires on the statement that pushes the depth past the configurable `maximumNestingLevel` option (default 3). Deeper statements inside an already-flagged one are not separately reported.

**`else if` chains do not add a level** (matching SonarJS): an `if` that is the `alternate` of a parent `if` is part of the same chain and is not counted. This is detected by marking each if's alternate-if rather than needing parent pointers.

Tests cover the 4-deep boundary, the exactly-3 pass, the else-if non-accumulation (4 `else if` branches → 0), that `try` counts as a level, and the `maximumNestingLevel` option end-to-end (native boundary, adapter, CLI). No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784011995&installation_id=136613492&pr_number=253&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F253&signature=4a890600bb71151ba0035782194c916a1d0ad6d7897a6d73b4b5c0aba4650754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->