### PR TITLE
feat(postgresql): port no-temporary-table

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -7,6 +7,7 @@ mod no_cluster;
 mod no_drop_database;
 mod no_select_star;
 mod no_set_not_null;
+mod no_temporary_table;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
 /// know the full surface even while only a subset is implemented.
@@ -108,6 +109,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-drop-database",
     "no-select-star",
     "no-set-not-null",
+    "no-temporary-table",
 ];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
@@ -130,6 +132,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-set-not-null",
         run: no_set_not_null::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-temporary-table",
+        run: no_temporary_table::run,
         uses_parse_error: false,
     },
 ];

--- a/crates/postgresql/src/rules/no_temporary_table.rs
+++ b/crates/postgresql/src/rules/no_temporary_table.rs
@@ -1,0 +1,20 @@
+//! Port of `no-temporary-table`: disallow `CREATE TEMPORARY TABLE` in versioned
+//! SQL — temp tables exist for the session only and rarely belong in migration
+//! files.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let Some(relation) = field(node, "relation") else {
+        return;
+    };
+    if str_field(relation, "relpersistence") == Some("t") {
+        ctx.report(node, "noTemporaryTable");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -65,6 +65,18 @@ const ruleMeta = Object.freeze({
         '`SET NOT NULL` scans the whole table for nulls under an `ACCESS EXCLUSIVE` lock. The safe pattern in production is to add a `CHECK (col IS NOT NULL) NOT VALID` constraint, `VALIDATE CONSTRAINT` separately, then `SET NOT NULL` (PG ≥ 12 reuses the validated CHECK and skips the scan).',
     },
   },
+  'no-temporary-table': {
+    type: 'suggestion',
+    description:
+      'Disallow `CREATE TEMPORARY TABLE` in versioned SQL — temp tables exist for the session only and rarely belong in migration files',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noTemporaryTable:
+        '`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.',
+    },
+  },
 });
 
 const implementedRuleNames = Object.freeze(implementedPostgresqlRuleNames());

--- a/status.json
+++ b/status.json
@@ -5671,19 +5671,19 @@
       },
       {
         "name": "no-temporary-table",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-temporary-table."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-temporary-table; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-time-type",


### PR DESCRIPTION
Part of #14. Ports \`no-temporary-table\`. Disallows \`CREATE TEMPORARY TABLE\` in versioned SQL by checking \`relpersistence == "t"\` on the \`CreateStmt\` relation node. Validated locally against upstream fixtures via the shipping adapter; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784020510&installation_id=136613492&pr_number=284&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F284&signature=aa111c5124f1d5aaf44649cc9616b808ac59b368969a86fcba295eca3f6eb752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->