### PR TITLE
fix(postgresql-eslint-parser): harden parser against deep input + FFI edge cases

### DIFF
--- a/crates/postgresql/src/embedded_code.rs
+++ b/crates/postgresql/src/embedded_code.rs
@@ -149,12 +149,13 @@ fn find_body_token(tokens: &[Token], start_search_from: u32) -> Option<BodyToken
             // u32. The closing `$` of the opening tag sits one past its index in
             // the `$`-stripped remainder.
             let tag_length = (after_dollar.find('$')? + 2) as u32;
-            // The token always spans at least its opening tag, so subtracting
-            // the tag length from `token.end` never underflows.
-            debug_assert!(token.end >= token.start + tag_length);
+            // The token normally spans both tags, but guard the subtraction
+            // anyway: an unterminated literal scanned to EOF could be shorter
+            // than two tags, and a wrapped `u32` would corrupt the range.
+            let inner_end = token.end.checked_sub(tag_length)?;
             return Some(BodyTokenInfo {
                 inner_start: token.start + tag_length,
-                inner_end: token.end - tag_length,
+                inner_end,
                 quote_style: "dollar",
             });
         }
@@ -164,7 +165,7 @@ fn find_body_token(tokens: &[Token], start_search_from: u32) -> Option<BodyToken
             // contents (sourceMap support for `''` escapes is deferred upstream).
             return Some(BodyTokenInfo {
                 inner_start: token.start + 1,
-                inner_end: token.end - 1,
+                inner_end: token.end.checked_sub(1)?,
                 quote_style: "single",
             });
         }

--- a/crates/postgresql/src/eslint.rs
+++ b/crates/postgresql/src/eslint.rs
@@ -195,10 +195,10 @@ fn traverse_visitor_keys(node: &Value, visitor_keys: &mut Map<String, Value>) {
     // (see `manipulate::add_types`) rely on that ordering, so reproduce it here
     // rather than using serde_json's raw insertion order.
     for key in js_key_order(object) {
-        if SKIP_KEYS.contains(&key.as_str()) {
+        if SKIP_KEYS.contains(&key) {
             continue;
         }
-        let Some(value) = object.get(&key) else {
+        let Some(value) = object.get(key) else {
             continue;
         };
         match value {
@@ -207,7 +207,7 @@ fn traverse_visitor_keys(node: &Value, visitor_keys: &mut Map<String, Value>) {
                 // Upstream adds the key when the array holds an object *or* is
                 // simply non-empty (so non-empty primitive arrays count too).
                 if contains_object || !items.is_empty() {
-                    add_visitor_key(visitor_keys, &ty, &key);
+                    add_visitor_key(visitor_keys, &ty, key);
                 }
                 if contains_object {
                     for item in items {
@@ -216,7 +216,7 @@ fn traverse_visitor_keys(node: &Value, visitor_keys: &mut Map<String, Value>) {
                 }
             }
             Value::Object(_) => {
-                add_visitor_key(visitor_keys, &ty, &key);
+                add_visitor_key(visitor_keys, &ty, key);
                 traverse_visitor_keys(value, visitor_keys);
             }
             _ => {}
@@ -228,17 +228,17 @@ fn traverse_visitor_keys(node: &Value, visitor_keys: &mut Map<String, Value>) {
 /// array-index keys (`"0"`, `"1"`, …) first in ascending numeric order, then the
 /// remaining keys in insertion order. Mirrors the order upstream's JS
 /// `Object.entries`/`Object.keys` yields.
-fn js_key_order(object: &Map<String, Value>) -> Vec<String> {
-    let mut index_keys: Vec<u32> = Vec::new();
-    let mut other_keys: Vec<String> = Vec::new();
+fn js_key_order(object: &Map<String, Value>) -> Vec<&str> {
+    let mut index_keys: Vec<(u32, &str)> = Vec::new();
+    let mut other_keys: Vec<&str> = Vec::new();
     for key in object.keys() {
         match array_index(key) {
-            Some(index) => index_keys.push(index),
-            None => other_keys.push(key.clone()),
+            Some(index) => index_keys.push((index, key.as_str())),
+            None => other_keys.push(key.as_str()),
         }
     }
-    index_keys.sort_unstable();
-    let mut ordered: Vec<String> = index_keys.into_iter().map(|i| i.to_string()).collect();
+    index_keys.sort_unstable_by_key(|(index, _)| *index);
+    let mut ordered: Vec<&str> = index_keys.into_iter().map(|(_, key)| key).collect();
     ordered.extend(other_keys);
     ordered
 }

--- a/crates/postgresql/src/ffi.rs
+++ b/crates/postgresql/src/ffi.rs
@@ -65,9 +65,15 @@ pub fn parse_to_json(sql: &str) -> Result<String, String> {
                     .into_owned())
             }
         } else {
-            let message = CStr::from_ptr((*result.error).message)
-                .to_string_lossy()
-                .into_owned();
+            // `error` is non-null here, but its `message` field is itself a
+            // `*mut c_char` the C ABI allows to be null (e.g. on an allocation
+            // failure inside libpg_query); guard the deref rather than trust it.
+            let message_ptr = (*result.error).message;
+            let message = if message_ptr.is_null() {
+                "libpg_query reported an error with no message".to_string()
+            } else {
+                CStr::from_ptr(message_ptr).to_string_lossy().into_owned()
+            };
             Err(message)
         };
 

--- a/crates/postgresql/src/text.rs
+++ b/crates/postgresql/src/text.rs
@@ -163,9 +163,14 @@ mod tests {
 
     // The following mirror upstream `src/utils.test.ts` (`createLineMap` /
     // `createByteToCharOffset`) so position resolution and byte↔unit conversion
-    // track upstream exactly. ESLint columns are UTF-16 code units; upstream's
-    // negative-offset JS edge case is not representable in this `u32` API and is
-    // intentionally omitted (offsets are never negative in practice).
+    // track upstream exactly. ESLint columns are UTF-16 code units. Three
+    // upstream cases are intentionally not ported:
+    //   * the negative-offset case — not representable in this `u32` API (and
+    //     offsets are never negative in practice);
+    //   * the `lineMap.code` property — `Source` stores UTF-16 units, not the
+    //     original string, so there is no equivalent field;
+    //   * the large-document "performance comparison" — redundant correctness
+    //     coverage already exercised by the position tests below.
     fn pos(code: &str, offset: u32) -> (u32, u32) {
         let p = Source::new(code).position(offset);
         (p.line, p.column)

--- a/npm/postgresql-eslint-parser/README.md
+++ b/npm/postgresql-eslint-parser/README.md
@@ -35,6 +35,11 @@ The public API mirrors upstream:
 - `parseForESLint(code)` → `{ ast, visitorKeys, scopeManager }` (`scopeManager`
   is always `null`, matching upstream).
 - `parse(code)` → the `Program` AST node.
+- `extractEmbeddedCode(program)` → `EmbeddedCode[]` — collect the embedded PL
+  function bodies from a parsed AST, in source order.
+
+A `./processor` entry point exports `createPlProcessor({ languages })`, an ESLint
+processor that lints those embedded PL bodies as virtual files.
 
 ## Supported platforms
 

--- a/npm/postgresql-eslint-parser/src/lib.rs
+++ b/npm/postgresql-eslint-parser/src/lib.rs
@@ -18,10 +18,26 @@ mod napi_abi {
     use napi_derive::napi;
     use oxlint_plugins_postgresql as core;
 
+    // libpg_query's bison parser keeps its grammar stack on the heap
+    // (`YYMAXDEPTH` ~ 10000), so a pathologically nested statement can yield an
+    // AST far deeper than the native call stack tolerates. The enrichment passes
+    // (`add_types`/`add_location`/…/`build_visitor_keys`) recurse over that tree,
+    // and a stack overflow under the release profile's `panic = "abort"` would
+    // abort the whole linter process. Run the parse on a dedicated thread with a
+    // large (reserved, not committed) stack so any realistically reachable depth
+    // is handled without truncating valid input.
+    const PARSE_STACK_SIZE: usize = 256 * 1024 * 1024;
+
     /// Parse `sourceText` and return the upstream `parseForESLint` result as a
     /// JSON string (`{ "ast": …, "visitorKeys": …, "scopeManager": null }`).
     #[napi]
     pub fn parse_for_eslint_json(source_text: String) -> String {
-        core::parse_for_eslint_json(&source_text)
+        std::thread::Builder::new()
+            .name("postgresql-parse".to_string())
+            .stack_size(PARSE_STACK_SIZE)
+            .spawn(move || core::parse_for_eslint_json(&source_text))
+            .expect("failed to spawn parser thread")
+            .join()
+            .expect("parser thread panicked")
     }
 }


### PR DESCRIPTION
Part of #15 — final-review hardening of the `postgresql-eslint-parser` port (follows #268, #301).

A multi-dimensional review (correctness, security, performance, design, tests) found one MAJOR and several minor items; this PR addresses them.

## MAJOR — deep-input recursion safety
libpg_query's bison parser keeps its grammar stack on the heap (`YYMAXDEPTH` ~10000), so a pathologically nested statement can yield an AST far deeper than the native call stack tolerates. The enrichment + visitor-key passes recurse over that tree, and a stack overflow under the release profile's `panic = "abort"` would abort the whole linter process. **Fix:** run the parse on a dedicated 256 MiB-stack thread at the NAPI entry (stack is reserved, not committed), handling any realistically reachable depth without truncating valid input.

## Hardening / docs / perf
- **FFI**: guard the libpg_query error `message` pointer against null before deref.
- **embedded_code**: replace the release-stripped `debug_assert!` with real `checked_sub` guards, so an unterminated dollar/single-quoted literal can never wrap a `u32` range.
- **Docs**: README now lists `extractEmbeddedCode` + the `./processor` entry; the `text.rs` test note enumerates the three intentionally-omitted upstream `utils.test.ts` cases (negative offset, `.code` property, perf loop).
- **Perf**: `js_key_order` borrows keys instead of cloning them per AST node.

Reviewers confirmed **no other major issues**: the FFI is otherwise sound (interior-NUL handled, C strings copied before free, free is unconditional), all ported tests faithfully match upstream assertions, and the full upstream test suite (fixtures + parse + utils + processor + embeddedCode) is at parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784024823&installation_id=136613492&pr_number=311&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F311&signature=6d779fd4ed61e82e6d23fcba7cc2ccdf8b26041a5002f1a1fe41c7cdc7277812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->