### PR TITLE
feat(eslint-markdown): add mdast (markdown-rs) scanning + port require-alt-text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1092,7 @@ name = "oxlint-plugins-eslint-markdown"
 version = "0.0.0"
 dependencies = [
  "insta",
+ "markdown",
  "oxlint-plugins-_carton",
  "regex",
 ]
@@ -1608,6 +1618,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-id-start"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ compact_str = "0.9.1"
 divan = "0.1.21"
 ghost-cell = "0.2.6"
 insta = "1.47.2"
+markdown = "1.0.0"
 napi = { version = "3.9.0", default-features = false, features = ["napi9", "serde-json"] }
 napi-build = "2.3.2"
 napi-derive = "3.5.6"

--- a/crates/eslint_markdown/Cargo.toml
+++ b/crates/eslint_markdown/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 publish = false
 
 [dependencies]
+markdown.workspace = true
 oxlint-plugins-carton.workspace = true
 regex.workspace = true
 

--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -1,7 +1,39 @@
 #![doc = "Rust implementation of @eslint/markdown rule logic."]
 
+use markdown::mdast;
 use oxlint_plugins_carton::{CompactString, FastHashMap, FastHashSet, SmallVec};
 use regex::Regex;
+
+// Rules whose logic is driven by the markdown-rs mdast tree (mirroring upstream's
+// mdast-based rules) rather than the regex `MarkdownFacts`. The tree is parsed
+// once per scan only when one of these rules is active.
+const MDAST_RULES: &[&str] = &["require-alt-text"];
+
+// Parse the source into an mdast tree with the same constructs upstream enables
+// for `markdown/gfm` (GFM tables, autolink literals, footnotes, strikethrough).
+fn parse_mdast(source_text: &str) -> Option<mdast::Node> {
+    markdown::to_mdast(source_text, &markdown::ParseOptions::gfm()).ok()
+}
+
+// Depth-first visit of every node in the tree.
+fn visit_mdast<'a>(node: &'a mdast::Node, visit: &mut impl FnMut(&'a mdast::Node)) {
+    visit(node);
+    if let Some(children) = node.children() {
+        for child in children {
+            visit_mdast(child, visit);
+        }
+    }
+}
+
+// The byte span of a node, taken from its mdast source position. Byte offsets are
+// converted to 1-indexed-line / 0-indexed-UTF-16-column locations by `LineIndex`,
+// keeping every rule on one column convention.
+fn node_span(node: &mdast::Node) -> Option<ByteSpan> {
+    node.position().map(|position| ByteSpan {
+        start: position.start.offset,
+        end: position.end.offset,
+    })
+}
 
 pub const RULE_NAMES: [&str; 21] = [
     "fenced-code-language",
@@ -218,6 +250,11 @@ pub fn scan_eslint_markdown(
 ) -> SmallVec<[Diagnostic; 32]> {
     let line_index = LineIndex::new(source_text);
     let facts = collect_facts(source_text, options);
+    let mdast = if MDAST_RULES.iter().any(|rule| options.is_enabled(rule)) {
+        parse_mdast(source_text)
+    } else {
+        None
+    };
     let mut diagnostics = SmallVec::new();
 
     if options.is_enabled("fenced-code-language") {
@@ -277,8 +314,10 @@ pub fn scan_eslint_markdown(
     if options.is_enabled("no-unused-definitions") {
         scan_unused_definitions(source_text, &line_index, &facts, options, &mut diagnostics);
     }
-    if options.is_enabled("require-alt-text") {
-        scan_require_alt_text(source_text, &line_index, &facts, &mut diagnostics);
+    if options.is_enabled("require-alt-text")
+        && let Some(tree) = &mdast
+    {
+        scan_require_alt_text(source_text, &line_index, tree, &mut diagnostics);
     }
     if options.is_enabled("table-column-count") {
         scan_table_column_count(source_text, &line_index, &facts, options, &mut diagnostics);
@@ -1417,39 +1456,105 @@ fn scan_unused_definitions(
 fn scan_require_alt_text(
     source_text: &str,
     line_index: &LineIndex,
-    facts: &MarkdownFacts<'_>,
+    tree: &mdast::Node,
     diagnostics: &mut SmallVec<[Diagnostic; 32]>,
 ) {
-    for link in &facts.links {
-        if link.is_image && link.label.trim().is_empty() {
+    visit_mdast(tree, &mut |node| match node {
+        // Markdown images / image references: flag when alt text is blank.
+        mdast::Node::Image(image) if image.alt.trim().is_empty() => {
+            push_alt_required(source_text, line_index, node_span(node), diagnostics);
+        }
+        mdast::Node::ImageReference(image) if image.alt.trim().is_empty() => {
+            push_alt_required(source_text, line_index, node_span(node), diagnostics);
+        }
+        // Raw HTML: scan each `<img>` tag for a usable alt attribute.
+        mdast::Node::Html(_) => {
+            if let Some(span) = node_span(node) {
+                scan_html_img_alt(source_text, line_index, span, diagnostics);
+            }
+        }
+        _ => {}
+    });
+}
+
+fn push_alt_required(
+    source_text: &str,
+    line_index: &LineIndex,
+    span: Option<ByteSpan>,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    if let Some(span) = span {
+        diagnostics.push(Diagnostic {
+            rule_name: "require-alt-text",
+            message_id: "altTextRequired",
+            data: DiagnosticData::default(),
+            loc: line_index.loc_for_span(source_text, span),
+            fix: None,
+        });
+    }
+}
+
+// Mirror upstream's `<img>` handling: strip comments, then for each img tag flag
+// it unless it carries a usable alt. `aria-hidden="true"` exempts the tag. An alt
+// attribute that is present but whitespace-only (and non-empty, e.g. `alt=" "`)
+// is flagged; a bare `alt` or `alt=""` is accepted.
+fn scan_html_img_alt(
+    source_text: &str,
+    line_index: &LineIndex,
+    span: ByteSpan,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    let Ok(img_re) = Regex::new(r#"(?i)<img(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?/?>"#) else {
+        return;
+    };
+    let text = strip_html_comments(source_text.get(span.start..span.end).unwrap_or(""));
+    for mat in img_re.find_iter(&text) {
+        let tag = mat.as_str();
+        if html_attribute(tag, "aria-hidden")
+            .flatten()
+            .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+        {
+            continue;
+        }
+        let flag = match html_attribute(tag, "alt") {
+            None => true,
+            Some(Some(value)) => value.trim().is_empty() && !value.is_empty(),
+            Some(None) => false,
+        };
+        if flag {
+            let start = span.start + mat.start();
             diagnostics.push(Diagnostic {
                 rule_name: "require-alt-text",
                 message_id: "altTextRequired",
                 data: DiagnosticData::default(),
-                loc: line_index.loc_for_span(source_text, link.span),
+                loc: line_index.loc_for_span(
+                    source_text,
+                    ByteSpan {
+                        start,
+                        end: start + tag.len(),
+                    },
+                ),
                 fix: None,
             });
         }
     }
-    for tag in &facts.html_tags {
-        if !tag.name.eq_ignore_ascii_case("img") {
-            continue;
-        }
-        let alt = html_attr(tag.raw.as_str(), "alt");
-        let aria_hidden = html_attr(tag.raw.as_str(), "aria-hidden");
-        if aria_hidden.is_some_and(|value| value.eq_ignore_ascii_case("true")) {
-            continue;
-        }
-        if alt.is_none_or(|value| value.trim().is_empty()) {
-            diagnostics.push(Diagnostic {
-                rule_name: "require-alt-text",
-                message_id: "altTextRequired",
-                data: DiagnosticData::default(),
-                loc: line_index.loc_for_span(source_text, tag.span),
-                fix: None,
-            });
-        }
-    }
+}
+
+// Match an HTML attribute the way upstream's `getHtmlAttributeRe` does:
+// `\s<name>(\s*=\s*['"]([^'"]*)['"])?`. Returns `None` if absent, `Some(None)` if
+// present without a value (bare), `Some(Some(value))` if present with a value.
+fn html_attribute(tag: &str, name: &str) -> Option<Option<CompactString>> {
+    let pattern = format_attr_pattern(name);
+    let attr_re = Regex::new(&pattern).ok()?;
+    let caps = attr_re.captures(tag)?;
+    Some(caps.get(1).map(|value| CompactString::from(value.as_str())))
+}
+
+fn format_attr_pattern(name: &str) -> CompactString {
+    let mut pattern = CompactString::from(r"(?i)\s");
+    pattern.push_str(name);
+    pattern.push_str(r#"(?:\s*=\s*['"]([^'"]*)['"])?"#);
+    pattern
 }
 
 fn scan_table_column_count(

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -48,10 +48,6 @@
     "no-unused-definitions": {
       "level": "off",
       "note": "Reference-usage tracking differs for footnotes and collapsed references."
-    },
-    "require-alt-text": {
-      "level": "off",
-      "note": "Divergence detecting images nested in HTML and reference-style images without alt text."
     }
   }
 }


### PR DESCRIPTION
## Why

Replaying the full upstream suite (#242) showed the hand-rolled regex line-scanner cannot reach **exact** parity for rules that depend on real CommonMark structure — reference resolution (which `[x]` is a reference vs text), inline rendering, block containers (blockquote stripping), and autolink-literal detection. Approximating these with regex would pass the captured fixtures but break on real input.

## Infrastructure

Adds an mdast-based scanning path via the **`markdown` crate** (markdown-rs, by the mdast/micromark author) — it produces the same mdast tree upstream's rules consume, with source positions, GFM, footnotes, and frontmatter.

- License: `markdown` is MIT; its sole transitive dep `unicode-id` is `MIT OR Apache-2.0` — all allowlisted in `deny.toml`.
- `parse_mdast` builds the tree once per scan, **only when an mdast-backed rule (`MDAST_RULES`) is active** (no overhead for the regex rules).
- `visit_mdast` walks the tree; `node_span` maps a node's **byte offsets** through the existing `LineIndex`, so mdast rules share the exact same column convention (1-indexed line / 0-indexed UTF-16 column) as every other rule and the parity harness.

## First migration (proof)

**`require-alt-text`** now walks `Image`/`ImageReference` nodes (blank `alt`) and `<img>` HTML tags (`aria-hidden="true"` exempt; bare `alt`/`alt=""` accepted; whitespace-only `alt=" "` flagged), matching upstream exactly. **Full parity: 39 valid / 30 invalid.**

The remaining 12 quarantined rules will migrate onto this path one PR at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784012825&installation_id=136613492&pr_number=254&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F254&signature=be630b0b3fd1093621d14b7180bdc147d0e7a81be7b3bb6bc6b7702bc95237a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->