### PR TITLE
feat(postgresql): port no-drop-database

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -4,6 +4,7 @@
 use crate::RuleDef;
 
 mod no_cluster;
+mod no_drop_database;
 mod no_select_star;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
@@ -101,13 +102,18 @@ pub const RULE_NAMES: [&str; 89] = [
 ];
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
-pub const IMPLEMENTED_RULE_NAMES: &[&str] = &["no-cluster", "no-select-star"];
+pub const IMPLEMENTED_RULE_NAMES: &[&str] = &["no-cluster", "no-drop-database", "no-select-star"];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-cluster",
         run: no_cluster::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-drop-database",
+        run: no_drop_database::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_drop_database.rs
+++ b/crates/postgresql/src/rules/no_drop_database.rs
@@ -1,0 +1,13 @@
+//! Port of `no-drop-database`: disallow `DROP DATABASE` because it is
+//! catastrophic if run by accident and should not live in versioned SQL.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "DropdbStmt") {
+        ctx.report(node, "noDropDatabase");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -29,6 +29,18 @@ const ruleMeta = Object.freeze({
         '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
     },
   },
+  'no-drop-database': {
+    type: 'problem',
+    description:
+      'Disallow `DROP DATABASE`; it is catastrophic if run by accident and should not live in versioned SQL',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDropDatabase:
+        '`DROP DATABASE` is catastrophic and irreversible. Database creation/deletion belongs in an explicit operator workflow, not in versioned SQL applied automatically by a migration tool.',
+    },
+  },
   'no-select-star': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5239,19 +5239,19 @@
       },
       {
         "name": "no-drop-database",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-drop-database."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-drop-database; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-drop-not-null",


### PR DESCRIPTION
Part of #14. Ports `no-drop-database`. Disallow `DROP DATABASE`; catastrophic if run by accident and should not live in versioned SQL. Validated locally against upstream fixtures via the shipping adapter; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784018589&installation_id=136613492&pr_number=271&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F271&signature=fe2327936a26eeb81249b78db18f889008f16a5ff7651189e7b078dcc77b2836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->