### PR TITLE
feat(postgresql): port no-set-search-path

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -8,6 +8,7 @@ mod no_drop_database;
 mod no_rename_column;
 mod no_select_star;
 mod no_set_not_null;
+mod no_set_search_path;
 mod no_temporary_table;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
@@ -111,6 +112,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-rename-column",
     "no-select-star",
     "no-set-not-null",
+    "no-set-search-path",
     "no-temporary-table",
 ];
 
@@ -139,6 +141,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-set-not-null",
         run: no_set_not_null::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-set-search-path",
+        run: no_set_search_path::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_set_search_path.rs
+++ b/crates/postgresql/src/rules/no_set_search_path.rs
@@ -1,0 +1,18 @@
+//! Port of `no-set-search-path`: disallow `SET search_path = ...` in versioned
+//! SQL. Changing `search_path` makes name resolution depend on session state
+//! and is a known security foot-gun, especially inside `SECURITY DEFINER`
+//! functions. Identifiers should be schema-qualified instead.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "VariableSetStmt") {
+        return;
+    }
+    if str_field(node, "name") == Some("search_path") {
+        ctx.report(node, "noSetSearchPath");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -77,6 +77,18 @@ const ruleMeta = Object.freeze({
         '`SET NOT NULL` scans the whole table for nulls under an `ACCESS EXCLUSIVE` lock. The safe pattern in production is to add a `CHECK (col IS NOT NULL) NOT VALID` constraint, `VALIDATE CONSTRAINT` separately, then `SET NOT NULL` (PG ≥ 12 reuses the validated CHECK and skips the scan).',
     },
   },
+  'no-set-search-path': {
+    type: 'suggestion',
+    description:
+      'Disallow `SET search_path = ...` in versioned SQL; qualify identifiers with their schema instead',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noSetSearchPath:
+        '`SET search_path` makes name resolution depend on session state and is a known foot-gun for security-definer functions and CREATE statements. Qualify identifiers with their schema (`audit.events`, `public.users`) instead.',
+    },
+  },
   'no-temporary-table': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5639,19 +5639,19 @@
       },
       {
         "name": "no-set-search-path",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-set-search-path."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-set-search-path; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-syntax-error",


### PR DESCRIPTION
Part of #14. Ports `no-set-search-path`. Disallows `SET search_path = ...` in versioned SQL by flagging `VariableSetStmt` nodes with `name: search_path`. Validated locally against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784022878&installation_id=136613492&pr_number=300&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F300&signature=be93573fa52745b23a92481a73c715d17fdca161e222dea5a8f80a8a5e8a867b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->