### PR TITLE
port(sonarjs): port single-char-in-character-classes (S6397)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 57] = [
+pub const RULE_NAMES: [&str; 58] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -81,6 +81,7 @@ pub const RULE_NAMES: [&str; 57] = [
     "no-empty-alternatives",
     "no-regex-spaces",
     "no-control-regex",
+    "single-char-in-character-classes",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -57,4 +57,5 @@ mod prefer_default_last;
 mod prefer_immediate_return;
 mod prefer_single_boolean_return;
 mod prefer_while;
+mod single_char_in_character_classes;
 mod todo_tag;

--- a/crates/sonarjs/src/rules/single_char_in_character_classes.rs
+++ b/crates/sonarjs/src/rules/single_char_in_character_classes.rs
@@ -1,0 +1,76 @@
+//! Rule `single-char-in-character-classes` (SonarJS key S6397).
+//!
+//! A character class that contains exactly one literal character (`[a]`,
+//! `[.]`) is redundant: the surrounding brackets add nothing, and the single
+//! character (escaped if necessary) can be used directly. Such classes are a
+//! sign of an over-complicated pattern.
+//!
+//! **Flagged** (a non-negated character class whose only element is one
+//! literal character):
+//! - `/[a]/`
+//! - `/[.]/`
+//! - `/(?:[5])/`, `/[a]+/` (at any nesting depth)
+//!
+//! **Not flagged**:
+//! - `/[ab]/`, `/[a-z]/` — more than one element, or a range.
+//! - `/[^a]/` — a negated class is meaningful (any char *except* `a`).
+//! - `/a/` — no character class at all.
+//!
+//! Narrow form: only a single *literal character* element is reported; a
+//! single class-escape element (`[\d]`) or a nested class is a documented
+//! follow-up. Behaviour is reproduced from the public RSPEC description (S6397)
+//! only; no upstream source, tests, fixtures, or message strings were consulted
+//! or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{CharacterClass, CharacterClassContents, Disjunction, Term};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "single-char-in-character-classes";
+
+/// Returns `true` when `class` is a non-negated character class whose only
+/// element is a single literal character.
+fn is_single_char_class(class: &CharacterClass<'_>) -> bool {
+    !class.negative
+        && class.body.len() == 1
+        && matches!(class.body[0], CharacterClassContents::Character(_))
+}
+
+fn collect_in_term(term: &Term<'_>, out: &mut SmallVec<[Span; 8]>) {
+    match term {
+        Term::CharacterClass(class) => {
+            if is_single_char_class(class) {
+                out.push(class.span);
+            }
+        }
+        Term::CapturingGroup(group) => collect_in_disjunction(&group.body, out),
+        Term::IgnoreGroup(group) => collect_in_disjunction(&group.body, out),
+        Term::LookAroundAssertion(look) => collect_in_disjunction(&look.body, out),
+        Term::Quantifier(quant) => collect_in_term(&quant.body, out),
+        _ => {}
+    }
+}
+
+fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>) {
+    for alt in disj.body.iter() {
+        for term in alt.body.iter() {
+            collect_in_term(term, out);
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_single_char_in_character_classes(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            collect_in_disjunction(&pattern.body, &mut out);
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "singleCharInCharacterClass", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -273,6 +273,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_empty_alternatives(it);
         self.check_no_regex_spaces(it);
         self.check_no_control_regex(it);
+        self.check_single_char_in_character_classes(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2651,3 +2651,39 @@ fn does_not_report_no_control_regex_for_hex_above_control_range() {
     let diagnostics = scan("no-control-regex", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_single_char_in_character_classes_for_one_char_class() {
+    let source = "const r = /[a]/;";
+    let diagnostics = scan("single-char-in-character-classes", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "singleCharInCharacterClass");
+}
+
+#[test]
+fn reports_single_char_in_character_classes_for_dot_in_class() {
+    let source = "const r = /[.]/;";
+    let diagnostics = scan("single-char-in-character-classes", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_single_char_in_character_classes_for_two_chars() {
+    let source = "const r = /[ab]/;";
+    let diagnostics = scan("single-char-in-character-classes", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_single_char_in_character_classes_for_range() {
+    let source = "const r = /[a-z]/;";
+    let diagnostics = scan("single-char-in-character-classes", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_single_char_in_character_classes_for_negated_class() {
+    let source = "const r = /[^a]/;";
+    let diagnostics = scan("single-char-in-character-classes", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -86,6 +86,9 @@ const messages = Object.freeze({
     controlCharacter:
       'Remove this control character from the regular expression or write it as a conventional escape.',
   },
+  'single-char-in-character-classes': {
+    singleCharInCharacterClass: 'Replace this single-character class with the character itself.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -249,6 +252,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow multiple consecutive spaces in a regular expression; use an explicit quantifier instead',
   'no-control-regex':
     'Disallow control characters written as \\x, \\u, or \\c escapes in regular expressions',
+  'single-char-in-character-classes':
+    'Disallow a regular-expression character class that contains only a single literal character',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -346,6 +351,7 @@ const ruleTypes = Object.freeze({
   'no-empty-alternatives': 'suggestion',
   'no-regex-spaces': 'suggestion',
   'no-control-regex': 'suggestion',
+  'single-char-in-character-classes': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -406,6 +412,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-empty-alternatives': 'error',
   'no-regex-spaces': 'error',
   'no-control-regex': 'error',
+  'single-char-in-character-classes': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -60,6 +60,7 @@ const expectedRuleNames = [
   'no-empty-alternatives',
   'no-regex-spaces',
   'no-control-regex',
+  'single-char-in-character-classes',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -1994,5 +1995,17 @@ describe('sonarjs native API', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].ruleName).toBe('no-control-regex');
     expect(diagnostics[0].messageId).toBe('controlCharacter');
+  });
+
+  it('reports single-char-in-character-classes for a one-character class', () => {
+    const diagnostics = scan('single-char-in-character-classes', 'const r = /[a]/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('single-char-in-character-classes');
+    expect(diagnostics[0].messageId).toBe('singleCharInCharacterClass');
+  });
+
+  it('does not report single-char-in-character-classes for a multi-character class', () => {
+    const diagnostics = scan('single-char-in-character-classes', 'const r = /[ab]/;');
+    expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -151,6 +151,7 @@ describe('sonarjs plugin shape', () => {
       'no-empty-alternatives',
       'no-regex-spaces',
       'no-control-regex',
+      'single-char-in-character-classes',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -209,6 +210,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-empty-alternatives']).toBe('object');
     expect(typeof plugin.rules['no-regex-spaces']).toBe('object');
     expect(typeof plugin.rules['no-control-regex']).toBe('object');
+    expect(typeof plugin.rules['single-char-in-character-classes']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -269,6 +271,9 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/no-empty-alternatives']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-regex-spaces']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-control-regex']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/single-char-in-character-classes']).toBe(
+      'error',
+    );
   });
 });
 
@@ -1276,5 +1281,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(no-control-regex)');
+  });
+
+  it('reports single-char-in-character-classes through the adapter', () => {
+    const source = 'const r = /[a]/;';
+    const reports = runRule('single-char-in-character-classes', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('singleCharInCharacterClass');
+  });
+
+  it('reports single-char-in-character-classes through the CLI', () => {
+    const result = runOxlint('single-char-in-character-classes', 'const r = /[a]/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(single-char-in-character-classes)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -13838,19 +13838,19 @@
       },
       {
         "name": "single-char-in-character-classes",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule single-char-in-character-classes (Sonar key S6397). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port (Sonar key S6397). Uses the shared regex_ast helper to walk a regex literal; flags a non-negated CharacterClass whose body is exactly one CharacterClassContents::Character (a single literal character), at any nesting depth. Negated classes, ranges, multi-element classes, and single class-escape elements (e.g. [\\d]) are not flagged; the class-escape and nested-class cases are documented follow-ups. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "single-character-alternation",


### PR DESCRIPTION
Clean-room port of the SonarJS `single-char-in-character-classes` rule (Sonar key S6397), built on the regex-AST helper (#276).

Flags a non-negated character class whose body is exactly one literal character — the surrounding brackets are redundant.

- **Flagged:** `/[a]/`, `/[.]/`, `/(?:[5])/`, `/[a]+/`
- **Not flagged:** `/[ab]/`, `/[a-z]/` (more than one element / a range), `/[^a]/` (negated, meaningful), `/a/` (no class).

Single class-escape elements (`/[\d]/`) and nested classes are documented follow-ups. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784023232&installation_id=136613492&pr_number=303&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F303&signature=1844cd94d387d4cd9d320621f3d79aa23ef37a373d7376c2855c805602823b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->