### PR TITLE
port(sonarjs): port cyclomatic-complexity (S1541)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 60] = [
+pub const RULE_NAMES: [&str; 61] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -84,6 +84,7 @@ pub const RULE_NAMES: [&str; 60] = [
     "single-char-in-character-classes",
     "duplicates-in-character-class",
     "anchor-precedence",
+    "cyclomatic-complexity",
 ];
 
 /// Returns the implemented rule names as a static slice.
@@ -125,6 +126,7 @@ pub fn scan_sonarjs(
         iife_function_starts: SmallVec::new(),
         string_literals: SmallVec::new(),
         excluded_string_starts: SmallVec::new(),
+        cyclomatic_complexity_stack: SmallVec::new(),
     };
     scanner.visit_program(&parser_return.program);
     scanner.diagnostics

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -8,6 +8,7 @@ mod class_name;
 mod class_prototype;
 mod comma_or_logical_or_case;
 mod constructor_for_side_effects;
+mod cyclomatic_complexity;
 mod duplicates_in_character_class;
 mod elseif_without_else;
 mod fixme_tag;

--- a/crates/sonarjs/src/rules/cyclomatic_complexity.rs
+++ b/crates/sonarjs/src/rules/cyclomatic_complexity.rs
@@ -1,0 +1,65 @@
+//! Rule `cyclomatic-complexity` (SonarJS key S1541).
+//!
+//! Clean-room port. Reports any function whose cyclomatic complexity exceeds the
+//! configured threshold. Complexity starts at 1 (for the function itself) and
+//! increments by 1 for each of the following decision-point nodes that appear
+//! anywhere inside the function body:
+//!
+//! - `if` statement (every `if`, including those in `else if` chains — McCabe
+//!   counts each branch test individually)
+//! - `for` statement
+//! - `for…in` statement
+//! - `for…of` statement
+//! - `while` statement
+//! - `do…while` statement
+//! - `case` clause in a `switch` statement (the `default` clause does NOT count)
+//! - `catch` clause in a `try` statement
+//! - conditional (ternary) expression (`?:`)
+//! - logical expression (`&&`, `||`, `??`) — each LogicalExpression node adds +1
+//!
+//! Decision-point nodes at the top level (outside any function) do not count;
+//! only nodes visited while a function frame is open contribute to complexity.
+//! Nested functions each maintain their own independent frame on a stack, so
+//! inner-function complexity does not inflate the outer function's count.
+//!
+//! A diagnostic fires when a function's complexity is **strictly greater than**
+//! the configured `threshold` option (default **10**).
+//!
+//! Behaviour is reproduced from the public RSPEC S1541 description only; no
+//! upstream source, tests, fixtures, or message strings were consulted or copied.
+
+use oxc_span::Span;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "cyclomatic-complexity";
+
+impl Scanner<'_> {
+    /// Pushes a new function frame onto the cyclomatic complexity stack with
+    /// base complexity 1 (the function itself counts as one path). Called on
+    /// entry to every function or arrow-function expression.
+    pub(crate) fn enter_cyclomatic_scope(&mut self, span: Span) {
+        self.cyclomatic_complexity_stack.push((span, 1));
+    }
+
+    /// Pops the top function frame and emits a diagnostic if the accumulated
+    /// complexity exceeds the configured threshold. Called on exit from the
+    /// function or arrow-function expression.
+    pub(crate) fn leave_cyclomatic_scope(&mut self) {
+        let Some((span, complexity)) = self.cyclomatic_complexity_stack.pop() else {
+            return;
+        };
+        if complexity > self.options.cyclomatic_complexity_threshold {
+            self.report(RULE_NAME, "cyclomaticComplexity", span);
+        }
+    }
+
+    /// Increments the complexity counter of the innermost open function frame
+    /// by 1. If no function frame is open (top-level code), this is a no-op so
+    /// decision points outside any function are silently ignored.
+    pub(crate) fn add_cyclomatic_complexity(&mut self) {
+        if let Some(top) = self.cyclomatic_complexity_stack.last_mut() {
+            top.1 += 1;
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -65,6 +65,11 @@ pub(crate) struct Scanner<'a> {
     /// Span-start offsets of string literals in excluded positions (import/export
     /// sources, JSX attribute values) that `no-duplicate-string` must skip.
     pub(crate) excluded_string_starts: SmallVec<[u32; 16]>,
+    /// Per-function frame stack for `cyclomatic-complexity`. One frame per open
+    /// function/arrow scope: `(function_span, accumulated_complexity)`. Decision
+    /// points inside nested functions update only the innermost frame; top-level
+    /// decision points find an empty stack and are silently ignored.
+    pub(crate) cyclomatic_complexity_stack: SmallVec<[(Span, u32); 8]>,
 }
 
 impl<'a> Scanner<'a> {
@@ -149,6 +154,9 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_switch_case(&mut self, it: &SwitchCase<'a>) {
         self.check_comma_or_logical_or_case(it);
         self.check_no_same_line_conditional(&it.consequent);
+        if it.test.is_some() {
+            self.add_cyclomatic_complexity();
+        }
         walk::walk_switch_case(self, it);
     }
 
@@ -160,6 +168,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_logical_expression(&mut self, it: &LogicalExpression<'a>) {
         self.check_no_identical_expressions_logical(it);
+        self.add_cyclomatic_complexity();
         walk::walk_logical_expression(self, it);
     }
 
@@ -173,6 +182,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
         self.check_no_nested_conditional(it);
         self.check_no_redundant_boolean_conditional(it);
+        self.add_cyclomatic_complexity();
         self.conditional_depth += 1;
         walk::walk_conditional_expression(self, it);
         self.conditional_depth -= 1;
@@ -185,6 +195,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         self.check_elseif_without_else(it);
         self.check_prefer_single_boolean_return(it);
         self.check_no_nested_assignment_condition(&it.test);
+        self.add_cyclomatic_complexity();
         let counted = self.enter_nested_control_flow_if(it);
         walk::walk_if_statement(self, it);
         self.leave_nested_control_flow(counted);
@@ -193,6 +204,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
         self.check_for_in(it);
         self.check_redundant_continue(&it.body);
+        self.add_cyclomatic_complexity();
         let counted = self.enter_nested_control_flow(it.span);
         walk::walk_for_in_statement(self, it);
         self.leave_nested_control_flow(counted);
@@ -204,6 +216,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
         if let Some(test) = &it.test {
             self.check_no_nested_assignment_condition(test);
         }
+        self.add_cyclomatic_complexity();
         let counted = self.enter_nested_control_flow(it.span);
         walk::walk_for_statement(self, it);
         self.leave_nested_control_flow(counted);
@@ -212,6 +225,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
         self.check_redundant_continue(&it.body);
         self.check_no_nested_assignment_condition(&it.test);
+        self.add_cyclomatic_complexity();
         let counted = self.enter_nested_control_flow(it.span);
         walk::walk_while_statement(self, it);
         self.leave_nested_control_flow(counted);
@@ -220,6 +234,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
         self.check_redundant_continue(&it.body);
         self.check_no_nested_assignment_condition(&it.test);
+        self.add_cyclomatic_complexity();
         let counted = self.enter_nested_control_flow(it.span);
         walk::walk_do_while_statement(self, it);
         self.leave_nested_control_flow(counted);
@@ -227,6 +242,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
         self.check_redundant_continue(&it.body);
+        self.add_cyclomatic_complexity();
         let counted = self.enter_nested_control_flow(it.span);
         walk::walk_for_of_statement(self, it);
         self.leave_nested_control_flow(counted);
@@ -320,7 +336,9 @@ impl<'a> Visit<'a> for Scanner<'a> {
         let track = self.enter_generator(it);
         self.enter_return_scope(it.span);
         self.jsx_function_stack.push(false);
+        self.enter_cyclomatic_scope(it.span);
         walk::walk_function(self, it, flags);
+        self.leave_cyclomatic_scope();
         self.leave_return_scope();
         self.leave_generator(it, track);
         self.check_max_lines_per_function(it.span);
@@ -329,7 +347,9 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
         self.enter_return_scope(it.span);
         self.jsx_function_stack.push(false);
+        self.enter_cyclomatic_scope(it.span);
         walk::walk_arrow_function_expression(self, it);
+        self.leave_cyclomatic_scope();
         self.leave_return_scope();
         self.check_max_lines_per_function(it.span);
     }
@@ -385,6 +405,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
 
     fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
         self.check_no_useless_catch(it);
+        self.add_cyclomatic_complexity();
         walk::walk_catch_clause(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2777,3 +2777,98 @@ fn does_not_report_anchor_precedence_when_middle_alt_is_anchored() {
     let diagnostics = scan("anchor-precedence", source);
     assert!(diagnostics.is_empty());
 }
+
+// --- cyclomatic-complexity (S1541) ---
+
+#[test]
+fn cyclomatic_complexity_exceeds_threshold_reports() {
+    // base 1 + 4 if statements = 5, threshold 3: 5 > 3 → 1 diagnostic
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 3;
+    let source = "function f(a,b,c,d){if(a){}if(b){}if(c){}if(d){}}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "cyclomatic-complexity");
+    assert_eq!(diagnostics[0].message_id, "cyclomaticComplexity");
+}
+
+#[test]
+fn cyclomatic_complexity_at_threshold_no_report() {
+    // base 1 + 3 ifs = 4, threshold 4: 4 is NOT > 4 → 0 diagnostics
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 4;
+    let source = "function f(a,b,c){if(a){}if(b){}if(c){}}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn cyclomatic_complexity_logical_operators_count() {
+    // "a&&b&&c" → 2 LogicalExpression nodes; base 1 + 2 = 3 > threshold 2 → 1 diagnostic
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 2;
+    let source = "function f(a,b,c){return a&&b&&c;}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "cyclomatic-complexity");
+}
+
+#[test]
+fn cyclomatic_complexity_default_case_not_counted() {
+    // switch with only a default clause: base 1 + 0 case clauses = 1, threshold 1: not > 1 → 0
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 1;
+    let source = "function f(x){switch(x){default:break;}}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn cyclomatic_complexity_toplevel_decision_points_not_counted() {
+    // ifs at top level (no enclosing function) → no frame → complexity never reported
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 1;
+    let source = "if(a){}if(b){}if(c){}if(d){}if(e){}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn cyclomatic_complexity_case_clause_counts() {
+    // switch with 2 case clauses + 1 default; base 1 + 2 cases = 3 > threshold 2 → 1 diagnostic
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 2;
+    let source = "function f(x){switch(x){case 1:break;case 2:break;default:break;}}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn cyclomatic_complexity_catch_clause_counts() {
+    // base 1 + 1 catch = 2 > threshold 1 → 1 diagnostic
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 1;
+    let source = "function f(){try{}catch(e){}}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn cyclomatic_complexity_nested_functions_independent() {
+    // outer: base 1 (no decision points in outer body itself) → not reported at threshold 1
+    // inner: base 1 + 2 ifs = 3 > threshold 1 → inner reported; outer not reported
+    let mut options = options_for("cyclomatic-complexity");
+    options.cyclomatic_complexity_threshold = 1;
+    let source = "function outer(){function inner(a,b){if(a){}if(b){}}}";
+    let diagnostics = scan_sonarjs(source, "sample.ts", &options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "cyclomaticComplexity");
+}
+
+#[test]
+fn cyclomatic_complexity_uses_default_threshold_when_unset() {
+    // default threshold is 10; a function with base 1 + 5 ifs = 6 must not be flagged
+    let source = "function f(a,b,c,d,e){if(a){}if(b){}if(c){}if(d){}if(e){}}";
+    let diagnostics = scan("cyclomatic-complexity", source);
+    assert!(diagnostics.is_empty());
+}

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -56,6 +56,9 @@ pub struct SonarjsOptions {
     pub nested_control_flow_threshold: u32,
     /// Threshold for `no-duplicate-string` (S1192); the SonarJS default is 3.
     pub no_duplicate_string_threshold: u32,
+    /// Maximum cyclomatic complexity per function for `cyclomatic-complexity` (S1541);
+    /// the SonarJS default is 10.
+    pub cyclomatic_complexity_threshold: u32,
 }
 
 impl Default for SonarjsOptions {
@@ -71,6 +74,7 @@ impl Default for SonarjsOptions {
             max_union_size_threshold: 3,
             nested_control_flow_threshold: 3,
             no_duplicate_string_threshold: 3,
+            cyclomatic_complexity_threshold: 10,
         }
     }
 }

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -224,6 +224,9 @@ const messages = Object.freeze({
   'no-duplicate-string': {
     duplicateString: 'Define this repeated string literal as a constant to avoid duplication.',
   },
+  'cyclomatic-complexity': {
+    cyclomaticComplexity: 'Refactor this function to reduce its cyclomatic complexity.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -339,6 +342,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow control flow statements (if/for/for-in/for-of/while/do-while/switch/try) nested beyond the configured maximumNestingLevel (default 3); else-if chains do not add a level',
   'no-duplicate-string':
     'Disallow string literals of 10+ characters containing a non-word character from appearing at least threshold (default 3) times in a file; import/export sources and JSX attribute values are excluded',
+  'cyclomatic-complexity':
+    'Disallow functions whose cyclomatic complexity exceeds the configured threshold (the "threshold" option; default 10); each if/for/while/do-while/case/catch/ternary/logical-operator adds +1',
 });
 
 const ruleTypes = Object.freeze({
@@ -402,6 +407,7 @@ const ruleTypes = Object.freeze({
   'max-lines-per-function': 'suggestion',
   'nested-control-flow': 'suggestion',
   'no-duplicate-string': 'suggestion',
+  'cyclomatic-complexity': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -465,6 +471,7 @@ const recommendedRuleConfig = Object.freeze({
   'nested-control-flow': 'error',
   'no-duplicate-string': 'error',
   'anchor-precedence': 'error',
+  'cyclomatic-complexity': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());
@@ -557,6 +564,15 @@ function schemaForRule(ruleName) {
       },
     ];
   }
+  if (ruleName === 'cyclomatic-complexity') {
+    return [
+      {
+        type: 'object',
+        properties: { threshold: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ];
+  }
   return [];
 }
 
@@ -581,6 +597,9 @@ function scanOptionsForRule(context, ruleName) {
   }
   if (ruleName === 'no-duplicate-string' && Number.isInteger(raw.threshold)) {
     options.noDuplicateStringThreshold = raw.threshold;
+  }
+  if (ruleName === 'cyclomatic-complexity' && Number.isInteger(raw.threshold)) {
+    options.cyclomaticComplexityThreshold = raw.threshold;
   }
   return options;
 }

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -25,6 +25,7 @@ mod napi_abi {
         pub max_union_size_threshold: Option<u32>,
         pub nested_control_flow_threshold: Option<u32>,
         pub no_duplicate_string_threshold: Option<u32>,
+        pub cyclomatic_complexity_threshold: Option<u32>,
     }
 
     #[napi(object)]
@@ -96,6 +97,9 @@ mod napi_abi {
             no_duplicate_string_threshold: options
                 .no_duplicate_string_threshold
                 .unwrap_or(default_options.no_duplicate_string_threshold),
+            cyclomatic_complexity_threshold: options
+                .cyclomatic_complexity_threshold
+                .unwrap_or(default_options.cyclomatic_complexity_threshold),
         };
 
         core::scan_sonarjs(&source_text, &filename, &core_options)

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -63,6 +63,7 @@ const expectedRuleNames = [
   'single-char-in-character-classes',
   'duplicates-in-character-class',
   'anchor-precedence',
+  'cyclomatic-complexity',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -2048,6 +2049,28 @@ describe('sonarjs native API', () => {
 
   it('does not report anchor-precedence when every branch is fully anchored', () => {
     const diagnostics = scan('anchor-precedence', 'const r = /^a$|^b$|^c$/;');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports cyclomatic-complexity when a function exceeds the threshold', () => {
+    // base 1 + 4 ifs = 5, custom threshold 3: 5 > 3 → 1 diagnostic
+    const source = 'function f(a,b,c,d){if(a){}if(b){}if(c){}if(d){}}';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['cyclomatic-complexity'],
+      cyclomaticComplexityThreshold: 3,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('cyclomatic-complexity');
+    expect(diagnostics[0].messageId).toBe('cyclomaticComplexity');
+  });
+
+  it('does not report cyclomatic-complexity when a function is within the threshold', () => {
+    // base 1 + 3 ifs = 4, threshold 4: 4 is not > 4 → 0 diagnostics
+    const source = 'function f(a,b,c){if(a){}if(b){}if(c){}}';
+    const diagnostics = scanSonarjs(source, 'sample.ts', {
+      ruleNames: ['cyclomatic-complexity'],
+      cyclomaticComplexityThreshold: 4,
+    });
     expect(diagnostics).toHaveLength(0);
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -154,6 +154,7 @@ describe('sonarjs plugin shape', () => {
       'single-char-in-character-classes',
       'duplicates-in-character-class',
       'anchor-precedence',
+      'cyclomatic-complexity',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -215,6 +216,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['single-char-in-character-classes']).toBe('object');
     expect(typeof plugin.rules['duplicates-in-character-class']).toBe('object');
     expect(typeof plugin.rules['anchor-precedence']).toBe('object');
+    expect(typeof plugin.rules['cyclomatic-complexity']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -280,6 +282,7 @@ describe('sonarjs plugin shape', () => {
     );
     expect(plugin.configs.recommended.rules['sonarjs/duplicates-in-character-class']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/anchor-precedence']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/cyclomatic-complexity']).toBe('error');
   });
 });
 
@@ -1335,5 +1338,44 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
     expect(result.stderr).toBe('');
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe('sonarjs(anchor-precedence)');
+  });
+
+  it('reports cyclomatic-complexity through the adapter with custom threshold', () => {
+    // base 1 + 4 ifs = 5 > threshold 3 → 1 report
+    const source = 'function f(a,b,c,d){if(a){}if(b){}if(c){}if(d){}}';
+    const reports = runRule('cyclomatic-complexity', source, { options: [{ threshold: 3 }] });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('cyclomaticComplexity');
+  });
+
+  it('does not report cyclomatic-complexity when function is within the threshold', () => {
+    // base 1 + 3 ifs = 4, threshold 4: 4 is not > 4 → 0 reports
+    const source = 'function f(a,b,c){if(a){}if(b){}if(c){}}';
+    const reports = runRule('cyclomatic-complexity', source, { options: [{ threshold: 4 }] });
+    expect(reports).toHaveLength(0);
+  });
+
+  it('reports cyclomatic-complexity through the CLI', () => {
+    // 11 ifs + base 1 = 12 > default threshold 10 → reported by CLI
+    const src =
+      'function f(a,b,c,d,e,f2,g,h,i,j,k)' +
+      '{if(a){}if(b){}if(c){}if(d){}if(e){}' +
+      'if(f2){}if(g){}if(h){}if(i){}if(j){}if(k){}}';
+    const result = runOxlint('cyclomatic-complexity', src);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(cyclomatic-complexity)');
+  });
+
+  it('exposes the cyclomatic-complexity threshold option in the rule schema', () => {
+    expect(plugin.rules['cyclomatic-complexity'].meta.schema).toEqual([
+      {
+        type: 'object',
+        properties: { threshold: { type: 'integer' } },
+        additionalProperties: false,
+      },
+    ]);
   });
 });

--- a/status.json
+++ b/status.json
@@ -10830,19 +10830,19 @@
       },
       {
         "name": "cyclomatic-complexity",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule cyclomatic-complexity (Sonar key S1541). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of S1541 (per-function McCabe cyclomatic complexity). Base complexity 1 per function; +1 for each if (including else-if), for, for-in, for-of, while, do-while, case clause (not default), catch, ternary (?:), and logical expression (&&/||/??). Top-level decision points outside any function are ignored. Configurable threshold option (default 10). SonarJS upstream is LGPL-3.0; implemented from public RSPEC only."
       },
       {
         "name": "declarations-in-global-scope",


### PR DESCRIPTION
Clean-room port of the SonarJS `cyclomatic-complexity` rule (Sonar key S1541), built on the per-rule options layer (#246).

Measures each function's McCabe cyclomatic complexity: base 1 plus +1 for every `if`, `for`, `for…in`, `for…of`, `while`, `do…while`, `case` clause (not `default`), `catch` clause, ternary `?:`, and logical `&&`/`||`/`??` operator. Reports a function whose complexity strictly exceeds the configurable `threshold` option (default 10).

Uses a per-function frame stack so nested functions are measured independently; decision points outside any function are not counted. Tests cover the boundary (exceed vs at-threshold), logical-operator counting, `default`-not-counted, top-level-not-counted, and the option end-to-end (native, adapter, CLI). No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784027171&installation_id=136613492&pr_number=317&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F317&signature=e53a748e637dbf8716b0080514bda359dc239662ca6ecd20eb2e4ab3fa8b5f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->