### PR TITLE
port(postgresql): no-add-check-constraint-without-not-valid

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,6 +3,7 @@
 
 use crate::RuleDef;
 
+mod no_add_check_constraint_without_not_valid;
 mod no_alter_column_type;
 mod no_cluster;
 mod no_composite_primary_key;
@@ -139,6 +140,7 @@ pub const RULE_NAMES: [&str; 89] = [
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "no-add-check-constraint-without-not-valid",
     "no-alter-column-type",
     "no-cluster",
     "no-composite-primary-key",
@@ -182,6 +184,11 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "no-add-check-constraint-without-not-valid",
+        run: no_add_check_constraint_without_not_valid::run,
+        uses_parse_error: false,
+    },
     RuleDef {
         name: "no-alter-column-type",
         run: no_alter_column_type::run,

--- a/crates/postgresql/src/rules/no_add_check_constraint_without_not_valid.rs
+++ b/crates/postgresql/src/rules/no_add_check_constraint_without_not_valid.rs
@@ -1,0 +1,33 @@
+//! Port of `no-add-check-constraint-without-not-valid`: disallow
+//! `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` without `NOT VALID`.
+//! The synchronous form holds ACCESS EXCLUSIVE for the entire validating scan.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    if str_field(def, "contype") != Some("CONSTR_CHECK") {
+        return;
+    }
+    // `skip_validation == true` means `NOT VALID` was supplied → allowed.
+    if def.get("skip_validation") == Some(&Value::Bool(true)) {
+        return;
+    }
+    // Report the `AlterTableCmd`, exactly like upstream; its computed span
+    // already covers the `CONSTRAINT … CHECK (…)` subtree.
+    ctx.report(node, "checkNotValid");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,18 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'no-add-check-constraint-without-not-valid': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` without `NOT VALID`; the synchronous form holds `ACCESS EXCLUSIVE` on the table for the entire validating scan',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      checkNotValid:
+        'Add this CHECK constraint with `NOT VALID` and run `VALIDATE CONSTRAINT` separately, so the validating scan does not block writers under `ACCESS EXCLUSIVE`.',
+    },
+  },
   'no-alter-column-type': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5063,19 +5063,19 @@
       },
       {
         "name": "no-add-check-constraint-without-not-valid",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-add-check-constraint-without-not-valid."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-add-check-constraint-without-not-valid; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-add-column-not-null-without-default",


### PR DESCRIPTION
## Summary

- Ports `no-add-check-constraint-without-not-valid` from eslint-plugin-postgresql to Rust/NAPI
- Detects `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` without `NOT VALID` (which holds ACCESS EXCLUSIVE for the full table scan)
- Reports the diagnostic starting at the `CONSTRAINT` keyword and extending to the end of the CHECK expression (via subtree max-end traversal, since libpg_query only gives the `Constraint` node a location token for the keyword itself)
- Full fixture parity: 1 valid + 1 invalid case all match upstream

## Test plan

- [x] `cargo clippy` clean
- [x] `cargo build` succeeds
- [x] Fixture validation: `VALID PASS with-not-valid`, `INVALID PASS synchronous-check`, `ALL MATCH`
- [x] `cargo fmt` applied
- [x] `npx prettier` applied to index.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784025924&installation_id=136613492&pr_number=314&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F314&signature=be2369af756ae21b35db5c80b79ed8e20fc68a0bc977f3d6765c91c76f0d0a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->