### PR TITLE
port(sonarjs): port duplicates-in-character-class (S5869)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 58] = [
+pub const RULE_NAMES: [&str; 59] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -82,6 +82,7 @@ pub const RULE_NAMES: [&str; 58] = [
     "no-regex-spaces",
     "no-control-regex",
     "single-char-in-character-classes",
+    "duplicates-in-character-class",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -7,6 +7,7 @@ mod class_name;
 mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
+mod duplicates_in_character_class;
 mod elseif_without_else;
 mod fixme_tag;
 mod for_in;

--- a/crates/sonarjs/src/rules/duplicates_in_character_class.rs
+++ b/crates/sonarjs/src/rules/duplicates_in_character_class.rs
@@ -1,0 +1,77 @@
+//! Rule `duplicates-in-character-class` (SonarJS key S5869).
+//!
+//! A character class that lists the same character more than once (`[aa]`) is
+//! redundant: the duplicate matches nothing extra and usually signals a typo or
+//! a misunderstanding of the pattern.
+//!
+//! **Flagged** — a literal character that appears more than once in the same
+//! character class:
+//! - `/[aa]/`
+//! - `/[abca]/` (the second `a`)
+//!
+//! **Not flagged**:
+//! - `/[ab]/` — distinct characters.
+//! - `/[a-z]/` — a range, not repeated literals.
+//!
+//! Narrow form: only exact duplicate *literal characters* within one class are
+//! reported. Overlaps that involve ranges or class escapes (for example `\w`
+//! overlapping `a`, or `\s` overlapping `\t`) are a documented follow-up, which
+//! keeps the rule free of false positives. Behaviour is reproduced from the
+//! public RSPEC description (S5869) only; no upstream source, tests, fixtures,
+//! or message strings were consulted or copied.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{CharacterClass, CharacterClassContents, Disjunction, Term};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "duplicates-in-character-class";
+
+/// Pushes the span of every literal character that repeats an earlier literal
+/// character in the same class body.
+fn collect_duplicate_chars(class: &CharacterClass<'_>, out: &mut SmallVec<[Span; 8]>) {
+    let mut seen: SmallVec<[u32; 8]> = SmallVec::new();
+    for content in class.body.iter() {
+        if let CharacterClassContents::Character(c) = content {
+            if seen.contains(&c.value) {
+                out.push(c.span);
+            } else {
+                seen.push(c.value);
+            }
+        }
+    }
+}
+
+fn collect_in_term(term: &Term<'_>, out: &mut SmallVec<[Span; 8]>) {
+    match term {
+        Term::CharacterClass(class) => collect_duplicate_chars(class, out),
+        Term::CapturingGroup(group) => collect_in_disjunction(&group.body, out),
+        Term::IgnoreGroup(group) => collect_in_disjunction(&group.body, out),
+        Term::LookAroundAssertion(look) => collect_in_disjunction(&look.body, out),
+        Term::Quantifier(quant) => collect_in_term(&quant.body, out),
+        _ => {}
+    }
+}
+
+fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>) {
+    for alt in disj.body.iter() {
+        for term in alt.body.iter() {
+            collect_in_term(term, out);
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_duplicates_in_character_class(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            collect_in_disjunction(&pattern.body, &mut out);
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "duplicateCharacter", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -274,6 +274,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_regex_spaces(it);
         self.check_no_control_regex(it);
         self.check_single_char_in_character_classes(it);
+        self.check_duplicates_in_character_class(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2687,3 +2687,33 @@ fn does_not_report_single_char_in_character_classes_for_negated_class() {
     let diagnostics = scan("single-char-in-character-classes", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_duplicates_in_character_class_for_repeated_char() {
+    let source = "const r = /[aa]/;";
+    let diagnostics = scan("duplicates-in-character-class", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "duplicates-in-character-class");
+    assert_eq!(diagnostics[0].message_id, "duplicateCharacter");
+}
+
+#[test]
+fn reports_duplicates_in_character_class_for_non_adjacent_repeat() {
+    let source = "const r = /[abca]/;";
+    let diagnostics = scan("duplicates-in-character-class", source);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn does_not_report_duplicates_in_character_class_for_distinct_chars() {
+    let source = "const r = /[abc]/;";
+    let diagnostics = scan("duplicates-in-character-class", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_duplicates_in_character_class_for_range() {
+    let source = "const r = /[a-z]/;";
+    let diagnostics = scan("duplicates-in-character-class", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -89,6 +89,9 @@ const messages = Object.freeze({
   'single-char-in-character-classes': {
     singleCharInCharacterClass: 'Replace this single-character class with the character itself.',
   },
+  'duplicates-in-character-class': {
+    duplicateCharacter: 'Remove this duplicated character from the character class.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -254,6 +257,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow control characters written as \\x, \\u, or \\c escapes in regular expressions',
   'single-char-in-character-classes':
     'Disallow a regular-expression character class that contains only a single literal character',
+  'duplicates-in-character-class':
+    'Disallow the same literal character appearing more than once in a regular-expression character class',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -352,6 +357,7 @@ const ruleTypes = Object.freeze({
   'no-regex-spaces': 'suggestion',
   'no-control-regex': 'suggestion',
   'single-char-in-character-classes': 'suggestion',
+  'duplicates-in-character-class': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -413,6 +419,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-regex-spaces': 'error',
   'no-control-regex': 'error',
   'single-char-in-character-classes': 'error',
+  'duplicates-in-character-class': 'error',
   'generator-without-yield': 'error',
   'no-exclusive-tests': 'error',
   'no-built-in-override': 'error',

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -61,6 +61,7 @@ const expectedRuleNames = [
   'no-regex-spaces',
   'no-control-regex',
   'single-char-in-character-classes',
+  'duplicates-in-character-class',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -2006,6 +2007,18 @@ describe('sonarjs native API', () => {
 
   it('does not report single-char-in-character-classes for a multi-character class', () => {
     const diagnostics = scan('single-char-in-character-classes', 'const r = /[ab]/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports duplicates-in-character-class for a repeated character', () => {
+    const diagnostics = scan('duplicates-in-character-class', 'const r = /[aa]/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('duplicates-in-character-class');
+    expect(diagnostics[0].messageId).toBe('duplicateCharacter');
+  });
+
+  it('does not report duplicates-in-character-class for distinct characters', () => {
+    const diagnostics = scan('duplicates-in-character-class', 'const r = /[abc]/;');
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -152,6 +152,7 @@ describe('sonarjs plugin shape', () => {
       'no-regex-spaces',
       'no-control-regex',
       'single-char-in-character-classes',
+      'duplicates-in-character-class',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -211,6 +212,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-regex-spaces']).toBe('object');
     expect(typeof plugin.rules['no-control-regex']).toBe('object');
     expect(typeof plugin.rules['single-char-in-character-classes']).toBe('object');
+    expect(typeof plugin.rules['duplicates-in-character-class']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -274,6 +276,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/single-char-in-character-classes']).toBe(
       'error',
     );
+    expect(plugin.configs.recommended.rules['sonarjs/duplicates-in-character-class']).toBe('error');
   });
 });
 
@@ -1297,5 +1300,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(single-char-in-character-classes)');
+  });
+
+  it('reports duplicates-in-character-class through the adapter', () => {
+    const source = 'const r = /[aa]/;';
+    const reports = runRule('duplicates-in-character-class', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('duplicateCharacter');
+  });
+
+  it('reports duplicates-in-character-class through the CLI', () => {
+    const result = runOxlint('duplicates-in-character-class', 'const r = /[aa]/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(duplicates-in-character-class)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10990,19 +10990,19 @@
       },
       {
         "name": "duplicates-in-character-class",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule duplicates-in-character-class (Sonar key S5869). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room narrow port (Sonar key S5869). Uses the shared regex_ast helper to walk a regex literal; within each CharacterClass body, flags every CharacterClassContents::Character whose codepoint value repeats an earlier literal character in the same class. Overlaps involving ranges or class escapes (\\w over a, \\s over \\t) are a documented follow-up, keeping the rule free of false positives. No upstream source, fixtures, tests, or messages were consulted or copied."
       },
       {
         "name": "dynamically-constructed-templates",


### PR DESCRIPTION
Clean-room narrow port of the SonarJS `duplicates-in-character-class` rule (Sonar key S5869), built on the regex-AST helper (#276).

Within each character class, flags every literal character whose codepoint repeats an earlier literal character in the same class.

- **Flagged:** `/[aa]/`, the second `a` in `/[abca]/`
- **Not flagged:** `/[ab]/`, `/[a-z]/` (distinct chars / a range)

Overlaps involving ranges or class escapes (`\w` over `a`, `\s` over `\t`) are a documented follow-up, keeping the rule free of false positives. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784023815&installation_id=136613492&pr_number=304&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F304&signature=760188100e4aaec9ed31e30aea7b22c462d496e106dfe6b099ac36e8f3a9e33c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->