### PR TITLE
feat(postgresql): port require-limit

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -9,6 +9,7 @@ mod no_rename_column;
 mod no_select_star;
 mod no_set_not_null;
 mod no_temporary_table;
+mod require_limit;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
 /// know the full surface even while only a subset is implemented.
@@ -112,6 +113,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-select-star",
     "no-set-not-null",
     "no-temporary-table",
+    "require-limit",
 ];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
@@ -144,6 +146,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-temporary-table",
         run: no_temporary_table::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-limit",
+        run: require_limit::run,
         uses_parse_error: false,
     },
 ];

--- a/crates/postgresql/src/rules/require_limit.rs
+++ b/crates/postgresql/src/rules/require_limit.rs
@@ -1,0 +1,29 @@
+//! Port of `require-limit`: require a `LIMIT` clause in every `SELECT`
+//! statement to prevent accidentally fetching unbounded result sets.
+//!
+//! libpg_query rewrites `INSERT INTO t VALUES (...)` as an `InsertStmt` whose
+//! inner `selectStmt` is a `SelectStmt` with a non-empty `valuesLists` and no
+//! `targetList`. `LIMIT` has no meaning there, so those synthetic nodes are
+//! skipped (upstream regression #159).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SelectStmt") {
+        return;
+    }
+    // Skip synthetic SelectStmt nodes produced by INSERT ... VALUES (...).
+    if array_field(node, "valuesLists").is_some_and(|v| !v.is_empty()) {
+        return;
+    }
+    // A SELECT has a LIMIT when `limitCount` is present and `limitOption` is
+    // not the parser's default sentinel "LIMIT_OPTION_DEFAULT".
+    let has_limit = field(node, "limitCount").is_some()
+        && str_field(node, "limitOption") != Some("LIMIT_OPTION_DEFAULT");
+    if !has_limit {
+        ctx.report(node, "missingLimit");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -89,6 +89,17 @@ const ruleMeta = Object.freeze({
         '`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.',
     },
   },
+  'require-limit': {
+    type: 'suggestion',
+    description: 'Require LIMIT clause in SELECT statements',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingLimit:
+        'SELECT statement should include a LIMIT clause to prevent excessive data retrieval',
+    },
+  },
 });
 
 const implementedRuleNames = Object.freeze(implementedPostgresqlRuleNames());

--- a/status.json
+++ b/status.json
@@ -6055,19 +6055,19 @@
       },
       {
         "name": "require-limit",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-limit."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-limit; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-named-constraint",


### PR DESCRIPTION
Part of #14. Ports `require-limit`. Requires a LIMIT clause in every SELECT statement to prevent unbounded result sets; skips synthetic SelectStmt nodes produced by INSERT ... VALUES (upstream regression fix #159). Validated locally against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784022382&installation_id=136613492&pr_number=295&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F295&signature=daf4ac3d95df8144eff60db6f385336469ef177d464ac089a71becac7b5f0e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->