### PR TITLE
feat(postgresql): port no-update-without-from-binding

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -31,6 +31,7 @@ mod no_set_search_path;
 mod no_temporary_table;
 mod no_truncate_cascade;
 mod no_unlogged_table;
+mod no_update_without_from_binding;
 mod no_vacuum_full;
 mod no_with_recursive_without_limit;
 mod require_limit;
@@ -161,6 +162,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-temporary-table",
     "no-truncate-cascade",
     "no-unlogged-table",
+    "no-update-without-from-binding",
     "no-vacuum-full",
     "no-with-recursive-without-limit",
     "require-limit",
@@ -308,6 +310,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-unlogged-table",
         run: no_unlogged_table::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-update-without-from-binding",
+        run: no_update_without_from_binding::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_update_without_from_binding.rs
+++ b/crates/postgresql/src/rules/no_update_without_from_binding.rs
@@ -1,0 +1,22 @@
+//! Port of `no-update-without-from-binding`: disallow `UPDATE ... FROM ...`
+//! without a `WHERE` clause, which produces a Cartesian product.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "UpdateStmt") {
+        return;
+    }
+    // Must have a FROM clause with at least one element
+    if array_field(node, "fromClause").is_none_or(|f| f.is_empty()) {
+        return;
+    }
+    // Must be missing a WHERE clause
+    if field(node, "whereClause").is_some() {
+        return;
+    }
+    ctx.report(node, "missingJoin");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -350,6 +350,18 @@ const ruleMeta = Object.freeze({
         '`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file.',
     },
   },
+  'no-update-without-from-binding': {
+    type: 'problem',
+    description:
+      'Disallow `UPDATE ... FROM` without a `WHERE` clause (Cartesian product with the target table)',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingJoin:
+        '`UPDATE ... FROM` without a `WHERE` clause produces a Cartesian product with the target table; add a `WHERE t.x = other.x` condition to bind the rows.',
+    },
+  },
   'no-vacuum-full': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5767,19 +5767,19 @@
       },
       {
         "name": "no-update-without-from-binding",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-update-without-from-binding."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-update-without-from-binding; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-vacuum-full",


### PR DESCRIPTION
Part of #14. Ports `no-update-without-from-binding`. Detects `UPDATE ... FROM ...` without a `WHERE` clause, which produces a Cartesian product with the target table. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784028424&installation_id=136613492&pr_number=321&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F321&signature=164c5c7f8d21d9ecf7b3e9fb907492a3ce4189d3e3827a772bbd06aa2c854b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->