### PR TITLE
port(sonarjs): port no-control-regex (S6324)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 56] = [
+pub const RULE_NAMES: [&str; 57] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -80,6 +80,7 @@ pub const RULE_NAMES: [&str; 56] = [
     "no-empty-group",
     "no-empty-alternatives",
     "no-regex-spaces",
+    "no-control-regex",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -20,6 +20,7 @@ mod no_all_duplicated_branches;
 mod no_built_in_override;
 mod no_case_label_in_switch;
 mod no_collapsible_if;
+mod no_control_regex;
 mod no_delete_var;
 mod no_duplicate_in_composite;
 mod no_duplicate_string;

--- a/crates/sonarjs/src/rules/no_control_regex.rs
+++ b/crates/sonarjs/src/rules/no_control_regex.rs
@@ -1,0 +1,126 @@
+//! Rule `no-control-regex` (SonarJS key S6324).
+//!
+//! A control character (U+0000 to U+001F) in a regular expression is almost
+//! certainly unintentional. The rule flags control characters written as a
+//! hexadecimal escape (`\xNN`), a unicode escape (`\uNNNN` or `\u{NN}`), or a
+//! control-letter escape (`\cX`), including occurrences inside character
+//! classes (both endpoints of a range are checked).
+//!
+//! The conventional named escapes `\t`, `\n`, `\r`, `\v`, and `\f` are NOT
+//! flagged; they are `CharacterKind::SingleEscape` and are a normal,
+//! intentional way to write whitespace characters.
+//!
+//! **Flagged**: `/\x1f/`, `/\cA/`, `/[\x00-\x1f]/`, and the `\u`-escape
+//! equivalents in the control range.
+//!
+//! **Not flagged**: `/\t/`, `/\n/`, `/\r/` (named escapes); `/\x20/` (value
+//! `0x20` is above the control range); `/A/` (a literal letter).
+//!
+//! Narrow form: literal (raw) control characters and octal escapes are a
+//! documented follow-up. Behaviour is reproduced from the public RSPEC
+//! description (S6324) only; no upstream source, tests, fixtures, or message
+//! strings were consulted or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{
+    Character, CharacterClassContents, CharacterKind, Disjunction, Term,
+};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-control-regex";
+
+/// Returns `true` when `c` is a control character written in one of the
+/// flagged escape forms (`\xNN`, `\uNNNN`/`\u{NN}`, or `\cX`).
+fn is_control_char(c: &Character) -> bool {
+    c.value <= 0x1F
+        && matches!(
+            c.kind,
+            CharacterKind::ControlLetter
+                | CharacterKind::HexadecimalEscape
+                | CharacterKind::UnicodeEscape
+        )
+}
+
+/// Collects spans of control characters found inside a `CharacterClass` body.
+fn collect_in_class_content(content: &CharacterClassContents<'_>, out: &mut SmallVec<[Span; 8]>) {
+    match content {
+        CharacterClassContents::Character(c) => {
+            if is_control_char(c) {
+                out.push(c.span);
+            }
+        }
+        CharacterClassContents::CharacterClassRange(r) => {
+            if is_control_char(&r.min) {
+                out.push(r.min.span);
+            }
+            if is_control_char(&r.max) {
+                out.push(r.max.span);
+            }
+        }
+        CharacterClassContents::NestedCharacterClass(cc) => {
+            for nested in cc.body.iter() {
+                collect_in_class_content(nested, out);
+            }
+        }
+        CharacterClassContents::CharacterClassEscape(_)
+        | CharacterClassContents::UnicodePropertyEscape(_)
+        | CharacterClassContents::ClassStringDisjunction(_) => {}
+    }
+}
+
+/// Collects spans of control characters found within a single `Term`.
+fn collect_in_term(term: &Term<'_>, out: &mut SmallVec<[Span; 8]>) {
+    match term {
+        Term::Character(c) => {
+            if is_control_char(c) {
+                out.push(c.span);
+            }
+        }
+        Term::CharacterClass(cc) => {
+            for content in cc.body.iter() {
+                collect_in_class_content(content, out);
+            }
+        }
+        Term::CapturingGroup(g) => {
+            collect_in_disjunction(&g.body, out);
+        }
+        Term::IgnoreGroup(g) => {
+            collect_in_disjunction(&g.body, out);
+        }
+        Term::LookAroundAssertion(l) => {
+            collect_in_disjunction(&l.body, out);
+        }
+        Term::Quantifier(q) => {
+            collect_in_term(&q.body, out);
+        }
+        _ => {}
+    }
+}
+
+fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>) {
+    for alt in disj.body.iter() {
+        for term in alt.body.iter() {
+            collect_in_term(term, out);
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_control_regex(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            for alt in pattern.body.body.iter() {
+                for term in alt.body.iter() {
+                    collect_in_term(term, &mut out);
+                }
+            }
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "controlCharacter", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -272,6 +272,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_empty_group(it);
         self.check_no_empty_alternatives(it);
         self.check_no_regex_spaces(it);
+        self.check_no_control_regex(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2603,3 +2603,51 @@ fn does_not_report_no_regex_spaces_for_spaces_inside_character_class() {
     let diagnostics = scan("no-regex-spaces", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_no_control_regex_for_hex_escape() {
+    let source = "const r = /\\x1f/;";
+    let diagnostics = scan("no-control-regex", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-control-regex");
+    assert_eq!(diagnostics[0].message_id, "controlCharacter");
+}
+
+#[test]
+fn reports_no_control_regex_for_unicode_escape() {
+    let source = "const r = /\\u001f/;";
+    let diagnostics = scan("no-control-regex", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-control-regex");
+    assert_eq!(diagnostics[0].message_id, "controlCharacter");
+}
+
+#[test]
+fn reports_no_control_regex_for_control_letter_escape() {
+    let source = "const r = /\\cA/;";
+    let diagnostics = scan("no-control-regex", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-control-regex");
+    assert_eq!(diagnostics[0].message_id, "controlCharacter");
+}
+
+#[test]
+fn reports_no_control_regex_for_range_in_character_class() {
+    let source = "const r = /[\\x00-\\x1f]/;";
+    let diagnostics = scan("no-control-regex", source);
+    assert_eq!(diagnostics.len(), 2);
+}
+
+#[test]
+fn does_not_report_no_control_regex_for_named_escape_tab() {
+    let source = "const r = /\\t/;";
+    let diagnostics = scan("no-control-regex", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_no_control_regex_for_hex_above_control_range() {
+    let source = "const r = /\\x20/;";
+    let diagnostics = scan("no-control-regex", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -82,6 +82,10 @@ const messages = Object.freeze({
   'no-regex-spaces': {
     multipleSpaces: 'Use a quantifier (e.g. " {3}") instead of multiple consecutive spaces.',
   },
+  'no-control-regex': {
+    controlCharacter:
+      'Remove this control character from the regular expression or write it as a conventional escape.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -243,6 +247,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow empty alternatives in a regular expression alternation (a stray, leading, or trailing "|")',
   'no-regex-spaces':
     'Disallow multiple consecutive spaces in a regular expression; use an explicit quantifier instead',
+  'no-control-regex':
+    'Disallow control characters written as \\x, \\u, or \\c escapes in regular expressions',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -339,6 +345,7 @@ const ruleTypes = Object.freeze({
   'no-empty-group': 'suggestion',
   'no-empty-alternatives': 'suggestion',
   'no-regex-spaces': 'suggestion',
+  'no-control-regex': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -398,6 +405,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-empty-group': 'error',
   'no-empty-alternatives': 'error',
   'no-regex-spaces': 'error',
+  'no-control-regex': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -59,6 +59,7 @@ const expectedRuleNames = [
   'no-empty-group',
   'no-empty-alternatives',
   'no-regex-spaces',
+  'no-control-regex',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1986,5 +1987,12 @@ describe('sonarjs native API', () => {
   it('does not report no-regex-spaces for a single space', () => {
     const diagnostics = scan('no-regex-spaces', 'const r = /a b/;');
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-control-regex for a hex escape control character', () => {
+    const diagnostics = scan('no-control-regex', 'const r = /\\x1f/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-control-regex');
+    expect(diagnostics[0].messageId).toBe('controlCharacter');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -150,6 +150,7 @@ describe('sonarjs plugin shape', () => {
       'no-empty-group',
       'no-empty-alternatives',
       'no-regex-spaces',
+      'no-control-regex',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -207,6 +208,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-empty-group']).toBe('object');
     expect(typeof plugin.rules['no-empty-alternatives']).toBe('object');
     expect(typeof plugin.rules['no-regex-spaces']).toBe('object');
+    expect(typeof plugin.rules['no-control-regex']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -266,6 +268,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-group']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-alternatives']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-regex-spaces']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-control-regex']).toBe('error');
   });
 });
 
@@ -1257,5 +1260,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-regex-spaces)');
+  });
+
+  it('reports no-control-regex for a hex escape control character through the adapter', () => {
+    const source = 'const r = /\\x1f/;';
+    const reports = runRule('no-control-regex', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('controlCharacter');
+  });
+
+  it('reports no-control-regex through the CLI', () => {
+    const result = runOxlint('no-control-regex', 'const r = /\\x1f/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-control-regex)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11838,19 +11838,19 @@
       },
       {
         "name": "no-control-regex",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-control-regex (Sonar key S6324). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S6324). Flags control characters (U+0000\u2013U+001F) written as \\x, \\u/\\u{}, or \\c escapes anywhere in a regex literal including inside character classes. Named escapes \\t\\n\\r\\v\\f (CharacterKind::SingleEscape) are not flagged. Literal raw control chars and octal escapes are a documented follow-up (false negatives, not false positives). No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "no-dead-store",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-control-regex` rule (Sonar key S6324), built on the regex-AST helper (#276).

Flags a control character (U+0000–U+001F) written as a hex escape (`\xNN`), a unicode escape (`\uNNNN`/`\u{NN}`), or a control-letter escape (`\cX`), anywhere in a regex literal — including inside character classes, where both endpoints of a range are checked.

- **Flagged:** `/\x1f/`, `/\cA/`, `/[\x00-\x1f]/`, and the `\u`-escape equivalents.
- **Not flagged:** the conventional named escapes `/\t/`, `/\n/`, `/\r/`, `/\v/`, `/\f/` (`CharacterKind::SingleEscape`); `/\x20/` (above the control range).

The kind filter (`ControlLetter | HexadecimalEscape | UnicodeEscape`, value ≤ 0x1F) is a zero-false-positive subset of ESLint's `no-control-regex`; literal raw control characters and octal escapes are a documented follow-up. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784022545&installation_id=136613492&pr_number=297&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F297&signature=33d6d1fac9e84af5bbad18c1291764cbe9be12bd03d0be4ce7e0d957554c9722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->