### PR TITLE
port(sonarjs): port no-duplicate-string (S1192)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 52] = [
+pub const RULE_NAMES: [&str; 53] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -75,6 +75,7 @@ pub const RULE_NAMES: [&str; 52] = [
     "max-lines",
     "nested-control-flow",
     "max-lines-per-function",
+    "no-duplicate-string",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -114,6 +115,8 @@ pub fn scan_sonarjs(
         comment_spans: SmallVec::new(),
         jsx_function_stack: SmallVec::new(),
         iife_function_starts: SmallVec::new(),
+        string_literals: SmallVec::new(),
+        excluded_string_starts: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -22,6 +22,7 @@ mod no_case_label_in_switch;
 mod no_collapsible_if;
 mod no_delete_var;
 mod no_duplicate_in_composite;
+mod no_duplicate_string;
 mod no_empty_character_class;
 mod no_exclusive_tests;
 mod no_function_declaration_in_block;

--- a/crates/sonarjs/src/rules/no_duplicate_string.rs
+++ b/crates/sonarjs/src/rules/no_duplicate_string.rs
@@ -1,0 +1,80 @@
+//! Rule `no-duplicate-string` (SonarJS key S1192).
+//!
+//! Clean-room port. Reports a string literal value that appears at least
+//! `threshold` (default 3) times in a file, where the value has at least
+//! 10 characters, contains a non-word character (non-[A-Za-z0-9_]), and is
+//! not the excluded literal `"application/json"`. String literals used as
+//! import/export module sources or as JSX attribute values are not counted.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::{Expression, StringLiteral};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-duplicate-string";
+
+fn qualifies(value: &str) -> bool {
+    if value.chars().count() < 10 {
+        return false;
+    }
+    if value == "application/json" {
+        return false;
+    }
+    value
+        .chars()
+        .any(|c| !(c.is_ascii_alphanumeric() || c == '_'))
+}
+
+impl<'a> Scanner<'a> {
+    pub(crate) fn record_string_literal(&mut self, lit: &StringLiteral<'a>) {
+        self.string_literals.push((lit.value.as_str(), lit.span));
+    }
+
+    pub(crate) fn finalize_no_duplicate_string(&mut self) {
+        if !self.options.has_rule(RULE_NAME) {
+            return;
+        }
+        let literals = self.string_literals.clone();
+        let threshold = self.options.no_duplicate_string_threshold;
+        let mut seen: SmallVec<[(&'a str, Span, u32); 16]> = SmallVec::new();
+        for (value, span) in &literals {
+            if self.excluded_string_starts.contains(&span.start) {
+                continue;
+            }
+            if !qualifies(value) {
+                continue;
+            }
+            let pos = seen.iter().position(|e| e.0 == *value);
+            if let Some(i) = pos {
+                seen[i].2 += 1;
+            } else {
+                seen.push((*value, *span, 1));
+            }
+        }
+        let mut to_report: SmallVec<[Span; 8]> = SmallVec::new();
+        for e in &seen {
+            if e.2 >= threshold {
+                to_report.push(e.1);
+            }
+        }
+        for span in to_report {
+            self.report(RULE_NAME, "duplicateString", span);
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn exclude_string(&mut self, lit: &StringLiteral<'_>) {
+        self.excluded_string_starts.push(lit.span.start);
+    }
+
+    pub(crate) fn exclude_string_expression(&mut self, expr: &Expression<'_>) {
+        if let Expression::StringLiteral(lit) = expr {
+            self.exclude_string(lit);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -5,11 +5,13 @@
 use oxc_ast::ast::{
     ArrowFunctionExpression, AssignmentExpression, BinaryExpression, BindingIdentifier,
     BlockStatement, CallExpression, CatchClause, Class, ConditionalExpression, DoWhileStatement,
-    ExpressionStatement, ForInStatement, ForOfStatement, ForStatement, Function, FunctionBody,
-    IdentifierReference, IfStatement, JSXElement, JSXFragment, LabeledStatement, LogicalExpression,
-    NewExpression, Program, RegExpLiteral, ReturnStatement, StaticMemberExpression, SwitchCase,
-    SwitchStatement, TSIntersectionType, TSPropertySignature, TSUnionType, TemplateLiteral,
-    TryStatement, UnaryExpression, WhileStatement, YieldExpression,
+    ExportAllDeclaration, ExportNamedDeclaration, ExpressionStatement, ForInStatement,
+    ForOfStatement, ForStatement, Function, FunctionBody, IdentifierReference, IfStatement,
+    ImportDeclaration, ImportExpression, JSXAttribute, JSXAttributeValue, JSXElement, JSXFragment,
+    LabeledStatement, LogicalExpression, NewExpression, Program, RegExpLiteral, ReturnStatement,
+    StaticMemberExpression, StringLiteral, SwitchCase, SwitchStatement, TSIntersectionType,
+    TSPropertySignature, TSUnionType, TemplateLiteral, TryStatement, UnaryExpression,
+    WhileStatement, YieldExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -58,6 +60,11 @@ pub(crate) struct Scanner<'a> {
     /// Span-start offsets of functions/arrows that are IIFEs (callee of a call);
     /// `max-lines-per-function` never reports these.
     pub(crate) iife_function_starts: SmallVec<[u32; 8]>,
+    /// (value, span) of every string literal seen, for `no-duplicate-string`.
+    pub(crate) string_literals: SmallVec<[(&'a str, Span); 32]>,
+    /// Span-start offsets of string literals in excluded positions (import/export
+    /// sources, JSX attribute values) that `no-duplicate-string` must skip.
+    pub(crate) excluded_string_starts: SmallVec<[u32; 16]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -104,6 +111,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_sonar_comments(&it.comments);
         self.check_no_same_line_conditional(&it.body);
         walk::walk_program(self, it);
+        self.finalize_no_duplicate_string();
     }
 
     fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
@@ -264,6 +272,11 @@ impl<'a> Visit<'a> for Scanner<'a> {
         walk::walk_reg_exp_literal(self, it);
     }
 
+    fn visit_string_literal(&mut self, it: &StringLiteral<'a>) {
+        self.record_string_literal(it);
+        walk::walk_string_literal(self, it);
+    }
+
     fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
         self.check_no_exclusive_tests(it);
         self.check_no_skipped_tests_member(it);
@@ -332,6 +345,35 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
         self.mark_jsx();
         walk::walk_jsx_fragment(self, it);
+    }
+
+    fn visit_jsx_attribute(&mut self, it: &JSXAttribute<'a>) {
+        if let Some(JSXAttributeValue::StringLiteral(lit)) = &it.value {
+            self.exclude_string(lit);
+        }
+        walk::walk_jsx_attribute(self, it);
+    }
+
+    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
+        self.exclude_string(&it.source);
+        walk::walk_import_declaration(self, it);
+    }
+
+    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
+        if let Some(source) = &it.source {
+            self.exclude_string(source);
+        }
+        walk::walk_export_named_declaration(self, it);
+    }
+
+    fn visit_export_all_declaration(&mut self, it: &ExportAllDeclaration<'a>) {
+        self.exclude_string(&it.source);
+        walk::walk_export_all_declaration(self, it);
+    }
+
+    fn visit_import_expression(&mut self, it: &ImportExpression<'a>) {
+        self.exclude_string_expression(&it.source);
+        walk::walk_import_expression(self, it);
     }
 
     fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2422,3 +2422,59 @@ fn does_not_report_max_lines_per_function_for_jsx_containing_arrow() {
     let diagnostics = scan_sonarjs(source, "sample.tsx", &options);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_duplicate_string_at_default_threshold() {
+    // "hello wrld" = 10 chars, has a space → qualifies; appears 3×; default threshold 3
+    let source = "const a = \"hello wrld\"; const b = \"hello wrld\"; const c = \"hello wrld\";";
+    let diagnostics = scan("no-duplicate-string", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-duplicate-string");
+    assert_eq!(diagnostics[0].message_id, "duplicateString");
+}
+
+#[test]
+fn does_not_report_no_duplicate_string_below_threshold() {
+    // "hello wrld" appears only twice; default threshold 3 → no report
+    let source = "const a = \"hello wrld\"; const b = \"hello wrld\";";
+    let diagnostics = scan("no-duplicate-string", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_duplicate_string_for_short_value() {
+    // "hi there" = 8 chars (< 10) → not counted; appears 3× but too short
+    let source = "const a = \"hi there\"; const b = \"hi there\"; const c = \"hi there\";";
+    let diagnostics = scan("no-duplicate-string", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_duplicate_string_for_all_word_chars() {
+    // "helloWorld1" = 11 chars but all word chars ([A-Za-z0-9_]) → not counted
+    let source = "const a = \"helloWorld1\"; const b = \"helloWorld1\"; const c = \"helloWorld1\";";
+    let diagnostics = scan("no-duplicate-string", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_duplicate_string_for_import_sources() {
+    // "some/module" = 11 chars, has '/' → would qualify if not excluded;
+    // appears 2× as import sources with custom threshold 2 → still 0
+    let mut options = options_for("no-duplicate-string");
+    options.no_duplicate_string_threshold = 2;
+    let source = "import a from \"some/module\";\nimport b from \"some/module\";";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn no_duplicate_string_respects_custom_threshold() {
+    let mut options = options_for("no-duplicate-string");
+    options.no_duplicate_string_threshold = 2;
+    let source = "const a = \"hello wrld\"; const b = \"hello wrld\";";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-duplicate-string");
+    assert_eq!(diagnostics[0].message_id, "duplicateString");
+}

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -54,6 +54,8 @@ pub struct SonarjsOptions {
     pub max_union_size_threshold: u32,
     /// Maximum nesting level for `nested-control-flow` (S134); the SonarJS default is 3.
     pub nested_control_flow_threshold: u32,
+    /// Threshold for `no-duplicate-string` (S1192); the SonarJS default is 3.
+    pub no_duplicate_string_threshold: u32,
 }
 
 impl Default for SonarjsOptions {
@@ -68,6 +70,7 @@ impl Default for SonarjsOptions {
             max_switch_cases_threshold: 30,
             max_union_size_threshold: 3,
             nested_control_flow_threshold: 3,
+            no_duplicate_string_threshold: 3,
         }
     }
 }

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -198,6 +198,9 @@ const messages = Object.freeze({
   'nested-control-flow': {
     nestedControlFlow: 'Refactor this code to reduce the nesting of control flow statements.',
   },
+  'no-duplicate-string': {
+    duplicateString: 'Define this repeated string literal as a constant to avoid duplication.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -297,6 +300,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow functions with more code lines than the configured maximum (the "maximum" option; default 200); IIFEs and JSX-containing functions are excluded',
   'nested-control-flow':
     'Disallow control flow statements (if/for/for-in/for-of/while/do-while/switch/try) nested beyond the configured maximumNestingLevel (default 3); else-if chains do not add a level',
+  'no-duplicate-string':
+    'Disallow string literals of 10+ characters containing a non-word character from appearing at least threshold (default 3) times in a file; import/export sources and JSX attribute values are excluded',
 });
 
 const ruleTypes = Object.freeze({
@@ -352,6 +357,7 @@ const ruleTypes = Object.freeze({
   'max-lines': 'suggestion',
   'max-lines-per-function': 'suggestion',
   'nested-control-flow': 'suggestion',
+  'no-duplicate-string': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -407,6 +413,7 @@ const recommendedRuleConfig = Object.freeze({
   'max-lines': 'error',
   'max-lines-per-function': 'error',
   'nested-control-flow': 'error',
+  'no-duplicate-string': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());
@@ -490,6 +497,15 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'no-duplicate-string') {
+    return [
+      {
+        type: 'object',
+        properties: { threshold: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
   return [];
 }
 
@@ -511,6 +527,9 @@ function scanOptionsForRule(context, ruleName) {
   }
   if (ruleName === 'nested-control-flow' && Number.isInteger(raw.maximumNestingLevel)) {
     options.nestedControlFlowThreshold = raw.maximumNestingLevel;
+  }
+  if (ruleName === 'no-duplicate-string' && Number.isInteger(raw.threshold)) {
+    options.noDuplicateStringThreshold = raw.threshold;
   }
   return options;
 }

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -24,6 +24,7 @@ mod napi_abi {
         pub max_switch_cases_threshold: Option<u32>,
         pub max_union_size_threshold: Option<u32>,
         pub nested_control_flow_threshold: Option<u32>,
+        pub no_duplicate_string_threshold: Option<u32>,
     }
 
     #[napi(object)]
@@ -92,6 +93,9 @@ mod napi_abi {
             nested_control_flow_threshold: options
                 .nested_control_flow_threshold
                 .unwrap_or(default_options.nested_control_flow_threshold),
+            no_duplicate_string_threshold: options
+                .no_duplicate_string_threshold
+                .unwrap_or(default_options.no_duplicate_string_threshold),
         };
 
         core::scan_sonarjs(&source_text, &filename, &core_options)

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -55,6 +55,7 @@ const expectedRuleNames = [
   'max-lines',
   'nested-control-flow',
   'max-lines-per-function',
+  'no-duplicate-string',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1929,5 +1930,22 @@ describe('sonarjs native API', () => {
       maxLinesPerFunctionThreshold: 5,
     });
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('passes the no-duplicate-string threshold through the native boundary', () => {
+    // "hello wrld" = 10 chars, has a space → qualifies; appears twice
+    const source = 'const a = "hello wrld"; const b = "hello wrld";';
+    const flagged = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['no-duplicate-string'],
+      noDuplicateStringThreshold: 2,
+    });
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].ruleName).toBe('no-duplicate-string');
+    expect(flagged[0].messageId).toBe('duplicateString');
+    const allowed = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['no-duplicate-string'],
+      noDuplicateStringThreshold: 3,
+    });
+    expect(allowed).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -146,6 +146,7 @@ describe('sonarjs plugin shape', () => {
       'max-lines',
       'nested-control-flow',
       'max-lines-per-function',
+      'no-duplicate-string',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -199,6 +200,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['max-lines']).toBe('object');
     expect(typeof plugin.rules['nested-control-flow']).toBe('object');
     expect(typeof plugin.rules['max-lines-per-function']).toBe('object');
+    expect(typeof plugin.rules['no-duplicate-string']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -254,6 +256,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/max-lines']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/nested-control-flow']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-lines-per-function']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-string']).toBe('error');
   });
 });
 
@@ -428,6 +431,14 @@ describe('sonarjs rules through direct adapter harness', () => {
     const reports = runRule('no-tab', source);
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe('noTab');
+  });
+
+  it('reports no-duplicate-string through the adapter with custom threshold', () => {
+    // "hello wrld" = 10 chars, has a space → qualifies; appears twice; threshold 2
+    const source = 'const a = "hello wrld"; const b = "hello wrld";';
+    const reports = runRule('no-duplicate-string', source, { options: [{ threshold: 2 }] });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('duplicateString');
   });
 });
 
@@ -1178,5 +1189,16 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     const source = 'function f() { return 1; }';
     const { diagnostics } = runOxlint('max-lines-per-function', source);
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-duplicate-string through the CLI', () => {
+    // "hello wrld" = 10 chars, has a space → qualifies; appears 3× (default threshold 3)
+    const src = 'const a = "hello wrld"; const b = "hello wrld"; const c = "hello wrld";';
+    const result = runOxlint('no-duplicate-string', src);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-duplicate-string)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11902,19 +11902,19 @@
       },
       {
         "name": "no-duplicate-string",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-duplicate-string (Sonar key S1192). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S1192. Counts qualifying string literal values (>= 10 chars, containing a non-word char, not \"application/json\") across a file; reports the first occurrence of any value whose count >= threshold (default 3). Import/export sources and JSX attribute values are excluded. Configurable threshold option. No upstream source, tests, fixtures, or messages were consulted or copied."
       },
       {
         "name": "no-duplicated-branches",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-duplicate-string` rule (Sonar key S1192), built on the per-rule options layer (#246).

Collects every string literal during the walk and, after traversal, reports the **first occurrence** of any value that appears at least `threshold` times (option `threshold`, default 3).

A value is counted only when it:
- is at least 10 characters,
- contains a non-word character (so identifier-like strings such as `helloWorld1` are ignored),
- is not `"application/json"`,
- and does not appear as an import/export module source or a JSX attribute value.

Occurrences are bucketed with a linear `SmallVec` scan (no `HashMap`, per the core constraints), and reporting is two-phase (collect spans, then report) to satisfy the borrow checker. Tests cover the threshold boundary, the ≥10-char and non-identifier-only criteria, the import-source exclusion, and the configurable `threshold` through the native boundary, adapter, and CLI. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784017795&installation_id=136613492&pr_number=265&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F265&signature=950cd503a4cd5b809739c536504ea61b76c4c057b449551deec63a8f4871004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->