### PR TITLE
fix(eslint-markdown): port no-empty-definitions to mdast

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 // Rules whose logic is driven by the markdown-rs mdast tree (mirroring upstream's
 // mdast-based rules) rather than the regex `MarkdownFacts`. The tree is parsed
 // once per scan only when one of these rules is active.
-const MDAST_RULES: &[&str] = &["require-alt-text"];
+const MDAST_RULES: &[&str] = &["no-empty-definitions", "require-alt-text"];
 
 // Parse the source into an mdast tree with the same constructs upstream enables
 // for `markdown/gfm` (GFM tables, autolink literals, footnotes, strikethrough).
@@ -275,8 +275,10 @@ pub fn scan_eslint_markdown(
     if options.is_enabled("no-duplicate-headings") {
         scan_duplicate_headings(source_text, &line_index, &facts, options, &mut diagnostics);
     }
-    if options.is_enabled("no-empty-definitions") {
-        scan_empty_definitions(source_text, &line_index, &facts, options, &mut diagnostics);
+    if options.is_enabled("no-empty-definitions")
+        && let Some(tree) = &mdast
+    {
+        scan_empty_definitions(source_text, &line_index, tree, options, &mut diagnostics);
     }
     if options.is_enabled("no-empty-images") {
         scan_empty_media(source_text, &line_index, &facts, true, &mut diagnostics);
@@ -920,38 +922,85 @@ fn scan_duplicate_headings(
 fn scan_empty_definitions(
     source_text: &str,
     line_index: &LineIndex,
-    facts: &MarkdownFacts<'_>,
+    tree: &mdast::Node,
     options: &ScanOptions,
     diagnostics: &mut SmallVec<[Diagnostic; 32]>,
 ) {
-    for definition in &facts.definitions {
-        if definition.is_footnote {
-            if options.check_footnote_definitions
-                && !is_allowed(&options.allow_footnote_definitions, &definition.identifier)
-                && definition.url.trim().is_empty()
+    visit_mdast(tree, &mut |node| match node {
+        // A link definition with no destination (`[x]:`, `[x]: <>`) or a bare
+        // fragment (`[x]: #`).
+        mdast::Node::Definition(definition) => {
+            let label = definition.label.as_deref().unwrap_or("");
+            let identifier = normalize_identifier(label);
+            if (definition.url.is_empty() || definition.url == "#")
+                && !is_allowed(&options.allow_definitions, &identifier)
             {
-                diagnostics.push(definition_diagnostic(
-                    "no-empty-definitions",
+                push_empty_definition(
+                    "emptyDefinition",
+                    source_text,
+                    line_index,
+                    node_span(node),
+                    &identifier,
+                    label.trim(),
+                    diagnostics,
+                );
+            }
+        }
+        // A footnote definition with no content, or whose only content is HTML
+        // comments.
+        mdast::Node::FootnoteDefinition(definition) if options.check_footnote_definitions => {
+            let label = definition.label.as_deref().unwrap_or("");
+            let identifier = normalize_identifier(label);
+            let empty = definition.children.is_empty()
+                || definition
+                    .children
+                    .iter()
+                    .all(|child| matches!(child, mdast::Node::Html(html) if is_only_comments(&html.value)));
+            if empty && !is_allowed(&options.allow_footnote_definitions, &identifier) {
+                push_empty_definition(
                     "emptyFootnoteDefinition",
                     source_text,
                     line_index,
-                    definition,
-                    None,
-                ));
+                    node_span(node),
+                    &identifier,
+                    label,
+                    diagnostics,
+                );
             }
-        } else if !is_allowed(&options.allow_definitions, &definition.identifier)
-            && (definition.url.trim().is_empty() || matches!(definition.url.as_str(), "#" | "<>"))
-        {
-            diagnostics.push(definition_diagnostic(
-                "no-empty-definitions",
-                "emptyDefinition",
-                source_text,
-                line_index,
-                definition,
-                None,
-            ));
         }
+        _ => {}
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_empty_definition(
+    message_id: &'static str,
+    source_text: &str,
+    line_index: &LineIndex,
+    span: Option<ByteSpan>,
+    identifier: &str,
+    label: &str,
+    diagnostics: &mut SmallVec<[Diagnostic; 32]>,
+) {
+    if let Some(span) = span {
+        diagnostics.push(Diagnostic {
+            rule_name: "no-empty-definitions",
+            message_id,
+            data: DiagnosticData {
+                identifier: Some(CompactString::from(identifier)),
+                label: Some(CompactString::from(label)),
+                ..DiagnosticData::default()
+            },
+            loc: line_index.loc_for_span(source_text, span),
+            fix: None,
+        });
     }
+}
+
+// True when the string contains only HTML comments (plus whitespace), matching
+// upstream `isOnlyComments`.
+fn is_only_comments(value: &str) -> bool {
+    strip_html_comments(value).trim().is_empty()
 }
 
 fn scan_empty_media(
@@ -1803,8 +1852,15 @@ fn normalize_identifier(value: &str) -> CompactString {
                 previous_space = true;
             }
         } else {
-            for lower in ch.to_lowercase() {
-                out.push(lower);
+            // Mirror micromark's `normalizeIdentifier(...).toLowerCase()`, i.e.
+            // `.toLowerCase().toUpperCase().toLowerCase()`, so case-folds such as
+            // ß/ẞ -> "ss" match upstream's identifiers.
+            for lowered in ch.to_lowercase() {
+                for uppered in lowered.to_uppercase() {
+                    for refolded in uppered.to_lowercase() {
+                        out.push(refolded);
+                    }
+                }
             }
             previous_space = false;
         }

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -13,10 +13,6 @@
       "level": "off",
       "note": "Heading-text normalisation differs (closed ATX trailing '#', collapsed inner spaces)."
     },
-    "no-empty-definitions": {
-      "level": "off",
-      "note": "Footnote multi-line content and escaped-caret labels classified differently from upstream."
-    },
     "no-missing-atx-heading-space": {
       "level": "off",
       "note": "PANICS on non-ASCII input (char-boundary slice at lib.rs position_for_offset); span/column divergences."


### PR DESCRIPTION
Promotes **`no-empty-definitions`** to full upstream parity (45 valid / 18 invalid) by rewriting it on the mdast tree (infra from #254).

- **Definition** nodes → `emptyDefinition` when the destination is empty (`[x]:`, `[x]: <>`) or bare `#` (upstream `!node.url || node.url === "#"`).
- **FootnoteDefinition** nodes (with `checkFootnoteDefinitions`) → `emptyFootnoteDefinition` when there are no children or every child is an HTML node of only comments (`isOnlyComments`). Fixes both false positives on multi-line footnote content and false negatives on comment-only footnotes.

`data.identifier` is computed from the raw label via `normalize_identifier` (markdown-rs strips internal whitespace from identifiers; micromark collapses to one space). Also fixed `normalize_identifier` to fold case like micromark (`toLowerCase().toUpperCase().toLowerCase()`) so ß/ẞ→"ss" and `allowDefinitions` matching like `GRÜẞE` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784013287&installation_id=136613492&pr_number=256&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F256&signature=a680ad62803abe13728cea8f25b82939616483bc787464dcb8499f4903e3d009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->