### PR TITLE
port(sonarjs): port no-collection-size-mischeck (S3981)

### DIFF
--- a/crates/sonarjs/src/lib.rs
+++ b/crates/sonarjs/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use crate::types::LineIndex;
 pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, SonarjsOptions};
 
 /// Names of every rule implemented by the sonarjs core, in registration order.
-pub const RULE_NAMES: [&str; 61] = [
+pub const RULE_NAMES: [&str; 62] = [
     "no-nested-template-literals",
     "no-nested-switch",
     "no-nested-conditional",
@@ -85,6 +85,7 @@ pub const RULE_NAMES: [&str; 61] = [
     "duplicates-in-character-class",
     "anchor-precedence",
     "cyclomatic-complexity",
+    "no-collection-size-mischeck",
 ];
 
 /// Returns the implemented rule names as a static slice.

--- a/crates/sonarjs/src/rules.rs
+++ b/crates/sonarjs/src/rules.rs
@@ -23,6 +23,7 @@ mod no_all_duplicated_branches;
 mod no_built_in_override;
 mod no_case_label_in_switch;
 mod no_collapsible_if;
+mod no_collection_size_mischeck;
 mod no_control_regex;
 mod no_delete_var;
 mod no_duplicate_in_composite;

--- a/crates/sonarjs/src/rules/no_collection_size_mischeck.rs
+++ b/crates/sonarjs/src/rules/no_collection_size_mischeck.rs
@@ -1,0 +1,74 @@
+//! Rule `no-collection-size-mischeck` (SonarJS key S3981).
+//!
+//! Clean-room port. Reports a `BinaryExpression` where one operand is a member
+//! access reading the property `length` or `size` (e.g. `arr.length`,
+//! `map.size`) and the other operand is the numeric literal `0`, AND the
+//! comparison is always-true or always-false because `length`/`size` are
+//! non-negative integers:
+//!
+//! - `<expr>.length < 0`  — always false (flag)
+//! - `<expr>.length >= 0` — always true  (flag)
+//! - `<expr>.size < 0`    — always false (flag)
+//! - `<expr>.size >= 0`   — always true  (flag)
+//! - and the mirrored forms `0 > <expr>.length` / `0 <= <expr>.length` etc.
+//!
+//! Only these four always-true/always-false shapes are flagged. Meaningful
+//! comparisons (`<= 0`, `> 0`, `=== 0`, `== 0`, `< 1`, etc.) are NOT flagged.
+//!
+//! Detection is purely syntactic: the rule fires on any `.length`/`.size`
+//! member access without verifying the receiver's type. This matches the
+//! behaviour of `eslint-plugin-sonarjs` when running without type information.
+//!
+//! Behaviour is reproduced from the public RSPEC S3981 description and the
+//! public docs of `eslint-plugin-sonarjs/no-collection-size-mischeck` only;
+//! no upstream source, tests, fixtures, or message strings were consulted or
+//! copied.
+
+use oxc_ast::ast::{BinaryExpression, Expression};
+use oxc_syntax::operator::BinaryOperator;
+
+use crate::scanner::Scanner;
+
+pub(crate) const RULE_NAME: &str = "no-collection-size-mischeck";
+
+/// Returns `true` when `expr` (after stripping parentheses) is a static member
+/// access with property name `length` or `size`.
+fn is_length_or_size(expr: &Expression<'_>) -> bool {
+    match expr.get_inner_expression() {
+        Expression::StaticMemberExpression(m) => {
+            m.property.name == "length" || m.property.name == "size"
+        }
+        _ => false,
+    }
+}
+
+/// Returns `true` when `expr` (after stripping parentheses) is the numeric
+/// literal `0`.
+fn is_zero(expr: &Expression<'_>) -> bool {
+    match expr.get_inner_expression() {
+        Expression::NumericLiteral(n) => n.value == 0.0,
+        _ => false,
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_no_collection_size_mischeck(&mut self, expr: &BinaryExpression<'_>) {
+        // Shape 1: <length_or_size> < 0  (always false)
+        // Shape 2: <length_or_size> >= 0 (always true)
+        // Shape 3: 0 > <length_or_size>  (always false, mirrors shape 1)
+        // Shape 4: 0 <= <length_or_size> (always true,  mirrors shape 2)
+        let flagged = matches!(
+            expr.operator,
+            BinaryOperator::LessThan | BinaryOperator::GreaterEqualThan
+        ) && is_length_or_size(&expr.left)
+            && is_zero(&expr.right)
+            || matches!(
+                expr.operator,
+                BinaryOperator::GreaterThan | BinaryOperator::LessEqualThan
+            ) && is_zero(&expr.left)
+                && is_length_or_size(&expr.right);
+        if flagged {
+            self.report(RULE_NAME, "collectionSizeMischeck", expr.span);
+        }
+    }
+}

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -163,6 +163,7 @@ impl<'a> Visit<'a> for Scanner<'a> {
     fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {
         self.check_no_redundant_boolean_binary(it);
         self.check_no_identical_expressions_binary(it);
+        self.check_no_collection_size_mischeck(it);
         walk::walk_binary_expression(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -2872,3 +2872,53 @@ fn cyclomatic_complexity_uses_default_threshold_when_unset() {
     let diagnostics = scan("cyclomatic-complexity", source);
     assert!(diagnostics.is_empty());
 }
+
+// no-collection-size-mischeck
+
+#[test]
+fn collection_size_mischeck_length_less_than_zero() {
+    let source = "const b = x.length < 0;";
+    let diagnostics = scan("no-collection-size-mischeck", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-collection-size-mischeck");
+    assert_eq!(diagnostics[0].message_id, "collectionSizeMischeck");
+}
+
+#[test]
+fn collection_size_mischeck_length_gte_zero() {
+    let source = "const b = x.length >= 0;";
+    let diagnostics = scan("no-collection-size-mischeck", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-collection-size-mischeck");
+    assert_eq!(diagnostics[0].message_id, "collectionSizeMischeck");
+}
+
+#[test]
+fn collection_size_mischeck_size_mirrored_gt() {
+    let source = "const b = 0 > arr.size;";
+    let diagnostics = scan("no-collection-size-mischeck", source);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "no-collection-size-mischeck");
+    assert_eq!(diagnostics[0].message_id, "collectionSizeMischeck");
+}
+
+#[test]
+fn collection_size_mischeck_no_report_gt_zero() {
+    let source = "const b = x.length > 0;";
+    let diagnostics = scan("no-collection-size-mischeck", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn collection_size_mischeck_no_report_strict_eq_zero() {
+    let source = "const b = x.length === 0;";
+    let diagnostics = scan("no-collection-size-mischeck", source);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn collection_size_mischeck_no_report_lte_zero() {
+    let source = "const b = x.length <= 0;";
+    let diagnostics = scan("no-collection-size-mischeck", source);
+    assert!(diagnostics.is_empty());
+}

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -227,6 +227,10 @@ const messages = Object.freeze({
   'cyclomatic-complexity': {
     cyclomaticComplexity: 'Refactor this function to reduce its cyclomatic complexity.',
   },
+  'no-collection-size-mischeck': {
+    collectionSizeMischeck:
+      'This size/length comparison is always true or always false; fix the comparison.',
+  },
 });
 
 const ruleDescriptions = Object.freeze({
@@ -344,6 +348,8 @@ const ruleDescriptions = Object.freeze({
     'Disallow string literals of 10+ characters containing a non-word character from appearing at least threshold (default 3) times in a file; import/export sources and JSX attribute values are excluded',
   'cyclomatic-complexity':
     'Disallow functions whose cyclomatic complexity exceeds the configured threshold (the "threshold" option; default 10); each if/for/while/do-while/case/catch/ternary/logical-operator adds +1',
+  'no-collection-size-mischeck':
+    'Disallow comparisons of collection .length or .size against 0 with < or >= that are always false or always true',
 });
 
 const ruleTypes = Object.freeze({
@@ -408,6 +414,7 @@ const ruleTypes = Object.freeze({
   'nested-control-flow': 'suggestion',
   'no-duplicate-string': 'suggestion',
   'cyclomatic-complexity': 'suggestion',
+  'no-collection-size-mischeck': 'suggestion',
 });
 
 const recommendedRuleConfig = Object.freeze({
@@ -472,6 +479,7 @@ const recommendedRuleConfig = Object.freeze({
   'no-duplicate-string': 'error',
   'anchor-precedence': 'error',
   'cyclomatic-complexity': 'error',
+  'no-collection-size-mischeck': 'error',
 });
 
 const implementedRuleNames = Object.freeze(implementedSonarjsRuleNames());

--- a/npm/sonarjs/test/api.test.mjs
+++ b/npm/sonarjs/test/api.test.mjs
@@ -64,6 +64,7 @@ const expectedRuleNames = [
   'duplicates-in-character-class',
   'anchor-precedence',
   'cyclomatic-complexity',
+  'no-collection-size-mischeck',
 ];
 
 function scan(ruleName, sourceText, filename = 'sample.ts') {
@@ -2072,5 +2073,12 @@ describe('sonarjs native API', () => {
       cyclomaticComplexityThreshold: 4,
     });
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it('reports no-collection-size-mischeck for always-false length < 0', () => {
+    const diagnostics = scan('no-collection-size-mischeck', 'const b = x.length < 0;');
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleName).toBe('no-collection-size-mischeck');
+    expect(diagnostics[0].messageId).toBe('collectionSizeMischeck');
   });
 });

--- a/npm/sonarjs/test/plugin.test.mjs
+++ b/npm/sonarjs/test/plugin.test.mjs
@@ -155,6 +155,7 @@ describe('sonarjs plugin shape', () => {
       'duplicates-in-character-class',
       'anchor-precedence',
       'cyclomatic-complexity',
+      'no-collection-size-mischeck',
     ]);
     expect(typeof plugin.rules['no-nested-template-literals']).toBe('object');
     expect(typeof plugin.rules['no-nested-switch']).toBe('object');
@@ -217,6 +218,7 @@ describe('sonarjs plugin shape', () => {
     expect(typeof plugin.rules['duplicates-in-character-class']).toBe('object');
     expect(typeof plugin.rules['anchor-precedence']).toBe('object');
     expect(typeof plugin.rules['cyclomatic-complexity']).toBe('object');
+    expect(typeof plugin.rules['no-collection-size-mischeck']).toBe('object');
     expect(Object.keys(plugin.configs)).toEqual(['recommended']);
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-template-literals']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/no-nested-switch']).toBe('error');
@@ -283,6 +285,7 @@ describe('sonarjs plugin shape', () => {
     expect(plugin.configs.recommended.rules['sonarjs/duplicates-in-character-class']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/anchor-precedence']).toBe('error');
     expect(plugin.configs.recommended.rules['sonarjs/cyclomatic-complexity']).toBe('error');
+    expect(plugin.configs.recommended.rules['sonarjs/no-collection-size-mischeck']).toBe('error');
   });
 });
 
@@ -1377,5 +1380,24 @@ describe('sonarjs rules through oxlint jsPlugins', () => {
         additionalProperties: false,
       },
     ]);
+  });
+
+  it('reports no-collection-size-mischeck through the adapter', () => {
+    const reports = runRule('no-collection-size-mischeck', 'const b = x.length < 0;');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe('collectionSizeMischeck');
+  });
+
+  it('does not report no-collection-size-mischeck for x.length > 0', () => {
+    const reports = runRule('no-collection-size-mischeck', 'const b = x.length > 0;');
+    expect(reports).toHaveLength(0);
+  });
+
+  it('reports no-collection-size-mischeck through the CLI', () => {
+    const result = runOxlint('no-collection-size-mischeck', 'const b = x.length < 0;');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('sonarjs(no-collection-size-mischeck)');
   });
 });

--- a/status.json
+++ b/status.json
@@ -11806,19 +11806,19 @@
       },
       {
         "name": "no-collection-size-mischeck",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-collection-size-mischeck (Sonar key S3981). SonarJS upstream is LGPL-3.0; this port is clean-room from observed behavior only \u2014 never copy upstream source, fixtures, tests, or messages."
+        "notes": "Clean-room port of Sonar key S3981. Purely syntactic: flags BinaryExpression where one side is a StaticMemberExpression with property name 'length' or 'size' and the other side is numeric literal 0, and the operator is < (always false) or >= (always true), including mirrored forms 0 > x.length and 0 <= x.length. No type info required. Message and tests independently authored."
       },
       {
         "name": "no-commented-code",


### PR DESCRIPTION
Clean-room port of the SonarJS `no-collection-size-mischeck` rule (Sonar key S3981).

Flags a comparison of a `.length`/`.size` member access against `0` whose result is always true or always false (length/size are non-negative):

- **Flagged:** `x.length < 0` (always false), `x.length >= 0` (always true), `0 > x.size`, `0 <= x.size`
- **Not flagged:** `x.length <= 0`, `x.length > 0`, `x.length === 0`, `x.length < 1` (all meaningful)

Detection is purely syntactic, matching `eslint-plugin-sonarjs`'s behavior without type information (confirmed via its docs). No upstream source, tests, fixtures, or messages were consulted or copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784028063&installation_id=136613492&pr_number=318&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F318&signature=8e8bf6a6a49597fbbea33aef09f857771cf7cce265cb5a6a5a95d3af13238a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->