### PR TITLE
port(sonarjs): regex-AST helper + no-empty-group (S6331)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_parser",
+ "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
  "oxlint-plugins-_carton",

--- a/crates/sonarjs/Cargo.toml
+++ b/crates/sonarjs/Cargo.toml
@@ -13,6 +13,7 @@ oxc_allocator.workspace = true
 oxc_ast.workspace = true
 oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
+oxc_regular_expression.workspace = true
 oxc_span.workspace = true
 oxc_syntax.workspace = true
 oxlint-plugins-carton.workspace = true

--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -4,6 +4,7 @@
 //! clean-room from the public RSPEC documentation and observed behaviour only;
 //! no upstream source, tests, fixtures, helper code, or messages are copied.
 
+mod regex_ast;
 mod rules;
 mod scanner;
 mod types;
@@ -22,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 53] = [
+pub const RULE_NAMES: [&str; 54] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -76,6 +77,7 @@ pub const RULE_NAMES: [&str; 53] = [
     "nested-control-flow",
     "max-lines-per-function",
     "no-duplicate-string",
+    "no-empty-group",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/regex_ast.rs
+++ b/crates/sonarjs/src/regex_ast.rs
@@ -1,0 +1,40 @@
+//! Shared helper for parsing regex literals with `oxc_regular_expression`.
+//!
+//! Centralises the `LiteralParser` call and the span-offset arithmetic so that
+//! individual rules can simply call [`with_parsed_regex_literal`] with a closure
+//! and collect results as owned (non-borrowing) data.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::Pattern;
+use oxc_regular_expression::{LiteralParser, Options as RegExpOptions};
+
+/// Parses the pattern of a regex *literal* and invokes `f` with the parsed AST,
+/// returning `f`'s result.  On a parse error, returns `R::default()` (so callers
+/// that collect spans simply get an empty collection).  Span positions in the
+/// returned pattern are already offset to the source file via [`RegExpOptions`].
+pub(crate) fn with_parsed_regex_literal<R, F>(lit: &RegExpLiteral<'_>, source_text: &str, f: F) -> R
+where
+    R: Default,
+    F: for<'alloc> FnOnce(&Pattern<'alloc>) -> R,
+{
+    let pattern_text = lit.regex.pattern.text.as_str();
+    let start = lit.span.start as usize;
+    let flags_start = start + 1 + pattern_text.len() + 1;
+    let flags = &source_text[flags_start..lit.span.end as usize];
+    let allocator = Allocator::default();
+    let parsed = LiteralParser::new(
+        &allocator,
+        pattern_text,
+        Some(flags),
+        RegExpOptions {
+            pattern_span_offset: lit.span.start + 1,
+            flags_span_offset: flags_start as u32,
+        },
+    )
+    .parse();
+    match parsed {
+        Ok(pattern) => f(&pattern),
+        Err(_) => R::default(),
+    }
+}

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -24,6 +24,7 @@ mod no_delete_var;
 mod no_duplicate_in_composite;
 mod no_duplicate_string;
 mod no_empty_character_class;
+mod no_empty_group;
 mod no_exclusive_tests;
 mod no_function_declaration_in_block;
 mod no_identical_conditions;

--- a/crates/sonarjs/src/rules/no_empty_group.rs
+++ b/crates/sonarjs/src/rules/no_empty_group.rs
@@ -1,0 +1,98 @@
+//! Rule `no-empty-group` (SonarJS key S6331).
+//!
+//! Clean-room port. A capturing group `(...)` or non-capturing group `(?:...)`
+//! whose body is completely empty contributes nothing to the match and is almost
+//! always a programmer mistake — a missing pattern, a forgotten character, or an
+//! accidental deletion.
+//!
+//! ## What is flagged
+//!
+//! Any **regex literal** that contains an empty capturing or non-capturing group:
+//!
+//! ```js
+//! /foo()bar/   // flagged — empty capturing group
+//! /(?:)/       // flagged — empty non-capturing group
+//! /(a)()/      // flagged — second group is empty
+//! ```
+//!
+//! ## What is NOT flagged
+//!
+//! - `(a)`, `(?:abc)` — non-empty groups.
+//! - `(a|)` — the *group* is not empty; it has two alternatives, one of which
+//!   happens to be empty. That is a separate concern (empty alternative) outside
+//!   the scope of this rule.
+//! - `(a)?` — a non-empty group wrapped in a quantifier.
+//!
+//! ## Scope: regex literals only
+//!
+//! This rule detects empty groups in **regex literals** (e.g. `/foo()bar/`) only.
+//! The `new RegExp("()")` string-argument form is out of scope for this PR and is
+//! left as a follow-up.
+//!
+//! Behaviour is reproduced from the public RSPEC description only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{Disjunction, Term};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-empty-group";
+
+/// Returns `true` when the disjunction represents a completely empty group body —
+/// exactly one alternative with no terms.
+fn disjunction_is_empty(disj: &Disjunction<'_>) -> bool {
+    disj.body.len() == 1 && disj.body[0].body.is_empty()
+}
+
+/// Recurses into a single [`Term`], pushing the span of any empty capturing or
+/// non-capturing group onto `out`.  Also recurses into quantifier bodies and
+/// lookaround assertion bodies so that empty groups at any nesting depth are found.
+fn collect_empty_groups_term<'a>(term: &Term<'a>, out: &mut SmallVec<[Span; 8]>) {
+    match term {
+        Term::CapturingGroup(group) => {
+            if disjunction_is_empty(&group.body) {
+                out.push(group.span);
+            }
+            collect_empty_groups(&group.body, out);
+        }
+        Term::IgnoreGroup(group) => {
+            if disjunction_is_empty(&group.body) {
+                out.push(group.span);
+            }
+            collect_empty_groups(&group.body, out);
+        }
+        Term::Quantifier(quant) => {
+            collect_empty_groups_term(&quant.body, out);
+        }
+        Term::LookAroundAssertion(look) => {
+            collect_empty_groups(&look.body, out);
+        }
+        _ => {}
+    }
+}
+
+/// Walks every alternative in `disj` and every term within each alternative,
+/// collecting the spans of any empty groups.
+fn collect_empty_groups<'a>(disj: &Disjunction<'a>, out: &mut SmallVec<[Span; 8]>) {
+    for alt in disj.body.iter() {
+        for term in alt.body.iter() {
+            collect_empty_groups_term(term, out);
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_empty_group(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            collect_empty_groups(&pattern.body, &mut out);
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "emptyGroup", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -269,6 +269,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
         self.check_no_empty_character_class(it);
+        self.check_no_empty_group(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2478,3 +2478,50 @@ fn no_duplicate_string_respects_custom_threshold() {
     assert_eq!(diagnostics[0].rule_name, "no-duplicate-string");
     assert_eq!(diagnostics[0].message_id, "duplicateString");
 }
+
+#[test]
+fn reports_no_empty_group_for_empty_capturing_group() {
+    let source = "const r = /foo()bar/;";
+    let diagnostics = scan("no-empty-group", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-empty-group");
+    assert_eq!(diagnostics[0].message_id, "emptyGroup");
+}
+
+#[test]
+fn reports_no_empty_group_for_empty_non_capturing_group() {
+    let source = "const r = /(?:)/;";
+    let diagnostics = scan("no-empty-group", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "emptyGroup");
+}
+
+#[test]
+fn reports_no_empty_group_for_second_group_only() {
+    let source = "const r = /(a)()/;";
+    let diagnostics = scan("no-empty-group", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "emptyGroup");
+}
+
+#[test]
+fn does_not_report_no_empty_group_for_non_empty_group() {
+    let source = "const r = /foo(bar)/;";
+    let diagnostics = scan("no-empty-group", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_empty_group_for_empty_alternative() {
+    // (a|) has two alternatives; the group itself is not empty
+    let source = "const r = /(a|)/;";
+    let diagnostics = scan("no-empty-group", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_empty_group_for_quantified_non_empty_group() {
+    let source = "const r = /(a)?/;";
+    let diagnostics = scan("no-empty-group", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -73,6 +73,9 @@ const messages = Object.freeze({
     emptyCharacterClass:
       'This empty character class [] can never match, so this regular expression will never match anything.',
   },
+  'no-empty-group': {
+    emptyGroup: 'Remove this empty group or add content to it.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -228,6 +231,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow using new solely for side effects without capturing or using the constructed object',
   'no-empty-character-class':
     'Disallow empty character classes in regular expression literals, which can never match',
+  'no-empty-group':
+    'Disallow empty capturing or non-capturing groups in regular expression literals',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -321,6 +326,7 @@ const ruleTypes = Object.freeze({
   'no-delete-var': 'problem',
   'constructor-for-side-effects': 'problem',
   'no-empty-character-class': 'problem',
+  'no-empty-group': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -377,6 +383,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-delete-var': 'error',
   'constructor-for-side-effects': 'error',
   'no-empty-character-class': 'error',
+  'no-empty-group': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -56,6 +56,7 @@ const expectedRuleNames = [
   'nested-control-flow',
   'max-lines-per-function',
   'no-duplicate-string',
+  'no-empty-group',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1947,5 +1948,17 @@ describe('sonarjs native API', () => {
       noDuplicateStringThreshold: 3,
     });
     expect(allowed).toHaveLength(0);
+  });
+
+  it('reports no-empty-group for an empty non-capturing group', () => {
+    const diagnostics = scan('no-empty-group', 'const r = /(?:)/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-empty-group');
+    expect(diagnostics[0].messageId).toBe('emptyGroup');
+  });
+
+  it('does not report no-empty-group for a non-empty group', () => {
+    const diagnostics = scan('no-empty-group', 'const r = /(?:abc)/;');
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -147,6 +147,7 @@ describe('sonarjs plugin shape', () => {
       'nested-control-flow',
       'max-lines-per-function',
       'no-duplicate-string',
+      'no-empty-group',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -201,6 +202,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['nested-control-flow']).toBe('object');
     expect(typeof plugin.rules['max-lines-per-function']).toBe('object');
     expect(typeof plugin.rules['no-duplicate-string']).toBe('object');
+    expect(typeof plugin.rules['no-empty-group']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -257,6 +259,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/nested-control-flow']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/max-lines-per-function']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-string']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-empty-group']).toBe('error');
   });
 });
 
@@ -1200,5 +1203,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-duplicate-string)');
+  });
+
+  it('reports no-empty-group for an empty non-capturing group through the adapter', () => {
+    const source = 'const r = /(?:)/;';
+    const reports = runRule('no-empty-group', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('emptyGroup');
+  });
+
+  it('reports no-empty-group through the CLI', () => {
+    const result = runOxlint('no-empty-group', 'const r = /(?:)/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-empty-group)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12014,19 +12014,19 @@
       },
       {
         "name": "no-empty-group",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-empty-group (Sonar key S6331). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (SonarJS key S6331). Detects empty capturing and non-capturing groups in regex literals via oxc_regular_expression AST. Never copied upstream source, fixtures, tests, or messages."
       },
       {
         "name": "no-empty-test-file",


### PR DESCRIPTION
Introduces the **regex-AST infrastructure** and the first regex-family rule.

**Infra:** a shared `regex_ast::with_parsed_regex_literal` helper (adds the `oxc_regular_expression` workspace dependency) that centralizes parsing a regex literal's pattern via `LiteralParser` and the span-offset arithmetic mapping regex-AST node spans back into the source file. It parses **on-demand per literal** (fresh allocator) and returns `R::default()` on a regex parse error — so a malformed literal never zeroes out the file's other diagnostics, and `no-invalid-regexp` stays portable later. A `for<'alloc>` closure bound keeps the arena-allocated AST from leaking past the borrow checker. This unblocks the ~12 remaining regex-family rules, each now a thin per-rule PR.

**Rule `no-empty-group` (Sonar key S6331):** walks the parsed pattern and flags a capturing `()` or non-capturing `(?:)` group whose body is empty (a single alternative with no terms), recursing through nested groups, quantifier bodies, and lookaround bodies.

- **Flagged:** `/foo()bar/`, `/(?:)/`, `/(a)()/`
- **Not flagged:** `/(a)/`, `/(?:abc)/`, `/(a)?/`, `/(a|)/` (an empty *alternative*, not an empty group — left for `no-empty-alternatives`).

No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784019538&installation_id=136613492&pr_number=276&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F276&signature=d65820c33c1a4952d7f55f47d4972e2218a1975caea565a84e9cb038148f3efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->