### PR TITLE
feat(postgresql): port no-equality-with-null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "postgresql-eslint-parser-napi"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-postgresql",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1783,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -6,6 +6,7 @@ use crate::RuleDef;
 mod no_cluster;
 mod no_distinct_on_without_order_by;
 mod no_drop_database;
+mod no_equality_with_null;
 mod no_implicit_join;
 mod no_rename_column;
 mod no_select_star;
@@ -113,6 +114,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-cluster",
     "no-distinct-on-without-order-by",
     "no-drop-database",
+    "no-equality-with-null",
     "no-implicit-join",
     "no-rename-column",
     "no-select-star",
@@ -137,6 +139,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-drop-database",
         run: no_drop_database::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-equality-with-null",
+        run: no_equality_with_null::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_equality_with_null.rs
+++ b/crates/postgresql/src/rules/no_equality_with_null.rs
@@ -1,0 +1,45 @@
+//! Port of `no-equality-with-null`: disallow `x = NULL` / `x <> NULL`.
+//! PostgreSQL's three-valued logic makes both evaluate to NULL (never true),
+//! silently filtering rows the author probably wanted.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+fn is_null_const(node: &Value) -> bool {
+    is_type(node, "A_Const") && node.get("isnull") == Some(&Value::Bool(true))
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "A_Expr") {
+        return;
+    }
+    if str_field(node, "kind") != Some("AEXPR_OP") {
+        return;
+    }
+    let Some(name) = array_field(node, "name") else {
+        return;
+    };
+    if name.len() != 1 {
+        return;
+    }
+    let Some(op) = name[0].get("sval").and_then(Value::as_str) else {
+        return;
+    };
+    if op != "=" && op != "<>" {
+        return;
+    }
+    let lexpr_null = field(node, "lexpr").is_some_and(is_null_const);
+    let rexpr_null = field(node, "rexpr").is_some_and(is_null_const);
+    if !lexpr_null && !rexpr_null {
+        return;
+    }
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("op"),
+        value: CompactString::from(op),
+    });
+    ctx.report_data(node, "useIsNull", data);
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 // Oxlint plugin port of eslint-plugin-postgresql (MIT).
 // SQL is parsed (libpg_query, PostgreSQL 17) and every rule runs in Rust through
@@ -7,133 +7,146 @@
 // adapter and native API while keeping CLI integration disabled in status
 // metadata (mirroring the @eslint/json and @eslint/markdown ports).
 
-const { eslintCompatPlugin } = require('@oxlint/plugins');
-const { implementedPostgresqlRuleNames, scanPostgresql } = require('./api.js');
+const { eslintCompatPlugin } = require("@oxlint/plugins");
+const { implementedPostgresqlRuleNames, scanPostgresql } = require("./api.js");
 
-const PLUGIN_NAME = 'postgresql';
-const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/postgresql';
+const PLUGIN_NAME = "postgresql";
+const DOCS_BASE =
+  "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/postgresql";
 const diagnosticsCache = new WeakMap();
 
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
-  'no-cluster': {
-    type: 'problem',
+  "no-cluster": {
+    type: "problem",
     description:
-      'Disallow the `CLUSTER` statement: it takes ACCESS EXCLUSIVE, rewrites the table, and is not maintained afterwards',
+      "Disallow the `CLUSTER` statement: it takes ACCESS EXCLUSIVE, rewrites the table, and is not maintained afterwards",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noCluster:
-        '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
+        "`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.",
     },
   },
-  'no-distinct-on-without-order-by': {
-    type: 'problem',
+  "no-distinct-on-without-order-by": {
+    type: "problem",
     description:
-      'Disallow `SELECT DISTINCT ON (...)` without an `ORDER BY`; the surviving row in each group is otherwise non-deterministic',
+      "Disallow `SELECT DISTINCT ON (...)` without an `ORDER BY`; the surviving row in each group is otherwise non-deterministic",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noDistinctOnWithoutOrderBy:
-        '`DISTINCT ON (...)` keeps an arbitrary row from each group unless `ORDER BY` is specified. Add an `ORDER BY` whose leading columns match the `DISTINCT ON` expressions.',
+        "`DISTINCT ON (...)` keeps an arbitrary row from each group unless `ORDER BY` is specified. Add an `ORDER BY` whose leading columns match the `DISTINCT ON` expressions.",
     },
   },
-  'no-drop-database': {
-    type: 'problem',
+  "no-drop-database": {
+    type: "problem",
     description:
-      'Disallow `DROP DATABASE`; it is catastrophic if run by accident and should not live in versioned SQL',
+      "Disallow `DROP DATABASE`; it is catastrophic if run by accident and should not live in versioned SQL",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noDropDatabase:
-        '`DROP DATABASE` is catastrophic and irreversible. Database creation/deletion belongs in an explicit operator workflow, not in versioned SQL applied automatically by a migration tool.',
+        "`DROP DATABASE` is catastrophic and irreversible. Database creation/deletion belongs in an explicit operator workflow, not in versioned SQL applied automatically by a migration tool.",
     },
   },
-  'no-select-star': {
-    type: 'suggestion',
+  "no-equality-with-null": {
+    type: "problem",
     description:
-      'Disallow `SELECT *` in queries to keep result schemas stable when the underlying table changes',
+      "Disallow `x = NULL` / `x <> NULL`; PostgreSQL's three-valued logic makes both expressions evaluate to NULL (i.e. neither true nor false), which silently filters away rows the author probably wanted",
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      useIsNull:
+        "`{{op}} NULL` always evaluates to NULL (treated as false). Use `IS NULL` / `IS NOT NULL` instead.",
+    },
+  },
+  "no-select-star": {
+    type: "suggestion",
+    description:
+      "Disallow `SELECT *` in queries to keep result schemas stable when the underlying table changes",
     recommended: false,
     fixable: undefined,
     schema: [],
     messages: {
       noSelectStar:
-        'Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.',
+        "Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.",
     },
   },
-  'no-implicit-join': {
-    type: 'suggestion',
+  "no-implicit-join": {
+    type: "suggestion",
     description:
-      'Disallow comma-separated FROM clauses (implicit cross joins); use explicit JOIN syntax',
+      "Disallow comma-separated FROM clauses (implicit cross joins); use explicit JOIN syntax",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noImplicitJoin:
-        'Comma-separated tables in `FROM` are an implicit cross join. Use explicit `JOIN ... ON ...` so the join condition lives next to the join.',
+        "Comma-separated tables in `FROM` are an implicit cross join. Use explicit `JOIN ... ON ...` so the join condition lives next to the join.",
     },
   },
-  'no-rename-column': {
-    type: 'problem',
+  "no-rename-column": {
+    type: "problem",
     description:
-      'Disallow `ALTER TABLE ... RENAME COLUMN` — every deployed reader of the old name breaks at deploy time',
+      "Disallow `ALTER TABLE ... RENAME COLUMN` — every deployed reader of the old name breaks at deploy time",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noRenameColumn:
-        '`RENAME COLUMN` breaks every running app that still selects/inserts by the old name. The safer pattern is to add a new column, dual-write, backfill, and drop the old one across separate deploys.',
+        "`RENAME COLUMN` breaks every running app that still selects/inserts by the old name. The safer pattern is to add a new column, dual-write, backfill, and drop the old one across separate deploys.",
     },
   },
-  'no-set-not-null': {
-    type: 'problem',
+  "no-set-not-null": {
+    type: "problem",
     description:
-      'Disallow `ALTER COLUMN ... SET NOT NULL` because it scans the whole table under ACCESS EXCLUSIVE',
+      "Disallow `ALTER COLUMN ... SET NOT NULL` because it scans the whole table under ACCESS EXCLUSIVE",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noSetNotNull:
-        '`SET NOT NULL` scans the whole table for nulls under an `ACCESS EXCLUSIVE` lock. The safe pattern in production is to add a `CHECK (col IS NOT NULL) NOT VALID` constraint, `VALIDATE CONSTRAINT` separately, then `SET NOT NULL` (PG ≥ 12 reuses the validated CHECK and skips the scan).',
+        "`SET NOT NULL` scans the whole table for nulls under an `ACCESS EXCLUSIVE` lock. The safe pattern in production is to add a `CHECK (col IS NOT NULL) NOT VALID` constraint, `VALIDATE CONSTRAINT` separately, then `SET NOT NULL` (PG ≥ 12 reuses the validated CHECK and skips the scan).",
     },
   },
-  'no-set-search-path': {
-    type: 'suggestion',
+  "no-set-search-path": {
+    type: "suggestion",
     description:
-      'Disallow `SET search_path = ...` in versioned SQL; qualify identifiers with their schema instead',
+      "Disallow `SET search_path = ...` in versioned SQL; qualify identifiers with their schema instead",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noSetSearchPath:
-        '`SET search_path` makes name resolution depend on session state and is a known foot-gun for security-definer functions and CREATE statements. Qualify identifiers with their schema (`audit.events`, `public.users`) instead.',
+        "`SET search_path` makes name resolution depend on session state and is a known foot-gun for security-definer functions and CREATE statements. Qualify identifiers with their schema (`audit.events`, `public.users`) instead.",
     },
   },
-  'no-temporary-table': {
-    type: 'suggestion',
+  "no-temporary-table": {
+    type: "suggestion",
     description:
-      'Disallow `CREATE TEMPORARY TABLE` in versioned SQL — temp tables exist for the session only and rarely belong in migration files',
+      "Disallow `CREATE TEMPORARY TABLE` in versioned SQL — temp tables exist for the session only and rarely belong in migration files",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       noTemporaryTable:
-        '`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.',
+        "`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.",
     },
   },
-  'require-limit': {
-    type: 'suggestion',
-    description: 'Require LIMIT clause in SELECT statements',
+  "require-limit": {
+    type: "suggestion",
+    description: "Require LIMIT clause in SELECT statements",
     recommended: true,
     fixable: undefined,
     schema: [],
     messages: {
       missingLimit:
-        'SELECT statement should include a LIMIT clause to prevent excessive data retrieval',
+        "SELECT statement should include a LIMIT clause to prevent excessive data retrieval",
     },
   },
 });
@@ -143,26 +156,34 @@ const recommendedRuleNames = Object.freeze(
   implementedRuleNames.filter((name) => ruleMeta[name]?.recommended === true),
 );
 const recommendedRuleConfig = Object.freeze(
-  Object.fromEntries(recommendedRuleNames.map((name) => [`${PLUGIN_NAME}/${name}`, 'error'])),
+  Object.fromEntries(
+    recommendedRuleNames.map((name) => [`${PLUGIN_NAME}/${name}`, "error"]),
+  ),
 );
 const allRuleConfig = Object.freeze(
-  Object.fromEntries(implementedRuleNames.map((name) => [`${PLUGIN_NAME}/${name}`, 'error'])),
+  Object.fromEntries(
+    implementedRuleNames.map((name) => [`${PLUGIN_NAME}/${name}`, "error"]),
+  ),
 );
 
 const rules = Object.freeze(
-  Object.fromEntries(implementedRuleNames.map((name) => [name, createPostgresqlRule(name)])),
+  Object.fromEntries(
+    implementedRuleNames.map((name) => [name, createPostgresqlRule(name)]),
+  ),
 );
 
 const plugin = eslintCompatPlugin({
   meta: {
-    name: 'eslint-plugin-postgresql',
-    version: '0.22.1',
+    name: "eslint-plugin-postgresql",
+    version: "0.22.1",
   },
   rules,
-  rulesConfig: Object.fromEntries(implementedRuleNames.map((name) => [name, 0])),
+  rulesConfig: Object.fromEntries(
+    implementedRuleNames.map((name) => [name, 0]),
+  ),
   configs: {
-    recommended: configFromRuleConfig('recommended', recommendedRuleConfig),
-    all: configFromRuleConfig('all', allRuleConfig),
+    recommended: configFromRuleConfig("recommended", recommendedRuleConfig),
+    all: configFromRuleConfig("all", allRuleConfig),
   },
 });
 
@@ -181,7 +202,7 @@ function createPostgresqlRule(ruleName) {
   const meta = ruleMeta[ruleName] ?? {};
   return {
     meta: {
-      type: meta.type ?? 'suggestion',
+      type: meta.type ?? "suggestion",
       docs: {
         description: meta.description,
         recommended: meta.recommended === true,
@@ -215,9 +236,10 @@ function diagnosticsForRule(context, ruleName) {
   const cacheKey = `${ruleName}\0${JSON.stringify(options)}`;
   let diagnostics = bySource.get(cacheKey);
   if (!diagnostics) {
-    diagnostics = scanPostgresql(sourceCode.text, { ruleNames: [ruleName], options }).filter(
-      (diagnostic) => diagnostic.ruleName === ruleName,
-    );
+    diagnostics = scanPostgresql(sourceCode.text, {
+      ruleNames: [ruleName],
+      options,
+    }).filter((diagnostic) => diagnostic.ruleName === ruleName);
     bySource.set(cacheKey, diagnostics);
   }
 

--- a/status.json
+++ b/status.json
@@ -5303,19 +5303,19 @@
       },
       {
         "name": "no-equality-with-null",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-equality-with-null."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-equality-with-null; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-grant-all",


### PR DESCRIPTION
Part of #14. Ports `no-equality-with-null`.

Disallow `x = NULL` / `x <> NULL`; PostgreSQL's three-valued logic makes both expressions evaluate to NULL (never true), silently filtering rows the author probably wanted. Uses `IS NULL` / `IS NOT NULL` instead. `!=` is normalized to `<>` by libpg_query.

Validated locally against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784024184&installation_id=136613492&pr_number=305&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F305&signature=95a9bdc31964661aee55b716dc71609077ccf40636bbbe3dd2cbbd44e0d3e012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->