### PR TITLE
feat(postgresql): port no-set-not-null

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -6,6 +6,7 @@ use crate::RuleDef;
 mod no_cluster;
 mod no_drop_database;
 mod no_select_star;
+mod no_set_not_null;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
 /// know the full surface even while only a subset is implemented.
@@ -102,7 +103,12 @@ pub const RULE_NAMES: [&str; 89] = [
 ];
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
-pub const IMPLEMENTED_RULE_NAMES: &[&str] = &["no-cluster", "no-drop-database", "no-select-star"];
+pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "no-cluster",
+    "no-drop-database",
+    "no-select-star",
+    "no-set-not-null",
+];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
@@ -119,6 +125,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-select-star",
         run: no_select_star::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-set-not-null",
+        run: no_set_not_null::run,
         uses_parse_error: false,
     },
 ];

--- a/crates/postgresql/src/rules/no_set_not_null.rs
+++ b/crates/postgresql/src/rules/no_set_not_null.rs
@@ -1,0 +1,13 @@
+//! Port of `no-set-not-null`: disallow `ALTER COLUMN ... SET NOT NULL` because
+//! it scans the whole table under ACCESS EXCLUSIVE.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "AlterTableCmd") && str_field(node, "subtype") == Some("AT_SetNotNull") {
+        ctx.report(node, "noSetNotNull");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -53,6 +53,18 @@ const ruleMeta = Object.freeze({
         'Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.',
     },
   },
+  'no-set-not-null': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER COLUMN ... SET NOT NULL` because it scans the whole table under ACCESS EXCLUSIVE',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noSetNotNull:
+        '`SET NOT NULL` scans the whole table for nulls under an `ACCESS EXCLUSIVE` lock. The safe pattern in production is to add a `CHECK (col IS NOT NULL) NOT VALID` constraint, `VALIDATE CONSTRAINT` separately, then `SET NOT NULL` (PG ≥ 12 reuses the validated CHECK and skips the scan).',
+    },
+  },
 });
 
 const implementedRuleNames = Object.freeze(implementedPostgresqlRuleNames());

--- a/status.json
+++ b/status.json
@@ -5623,19 +5623,19 @@
       },
       {
         "name": "no-set-not-null",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-set-not-null."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-set-not-null; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-set-search-path",


### PR DESCRIPTION
Part of #14. Ports `no-set-not-null`.

Disallow `ALTER COLUMN ... SET NOT NULL` because it scans the whole table under an ACCESS EXCLUSIVE lock.

Validated locally against upstream fixtures via the shipping adapter; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784019771&installation_id=136613492&pr_number=278&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F278&signature=2775506538f1313bc025f26aaa6ff62e181336176ca8d49d453e023aa37be4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->