### PR TITLE
port(sonarjs): port anchor-precedence (S5850)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "postgresql-eslint-parser-napi"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-postgresql",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1783,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 59] = [
+pub const RULE_NAMES: [&str; 60] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -83,6 +83,7 @@ pub const RULE_NAMES: [&str; 59] = [
     "no-control-regex",
     "single-char-in-character-classes",
     "duplicates-in-character-class",
+    "anchor-precedence",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -1,6 +1,7 @@
 //! Clean-room rule implementations for the sonarjs port. Each module attaches
 //! one `check_*` method to [`crate::scanner::Scanner`].
 
+mod anchor_precedence;
 mod arguments_usage;
 mod array_constructor;
 mod class_name;

--- a/crates/sonarjs/src/rules/anchor_precedence.rs
+++ b/crates/sonarjs/src/rules/anchor_precedence.rs
@@ -1,0 +1,123 @@
+//! Rule `anchor-precedence` (SonarJS key S5850).
+//!
+//! Clean-room port. Behaviour is reproduced from the public RSPEC description
+//! (S5850) only; no upstream source, tests, fixtures, or message strings were
+//! consulted or copied.
+//!
+//! In a regular expression like `/^a|b|c$/`, operator precedence means the `^`
+//! anchors only the first alternative and `$` only the last:
+//! `(^a)|(b)|(c$)`. The author almost certainly intended `/^(a|b|c)$/`.
+//!
+//! ## What is flagged
+//!
+//! A **top-level** alternation with two or more alternatives where the first
+//! alternative begins with `^` or the last alternative ends with `$`, but the
+//! anchor is not consistently applied across every branch:
+//!
+//! ```js
+//! /^a|b|c$/   // flagged — ^ anchors only first, $ anchors only last
+//! /^a|b/      // flagged — ^ anchors only the first alternative
+//! /a|b$/      // flagged — $ anchors only the last alternative
+//! ```
+//!
+//! ## What is NOT flagged
+//!
+//! - `/^(a|b|c)$/` — one top-level alternative; nested `|` is inside a group.
+//! - `/^a$|^b$|^c$/` — every branch is fully anchored (first ends with `$`).
+//! - `/a|b|c/` — no anchors at all.
+//! - `/^\s+|\s+$/g` — exactly two alternatives with complementary anchors
+//!   (the "trim" idiom), explicitly excluded.
+//! - Any pattern where a middle alternative carries its own anchor (likely
+//!   intentional mixed anchoring).
+//!
+//! Only the top-level disjunction is inspected; the rule never recurses into
+//! groups or lookarounds.
+
+use oxc_ast::ast::RegExpLiteral;
+use oxc_regular_expression::ast::{Alternative, BoundaryAssertionKind, Disjunction, Term};
+use oxc_span::Span;
+use oxlint_plugins_carton::SmallVec;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "anchor-precedence";
+
+/// Returns `true` when the first term of `alt` is a `^` start-boundary
+/// assertion.
+fn starts_with_caret(alt: &Alternative<'_>) -> bool {
+    match alt.body.first() {
+        Some(Term::BoundaryAssertion(a)) => matches!(a.kind, BoundaryAssertionKind::Start),
+        _ => false,
+    }
+}
+
+/// Returns `true` when the last term of `alt` is a `$` end-boundary
+/// assertion.
+fn ends_with_dollar(alt: &Alternative<'_>) -> bool {
+    match alt.body.last() {
+        Some(Term::BoundaryAssertion(a)) => matches!(a.kind, BoundaryAssertionKind::End),
+        _ => false,
+    }
+}
+
+/// Checks the top-level disjunction for the anchor-precedence problem and
+/// pushes the disjunction span when a violation is found.
+fn check_top_level_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>) {
+    let alts = &disj.body;
+    let len = alts.len();
+    if len < 2 {
+        return;
+    }
+
+    let first = match alts.first() {
+        Some(a) => a,
+        None => return,
+    };
+    let last = match alts.last() {
+        Some(a) => a,
+        None => return,
+    };
+
+    // Complementary-anchor ("trim") exception: exactly two alternatives where
+    // the first starts with `^` and the second ends with `$`.  This covers
+    // patterns like `/^\s+|\s+$/g` that are not a precedence mistake.
+    if len == 2 && starts_with_caret(first) && ends_with_dollar(last) {
+        return;
+    }
+
+    let has_start_anchor = starts_with_caret(first);
+    let has_end_anchor = ends_with_dollar(last);
+    if !has_start_anchor && !has_end_anchor {
+        return;
+    }
+
+    // If the first alternative is fully anchored (it also ends with `$`) or
+    // the last starts with `^`, the author is using intentional varied
+    // anchoring across branches — not a precedence mistake.
+    if ends_with_dollar(first) || starts_with_caret(last) {
+        return;
+    }
+
+    // If any middle alternative carries its own anchor the pattern is more
+    // likely intentional.
+    for alt in alts.iter().skip(1).take(len - 2) {
+        if starts_with_caret(alt) || ends_with_dollar(alt) {
+            return;
+        }
+    }
+
+    out.push(disj.span);
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_anchor_precedence(&mut self, lit: &RegExpLiteral<'_>) {
+        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
+            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+            check_top_level_disjunction(&pattern.body, &mut out);
+            out
+        });
+        for span in spans {
+            self.report(RULE_NAME, "anchorPrecedence", span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -275,6 +275,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_no_control_regex(it);
         self.check_single_char_in_character_classes(it);
         self.check_duplicates_in_character_class(it);
+        self.check_anchor_precedence(it);
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2717,3 +2717,63 @@ fn does_not_report_duplicates_in_character_class_for_range() {
     let diagnostics = scan("duplicates-in-character-class", source);
     assert!(diagnostics.is_empty());
 }
+
+#[test]
+fn reports_anchor_precedence_for_caret_on_first_of_three_alts() {
+    let source = "const r = /^a|b|c$/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "anchor-precedence");
+    assert_eq!(diagnostics[0].message_id, "anchorPrecedence");
+}
+
+#[test]
+fn reports_anchor_precedence_for_caret_only_on_first_of_two_alts() {
+    let source = "const r = /^a|b/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "anchorPrecedence");
+}
+
+#[test]
+fn reports_anchor_precedence_for_dollar_only_on_last_of_two_alts() {
+    let source = "const r = /a|b$/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "anchorPrecedence");
+}
+
+#[test]
+fn does_not_report_anchor_precedence_for_grouped_alts() {
+    let source = "const r = /^(a|b|c)$/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_anchor_precedence_for_no_anchors() {
+    let source = "const r = /a|b|c/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_anchor_precedence_for_trim_idiom() {
+    let source = "const r = /^\\s+|\\s+$/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_anchor_precedence_when_all_branches_fully_anchored() {
+    let source = "const r = /^a$|^b$|^c$/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn does_not_report_anchor_precedence_when_middle_alt_is_anchored() {
+    let source = "const r = /^a|^b|c$/;";
+    let diagnostics = scan("anchor-precedence", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -92,6 +92,10 @@ const messages = Object.freeze({
   'duplicates-in-character-class': {
     duplicateCharacter: 'Remove this duplicated character from the character class.',
   },
+  'anchor-precedence': {
+    anchorPrecedence:
+      'Group the alternatives or add anchors to each branch to make operator precedence explicit.',
+  },
   'generator-without-yield': {
     generatorWithoutYield:
       "This generator contains no 'yield'; either add a 'yield' or convert it to a regular function.",
@@ -259,6 +263,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow a regular-expression character class that contains only a single literal character',
   'duplicates-in-character-class':
     'Disallow the same literal character appearing more than once in a regular-expression character class',
+  'anchor-precedence':
+    'Disallow regex alternations where ^ or $ anchors only one branch due to operator precedence',
   'generator-without-yield':
     "Disallow generator functions that contain no 'yield' expression and therefore behave like plain functions",
   'no-exclusive-tests':
@@ -358,6 +364,7 @@ const ruleTypes = Object.freeze({
   'no-control-regex': 'suggestion',
   'single-char-in-character-classes': 'suggestion',
   'duplicates-in-character-class': 'suggestion',
+  'anchor-precedence': 'suggestion',
   'generator-without-yield': 'problem',
   'no-exclusive-tests': 'problem',
   'no-built-in-override': 'problem',
@@ -457,6 +464,7 @@ const recommendedRuleConfig = Object.freeze({
   'max-lines-per-function': 'error',
   'nested-control-flow': 'error',
   'no-duplicate-string': 'error',
+  'anchor-precedence': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -62,6 +62,7 @@ const expectedRuleNames = [
   'no-control-regex',
   'single-char-in-character-classes',
   'duplicates-in-character-class',
+  'anchor-precedence',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -2019,6 +2020,34 @@ describe('sonarjs native API', () => {
 
   it('does not report duplicates-in-character-class for distinct characters', () => {
     const diagnostics = scan('duplicates-in-character-class', 'const r = /[abc]/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports anchor-precedence when ^ anchors only the first of three alternatives', () => {
+    const diagnostics = scan('anchor-precedence', 'const r = /^a|b|c$/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('anchor-precedence');
+    expect(diagnostics[0].messageId).toBe('anchorPrecedence');
+  });
+
+  it('reports anchor-precedence when ^ anchors only the first of two alternatives', () => {
+    const diagnostics = scan('anchor-precedence', 'const r = /^a|b/;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].messageId).toBe('anchorPrecedence');
+  });
+
+  it('does not report anchor-precedence for a grouped alternation', () => {
+    const diagnostics = scan('anchor-precedence', 'const r = /^(a|b|c)$/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report anchor-precedence for the two-branch trim idiom', () => {
+    const diagnostics = scan('anchor-precedence', 'const r = /^\\s+|\\s+$/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('does not report anchor-precedence when every branch is fully anchored', () => {
+    const diagnostics = scan('anchor-precedence', 'const r = /^a$|^b$|^c$/;');
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -153,6 +153,7 @@ describe('sonarjs plugin shape', () => {
       'no-control-regex',
       'single-char-in-character-classes',
       'duplicates-in-character-class',
+      'anchor-precedence',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -213,6 +214,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['no-control-regex']).toBe('object');
     expect(typeof plugin.rules['single-char-in-character-classes']).toBe('object');
     expect(typeof plugin.rules['duplicates-in-character-class']).toBe('object');
+    expect(typeof plugin.rules['anchor-precedence']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -277,6 +279,7 @@ describe('sonarjs plugin shape', () => {
       'error',
     );
     expect(plugin.configs.recommended.rules['sonarjs/duplicates-in-character-class']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/anchor-precedence']).toBe('error');
   });
 });
 
@@ -1316,5 +1319,21 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(duplicates-in-character-class)');
+  });
+
+  it('reports anchor-precedence through the adapter', () => {
+    const source = 'const r = /^a|b|c$/;';
+    const reports = runRule('anchor-precedence', source);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('anchorPrecedence');
+  });
+
+  it('reports anchor-precedence through the CLI', () => {
+    const result = runOxlint('anchor-precedence', 'const r = /^a|b|c$/;');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(anchor-precedence)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -10046,19 +10046,19 @@
     "rules": [
       {
         "name": "anchor-precedence",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule anchor-precedence (Sonar key S5850). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of S5850 (anchor-precedence). Flags top-level alternations where ^ anchors only the first branch or $ only the last, due to operator precedence. Excludes: single-alternative patterns (grouped), patterns where every branch is fully anchored, and the two-branch complementary trim idiom (^...|...$). Never recurses into groups. SonarJS upstream is LGPL-3.0; implemented from public RSPEC description only."
       },
       {
         "name": "argument-type",


### PR DESCRIPTION
Clean-room port of the SonarJS `anchor-precedence` rule (Sonar key S5850), built on the regex-AST helper (#276).

In a top-level alternation of two or more branches, flags the case where `^` anchors only the first branch or `$` only the last — e.g. `/^a|b|c$/` parses as `(^a)|(b)|(c$)`, when the author almost certainly meant `/^(a|b|c)$/`.

- **Flagged:** `/^a|b|c$/`, `/^a|b/`, `/a|b$/`
- **Not flagged:** `/^(a|b|c)$/` (group anchors all), `/^a$|^b$/` (every branch anchored), `/a|b|c/` (no anchors), `/^\s+|\s+$/` (the complementary "trim" idiom), `/^a|^b/`, `/a$|b$/`.

Conservative, zero-false-positive guards exclude all intentional-anchoring shapes; only the top-level disjunction is inspected. No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784025601&installation_id=136613492&pr_number=313&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F313&signature=3452061254b62b6fa3a93c8607ce8aa5651cdb3162bb3e4de1d06da0c4ee4eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->