### PR TITLE
fix(eslint-markdown): port no-unused-definitions to mdast

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -7,7 +7,11 @@ use regex::Regex;
 // Rules whose logic is driven by the markdown-rs mdast tree (mirroring upstream's
 // mdast-based rules) rather than the regex `MarkdownFacts`. The tree is parsed
 // once per scan only when one of these rules is active.
-const MDAST_RULES: &[&str] = &["no-empty-definitions", "require-alt-text"];
+const MDAST_RULES: &[&str] = &[
+    "no-empty-definitions",
+    "no-unused-definitions",
+    "require-alt-text",
+];
 
 // Parse the source into an mdast tree with the same constructs upstream enables
 // for `markdown/gfm` (GFM tables, autolink literals, footnotes, strikethrough).
@@ -313,8 +317,10 @@ pub fn scan_eslint_markdown(
     if options.is_enabled("no-space-in-emphasis") {
         scan_space_in_emphasis(source_text, &line_index, &facts, options, &mut diagnostics);
     }
-    if options.is_enabled("no-unused-definitions") {
-        scan_unused_definitions(source_text, &line_index, &facts, options, &mut diagnostics);
+    if options.is_enabled("no-unused-definitions")
+        && let Some(tree) = &mdast
+    {
+        scan_unused_definitions(source_text, &line_index, tree, options, &mut diagnostics);
     }
     if options.is_enabled("require-alt-text")
         && let Some(tree) = &mdast
@@ -1466,40 +1472,93 @@ fn scan_space_in_emphasis(
 fn scan_unused_definitions(
     source_text: &str,
     line_index: &LineIndex,
-    facts: &MarkdownFacts<'_>,
+    tree: &mdast::Node,
     options: &ScanOptions,
     diagnostics: &mut SmallVec<[Diagnostic; 32]>,
 ) {
-    let used = used_label_ids(facts, false);
-    let used_footnotes = used_label_ids(facts, true);
-    for definition in &facts.definitions {
-        if definition.is_footnote {
-            if options.check_footnote_definitions
-                && !is_allowed(&options.allow_footnote_definitions, &definition.identifier)
-                && !used_footnotes.contains(&definition.identifier)
-            {
-                diagnostics.push(definition_diagnostic(
-                    "no-unused-definitions",
-                    "unusedFootnoteDefinition",
-                    source_text,
-                    line_index,
-                    definition,
-                    None,
-                ));
-            }
-        } else if !is_allowed(&options.allow_definitions, &definition.identifier)
-            && !used.contains(&definition.identifier)
-        {
-            diagnostics.push(definition_diagnostic(
-                "no-unused-definitions",
-                "unusedDefinition",
-                source_text,
-                line_index,
-                definition,
-                None,
+    // (identifier, label-for-data, span, is_footnote)
+    let mut defs: SmallVec<[(CompactString, CompactString, ByteSpan, bool); 16]> = SmallVec::new();
+    let mut used = FastHashSet::<CompactString>::default();
+    let mut used_footnotes = FastHashSet::<CompactString>::default();
+
+    visit_mdast(tree, &mut |node| match node {
+        mdast::Node::LinkReference(reference) => {
+            used.insert(reference_identifier(
+                reference.label.as_deref(),
+                &reference.identifier,
             ));
         }
+        mdast::Node::ImageReference(reference) => {
+            used.insert(reference_identifier(
+                reference.label.as_deref(),
+                &reference.identifier,
+            ));
+        }
+        mdast::Node::FootnoteReference(reference) => {
+            used_footnotes.insert(reference_identifier(
+                reference.label.as_deref(),
+                &reference.identifier,
+            ));
+        }
+        mdast::Node::Definition(definition) => {
+            if let Some(span) = node_span(node) {
+                let label = definition.label.as_deref().unwrap_or("");
+                defs.push((
+                    normalize_identifier(label),
+                    CompactString::from(label.trim()),
+                    span,
+                    false,
+                ));
+            }
+        }
+        mdast::Node::FootnoteDefinition(definition) => {
+            if let Some(span) = node_span(node) {
+                let label = definition.label.as_deref().unwrap_or("");
+                defs.push((
+                    normalize_identifier(label),
+                    CompactString::from(label),
+                    span,
+                    true,
+                ));
+            }
+        }
+        _ => {}
+    });
+
+    for (identifier, label, span, is_footnote) in &defs {
+        let (allow, used_set, message_id) = if *is_footnote {
+            if !options.check_footnote_definitions {
+                continue;
+            }
+            (
+                &options.allow_footnote_definitions,
+                &used_footnotes,
+                "unusedFootnoteDefinition",
+            )
+        } else {
+            (&options.allow_definitions, &used, "unusedDefinition")
+        };
+        if !is_allowed(allow, identifier) && !used_set.contains(identifier) {
+            diagnostics.push(Diagnostic {
+                rule_name: "no-unused-definitions",
+                message_id,
+                data: DiagnosticData {
+                    identifier: Some(identifier.clone()),
+                    label: Some(label.clone()),
+                    ..DiagnosticData::default()
+                },
+                loc: line_index.loc_for_span(source_text, *span),
+                fix: None,
+            });
+        }
     }
+}
+
+// The normalized identifier of a reference, from its label (falling back to the
+// mdast identifier when a label is absent), kept consistent with how definition
+// identifiers are normalized.
+fn reference_identifier(label: Option<&str>, identifier: &str) -> CompactString {
+    normalize_identifier(label.unwrap_or(identifier))
 }
 
 fn scan_require_alt_text(
@@ -1713,15 +1772,6 @@ fn definition_ids(facts: &MarkdownFacts<'_>, footnotes: bool) -> FastHashSet<Com
         .iter()
         .filter(|definition| definition.is_footnote == footnotes)
         .map(|definition| definition.identifier.clone())
-        .collect()
-}
-
-fn used_label_ids(facts: &MarkdownFacts<'_>, footnotes: bool) -> FastHashSet<CompactString> {
-    facts
-        .label_refs
-        .iter()
-        .filter(|label_ref| label_ref.is_footnote == footnotes)
-        .map(|label_ref| normalize_identifier(label_ref.label.as_str()))
         .collect()
 }
 

--- a/npm/eslint-markdown/test/parity.json
+++ b/npm/eslint-markdown/test/parity.json
@@ -40,10 +40,6 @@
     "no-space-in-emphasis": {
       "level": "off",
       "note": "Fundamentally different emphasis-marker scan; large divergence in spans and counts."
-    },
-    "no-unused-definitions": {
-      "level": "off",
-      "note": "Reference-usage tracking differs for footnotes and collapsed references."
     }
   }
 }


### PR DESCRIPTION
Promotes **`no-unused-definitions`** to full upstream parity (31 valid / 11 invalid) via the mdast tree (infra #254).

Collects referenced identifiers from `linkReference`/`imageReference`/`footnoteReference` nodes, then flags `Definition`/`FootnoteDefinition` nodes whose identifier is never referenced (honouring `allowDefinitions`/`allowFootnoteDefinitions`/`checkFootnoteDefinitions`). This correctly treats collapsed `[x][]` and shortcut `[x]` references as usages — the regex scanner missed them. Identifiers are normalized from the raw label for consistency with the reported `data.identifier`. Removes the now-unused `used_label_ids` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784013731&installation_id=136613492&pr_number=257&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F257&signature=cd4363df83a1a563784c0cd20899a12f2c9da074c51fb4d4a5ffe7154ab1e605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->