### PR TITLE
feat(postgresql): port no-implicit-join

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -5,6 +5,7 @@ use crate::RuleDef;
 
 mod no_cluster;
 mod no_drop_database;
+mod no_implicit_join;
 mod no_rename_column;
 mod no_select_star;
 mod no_set_not_null;
@@ -108,6 +109,7 @@ pub const RULE_NAMES: [&str; 89] = [
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-cluster",
     "no-drop-database",
+    "no-implicit-join",
     "no-rename-column",
     "no-select-star",
     "no-set-not-null",
@@ -124,6 +126,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-drop-database",
         run: no_drop_database::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-implicit-join",
+        run: no_implicit_join::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_implicit_join.rs
+++ b/crates/postgresql/src/rules/no_implicit_join.rs
@@ -1,0 +1,18 @@
+//! Port of `no-implicit-join`: disallow comma-separated FROM clauses (implicit
+//! cross joins). Whenever the `FROM` list contains more than one item, the
+//! tables are implicitly cross-joined, which is almost always a mistake.
+//! Explicit `JOIN … ON …` should be used instead.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, is_type};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SelectStmt") {
+        return;
+    }
+    if array_field(node, "fromClause").is_some_and(|f| f.len() > 1) {
+        ctx.report(node, "noImplicitJoin");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -53,6 +53,18 @@ const ruleMeta = Object.freeze({
         'Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.',
     },
   },
+  'no-implicit-join': {
+    type: 'suggestion',
+    description:
+      'Disallow comma-separated FROM clauses (implicit cross joins); use explicit JOIN syntax',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noImplicitJoin:
+        'Comma-separated tables in `FROM` are an implicit cross join. Use explicit `JOIN ... ON ...` so the join condition lives next to the join.',
+    },
+  },
   'no-rename-column': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5399,19 +5399,19 @@
       },
       {
         "name": "no-implicit-join",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-implicit-join."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-implicit-join; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-leading-wildcard-like",


### PR DESCRIPTION
Part of #14. Ports `no-implicit-join`. Disallows comma-separated FROM clauses (implicit cross joins); a FROM list with more than one entry should use explicit JOIN syntax. Validated locally against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784022243&installation_id=136613492&pr_number=294&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F294&signature=bf2a47d30dfa90870f03e669a709870ab661a7d5123db1859affbb4950d8174d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->