### PR TITLE
feat(postgresql-eslint-parser): port processor, extractEmbeddedCode + remaining upstream unit tests

### DIFF
--- a/crates/postgresql/src/text.rs
+++ b/crates/postgresql/src/text.rs
@@ -160,4 +160,75 @@ mod tests {
         assert_eq!(s.byte_to_unit(1), Some(1));
         assert_eq!(s.byte_to_unit(3), Some(2)); // closing quote at unit 2
     }
+
+    // The following mirror upstream `src/utils.test.ts` (`createLineMap` /
+    // `createByteToCharOffset`) so position resolution and byte↔unit conversion
+    // track upstream exactly. ESLint columns are UTF-16 code units; upstream's
+    // negative-offset JS edge case is not representable in this `u32` API and is
+    // intentionally omitted (offsets are never negative in practice).
+    fn pos(code: &str, offset: u32) -> (u32, u32) {
+        let p = Source::new(code).position(offset);
+        (p.line, p.column)
+    }
+
+    #[test]
+    fn get_position_single_and_multi_line() {
+        assert_eq!(pos("SELECT * FROM users", 0), (1, 0));
+        assert_eq!(pos("SELECT * FROM users", 7), (1, 7));
+        assert_eq!(pos("SELECT * FROM users", 19), (1, 19)); // end of line
+        assert_eq!(pos("SELECT *\nFROM users", 9), (2, 0)); // second line start
+        assert_eq!(pos("SELECT *\nFROM users", 14), (2, 5)); // second line middle
+        assert_eq!(pos("SELECT *\nFROM users\nWHERE id = 1", 21), (3, 1));
+    }
+
+    #[test]
+    fn get_position_edge_cases() {
+        assert_eq!(pos("", 0), (1, 0)); // empty string
+        assert_eq!(pos("\n\n\n", 2), (3, 0)); // only newlines
+        assert_eq!(pos("SELECT *\r\nFROM users", 10), (2, 0)); // CRLF
+        assert_eq!(pos("SELECT * FROM users", 29), (1, 29)); // beyond length
+        assert_eq!(pos("SELECT * FROM users\n", 20), (2, 0)); // trailing newline
+        assert_eq!(pos("SELECT *\nFROM users\r\nWHERE id = 1\n", 21), (3, 0)); // mixed
+    }
+
+    #[test]
+    fn line_start_offsets() {
+        assert_eq!(Source::new("SELECT * FROM users").line_starts, vec![0]);
+        assert_eq!(
+            Source::new("SELECT *\nFROM users\nWHERE id = 1").line_starts,
+            vec![0, 9, 20]
+        );
+        assert_eq!(
+            Source::new("SELECT *\n\nFROM users").line_starts,
+            vec![0, 9, 10]
+        );
+        assert_eq!(
+            Source::new("SELECT *\n\n\nFROM users").line_starts,
+            vec![0, 9, 10, 11]
+        );
+    }
+
+    #[test]
+    fn byte_to_unit_identity_and_multibyte() {
+        let ascii = Source::new("SELECT * FROM users");
+        assert_eq!(ascii.byte_to_unit(0), Some(0));
+        assert_eq!(ascii.byte_to_unit(7), Some(7));
+        assert_eq!(ascii.byte_to_unit(19), Some(19));
+
+        // "-- 日本語\nSELECT 1": each CJK char is 3 UTF-8 bytes, 1 UTF-16 unit.
+        let s = Source::new("-- 日本語\nSELECT 1");
+        assert_eq!(s.byte_to_unit(20), Some(14)); // the `1`
+        assert_eq!(s.byte_to_unit(13), Some(7)); // the `S`
+    }
+
+    #[test]
+    fn byte_to_unit_surrogate_pairs_and_clamping() {
+        // "😀" is 4 UTF-8 bytes and 2 UTF-16 units (a surrogate pair).
+        let s = Source::new("-- 😀\nSELECT 1");
+        assert_eq!(s.byte_to_unit(15), Some(13)); // the `1`
+        assert_eq!(s.byte_to_unit(3), Some(3)); // first byte of the emoji
+        // Byte offsets past the end clamp to the UTF-16 length.
+        let cjk = Source::new("日本語");
+        assert_eq!(cjk.byte_to_unit(100), Some(cjk.len()));
+    }
 }

--- a/npm/postgresql-eslint-parser/api.d.ts
+++ b/npm/postgresql-eslint-parser/api.d.ts
@@ -24,8 +24,25 @@ export interface ParseResult {
   scopeManager: null;
 }
 
+/** A PL function body embedded in a `CREATE FUNCTION` / `CREATE PROCEDURE`. */
+export interface EmbeddedCode {
+  type: 'EmbeddedCode';
+  /** The lower-cased `LANGUAGE` clause (e.g. `"plv8"`, `"plpgsql"`). */
+  language: string;
+  /** The body text, as libpg_query reports it (escapes already resolved). */
+  source: string;
+  /** Whether the body was dollar-quoted (`$$`) or single-quoted (`'`). */
+  quoteStyle: 'dollar' | 'single';
+  /** Absolute UTF-16 offsets of the body contents within the SQL source. */
+  range: Range;
+  loc: SourceLocation;
+}
+
 /** Parse PostgreSQL SQL into an ESLint-compatible AST. */
 export declare function parseForESLint(code: string): ParseResult;
 
 /** Parse PostgreSQL SQL and return only the `Program` AST node. */
 export declare function parse(code: string): Node;
+
+/** Collect every `EmbeddedCode` node in a parsed program, in source order. */
+export declare function extractEmbeddedCode(program: Node): EmbeddedCode[];

--- a/npm/postgresql-eslint-parser/api.js
+++ b/npm/postgresql-eslint-parser/api.js
@@ -29,4 +29,24 @@ function parse(code) {
   return parseForESLint(code).ast;
 }
 
-module.exports = { parse, parseForESLint };
+/**
+ * Collect every `EmbeddedCode` node in a parsed program, in source order.
+ * Mirrors upstream `extractEmbeddedCode`: the parser attaches an `embeddedCode`
+ * node to each top-level `CreateFunctionStmt` that carries a PL body, so this
+ * walks `program.body` and gathers them.
+ * @param {object} program the `Program` AST node from {@link parseForESLint}.
+ * @returns {object[]} the `EmbeddedCode` nodes (`{ type, language, source, quoteStyle, range, loc }`).
+ */
+function extractEmbeddedCode(program) {
+  const result = [];
+  const body = program && Array.isArray(program.body) ? program.body : [];
+  for (const node of body) {
+    const embedded = node && node.embeddedCode;
+    if (embedded && embedded.type === 'EmbeddedCode') {
+      result.push(embedded);
+    }
+  }
+  return result;
+}
+
+module.exports = { extractEmbeddedCode, parse, parseForESLint };

--- a/npm/postgresql-eslint-parser/package.json
+++ b/npm/postgresql-eslint-parser/package.json
@@ -40,6 +40,8 @@
     "index.js",
     "api.js",
     "api.d.ts",
+    "processor.js",
+    "processor.d.ts",
     "native.js",
     "native.d.ts",
     "*.node",
@@ -58,6 +60,11 @@
       "types": "./api.d.ts",
       "require": "./api.js",
       "default": "./api.js"
+    },
+    "./processor": {
+      "types": "./processor.d.ts",
+      "require": "./processor.js",
+      "default": "./processor.js"
     },
     "./native": {
       "types": "./native.d.ts",

--- a/npm/postgresql-eslint-parser/processor.d.ts
+++ b/npm/postgresql-eslint-parser/processor.d.ts
@@ -1,0 +1,40 @@
+export interface PlProcessorOptions {
+  /**
+   * Maps a lower-cased `LANGUAGE` clause to a virtual-file extension (which MUST
+   * start with `.`, e.g. `".js"`, `".py"`, `".plpgsql"`).
+   */
+  languages: Record<string, string>;
+  /**
+   * What to do with a body whose language is not in `languages`. `"skip"`
+   * (default) drops it; `"error"` throws.
+   */
+  unknown?: 'skip' | 'error';
+}
+
+export interface FixDescriptor {
+  range: [number, number];
+  text: string;
+}
+
+/** A minimal subset of ESLint's `Linter.LintMessage` shape. */
+export interface ProcessorMessage {
+  ruleId?: string | null;
+  severity?: number;
+  message?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  fix?: FixDescriptor;
+  [key: string]: unknown;
+}
+
+export interface PlProcessor {
+  meta: { name: string; version: string };
+  supportsAutofix: boolean;
+  preprocess: (text: string, filename: string) => Array<{ text: string; filename: string }>;
+  postprocess: (messageLists: ProcessorMessage[][], filename: string) => ProcessorMessage[];
+}
+
+/** Create an ESLint processor that lints embedded PL function bodies. */
+export declare function createPlProcessor(options: PlProcessorOptions): PlProcessor;

--- a/npm/postgresql-eslint-parser/processor.js
+++ b/npm/postgresql-eslint-parser/processor.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// ESLint processor that lints PL function bodies embedded in SQL, ported
+// verbatim from upstream `src/processor.ts`. `preprocess` extracts each PL body
+// into a virtual file (keyed by the configured LANGUAGE → extension map);
+// `postprocess` translates the lint messages' line/column (and dollar-quote fix
+// ranges) back into the original SQL's coordinate system.
+
+const { extractEmbeddedCode, parseForESLint } = require('./api.js');
+
+const PROCESSOR_VERSION = '1';
+
+// Convert a (line, column) pair reported in the virtual file's coordinate
+// system back to the original SQL's coordinate system. ESLint reports both
+// values 1-indexed; our parser exposes line 1-indexed but column 0-indexed, so
+// when the message lands on the first line of the body we add columns
+// (0-indexed + 1-indexed = 1-indexed). For lines past the first, columns reset
+// to the start of the line and need no offset.
+function translateLineColumn(body, line, column) {
+  const sqlLine = body.loc.start.line + (line - 1);
+  const sqlColumn = line === 1 ? body.loc.start.column + column : column;
+  return { line: sqlLine, column: sqlColumn };
+}
+
+function translateMessage(message, body) {
+  const translated = { ...message };
+
+  if (typeof message.line === 'number' && typeof message.column === 'number') {
+    const start = translateLineColumn(body, message.line, message.column);
+    translated.line = start.line;
+    translated.column = start.column;
+  }
+
+  if (typeof message.endLine === 'number' && typeof message.endColumn === 'number') {
+    const end = translateLineColumn(body, message.endLine, message.endColumn);
+    translated.endLine = end.line;
+    translated.endColumn = end.column;
+  }
+
+  // Fix ranges are absolute character offsets in the file ESLint linted — i.e.
+  // the virtual file. Translating them to the original SQL only works cleanly
+  // for dollar-quoted bodies, where the virtual file's characters map 1:1 to a
+  // contiguous slice of the SQL. Single-quoted bodies with `''` escapes would
+  // need a sourceMap; drop fixes there rather than report wrong ranges.
+  if (message.fix) {
+    if (body.quoteStyle === 'dollar') {
+      translated.fix = {
+        range: [body.range[0] + message.fix.range[0], body.range[0] + message.fix.range[1]],
+        text: message.fix.text,
+      };
+    } else {
+      delete translated.fix;
+    }
+  }
+
+  return translated;
+}
+
+/**
+ * Create an ESLint processor that lints embedded PL function bodies.
+ * @param {{ languages: Record<string, string>, unknown?: 'skip' | 'error' }} options
+ *   `languages` maps a lower-cased LANGUAGE clause to a virtual-file extension
+ *   (which MUST start with `.`); `unknown` controls bodies whose language is not
+ *   mapped (`'skip'` drops them, `'error'` throws).
+ */
+function createPlProcessor(options) {
+  const { languages, unknown = 'skip' } = options;
+  // ESLint always calls postprocess right after preprocess for the same file,
+  // so caching by filename is enough — even when several files are linted
+  // concurrently they each have a distinct key.
+  const blockCache = new Map();
+
+  return {
+    meta: {
+      name: 'postgresql-eslint-parser/processor',
+      version: PROCESSOR_VERSION,
+    },
+    supportsAutofix: true,
+    preprocess(text, filename) {
+      const { ast } = parseForESLint(text);
+      const bodies = extractEmbeddedCode(ast);
+      const blocks = [];
+
+      for (const body of bodies) {
+        const ext = languages[body.language];
+        if (ext == null) {
+          if (unknown === 'error') {
+            throw new Error(
+              `postgresql-eslint-parser/processor: no virtual-file extension configured for LANGUAGE "${body.language}"`,
+            );
+          }
+          continue;
+        }
+        blocks.push({ body, ext });
+      }
+
+      blockCache.set(
+        filename,
+        blocks.map(({ body }) => ({ body })),
+      );
+
+      return blocks.map(({ body, ext }, index) => ({
+        text: body.source,
+        filename: `${index}${ext}`,
+      }));
+    },
+    postprocess(messageLists, filename) {
+      const blocks = blockCache.get(filename) ?? [];
+      blockCache.delete(filename);
+
+      const result = [];
+      for (let i = 0; i < messageLists.length; i++) {
+        const block = blocks[i];
+        const messages = messageLists[i];
+        if (!block || !messages) continue;
+        for (const message of messages) {
+          result.push(translateMessage(message, block.body));
+        }
+      }
+      return result;
+    },
+  };
+}
+
+module.exports = { createPlProcessor };

--- a/npm/postgresql-eslint-parser/test/embedded-code.test.mjs
+++ b/npm/postgresql-eslint-parser/test/embedded-code.test.mjs
@@ -1,0 +1,59 @@
+// Ported from upstream src/embeddedCode.test.ts.
+
+import { describe, expect, it } from 'vitest';
+
+import { extractEmbeddedCode, parseForESLint } from '../api.js';
+
+describe('extractEmbeddedCode', () => {
+  it('returns an EmbeddedCode for every PL function body', () => {
+    const sql = `
+CREATE FUNCTION a() RETURNS int AS $$ return 1; $$ LANGUAGE plv8;
+CREATE FUNCTION b() RETURNS int AS $$ return 2; $$ LANGUAGE plv8;
+`;
+    const { ast } = parseForESLint(sql);
+    const bodies = extractEmbeddedCode(ast);
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.source).toBe(' return 1; ');
+    expect(bodies[1]?.source).toBe(' return 2; ');
+  });
+
+  it('preserves source order', () => {
+    const sql = `
+CREATE FUNCTION first() RETURNS text AS $$ return "x"; $$ LANGUAGE plv8;
+CREATE FUNCTION second() RETURNS text AS $$ return "y"; $$ LANGUAGE plpython3u;
+CREATE FUNCTION third() RETURNS text AS $$ return "z"; $$ LANGUAGE plv8;
+`;
+    const { ast } = parseForESLint(sql);
+    const langs = extractEmbeddedCode(ast).map((b) => b.language);
+    expect(langs).toEqual(['plv8', 'plpython3u', 'plv8']);
+  });
+
+  it('reports absolute SQL ranges that slice back to the body', () => {
+    const sql = 'CREATE FUNCTION f() RETURNS int AS $$  return 42;  $$ LANGUAGE plv8;';
+    const { ast } = parseForESLint(sql);
+    const [body] = extractEmbeddedCode(ast);
+    expect(body).toBeDefined();
+    const sliced = sql.slice(body.range[0], body.range[1]);
+    expect(sliced).toBe(body.source);
+  });
+
+  it('skips C-style two-argument AS clauses', () => {
+    const sql = `CREATE FUNCTION c() RETURNS int AS 'libname', 'symbol' LANGUAGE c;`;
+    const { ast } = parseForESLint(sql);
+    expect(extractEmbeddedCode(ast)).toEqual([]);
+  });
+
+  it('handles dollar-quote tags', () => {
+    const sql = `CREATE FUNCTION t() RETURNS int AS $body$ return 1; $body$ LANGUAGE plv8;`;
+    const { ast } = parseForESLint(sql);
+    const [body] = extractEmbeddedCode(ast);
+    expect(body?.quoteStyle).toBe('dollar');
+    expect(body?.source).toBe(' return 1; ');
+  });
+
+  it('lower-cases the LANGUAGE clause', () => {
+    const sql = `CREATE FUNCTION u() RETURNS int AS $$ return 1; $$ LANGUAGE PLV8;`;
+    const { ast } = parseForESLint(sql);
+    expect(extractEmbeddedCode(ast)[0]?.language).toBe('plv8');
+  });
+});

--- a/npm/postgresql-eslint-parser/test/parse.test.mjs
+++ b/npm/postgresql-eslint-parser/test/parse.test.mjs
@@ -1,0 +1,92 @@
+// Ported from upstream src/parse.test.ts — source-location accuracy across
+// multi-byte / surrogate-pair comments, and token classification.
+
+import { describe, expect, it } from 'vitest';
+
+import { parseForESLint } from '../api.js';
+
+const findFirst = (body, type) => {
+  const visit = (node) => {
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        const found = visit(child);
+        if (found) return found;
+      }
+      return null;
+    }
+    if (node && typeof node === 'object') {
+      if (node.type === type) return node;
+      for (const [key, value] of Object.entries(node)) {
+        if (key === 'parent' || key === 'loc' || key === 'range') continue;
+        const found = visit(value);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+  return visit(body);
+};
+
+const requireFirst = (body, type) => {
+  const node = findFirst(body, type);
+  if (!node) throw new Error(`Could not find a ${type} node`);
+  return node;
+};
+
+describe('parseForESLint - source location accuracy', () => {
+  it('reports correct line/column when multi-byte comments precede a statement', () => {
+    const code = '-- 日本語\nSELECT 1';
+    const { ast } = parseForESLint(code);
+
+    const constNode = requireFirst(ast.body, 'A_Const');
+    expect(constNode.loc).toEqual({
+      start: { line: 2, column: 7 },
+      end: { line: 2, column: 8 },
+    });
+    expect(constNode.range).toEqual([14, 15]);
+  });
+
+  it('does not push child loc onto wrong lines after multi-line, multi-byte comments', () => {
+    const code = [
+      '-- これはテーブル定義です',
+      '-- 列の説明: ID は主キーです',
+      'SELECT id FROM users WHERE id = 1',
+    ].join('\n');
+    const { ast } = parseForESLint(code);
+
+    const constNode = requireFirst(ast.body, 'A_Const');
+    expect(constNode.loc.start.line).toBe(3);
+  });
+
+  it('handles surrogate pairs (emoji) before a statement', () => {
+    const code = '-- 😀\nSELECT 1';
+    const { ast } = parseForESLint(code);
+    const constNode = requireFirst(ast.body, 'A_Const');
+    expect(constNode.loc).toEqual({
+      start: { line: 2, column: 7 },
+      end: { line: 2, column: 8 },
+    });
+  });
+});
+
+describe('parseForESLint - token classification', () => {
+  const tokenValuesByType = (code) => {
+    const { ast } = parseForESLint(code);
+    const grouped = {};
+    for (const token of ast.tokens ?? []) {
+      (grouped[token.type] ??= []).push(token.value);
+    }
+    return grouped;
+  };
+
+  it('classifies well-formed integers, decimals, and exponents as Numeric', () => {
+    const tokens = tokenValuesByType('SELECT 1, 1.5, 2e10, 3.5E-2');
+    expect(tokens.Numeric).toEqual(['1', '1.5', '2e10', '3.5E-2']);
+  });
+
+  it('falls back to Identifier for malformed numeric-looking lexemes', () => {
+    const tokens = tokenValuesByType('1..2 1e');
+    expect(tokens.Numeric ?? []).toEqual([]);
+    expect(tokens.Identifier).toEqual(['1..2', '1e']);
+  });
+});

--- a/npm/postgresql-eslint-parser/test/processor.test.mjs
+++ b/npm/postgresql-eslint-parser/test/processor.test.mjs
@@ -1,0 +1,94 @@
+// Ported from upstream src/processor.test.ts.
+
+import { describe, expect, it } from 'vitest';
+
+import { createPlProcessor } from '../processor.js';
+
+describe('createPlProcessor', () => {
+  const sql = `CREATE FUNCTION f() RETURNS int AS $$
+  return 42;
+$$ LANGUAGE plv8;
+CREATE FUNCTION g() RETURNS int AS $$ return 1; $$ LANGUAGE plpython3u;
+`;
+
+  it('emits one virtual file per body with the configured extension', () => {
+    const processor = createPlProcessor({
+      languages: { plv8: '.js', plpython3u: '.py' },
+    });
+
+    const blocks = processor.preprocess(sql, 'queries.sql');
+    expect(blocks).toEqual([
+      { text: '\n  return 42;\n', filename: '0.js' },
+      { text: ' return 1; ', filename: '1.py' },
+    ]);
+  });
+
+  it('skips bodies whose language is not mapped (default)', () => {
+    const processor = createPlProcessor({ languages: { plv8: '.js' } });
+    const blocks = processor.preprocess(sql, 'queries.sql');
+    expect(blocks).toEqual([{ text: '\n  return 42;\n', filename: '0.js' }]);
+  });
+
+  it("throws on unknown languages when unknown: 'error'", () => {
+    const processor = createPlProcessor({
+      languages: { plv8: '.js' },
+      unknown: 'error',
+    });
+    expect(() => processor.preprocess(sql, 'queries.sql')).toThrow(/plpython3u/);
+  });
+
+  it('translates message line/column back to the SQL coordinate system', () => {
+    const processor = createPlProcessor({
+      languages: { plv8: '.js', plpython3u: '.py' },
+    });
+    processor.preprocess(sql, 'queries.sql');
+
+    const messages = processor.postprocess(
+      [[{ ruleId: 'no-magic-numbers', line: 2, column: 3 }], []],
+      'queries.sql',
+    );
+
+    expect(messages).toEqual([{ ruleId: 'no-magic-numbers', line: 2, column: 3 }]);
+  });
+
+  it("translates first-line columns by adding the body's start column", () => {
+    const oneLine = `CREATE FUNCTION x() RETURNS int AS $$ return 1; $$ LANGUAGE plv8;`;
+    const processor = createPlProcessor({ languages: { plv8: '.js' } });
+    processor.preprocess(oneLine, 'q.sql');
+
+    const out = processor.postprocess([[{ ruleId: 'r', line: 1, column: 2 }]], 'q.sql');
+    expect(out[0]).toMatchObject({ line: 1, column: 39 });
+  });
+
+  it("offsets dollar-quote fix ranges by the body's absolute start", () => {
+    const oneLine = `CREATE FUNCTION x() RETURNS int AS $$ return 1; $$ LANGUAGE plv8;`;
+    const processor = createPlProcessor({ languages: { plv8: '.js' } });
+    processor.preprocess(oneLine, 'q.sql');
+
+    const out = processor.postprocess(
+      [[{ ruleId: 'r', line: 1, column: 1, fix: { range: [1, 7], text: 'RETURN' } }]],
+      'q.sql',
+    );
+    expect(out[0]?.fix).toEqual({ range: [38, 44], text: 'RETURN' });
+  });
+
+  it('drops fixes for single-quoted bodies to avoid wrong positions', () => {
+    const sqlSingle = `CREATE FUNCTION p() RETURNS void AS '
+  RAISE NOTICE ''hi'';
+' LANGUAGE plpgsql;`;
+    const processor = createPlProcessor({ languages: { plpgsql: '.plpgsql' } });
+    processor.preprocess(sqlSingle, 'p.sql');
+    const out = processor.postprocess(
+      [[{ ruleId: 'r', line: 1, column: 1, fix: { range: [0, 1], text: 'X' } }]],
+      'p.sql',
+    );
+    expect(out[0]?.fix).toBeUndefined();
+  });
+
+  it('declares supportsAutofix and meta name/version', () => {
+    const processor = createPlProcessor({ languages: { plv8: '.js' } });
+    expect(processor.supportsAutofix).toBe(true);
+    expect(processor.meta.name).toBe('postgresql-eslint-parser/processor');
+    expect(processor.meta.version).toMatch(/\d+/);
+  });
+});


### PR DESCRIPTION
Part of #15 — follow-up to #268 (parser at full fixture parity).

Completes the parser package's public API + test coverage to match upstream `postgresql-eslint-parser`.

## What's here
- **`extractEmbeddedCode(program)`** (`api.js`) — collects `EmbeddedCode` nodes from the AST in source order.
- **`processor.js`** (new `./processor` export) — port of upstream's `createPlProcessor` ESLint processor: `preprocess` emits one virtual file per PL body, `postprocess` translates message line/column and dollar-quote fix ranges back to SQL coordinates. Pure JS over `parseForESLint` + `extractEmbeddedCode`.
- **Ported upstream unit suites** (verbatim):
  - `test/parse.test.mjs` — multi-byte / surrogate-pair loc accuracy, token classification.
  - `test/embedded-code.test.mjs` — `extractEmbeddedCode`.
  - `test/processor.test.mjs` — `createPlProcessor`.
  - `utils.test.ts` → Rust unit tests in `crates/postgresql/src/text.rs` (`getPosition`, `lineStartOffsets`, `byteToCharOffset`). The JS negative-offset edge case is not representable in the `u32` API and is documented as omitted.

With #268, this brings the full upstream parser test suite (`fixtures` + `parse` + `utils` + `processor` + `embeddedCode`) to parity.

## Notes
- The parser's AST is snapshot-covered by the committed fixture replay (`test/fixtures.test.mjs`); insta is reserved for rule diagnostics, of which the parser has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784023109&installation_id=136613492&pr_number=301&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F301&signature=32129b0de22f20027bf1fd18281693c783303a82ce3bc3b49477f89f4ba4363b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->