### PR TITLE
feat(postgresql): port no-distinct-on-without-order-by

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -4,6 +4,7 @@
 use crate::RuleDef;
 
 mod no_cluster;
+mod no_distinct_on_without_order_by;
 mod no_drop_database;
 mod no_rename_column;
 mod no_select_star;
@@ -107,6 +108,7 @@ pub const RULE_NAMES: [&str; 89] = [
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-cluster",
+    "no-distinct-on-without-order-by",
     "no-drop-database",
     "no-rename-column",
     "no-select-star",
@@ -119,6 +121,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-cluster",
         run: no_cluster::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-distinct-on-without-order-by",
+        run: no_distinct_on_without_order_by::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_distinct_on_without_order_by.rs
+++ b/crates/postgresql/src/rules/no_distinct_on_without_order_by.rs
@@ -1,0 +1,33 @@
+//! Port of `no-distinct-on-without-order-by`: disallow `SELECT DISTINCT ON (...)`
+//! without a matching `ORDER BY`. Without `ORDER BY`, the surviving row in each
+//! distinct group is non-deterministic (PostgreSQL picks one arbitrarily).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, is_type};
+
+/// A `SelectStmt` has `DISTINCT ON` (as opposed to plain `DISTINCT`) when its
+/// `distinctClause` array is non-empty **and** at least one element carries a
+/// `type` field. Plain `DISTINCT` (no column list) emits a single element with
+/// no `type`.
+fn has_distinct_on(node: &Value) -> bool {
+    let Some(distinct_clause) = array_field(node, "distinctClause") else {
+        return false;
+    };
+    distinct_clause.iter().any(|e| e.get("type").is_some())
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SelectStmt") {
+        return;
+    }
+    if !has_distinct_on(node) {
+        return;
+    }
+    // Allow if there is at least one sort clause.
+    if array_field(node, "sortClause").is_some_and(|s| !s.is_empty()) {
+        return;
+    }
+    ctx.report(node, "noDistinctOnWithoutOrderBy");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -29,6 +29,18 @@ const ruleMeta = Object.freeze({
         '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
     },
   },
+  'no-distinct-on-without-order-by': {
+    type: 'problem',
+    description:
+      'Disallow `SELECT DISTINCT ON (...)` without an `ORDER BY`; the surviving row in each group is otherwise non-deterministic',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDistinctOnWithoutOrderBy:
+        '`DISTINCT ON (...)` keeps an arbitrary row from each group unless `ORDER BY` is specified. Add an `ORDER BY` whose leading columns match the `DISTINCT ON` expressions.',
+    },
+  },
   'no-drop-database': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5207,19 +5207,19 @@
       },
       {
         "name": "no-distinct-on-without-order-by",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-distinct-on-without-order-by."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-distinct-on-without-order-by; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-drop-column",


### PR DESCRIPTION
Part of #14. Ports `no-distinct-on-without-order-by`. Disallows `SELECT DISTINCT ON (...)` without an `ORDER BY` clause, which leaves the surviving row per group non-deterministic. Validated locally against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784022124&installation_id=136613492&pr_number=293&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F293&signature=fb5bbd248d2087af07dafef7c703ac06fa9d7f07c71d04bcd37fc3c0f28fc4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->