### PR TITLE
feat(postgresql): port no-rename-column

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -5,6 +5,7 @@ use crate::RuleDef;
 
 mod no_cluster;
 mod no_drop_database;
+mod no_rename_column;
 mod no_select_star;
 mod no_set_not_null;
 
@@ -106,6 +107,7 @@ pub const RULE_NAMES: [&str; 89] = [
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-cluster",
     "no-drop-database",
+    "no-rename-column",
     "no-select-star",
     "no-set-not-null",
 ];
@@ -120,6 +122,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-drop-database",
         run: no_drop_database::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-rename-column",
+        run: no_rename_column::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_rename_column.rs
+++ b/crates/postgresql/src/rules/no_rename_column.rs
@@ -1,0 +1,13 @@
+//! Port of `no-rename-column`: disallow `ALTER TABLE ... RENAME COLUMN` —
+//! every deployed reader of the old name breaks at deploy time.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "RenameStmt") && str_field(node, "renameType") == Some("OBJECT_COLUMN") {
+        ctx.report(node, "noRenameColumn");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -53,6 +53,18 @@ const ruleMeta = Object.freeze({
         'Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.',
     },
   },
+  'no-rename-column': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ... RENAME COLUMN` — every deployed reader of the old name breaks at deploy time',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noRenameColumn:
+        '`RENAME COLUMN` breaks every running app that still selects/inserts by the old name. The safer pattern is to add a new column, dual-write, backfill, and drop the old one across separate deploys.',
+    },
+  },
   'no-set-not-null': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5527,19 +5527,19 @@
       },
       {
         "name": "no-rename-column",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-rename-column."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-rename-column; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-rename-table",


### PR DESCRIPTION
Part of #14. Ports \`no-rename-column\`. Disallows \`ALTER TABLE ... RENAME COLUMN\` by checking \`renameType == "OBJECT_COLUMN"\` on \`RenameStmt\` nodes. Validated locally against upstream fixtures via the shipping adapter; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784020732&installation_id=136613492&pr_number=286&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F286&signature=11f725faa404b078c4d8efc45d8462affbe689eb71e6a321bfe1e39e889b1c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->