### PR TITLE
docs(unocss): cite upstream sortRules in parity quarantine reasons

### DIFF
--- a/npm/unocss/test/parity.json
+++ b/npm/unocss/test/parity.json
@@ -11,7 +11,7 @@
       "invalid": [
         {
           "index": 9,
-          "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens; the heuristic only sorts when every token is recognized, while the engine sorts the recognized subset in place."
+          "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens. Upstream `sortRules` emits unrecognized tokens first (in original order) then recognized tokens sorted by engine order; recognition is `uno.parseToken`. The heuristic's `is_unocss_token` is intentionally over-broad (e.g. `m-class` looks like a margin utility but `parseToken` rejects it), so it cannot safely reproduce unknowns-first without the engine and instead bails when any token is unrecognized. Engine-dependent."
         }
       ]
     },
@@ -19,7 +19,7 @@
       "invalid": [
         {
           "index": 2,
-          "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens; the heuristic only sorts when every token is recognized."
+          "reason": "interpolated quasi mixes UnoCSS and non-UnoCSS tokens; reproducing upstream `sortRules` (unrecognized tokens first, then recognized tokens by engine order) needs precise `uno.parseToken` recognition the heuristic lacks, so it bails when any token is unrecognized. Engine-dependent."
         }
       ]
     }


### PR DESCRIPTION
Documentation-only. Makes the engine-dependency of the remaining quarantined `order` cases precise and verifiable against upstream `virtual-shared/integration/src/sort-rules.ts`: `sortRules` emits unrecognized tokens first (original order) then recognized tokens sorted by engine order, where recognition is `uno.parseToken`. The port's heuristic `is_unocss_token` is intentionally over-broad (e.g. accepts `m-class`, which `parseToken` rejects), so it cannot reproduce the unknowns-first behavior without the engine and bails when any token is unrecognized — confirming the quarantine is principled, not a coverage gap. No code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784013270&installation_id=136613492&pr_number=255&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F255&signature=4c0eb5387274cb0da5e7bb042d593d8dff222f2f19a697e53feddd1ddb424a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->