### PR TITLE
feat(postgresql): port no-not-in-subquery

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -17,6 +17,7 @@ mod no_having_without_group_by;
 mod no_implicit_join;
 mod no_leading_wildcard_like;
 mod no_natural_join;
+mod no_not_in_subquery;
 mod no_on_delete_cascade;
 mod no_order_by_ordinal;
 mod no_rename_column;
@@ -145,6 +146,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-implicit-join",
     "no-leading-wildcard-like",
     "no-natural-join",
+    "no-not-in-subquery",
     "no-on-delete-cascade",
     "no-order-by-ordinal",
     "no-rename-column",
@@ -234,6 +236,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-natural-join",
         run: no_natural_join::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-not-in-subquery",
+        run: no_not_in_subquery::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_not_in_subquery.rs
+++ b/crates/postgresql/src/rules/no_not_in_subquery.rs
@@ -1,0 +1,36 @@
+//! Port of `no-not-in-subquery`: disallow `NOT IN (subquery)` because it
+//! returns no rows when the subquery yields any NULL — use `NOT EXISTS` instead.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "BoolExpr") {
+        return;
+    }
+    if str_field(node, "boolop") != Some("NOT_EXPR") {
+        return;
+    }
+    let args = match array_field(node, "args") {
+        Some(a) if a.len() == 1 => a,
+        _ => return,
+    };
+    let sub = &args[0];
+    if !is_type(sub, "SubLink") {
+        return;
+    }
+    if str_field(sub, "subLinkType") != Some("ANY_SUBLINK") {
+        return;
+    }
+    // operName must be absent or null (plain IN, not a custom operator)
+    if field(sub, "operName").is_some_and(|v| !v.is_null()) {
+        return;
+    }
+    // testexpr must be present and non-null
+    if field(sub, "testexpr").is_none_or(|v| v.is_null()) {
+        return;
+    }
+    ctx.report(node, "noNotInSubquery");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -195,6 +195,18 @@ const ruleMeta = Object.freeze({
         'Avoid `NATURAL JOIN`. The join columns are implicit — any future column with a matching name on both sides silently changes the result. Use `JOIN ... USING (...)` or `JOIN ... ON ...` and name the columns.',
     },
   },
+  'no-not-in-subquery': {
+    type: 'problem',
+    description:
+      'Disallow `NOT IN (subquery)` because it returns no rows when the subquery yields any NULL',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNotInSubquery:
+        '`NOT IN (subquery)` returns no rows if the subquery yields any NULL — almost certainly not what you want. Use `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` instead; it handles NULL correctly.',
+    },
+  },
   'no-on-delete-cascade': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5463,19 +5463,19 @@
       },
       {
         "name": "no-not-in-subquery",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-not-in-subquery."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-not-in-subquery; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-numeric-without-precision",


### PR DESCRIPTION
Part of #14. Ports `no-not-in-subquery`. Detects `NOT IN (subquery)` which silently returns no rows when the subquery yields any NULL; reports the `BoolExpr` node and suggests using `NOT EXISTS` instead. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784028110&installation_id=136613492&pr_number=319&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F319&signature=84825620639cd58ddb4d77abc8414fdcde1409a24839a0f140a1641264391a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->