### PR TITLE
port(sonarjs): port no-empty-alternatives (S6323)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 54] = [
+pub const RULE_NAMES: [&str; 55] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -78,6 +78,7 @@ pub const RULE_NAMES: [&str; 54] = [
     "max-lines-per-function",
     "no-duplicate-string",
     "no-empty-group",
+    "no-empty-alternatives",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -23,6 +23,7 @@ mod no_collapsible_if;
 mod no_delete_var;
 mod no_duplicate_in_composite;
 mod no_duplicate_string;
+mod no_empty_alternatives;
 mod no_empty_character_class;
 mod no_empty_group;
 mod no_exclusive_tests;

--- a/crates/sonarjs/src/rules/no_empty_alternatives.rs
+++ b/crates/sonarjs/src/rules/no_empty_alternatives.rs
@@ -1,0 +1,82 @@
+//! Rule `no-empty-alternatives` (SonarJS key S6323).
+//!
+//! Clean-room port. An alternation (`a|b|c`) with an empty alternative matches
+//! the empty string for that branch, which is almost always a mistake: a
+//! stray, leading, or trailing `|`, or a `||` typo. Such code should drop the
+//! empty branch or, if matching nothing is intended, use an explicit optional.
+//!
+//! ## What is flagged
+//!
+//! A `|` alternation (a disjunction with **two or more** alternatives) where at
+//! least one alternative is empty:
+//!
+//! ```js
+//! /a|/      // flagged — trailing empty alternative
+//! /|a/      // flagged — leading empty alternative
+//! /a||b/    // flagged — empty middle alternative
+//! /(?:a|)/  // flagged — empty alternative inside a group
+//! ```
+//!
+//! ## What is NOT flagged
+//!
+//! - `/a|b/`, `/a|b|c/` — every alternative has content.
+//! - `/(?:)/`, `/()/` — a group whose whole body is empty has a *single* empty
+//!   alternative (no `|`); that is the separate `no-empty-group` rule.
+//! - `/(a)?/` — an optional group, not an alternation.
+//!
+//! Detects empty alternatives in **regex literals** only; the
+//! `new RegExp("a|")` string form is a documented follow-up. Behaviour is
+//! reproduced from the public RSPEC description (S6323) only; no upstream
+//! source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{Disjunction, Term};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-empty-alternatives";
+
+/// Recurses into a [`Term`], descending into group, quantifier, and lookaround
+/// bodies so empty alternatives at any nesting depth are found.
+fn collect_empty_alternatives_term<'a>(term: &Term<'a>, out: &mut SmallVec<[Span; 8]>) {
+    match term {
+        Term::CapturingGroup(group) => collect_empty_alternatives(&group.body, out),
+        Term::IgnoreGroup(group) => collect_empty_alternatives(&group.body, out),
+        Term::Quantifier(quant) => collect_empty_alternatives_term(&quant.body, out),
+        Term::LookAroundAssertion(look) => collect_empty_alternatives(&look.body, out),
+        _ => {}
+    }
+}
+
+/// Walks `disj`: when it is a real alternation (two or more alternatives), the
+/// span of every empty alternative is collected; then every term is recursed
+/// into to find nested alternations.
+fn collect_empty_alternatives<'a>(disj: &Disjunction<'a>, out: &mut SmallVec<[Span; 8]>) {
+    if disj.body.len() >= 2 {
+        for alt in disj.body.iter() {
+            if alt.body.is_empty() {
+                out.push(alt.span);
+            }
+        }
+    }
+    for alt in disj.body.iter() {
+        for term in alt.body.iter() {
+            collect_empty_alternatives_term(term, out);
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_empty_alternatives(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            collect_empty_alternatives(&pattern.body, &mut out);
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "emptyAlternative", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -270,6 +270,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
         self.check_no_empty_character_class(it);
         self.check_no_empty_group(it);
+        self.check_no_empty_alternatives(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2525,3 +2525,42 @@ fn does_not_report_no_empty_group_for_quantified_non_empty_group() {
     let diagnostics = scan("no-empty-group", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_empty_alternatives_for_trailing_empty_alternative() {
+    let source = "const r = /a|/;";
+    let diagnostics = scan("no-empty-alternatives", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-empty-alternatives");
+    assert_eq!(diagnostics[0].message_id, "emptyAlternative");
+}
+
+#[test]
+fn reports_no_empty_alternatives_for_leading_empty_alternative() {
+    let source = "const r = /|a/;";
+    let diagnostics = scan("no-empty-alternatives", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn reports_no_empty_alternatives_for_empty_alternative_in_group() {
+    let source = "const r = /(?:a|)/;";
+    let diagnostics = scan("no-empty-alternatives", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_no_empty_alternatives_when_all_have_content() {
+    let source = "const r = /a|b|c/;";
+    let diagnostics = scan("no-empty-alternatives", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_empty_alternatives_for_empty_group() {
+    // An empty group has a single empty alternative (no `|`), which is the
+    // no-empty-group rule's concern, not an empty alternative.
+    let source = "const r = /(?:)/;";
+    let diagnostics = scan("no-empty-alternatives", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -76,6 +76,9 @@ const messages = Object.freeze({
   'no-empty-group': {
     emptyGroup: 'Remove this empty group or add content to it.',
   },
+  'no-empty-alternatives': {
+    emptyAlternative: 'Remove this empty alternative or replace the alternation with an optional.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -233,6 +236,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow empty character classes in regular expression literals, which can never match',
   'no-empty-group':
     'Disallow empty capturing or non-capturing groups in regular expression literals',
+  'no-empty-alternatives':
+    'Disallow empty alternatives in a regular expression alternation (a stray, leading, or trailing "|")',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -327,6 +332,7 @@ const ruleTypes = Object.freeze({
   'constructor-for-side-effects': 'problem',
   'no-empty-character-class': 'problem',
   'no-empty-group': 'suggestion',
+  'no-empty-alternatives': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -384,6 +390,7 @@ const recommendedRuleConfig = Object.freeze({
   'constructor-for-side-effects': 'error',
   'no-empty-character-class': 'error',
   'no-empty-group': 'error',
+  'no-empty-alternatives': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -57,6 +57,7 @@ const expectedRuleNames = [
   'max-lines-per-function',
   'no-duplicate-string',
   'no-empty-group',
+  'no-empty-alternatives',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1959,6 +1960,18 @@ describe('sonarjs native API', () => {
 
   it('does not report no-empty-group for a non-empty group', () => {
     const diagnostics = scan('no-empty-group', 'const r = /(?:abc)/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-empty-alternatives for a trailing empty alternative', () => {
+    const diagnostics = scan('no-empty-alternatives', 'const r = /a|/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-empty-alternatives');
+    expect(diagnostics[0].messageId).toBe('emptyAlternative');
+  });
+
+  it('does not report no-empty-alternatives when all alternatives have content', () => {
+    const diagnostics = scan('no-empty-alternatives', 'const r = /a|b/;');
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -148,6 +148,7 @@ describe('sonarjs plugin shape', () => {
       'max-lines-per-function',
       'no-duplicate-string',
       'no-empty-group',
+      'no-empty-alternatives',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -203,6 +204,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['max-lines-per-function']).toBe('object');
     expect(typeof plugin.rules['no-duplicate-string']).toBe('object');
     expect(typeof plugin.rules['no-empty-group']).toBe('object');
+    expect(typeof plugin.rules['no-empty-alternatives']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -260,6 +262,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/max-lines-per-function']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-string']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-group']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-empty-alternatives']).toBe('error');
   });
 });
 
@@ -1219,5 +1222,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-empty-group)');
+  });
+
+  it('reports no-empty-alternatives for a trailing empty alternative through the adapter', () => {
+    const source = 'const r = /a|/;';
+    const reports = runRule('no-empty-alternatives', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('emptyAlternative');
+  });
+
+  it('reports no-empty-alternatives through the CLI', () => {
+    const result = runOxlint('no-empty-alternatives', 'const r = /a|/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-empty-alternatives)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11966,19 +11966,19 @@
       },
       {
         "name": "no-empty-alternatives",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-empty-alternatives (Sonar key S6323). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S6323). Uses the shared regex_ast helper to parse a regex literal and walk every disjunction (top-level + group/lookaround bodies); a disjunction with two or more alternatives where some alternative body is empty is flagged at each empty alternative's span. A single empty alternative with no `|` (an empty group) is left to no-empty-group. Regex-literal scope only; the new RegExp(string) form is a documented follow-up. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-empty-character-class",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-empty-alternatives` rule (Sonar key S6323), built on the regex-AST helper (#276).

Walks every disjunction (top-level and group/lookaround bodies) of a regex literal and flags each empty alternative of a real alternation (a disjunction with two or more alternatives) — a stray, leading, trailing, or doubled `|`.

- **Flagged:** `/a|/`, `/|a/`, `/a||b/`, `/(?:a|)/`
- **Not flagged:** `/a|b/`, `/a|b|c/`, `/(?:)/` (an empty *group*, handled by `no-empty-group`), `/(a)?/`.

Regex-literal scope only; the `new RegExp("a|")` form is a documented follow-up. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784020269&installation_id=136613492&pr_number=283&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F283&signature=3617639f158f629feb67ea802c9c8a38e2049c1f0e7acd30cbacf47cd56614a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->