### PR TITLE
feat(postgresql): port prefer-exists-over-in-subquery

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -32,6 +32,7 @@ mod no_truncate_cascade;
 mod no_unlogged_table;
 mod no_vacuum_full;
 mod no_with_recursive_without_limit;
+mod prefer_exists_over_in_subquery;
 mod require_limit;
 mod require_where_in_delete;
 mod require_where_in_update;
@@ -161,6 +162,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-unlogged-table",
     "no-vacuum-full",
     "no-with-recursive-without-limit",
+    "prefer-exists-over-in-subquery",
     "require-limit",
     "require-where-in-delete",
     "require-where-in-update",
@@ -311,6 +313,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-with-recursive-without-limit",
         run: no_with_recursive_without_limit::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-exists-over-in-subquery",
+        run: prefer_exists_over_in_subquery::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/prefer_exists_over_in_subquery.rs
+++ b/crates/postgresql/src/rules/prefer_exists_over_in_subquery.rs
@@ -1,0 +1,17 @@
+//! Port of `prefer-exists-over-in-subquery`: prefer `EXISTS (...)` over
+//! `IN (subquery)` because `IN` returns NULL when the subquery has any NULL row,
+//! silently turning rows into no-matches; `EXISTS` is unambiguously boolean.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SubLink") {
+        return;
+    }
+    if str_field(node, "subLinkType") == Some("ANY_SUBLINK") {
+        ctx.report(node, "preferExists");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -362,6 +362,17 @@ const ruleMeta = Object.freeze({
         'Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.',
     },
   },
+  'prefer-exists-over-in-subquery': {
+    type: 'suggestion',
+    description: 'Prefer `EXISTS (...)` over `IN (subquery)` to avoid NULL-related surprises',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferExists:
+        'Use `EXISTS (...)` instead of `IN (subquery)`. `IN` returns NULL when the subquery has any NULL row, which silently turns the row into a no-match; `EXISTS` is unambiguously boolean.',
+    },
+  },
   'require-limit': {
     type: 'suggestion',
     description: 'Require LIMIT clause in SELECT statements',

--- a/status.json
+++ b/status.json
@@ -5927,19 +5927,19 @@
       },
       {
         "name": "prefer-exists-over-in-subquery",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-exists-over-in-subquery."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-exists-over-in-subquery; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-explicit-null-ordering",


### PR DESCRIPTION
Part of #14. Ports `prefer-exists-over-in-subquery`. Detects `IN (subquery)` and `= ANY (subquery)` patterns (SubLink with ANY_SUBLINK type) and suggests using `EXISTS` which is unambiguously boolean. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784028248&installation_id=136613492&pr_number=320&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F320&signature=8da300b2635f6e4bd8f3db22d807da86008a0f3ba8bc59f0383588b198ef0797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->