### PR TITLE
port(sonarjs): port no-regex-spaces (S6326)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 55] = [
+pub const RULE_NAMES: [&str; 56] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -79,6 +79,7 @@ pub const RULE_NAMES: [&str; 55] = [
     "no-duplicate-string",
     "no-empty-group",
     "no-empty-alternatives",
+    "no-regex-spaces",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -42,6 +42,7 @@ mod no_primitive_wrappers;
 mod no_redundant_boolean;
 mod no_redundant_jump;
 mod no_redundant_optional;
+mod no_regex_spaces;
 mod no_same_line_conditional;
 mod no_skipped_tests;
 mod no_small_switch;

--- a/crates/sonarjs/src/rules/no_regex_spaces.rs
+++ b/crates/sonarjs/src/rules/no_regex_spaces.rs
@@ -1,0 +1,120 @@
+//! Rule `no-regex-spaces` (SonarJS key S6326).
+//!
+//! A run of two or more consecutive literal space characters inside a regex
+//! pattern is hard to count visually and should use an explicit quantifier
+//! instead (e.g. ` {3}`). Spaces inside character classes are excluded.
+//!
+//! ## What is flagged
+//!
+//! A run of **two or more consecutive literal space characters** (U+0020) in
+//! a regex literal pattern that are NOT inside a character class and NOT
+//! expressed via a quantifier:
+//!
+//! ```js
+//! /foo   bar/ // flagged — 3 consecutive spaces
+//! /a  b/      // flagged — 2 consecutive spaces
+//! ```
+//!
+//! ## What is NOT flagged
+//!
+//! - `/a b/`      — a single space.
+//! - `/a {3}b/`   — one space + quantifier (parsed as a single `Quantifier`
+//!   term, not two consecutive `Character` terms).
+//! - `/[  ]{2}/`  — spaces inside a character class live in `CharacterClass`
+//!   body, not in `Alternative.body`, so they are not detected.
+//!
+//! Behaviour is reproduced from the public RSPEC description (S6326) and the
+//! ESLint `no-regex-spaces` rule specification only; no upstream source,
+//! tests, fixtures, or message strings were consulted or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{Disjunction, Term};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-regex-spaces";
+
+/// Returns the character `Span` if `term` is a literal space character
+/// (U+0020), otherwise `None`.
+fn space_char_span(term: &Term<'_>) -> Option<Span> {
+    match term {
+        Term::Character(c) if c.value == 0x20 => Some(c.span),
+        _ => None,
+    }
+}
+
+/// Scans `terms` for maximal runs of two or more consecutive literal spaces,
+/// pushing one `Span` per run onto `out`.  After detecting runs at this level,
+/// recurses into each term so that nested group / quantifier / lookaround
+/// bodies are also scanned.
+fn scan_alternative(terms: &[Term<'_>], out: &mut SmallVec<[Span; 8]>) {
+    // Detect maximal runs of consecutive literal space characters at this level.
+    let mut i = 0;
+    while i < terms.len() {
+        if let Some(first) = space_char_span(&terms[i]) {
+            let mut last = first;
+            let mut j = i + 1;
+            while j < terms.len() {
+                if let Some(s) = space_char_span(&terms[j]) {
+                    last = s;
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            if j - i >= 2 {
+                out.push(Span::new(first.start, last.end));
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    // Recurse into nested group / quantifier / lookaround bodies.
+    for term in terms {
+        recurse_term(term, out);
+    }
+}
+
+/// Recurses into a [`Term`], descending into group, quantifier, and lookaround
+/// bodies so that consecutive spaces at any nesting depth are found.
+fn recurse_term(term: &Term<'_>, out: &mut SmallVec<[Span; 8]>) {
+    match term {
+        Term::CapturingGroup(group) => {
+            scan_disjunction(&group.body, out);
+        }
+        Term::IgnoreGroup(group) => {
+            scan_disjunction(&group.body, out);
+        }
+        Term::LookAroundAssertion(look) => {
+            scan_disjunction(&look.body, out);
+        }
+        Term::Quantifier(quant) => {
+            recurse_term(&quant.body, out);
+        }
+        _ => {}
+    }
+}
+
+fn scan_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>) {
+    for alt in disj.body.iter() {
+        scan_alternative(&alt.body, out);
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_regex_spaces(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            for alt in pattern.body.body.iter() {
+                scan_alternative(&alt.body, &mut out);
+            }
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "multipleSpaces", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -271,6 +271,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_empty_character_class(it);
         self.check_no_empty_group(it);
         self.check_no_empty_alternatives(it);
+        self.check_no_regex_spaces(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2564,3 +2564,42 @@ fn does_not_report_no_empty_alternatives_for_empty_group() {
     let diagnostics = scan("no-empty-alternatives", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_regex_spaces_for_two_consecutive_spaces() {
+    let source = "const r = /a  b/;";
+    let diagnostics = scan("no-regex-spaces", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-regex-spaces");
+    assert_eq!(diagnostics[0].message_id, "multipleSpaces");
+}
+
+#[test]
+fn reports_no_regex_spaces_for_three_consecutive_spaces() {
+    let source = "const r = /foo   bar/;";
+    let diagnostics = scan("no-regex-spaces", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-regex-spaces");
+    assert_eq!(diagnostics[0].message_id, "multipleSpaces");
+}
+
+#[test]
+fn does_not_report_no_regex_spaces_for_single_space() {
+    let source = "const r = /a b/;";
+    let diagnostics = scan("no-regex-spaces", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_regex_spaces_for_space_with_quantifier() {
+    let source = "const r = /a {2}b/;";
+    let diagnostics = scan("no-regex-spaces", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_regex_spaces_for_spaces_inside_character_class() {
+    let source = "const r = /[  ]{2}/;";
+    let diagnostics = scan("no-regex-spaces", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -79,6 +79,9 @@ const messages = Object.freeze({
   'no-empty-alternatives': {
     emptyAlternative: 'Remove this empty alternative or replace the alternation with an optional.',
   },
+  'no-regex-spaces': {
+    multipleSpaces: 'Use a quantifier (e.g. " {3}") instead of multiple consecutive spaces.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -238,6 +241,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow empty capturing or non-capturing groups in regular expression literals',
   'no-empty-alternatives':
     'Disallow empty alternatives in a regular expression alternation (a stray, leading, or trailing "|")',
+  'no-regex-spaces':
+    'Disallow multiple consecutive spaces in a regular expression; use an explicit quantifier instead',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -333,6 +338,7 @@ const ruleTypes = Object.freeze({
   'no-empty-character-class': 'problem',
   'no-empty-group': 'suggestion',
   'no-empty-alternatives': 'suggestion',
+  'no-regex-spaces': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -391,6 +397,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-empty-character-class': 'error',
   'no-empty-group': 'error',
   'no-empty-alternatives': 'error',
+  'no-regex-spaces': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -58,6 +58,7 @@ const expectedRuleNames = [
   'no-duplicate-string',
   'no-empty-group',
   'no-empty-alternatives',
+  'no-regex-spaces',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1972,6 +1973,18 @@ describe('sonarjs native API', () => {
 
   it('does not report no-empty-alternatives when all alternatives have content', () => {
     const diagnostics = scan('no-empty-alternatives', 'const r = /a|b/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-regex-spaces for two consecutive spaces in a regex', () => {
+    const diagnostics = scan('no-regex-spaces', 'const r = /a  b/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-regex-spaces');
+    expect(diagnostics[0].messageId).toBe('multipleSpaces');
+  });
+
+  it('does not report no-regex-spaces for a single space', () => {
+    const diagnostics = scan('no-regex-spaces', 'const r = /a b/;');
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -149,6 +149,7 @@ describe('sonarjs plugin shape', () => {
       'no-duplicate-string',
       'no-empty-group',
       'no-empty-alternatives',
+      'no-regex-spaces',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -205,6 +206,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-duplicate-string']).toBe('object');
     expect(typeof plugin.rules['no-empty-group']).toBe('object');
     expect(typeof plugin.rules['no-empty-alternatives']).toBe('object');
+    expect(typeof plugin.rules['no-regex-spaces']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -263,6 +265,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-duplicate-string']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-group']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-alternatives']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-regex-spaces']).toBe('error');
   });
 });
 
@@ -1238,5 +1241,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-empty-alternatives)');
+  });
+
+  it('reports no-regex-spaces for two consecutive spaces through the adapter', () => {
+    const source = 'const r = /a  b/;';
+    const reports = runRule('no-regex-spaces', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('multipleSpaces');
+  });
+
+  it('reports no-regex-spaces through the CLI', () => {
+    const result = runOxlint('no-regex-spaces', 'const r = /a  b/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-regex-spaces)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -12878,19 +12878,19 @@
       },
       {
         "name": "no-regex-spaces",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-regex-spaces (Sonar key S6326). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S6326). Uses the shared regex_ast helper to walk every Alternative's term sequence, detecting maximal runs of two or more consecutive literal space characters (U+0020). Spaces inside character classes are naturally excluded (they live in CharacterClass.body, not Alternative.body). A quantified space ` {n}` is a single Quantifier term, not multiple Character terms, so it is also naturally excluded. Recurses into capturing groups, non-capturing groups, lookaround assertions, and quantifier bodies. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-require-or-define",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-regex-spaces` rule (Sonar key S6326), built on the regex-AST helper (#276).

Within each regex-literal alternative, flags maximal runs of two or more consecutive literal space characters (U+0020), recursing into group/quantifier/lookaround bodies.

- **Flagged:** `/a  b/`, `/foo   bar/`
- **Not flagged:** `/a b/` (single space), `/a {3}b/` (a single space + quantifier is one `Quantifier` term, not consecutive `Character` terms), `/[  ]{2}/` (spaces inside a character class live in a separate node).

No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784021279&installation_id=136613492&pr_number=291&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F291&signature=dc8917f8ffed6c3f5ae74cbc5e27950e9bcf46735c4fb6fa1f9f5717c5ab47a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->