### PR TITLE
port(sonarjs): port max-lines-per-function (S138)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 51] = [
+pub const RULE_NAMES: [&str; 52] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -74,6 +74,7 @@ pub const RULE_NAMES: [&str; 51] = [
     "class-name",
     "max-lines",
     "nested-control-flow",
+    "max-lines-per-function",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -110,6 +111,9 @@ pub fn scan_sonarjs(
         return_kind_stack: SmallVec::new(),
         control_flow_depth: 0,
         else_if_starts: SmallVec::new(),
+        comment_spans: SmallVec::new(),
+        jsx_function_stack: SmallVec::new(),
+        iife_function_starts: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -12,6 +12,7 @@ mod fixme_tag;
 mod for_in;
 mod generator_without_yield;
 mod max_lines;
+mod max_lines_per_function;
 mod max_switch_cases;
 mod max_union_size;
 mod nested_control_flow;

--- a/crates/sonarjs/src/rules/max_lines.rs
+++ b/crates/sonarjs/src/rules/max_lines.rs
@@ -23,27 +23,26 @@
 //! A diagnostic is emitted when the code-line count is **strictly greater
 //! than** the threshold; a file with exactly the threshold lines is accepted.
 
-use oxc_ast::ast::Comment;
 use oxc_span::Span;
 
 use crate::scanner::Scanner;
 
 pub(crate) const RULE_NAME: &str = "max-lines";
 
-/// Returns `true` when byte offset `abs` falls inside `comment`'s span.
-fn span_covers(comment: &Comment, abs: u32) -> bool {
-    comment.span.start <= abs && abs < comment.span.end
+/// Returns `true` when byte offset `abs` falls inside `span`.
+pub(crate) fn span_covers(span: Span, abs: u32) -> bool {
+    span.start <= abs && abs < span.end
 }
 
 /// Returns `true` when the slice `source[start..end]` contains at least one
 /// character that is not whitespace and not covered by any comment span.
-fn line_has_code(source: &str, start: usize, end: usize, comments: &[Comment]) -> bool {
+pub(crate) fn line_has_code(source: &str, start: usize, end: usize, comments: &[Span]) -> bool {
     for (offset, ch) in source[start..end].char_indices() {
         if ch.is_whitespace() {
             continue;
         }
         let abs = (start + offset) as u32;
-        if !comments.iter().any(|c| span_covers(c, abs)) {
+        if !comments.iter().any(|c| span_covers(*c, abs)) {
             return true;
         }
     }
@@ -52,7 +51,7 @@ fn line_has_code(source: &str, start: usize, end: usize, comments: &[Comment]) -
 
 /// Counts the number of code lines in `source`, excluding blank lines and
 /// lines that are entirely inside comment spans.
-fn count_code_lines(source: &str, comments: &[Comment]) -> u32 {
+fn count_code_lines(source: &str, comments: &[Span]) -> u32 {
     let mut count = 0u32;
     let mut start = 0usize;
     for (i, b) in source.bytes().enumerate() {
@@ -71,8 +70,8 @@ fn count_code_lines(source: &str, comments: &[Comment]) -> u32 {
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_max_lines(&mut self, comments: &[Comment]) {
-        let code_lines = count_code_lines(self.source_text, comments);
+    pub(crate) fn check_max_lines(&mut self) {
+        let code_lines = count_code_lines(self.source_text, &self.comment_spans);
         if code_lines <= self.options.max_lines_threshold {
             return;
         }

--- a/crates/sonarjs/src/rules/max_lines_per_function.rs
+++ b/crates/sonarjs/src/rules/max_lines_per_function.rs
@@ -1,0 +1,114 @@
+//! Rule `max-lines-per-function` (SonarJS key S138).
+//!
+//! Clean-room port. Reports a function whose code-line count exceeds the
+//! configured threshold because very long functions are hard to read and
+//! maintain.
+//!
+//! ## What counts as a "code line"
+//!
+//! The same definition as `max-lines`: a physical line that contains at least
+//! one character that is NOT whitespace AND NOT inside a comment span.
+//!
+//! Code lines are counted over the function's own line span (from the first
+//! byte of the function keyword/arrow to the closing brace).
+//!
+//! ## Exclusions
+//!
+//! 1. **IIFEs** — a function/arrow that is directly the `callee` of a
+//!    `CallExpression` is never reported.
+//! 2. **JSX-containing functions** — a function/arrow whose subtree contains
+//!    any `JSXElement` or `JSXFragment` is never reported. This is a
+//!    deliberately broad, zero-false-positive broadening of SonarJS's
+//!    React-component exclusion (SonarJS excludes capitalized-name components
+//!    that return JSX; excluding any JSX-containing function is a superset, so
+//!    we never over-report — we only under-report some, which is acceptable).
+//!
+//! ## Threshold
+//!
+//! Mirrors SonarJS's configurable `maximum` option
+//! (`self.options.max_lines_per_function_threshold`); when no option is
+//! supplied the SonarJS default of **200** is used.
+//!
+//! A diagnostic is emitted when the code-line count is **strictly greater
+//! than** the threshold.
+
+use oxc_ast::ast::Expression;
+use oxc_span::Span;
+
+use crate::rules::max_lines::line_has_code;
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "max-lines-per-function";
+
+/// Counts the code lines the function occupies, from the line containing
+/// `span.start` (the signature line) through the line containing the closing
+/// brace, inclusive — matching SonarJS S138, which counts non-blank,
+/// non-comment-only lines over `function.loc.start.line ..= end.line`. Blank
+/// and comment-only lines are skipped (delegated to `line_has_code`).
+fn count_code_lines_in_span(source: &str, comments: &[Span], span: Span) -> u32 {
+    let span_start = span.start as usize;
+    let span_end = span.end as usize;
+    // Start at the beginning of the line that contains the function's first byte.
+    let first_line_start = source[..span_start].rfind('\n').map_or(0, |i| i + 1);
+
+    let mut count = 0u32;
+    let mut line_start = first_line_start;
+    for (offset, b) in source[first_line_start..].bytes().enumerate() {
+        if b != b'\n' {
+            continue;
+        }
+        // A line that begins at or after `span_end` is past the function.
+        if line_start >= span_end {
+            break;
+        }
+        let line_end = first_line_start + offset;
+        if line_has_code(source, line_start, line_end, comments) {
+            count += 1;
+        }
+        line_start = first_line_start + offset + 1;
+    }
+    // A final line with no trailing newline that still overlaps the span.
+    if line_start < span_end
+        && line_start < source.len()
+        && line_has_code(source, line_start, source.len(), comments)
+    {
+        count += 1;
+    }
+    count
+}
+
+impl Scanner<'_> {
+    /// Records the callee of a call when it is a function/arrow literal (an
+    /// IIFE), so `max-lines-per-function` can skip reporting that function.
+    pub(crate) fn record_iife_callee(&mut self, callee: &Expression<'_>) {
+        let start = match callee.get_inner_expression() {
+            Expression::FunctionExpression(func) => func.span.start,
+            Expression::ArrowFunctionExpression(arrow) => arrow.span.start,
+            _ => return,
+        };
+        self.iife_function_starts.push(start);
+    }
+
+    /// Marks the innermost open function/arrow frame as containing JSX.
+    pub(crate) fn mark_jsx(&mut self) {
+        if let Some(top) = self.jsx_function_stack.last_mut() {
+            *top = true;
+        }
+    }
+
+    /// Pops the JSX frame and reports if the function exceeds the threshold.
+    pub(crate) fn check_max_lines_per_function(&mut self, span: Span) {
+        let has_jsx = self.jsx_function_stack.pop().unwrap_or(true);
+        if has_jsx {
+            return;
+        }
+        if self.iife_function_starts.contains(&span.start) {
+            return;
+        }
+        let count = count_code_lines_in_span(self.source_text, &self.comment_spans, span);
+        if count <= self.options.max_lines_per_function_threshold {
+            return;
+        }
+        self.report(RULE_NAME, "maxLinesPerFunction", span);
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -6,10 +6,10 @@ use oxc_ast::ast::{
     ArrowFunctionExpression, AssignmentExpression, BinaryExpression, BindingIdentifier,
     BlockStatement, CallExpression, CatchClause, Class, ConditionalExpression, DoWhileStatement,
     ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function, FunctionBody,
-    IdentifierReference, IfStatement, LabeledStatement, LogicalExpression, NewExpression, Program,
-    RegExpLiteral, ReturnStatement, StaticMemberExpression, SwitchCase, SwitchStatement,
-    TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral, TryStatement,
-    UnaryExpression, WhileStatement, YieldExpression,
+    IdentifierReference, IfStatement, JSXElement, JSXFragment, LabeledStatement, LogicalExpression,
+    NewExpression, Program, RegExpLiteral, ReturnStatement, StaticMemberExpression, SwitchCase,
+    SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
+    TryStatement, UnaryExpression, WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -50,6 +50,14 @@ pub(crate) struct Scanner<'a> {
     /// Span-start offsets of `if` statements that are the `else`-branch of a parent
     /// `if` (an `else if`); these do not increment the nesting depth.
     pub(crate) else_if_starts: SmallVec<[u32; 8]>,
+    /// Comment spans for the current file, collected in `visit_program`.
+    pub(crate) comment_spans: SmallVec<[Span; 16]>,
+    /// JSX-tracking frames, one per open function/arrow; `max-lines-per-function`
+    /// skips any function whose frame is `true`.
+    pub(crate) jsx_function_stack: SmallVec<[bool; 8]>,
+    /// Span-start offsets of functions/arrows that are IIFEs (callee of a call);
+    /// `max-lines-per-function` never reports these.
+    pub(crate) iife_function_starts: SmallVec<[u32; 8]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -86,8 +94,11 @@ impl Scanner<'_> {
 
 impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_program(&mut self, it: &Program<'a>) {
+        for comment in &it.comments {
+            self.comment_spans.push(comment.span);
+        }
         self.check_no_tab();
-        self.check_max_lines(&it.comments);
+        self.check_max_lines();
         self.check_fixme_tag(&it.comments);
         self.check_todo_tag(&it.comments);
         self.check_no_sonar_comments(&it.comments);
@@ -263,6 +274,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_skipped_tests_call(it);
         self.check_array_constructor_call(it);
         self.check_no_nested_incdec_call(it);
+        self.record_iife_callee(&it.callee);
         walk::walk_call_expression(self, it);
     }
 
@@ -287,15 +299,19 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
         let track = self.enter_generator(it);
         self.enter_return_scope(it.span);
+        self.jsx_function_stack.push(false);
         walk::walk_function(self, it, flags);
         self.leave_return_scope();
         self.leave_generator(it, track);
+        self.check_max_lines_per_function(it.span);
     }
 
     fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
         self.enter_return_scope(it.span);
+        self.jsx_function_stack.push(false);
         walk::walk_arrow_function_expression(self, it);
         self.leave_return_scope();
+        self.check_max_lines_per_function(it.span);
     }
 
     fn visit_return_statement(&mut self, it: &ReturnStatement<'a>) {
@@ -306,6 +322,16 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {
         self.mark_generator_yield();
         walk::walk_yield_expression(self, it);
+    }
+
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        self.mark_jsx();
+        walk::walk_jsx_element(self, it);
+    }
+
+    fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
+        self.mark_jsx();
+        walk::walk_jsx_fragment(self, it);
     }
 
     fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2369,3 +2369,56 @@ fn nested_control_flow_respects_custom_threshold() {
     assert_eq!(diagnostics[0].rule_name, "nested-control-flow");
     assert_eq!(diagnostics[0].message_id, "nestedControlFlow");
 }
+
+#[test]
+fn reports_max_lines_per_function_for_function_over_threshold() {
+    let mut options = options_for("max-lines-per-function");
+    options.max_lines_per_function_threshold = 5;
+    // 6 code lines (signature + 4 body + closing brace) → strictly above 5 → 1 diagnostic
+    let source = "function f() {\n  a;\n  b;\n  c;\n  d;\n}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "max-lines-per-function");
+    assert_eq!(diagnostics[0].message_id, "maxLinesPerFunction");
+}
+
+#[test]
+fn does_not_report_max_lines_per_function_at_exactly_threshold() {
+    let mut options = options_for("max-lines-per-function");
+    options.max_lines_per_function_threshold = 5;
+    // 5 code lines (signature + 3 body + closing brace), exactly at the threshold → 0
+    let source = "function f() {\n  a;\n  b;\n  c;\n}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_count_blank_and_comment_lines_in_function() {
+    let mut options = options_for("max-lines-per-function");
+    options.max_lines_per_function_threshold = 5;
+    // 7 physical lines, but the comment-only and blank lines are excluded →
+    // 5 code lines, exactly at the threshold → 0 diagnostics
+    let source = "function f() {\n  // c\n  a;\n\n  b;\n  c;\n}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_max_lines_per_function_for_iife() {
+    let mut options = options_for("max-lines-per-function");
+    options.max_lines_per_function_threshold = 5;
+    // 6 code lines (above the threshold) but it's an IIFE → 0 diagnostics
+    let source = "(function() {\n  a;\n  b;\n  c;\n  d;\n})();";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_max_lines_per_function_for_jsx_containing_arrow() {
+    let mut options = options_for("max-lines-per-function");
+    options.max_lines_per_function_threshold = 5;
+    // 6 code lines (above the threshold) but the body contains JSX → 0 (parsed as TSX)
+    let source = "const f = () => {\n  a;\n  b;\n  c;\n  return <div />;\n};";
+    let diagnostics = scan_sonarjs(source, "sample.tsx", &options);
+    assert!(diagnostics.is_empty());
+}

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -46,6 +46,8 @@ pub struct SonarjsOptions {
     pub rule_names: SmallVec<[CompactString; 32]>,
     /// Threshold for `max-lines` (S104); the SonarJS default is 1000.
     pub max_lines_threshold: u32,
+    /// Threshold for `max-lines-per-function` (S138); the SonarJS default is 200.
+    pub max_lines_per_function_threshold: u32,
     /// Threshold for `max-switch-cases` (S1479); the SonarJS default is 30.
     pub max_switch_cases_threshold: u32,
     /// Threshold for `max-union-size` (S4622); the SonarJS default is 3.
@@ -62,6 +64,7 @@ impl Default for SonarjsOptions {
                 .map(|rule_name| CompactString::from(*rule_name))
                 .collect(),
             max_lines_threshold: 1000,
+            max_lines_per_function_threshold: 200,
             max_switch_cases_threshold: 30,
             max_union_size_threshold: 3,
             nested_control_flow_threshold: 3,

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -191,6 +191,10 @@ const messages = Object.freeze({
   'max-lines': {
     maxLines: 'This file has more lines than the maximum allowed; split it into smaller files.',
   },
+  'max-lines-per-function': {
+    maxLinesPerFunction:
+      'This function has more lines than the maximum allowed; split it into smaller functions.',
+  },
   'nested-control-flow': {
     nestedControlFlow: 'Refactor this code to reduce the nesting of control flow statements.',
   },
@@ -289,6 +293,8 @@ const ruleDescriptions = Object.freeze({
     'Require class names to start with an uppercase letter, following the PascalCase convention',
   'max-lines':
     'Disallow files with more code lines than the configured maximum (the "maximum" option; default 1000); blank lines and comment-only lines are not counted',
+  'max-lines-per-function':
+    'Disallow functions with more code lines than the configured maximum (the "maximum" option; default 200); IIFEs and JSX-containing functions are excluded',
   'nested-control-flow':
     'Disallow control flow statements (if/for/for-in/for-of/while/do-while/switch/try) nested beyond the configured maximumNestingLevel (default 3); else-if chains do not add a level',
 });
@@ -344,6 +350,7 @@ const ruleTypes = Object.freeze({
   'no-useless-increment': 'suggestion',
   'class-name': 'suggestion',
   'max-lines': 'suggestion',
+  'max-lines-per-function': 'suggestion',
   'nested-control-flow': 'suggestion',
 });
 
@@ -398,6 +405,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-useless-increment': 'error',
   'class-name': 'error',
   'max-lines': 'error',
+  'max-lines-per-function': 'error',
   'nested-control-flow': 'error',
 });
 
@@ -464,6 +472,15 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'max-lines-per-function') {
+    return [
+      {
+        type: 'object',
+        properties: { maximum: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
   if (ruleName === 'nested-control-flow') {
     return [
       {
@@ -488,6 +505,9 @@ function scanOptionsForRule(context, ruleName) {
   }
   if (ruleName === 'max-lines' && Number.isInteger(raw.maximum)) {
     options.maxLinesThreshold = raw.maximum;
+  }
+  if (ruleName === 'max-lines-per-function' && Number.isInteger(raw.maximum)) {
+    options.maxLinesPerFunctionThreshold = raw.maximum;
   }
   if (ruleName === 'nested-control-flow' && Number.isInteger(raw.maximumNestingLevel)) {
     options.nestedControlFlowThreshold = raw.maximumNestingLevel;

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -20,6 +20,7 @@ mod napi_abi {
     pub struct SonarjsScanOptions {
         pub rule_names: Option<Vec<String>>,
         pub max_lines_threshold: Option<u32>,
+        pub max_lines_per_function_threshold: Option<u32>,
         pub max_switch_cases_threshold: Option<u32>,
         pub max_union_size_threshold: Option<u32>,
         pub nested_control_flow_threshold: Option<u32>,
@@ -79,6 +80,9 @@ mod napi_abi {
             max_lines_threshold: options
                 .max_lines_threshold
                 .unwrap_or(default_options.max_lines_threshold),
+            max_lines_per_function_threshold: options
+                .max_lines_per_function_threshold
+                .unwrap_or(default_options.max_lines_per_function_threshold),
             max_switch_cases_threshold: options
                 .max_switch_cases_threshold
                 .unwrap_or(default_options.max_switch_cases_threshold),

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -54,6 +54,7 @@ const expectedRuleNames = [
   'class-name',
   'max-lines',
   'nested-control-flow',
+  'max-lines-per-function',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1906,5 +1907,27 @@ describe('sonarjs native API', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].ruleName).toBe('nested-control-flow');
     expect(diagnostics[0].messageId).toBe('nestedControlFlow');
+  });
+
+  it('reports max-lines-per-function for a function over the threshold', () => {
+    const source =
+      'function f() {\n  const a = 1;\n  const b = 2;\n  const c = 3;\n  return a + b + c;\n}';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-lines-per-function'],
+      maxLinesPerFunctionThreshold: 3,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('max-lines-per-function');
+    expect(diagnostics[0].messageId).toBe('maxLinesPerFunction');
+  });
+
+  it('does not report max-lines-per-function for a function at exactly the threshold', () => {
+    // 5 code lines (signature + 3 body + closing brace), exactly at the threshold
+    const source = 'function f() {\n  const a = 1;\n  const b = 2;\n  return a + b;\n}';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['max-lines-per-function'],
+      maxLinesPerFunctionThreshold: 5,
+    });
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -145,6 +145,7 @@ describe('sonarjs plugin shape', () => {
       'class-name',
       'max-lines',
       'nested-control-flow',
+      'max-lines-per-function',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -197,6 +198,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['class-name']).toBe('object');
     expect(typeof plugin.rules['max-lines']).toBe('object');
     expect(typeof plugin.rules['nested-control-flow']).toBe('object');
+    expect(typeof plugin.rules['max-lines-per-function']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -251,6 +253,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/class-name']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-lines']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/nested-control-flow']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/max-lines-per-function']).toBe('error');
   });
 });
 
@@ -1128,6 +1131,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(runRule('max-lines', source, { options: [{ maximum: 3 }] })).toHaveLength(0);
   });
 
+  it('reports max-lines-per-function when function exceeds threshold', () => {
+    const source =
+      'function f() {\n  const a = 1;\n  const b = 2;\n  const c = 3;\n  return a + b + c;\n}';
+    const reports = runRule('max-lines-per-function', source, { options: [{ maximum: 3 }] });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('maxLinesPerFunction');
+  });
+
+  it('does not report max-lines-per-function when function is within threshold', () => {
+    // 5 code lines (signature + 3 body + closing brace), exactly at the threshold
+    const source = 'function f() {\n  const a = 1;\n  const b = 2;\n  return a + b;\n}';
+    const reports = runRule('max-lines-per-function', source, { options: [{ maximum: 5 }] });
+    expect(reports).toHaveLength(0);
+  });
+
   it('reports max-lines through the CLI', () => {
     const source = 'const a = 1;\nconst b = 2;\nconst c = 3;';
     const result = runOxlint('max-lines', source);
@@ -1154,5 +1172,11 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(nested-control-flow)');
+  });
+
+  it('does not report max-lines-per-function for a short function (default 200)', () => {
+    const source = 'function f() { return 1; }';
+    const { diagnostics } = runOxlint('max-lines-per-function', source);
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/status.json
+++ b/status.json
@@ -11534,19 +11534,19 @@
       },
       {
         "name": "max-lines-per-function",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule max-lines-per-function (Sonar key S138). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of S138. Counts code lines (non-blank, non-comment-only) over the function's own line span. Reports FunctionDeclaration, FunctionExpression, and ArrowFunctionExpression when the count strictly exceeds the configurable maximum (default 200). IIFEs (function/arrow that is the direct callee of a CallExpression) are never reported. JSX-containing functions (any function whose subtree contains a JSXElement or JSXFragment) are never reported \u2014 this is a deliberate broadening of SonarJS's React-component exclusion; we exclude any JSX-containing function rather than only capitalized-name components, so we never over-report."
       },
       {
         "name": "max-switch-cases",


### PR DESCRIPTION
Clean-room port of the SonarJS `max-lines-per-function` rule (Sonar key S138), built on the per-rule options layer (#246) and the `max-lines` line-counting (#251).

Counts code lines (non-blank, non-comment-only) over each function's **full line span** — the signature line through the closing-brace line — and reports a `FunctionDeclaration` / `FunctionExpression` / `ArrowFunctionExpression` whose count strictly exceeds the configurable `maximum` option (default 200).

**Two zero-false-positive exclusions:**
- **IIFEs** — a function/arrow that is directly the callee of a call (recorded at call sites).
- **JSX-containing functions** — tracked via a per-function frame marked when a `JSXElement`/`JSXFragment` is visited; a deliberately broad superset of SonarJS's React-component exclusion (so we never over-report).

Refactors the shared line-counting helpers to key on comment spans collected once per file in `visit_program`, so `max-lines` and `max-lines-per-function` share them. Tests cover the over/at-threshold boundary, the blank/comment exclusion, IIFE exclusion, JSX exclusion, and the option through the native boundary, adapter, and CLI. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784014016&installation_id=136613492&pr_number=258&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F258&signature=e82ca3e86baaffa2c71d77932b4e07980eff179a1d076e1fe6a12656eeb3cdea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->