### PR TITLE
fix(eslint-markdown): parse the upstream dialect (commonmark vs gfm)

### DIFF
--- a/crates/eslint_markdown/src/lib.rs
+++ b/crates/eslint_markdown/src/lib.rs
@@ -73,8 +73,20 @@ const MDAST_RULES: &[&str] = &[
 
 // Parse the source into an mdast tree with the same constructs upstream enables
 // for `markdown/gfm` (GFM tables, autolink literals, footnotes, strikethrough).
-fn parse_mdast(source_text: &str, math: bool, frontmatter: bool) -> Option<mdast::Node> {
-    let mut options = markdown::ParseOptions::gfm();
+fn parse_mdast(
+    source_text: &str,
+    math: bool,
+    frontmatter: bool,
+    commonmark: bool,
+) -> Option<mdast::Node> {
+    // The dialect mirrors the upstream RuleTester `language`: `markdown/gfm`
+    // (default for Oxlint) adds tables, autolink literals, strikethrough and
+    // footnotes; `markdown/commonmark` enables none of those.
+    let mut options = if commonmark {
+        markdown::ParseOptions::default()
+    } else {
+        markdown::ParseOptions::gfm()
+    };
     if math {
         options.constructs.math_flow = true;
         options.constructs.math_text = true;
@@ -151,6 +163,8 @@ pub struct ScanOptions {
     pub math: bool,
     /// Whether `---`/`+++` frontmatter is parsed (upstream `languageOptions.frontmatter`).
     pub frontmatter: bool,
+    /// Parse as CommonMark instead of GFM (upstream `language: "markdown/commonmark"`).
+    pub commonmark: bool,
 }
 
 impl Default for ScanOptions {
@@ -178,6 +192,7 @@ impl Default for ScanOptions {
             check_missing_table_cells: false,
             math: false,
             frontmatter: false,
+            commonmark: false,
         }
     }
 }
@@ -318,7 +333,12 @@ pub fn scan_eslint_markdown(
         MarkdownFacts::default()
     };
     let mdast = if MDAST_RULES.iter().any(|rule| options.is_enabled(rule)) {
-        parse_mdast(source_text, options.math, options.frontmatter)
+        parse_mdast(
+            source_text,
+            options.math,
+            options.frontmatter,
+            options.commonmark,
+        )
     } else {
         None
     };

--- a/npm/eslint-markdown/api.d.ts
+++ b/npm/eslint-markdown/api.d.ts
@@ -79,6 +79,7 @@ export type ScanEslintMarkdownOptions = {
   checkMissingTableCells?: boolean;
   math?: boolean;
   frontmatter?: boolean;
+  commonmark?: boolean;
 };
 
 export function implementedEslintMarkdownRuleNames(): EslintMarkdownRuleName[];

--- a/npm/eslint-markdown/api.js
+++ b/npm/eslint-markdown/api.js
@@ -41,6 +41,7 @@ function normalizeOptions(options) {
     checkMissingTableCells: normalizeBoolean(options.checkMissingTableCells),
     math: normalizeBoolean(options.math),
     frontmatter: normalizeBoolean(options.frontmatter),
+    commonmark: normalizeBoolean(options.commonmark),
   };
 }
 

--- a/npm/eslint-markdown/index.js
+++ b/npm/eslint-markdown/index.js
@@ -348,6 +348,12 @@ function diagnosticsForRule(context, ruleName) {
   if (context.languageOptions?.frontmatter) {
     scanOptions.frontmatter = true;
   }
+  // Dialect: Oxlint drives Markdown as GFM by default. The parity harness selects
+  // the CommonMark dialect (upstream `language: "markdown/commonmark"`) by setting
+  // `languageOptions.commonmark`.
+  if (context.languageOptions?.commonmark === true) {
+    scanOptions.commonmark = true;
+  }
   const cacheKey = `${ruleName}\0${JSON.stringify(scanOptions)}`;
   let diagnostics = bySource.get(cacheKey);
   if (!diagnostics) {

--- a/npm/eslint-markdown/src/lib.rs
+++ b/npm/eslint-markdown/src/lib.rs
@@ -36,6 +36,7 @@ mod napi_abi {
         pub check_missing_table_cells: Option<bool>,
         pub math: Option<bool>,
         pub frontmatter: Option<bool>,
+        pub commonmark: Option<bool>,
     }
 
     #[napi(object)]
@@ -131,6 +132,7 @@ mod napi_abi {
             check_missing_table_cells: options.check_missing_table_cells.unwrap_or(false),
             math: options.math.unwrap_or(false),
             frontmatter: options.frontmatter.unwrap_or(false),
+            commonmark: options.commonmark.unwrap_or(false),
         };
 
         if core_options.rule_names.is_empty() && default_rule_names {

--- a/npm/eslint-markdown/test/fixtures/no-missing-label-refs.json
+++ b/npm/eslint-markdown/test/fixtures/no-missing-label-refs.json
@@ -273,7 +273,8 @@
         {
           "allowLabels": ["-"]
         }
-      ]
+      ],
+      "language": "markdown/gfm"
     },
     {
       "code": "$(A \\\\cdot x)[i] = \\\\sum_{j=1}^{n} A[i][j] , x[j]$",

--- a/npm/eslint-markdown/test/fixtures/no-reference-like-urls.json
+++ b/npm/eslint-markdown/test/fixtures/no-reference-like-urls.json
@@ -54,10 +54,12 @@
       "code": "![image](<uri>)\n\n[uri]: https://example.com/uri"
     },
     {
-      "code": "<http://foo>\n\n[http://foo]: hi"
+      "code": "<http://foo>\n\n[http://foo]: hi",
+      "language": "markdown/gfm"
     },
     {
-      "code": "http://foo\n\n[http://foo]: hi"
+      "code": "http://foo\n\n[http://foo]: hi",
+      "language": "markdown/gfm"
     },
     {
       "code": "# Heading with [Mercury](mercury)\n# Heading with ![Mercury](mercury)\n\n[venus]: https://example.com/venus/"
@@ -72,10 +74,12 @@
       "code": "Heading with [Mercury][mercury]\n===============================\nHeading with ![Mercury][mercury]\n================================\n\n[mercury]: https://example.com/mercury"
     },
     {
-      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury](mercury)  |\n| Mercury | ![Mercury](mercury) |\n\n[venus]: https://example.com/venus/"
+      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury](mercury)  |\n| Mercury | ![Mercury](mercury) |\n\n[venus]: https://example.com/venus/",
+      "language": "markdown/gfm"
     },
     {
-      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury][mercury]  |\n| Mercury | ![Mercury][mercury] |\n\n[mercury]: https://example.com/mercury"
+      "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury][mercury]  |\n| Mercury | ![Mercury][mercury] |\n\n[mercury]: https://example.com/mercury",
+      "language": "markdown/gfm"
     },
     {
       "code": "\\[Mercury](mercury)\n\n[mercury]: https://example.com/mercury"
@@ -873,6 +877,7 @@
     },
     {
       "code": "| Planet  | Link                |\n|---------|---------------------|\n| Mercury | [Mercury](mercury)  |\n| Mercury | ![Mercury](mercury) |\n\n[mercury]: https://example.com/mercury",
+      "language": "markdown/gfm",
       "errors": [
         {
           "messageId": "referenceLikeUrl",

--- a/npm/eslint-markdown/test/fixtures/no-reversed-media-syntax.json
+++ b/npm/eslint-markdown/test/fixtures/no-reversed-media-syntax.json
@@ -174,7 +174,8 @@
       "code": "[(hi)[something]][ref]\n\n[ref]: https://example.com"
     },
     {
-      "code": "| ESLint                        | Sunset                            |\n| ----------------------------- | --------------------------------- |\n| [ESLint](https://eslint.org/) | ![A beautiful sunset](sunset.png) |"
+      "code": "| ESLint                        | Sunset                            |\n| ----------------------------- | --------------------------------- |\n| [ESLint](https://eslint.org/) | ![A beautiful sunset](sunset.png) |",
+      "language": "markdown/gfm"
     },
     {
       "code": "$(A \\cdot x)[i] = \\sum_{j=1}^{n} A[i][j] , x[j]$",
@@ -329,6 +330,7 @@
     },
     {
       "code": "(~~foo~~)[]",
+      "language": "markdown/gfm",
       "errors": [
         {
           "messageId": "reversedSyntax",
@@ -355,6 +357,7 @@
     },
     {
       "code": "[^1]: !(Footnote alt)[https://example.com]",
+      "language": "markdown/gfm",
       "errors": [
         {
           "messageId": "reversedSyntax",
@@ -368,6 +371,7 @@
     },
     {
       "code": "[^1]: (Footnote text)[https://example.com]",
+      "language": "markdown/gfm",
       "errors": [
         {
           "messageId": "reversedSyntax",
@@ -655,6 +659,7 @@
     },
     {
       "code": "| ESLint                        | Sunset                            |\n| ----------------------------- | --------------------------------- |\n| (ESLint)[https://eslint.org/] | !(A beautiful sunset)[sunset.png] |",
+      "language": "markdown/gfm",
       "errors": [
         {
           "messageId": "reversedSyntax",

--- a/npm/eslint-markdown/test/harness.mjs
+++ b/npm/eslint-markdown/test/harness.mjs
@@ -90,7 +90,9 @@ function applyFixes(code, descriptors) {
 
 // Run a rule over one case and return both the formatted reports and the raw
 // descriptors (the latter needed to apply fixes for `output` assertions).
-export function runRule(ruleName, testCase) {
+// `dialect` is the effective upstream `language` ('markdown/commonmark' or
+// 'markdown/gfm') for the case; it selects the parse dialect.
+export function runRule(ruleName, testCase, dialect = 'markdown/gfm') {
   const rule = plugin.rules[ruleName];
   if (!rule) {
     throw new Error(`Unknown rule: ${ruleName}`);
@@ -111,8 +113,12 @@ export function runRule(ruleName, testCase) {
     sourceCode,
     filename: testCase.filename ?? 'file.md',
     // Mirror the upstream RuleTester case's languageOptions (e.g. `{ math: true }`),
-    // which the adapter maps onto the scan options.
-    languageOptions: testCase.languageOptions,
+    // plus the dialect selector (`commonmark`), which the adapter maps onto the
+    // scan options.
+    languageOptions: {
+      ...testCase.languageOptions,
+      commonmark: dialect === 'markdown/commonmark',
+    },
     report(descriptor) {
       descriptors.push(descriptor);
     },

--- a/npm/eslint-markdown/test/upstream.test.mjs
+++ b/npm/eslint-markdown/test/upstream.test.mjs
@@ -106,13 +106,17 @@ describe('eslint-markdown upstream parity', () => {
     const ruleName = file.replace(/\.json$/, '');
     const fixture = JSON.parse(readFileSync(join(FIXTURES_DIR, file), 'utf8'));
     const quarantined = levelFor(ruleName) === 'off';
+    // The dialect for a case is its own `language` override, falling back to the
+    // suite-level language captured at sync time.
+    const suiteLanguage = fixture.__generated?.language ?? 'markdown/gfm';
+    const dialectOf = (testCase) => testCase.language ?? suiteLanguage;
 
     describe(ruleName, () => {
       describe('valid', () => {
         fixture.valid.forEach((testCase, index) => {
           const run = quarantined || !isReplayable(testCase) ? it.skip : it;
           run(label(testCase, index), () => {
-            expect(runRule(ruleName, testCase).reports).toEqual([]);
+            expect(runRule(ruleName, testCase, dialectOf(testCase)).reports).toEqual([]);
           });
         });
       });
@@ -124,7 +128,7 @@ describe('eslint-markdown upstream parity', () => {
             return;
           }
           it(label(testCase, index), () => {
-            const { reports, output } = runRule(ruleName, testCase);
+            const { reports, output } = runRule(ruleName, testCase, dialectOf(testCase));
             assertErrors(reports, testCase.errors);
             if ('output' in testCase) {
               const expectedOutput = testCase.output === null ? testCase.code : testCase.output;

--- a/tools/tasks/sync-eslint-markdown-tests.ts
+++ b/tools/tasks/sync-eslint-markdown-tests.ts
@@ -60,6 +60,7 @@ type RawCase =
       options?: unknown[];
       filename?: string;
       only?: boolean;
+      language?: string;
       languageOptions?: Record<string, unknown>;
       errors?: unknown;
     };
@@ -78,6 +79,7 @@ type NormCase = {
   code: string;
   options?: unknown[];
   filename?: string;
+  language?: string;
   languageOptions?: Record<string, unknown>;
   output?: string | null;
   errors?: NormError[] | number;
@@ -238,6 +240,10 @@ function normalizeCase(raw: RawCase, isInvalid: boolean): NormCase | null {
   }
   if (typeof value.filename === 'string') {
     out.filename = value.filename;
+  }
+  // A per-case `language` override (the suite-level language lives in __generated).
+  if (typeof value.language === 'string') {
+    out.language = value.language;
   }
   if (value.languageOptions && typeof value.languageOptions === 'object') {
     const languageOptions = safeClone(value.languageOptions);


### PR DESCRIPTION
Closes a parity-guarantee gap found in the final review: the harness replayed **every** case as GFM, so `markdown/commonmark` suites were parsed as GFM (passing only because GFM is a superset — a latent false-PASS risk on future submodule bumps).

Threads the dialect end to end:
- core `parse_mdast(.., commonmark)` → `ParseOptions::default()` (CommonMark) vs `gfm()`; through `ScanOptions` → NAPI → `api.js` → adapter (`languageOptions.commonmark`; Oxlint stays GFM by default).
- the sync captures each case's per-case `language` override (suite-level language already in `__generated.language`); the harness derives the effective dialect and selects CommonMark for `markdown/commonmark` cases.

All 21 rules still pass the full upstream suite — now under the dialect each case actually declares (verified locally; 3 commonmark suites with 11 per-case GFM overrides exercised both paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784025505&installation_id=136613492&pr_number=312&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F312&signature=7e82068ba4d510d7371ef5993b109d16b00b1f09f4735a2a9f32ca96c6c7f168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->