### PR TITLE
feat(postgresql): port no-cluster

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,6 +3,7 @@
 
 use crate::RuleDef;
 
+mod no_cluster;
 mod no_select_star;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
@@ -100,11 +101,18 @@ pub const RULE_NAMES: [&str; 89] = [
 ];
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
-pub const IMPLEMENTED_RULE_NAMES: &[&str] = &["no-select-star"];
+pub const IMPLEMENTED_RULE_NAMES: &[&str] = &["no-cluster", "no-select-star"];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
-pub(crate) const REGISTRY: &[RuleDef] = &[RuleDef {
-    name: "no-select-star",
-    run: no_select_star::run,
-    uses_parse_error: false,
-}];
+pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "no-cluster",
+        run: no_cluster::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-select-star",
+        run: no_select_star::run,
+        uses_parse_error: false,
+    },
+];

--- a/crates/postgresql/src/rules/no_cluster.rs
+++ b/crates/postgresql/src/rules/no_cluster.rs
@@ -1,0 +1,13 @@
+//! Port of `no-cluster`: disallow the `CLUSTER` statement (takes ACCESS
+//! EXCLUSIVE, rewrites the table, and is not maintained afterwards).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "ClusterStmt") {
+        ctx.report(node, "noCluster");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,18 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'no-cluster': {
+    type: 'problem',
+    description:
+      'Disallow the `CLUSTER` statement: it takes ACCESS EXCLUSIVE, rewrites the table, and is not maintained afterwards',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCluster:
+        '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
+    },
+  },
   'no-select-star': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5143,19 +5143,19 @@
       },
       {
         "name": "no-cluster",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-cluster."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-cluster; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-composite-primary-key",


### PR DESCRIPTION
Part of #14. Ports `no-cluster` from `eslint-plugin-postgresql`.

Disallows the `CLUSTER` statement (takes `ACCESS EXCLUSIVE`, rewrites the table, not maintained afterwards). A one-node visitor over `ClusterStmt`; reports the whole statement.

Validated locally against the upstream fixtures (`no-cluster.json`: valid `VACUUM`, invalid `CLUSTER … USING …` with exact 1-indexed span) via the shipping adapter + harness; `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784017936&installation_id=136613492&pr_number=267&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F267&signature=c100076dc98847f54b630948c6a9931f4ac1e053452d6ae987450c71c06277b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->