### PR TITLE
feat(postgresql): port require-named-constraint

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -34,6 +34,7 @@ mod no_unlogged_table;
 mod no_vacuum_full;
 mod no_with_recursive_without_limit;
 mod require_limit;
+mod require_named_constraint;
 mod require_where_in_delete;
 mod require_where_in_update;
 
@@ -164,6 +165,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-vacuum-full",
     "no-with-recursive-without-limit",
     "require-limit",
+    "require-named-constraint",
     "require-where-in-delete",
     "require-where-in-update",
 ];
@@ -323,6 +325,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-limit",
         run: require_limit::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-named-constraint",
+        run: require_named_constraint::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/require_named_constraint.rs
+++ b/crates/postgresql/src/rules/require_named_constraint.rs
@@ -1,0 +1,60 @@
+//! Port of `require-named-constraint`: require an explicit `CONSTRAINT <name>`
+//! on table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+const UNNAMED_CONTYPES: &[&str] = &[
+    "CONSTR_CHECK",
+    "CONSTR_UNIQUE",
+    "CONSTR_FOREIGN",
+    "CONSTR_EXCLUSION",
+];
+
+fn is_unnamed_constraint(elt: &Value) -> bool {
+    if !is_type(elt, "Constraint") {
+        return false;
+    }
+    let contype = match str_field(elt, "contype") {
+        Some(ct) => ct,
+        None => return false,
+    };
+    if !UNNAMED_CONTYPES.contains(&contype) {
+        return false;
+    }
+    // conname must be absent or an empty string
+    match field(elt, "conname") {
+        None => true,
+        Some(v) => v.as_str().is_some_and(|s| s.is_empty()),
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "CreateStmt") {
+        let elts = match array_field(node, "tableElts") {
+            Some(e) => e,
+            None => return,
+        };
+        for elt in elts {
+            if is_unnamed_constraint(elt) {
+                ctx.report(elt, "requireNamedConstraint");
+            }
+        }
+        return;
+    }
+
+    if is_type(node, "AlterTableCmd") {
+        if str_field(node, "subtype") != Some("AT_AddConstraint") {
+            return;
+        }
+        let def = match field(node, "def") {
+            Some(d) => d,
+            None => return,
+        };
+        if is_unnamed_constraint(def) {
+            ctx.report(node, "requireNamedConstraint");
+        }
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -385,6 +385,18 @@ const ruleMeta = Object.freeze({
         'SELECT statement should include a LIMIT clause to prevent excessive data retrieval',
     },
   },
+  'require-named-constraint': {
+    type: 'suggestion',
+    description:
+      'Require an explicit `CONSTRAINT <name>` on table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      requireNamedConstraint:
+        'Table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints should be named with `CONSTRAINT <name>`. Auto-generated names are unpredictable across environments and make later `DROP CONSTRAINT` / `ALTER CONSTRAINT` migrations brittle.',
+    },
+  },
   'require-where-in-delete': {
     type: 'problem',
     description: 'Require a WHERE clause in DELETE statements',

--- a/status.json
+++ b/status.json
@@ -6071,19 +6071,19 @@
       },
       {
         "name": "require-named-constraint",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-named-constraint."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-named-constraint; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-on-delete-action",


### PR DESCRIPTION
Part of #14. Ports `require-named-constraint`. Flags table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints without an explicit `CONSTRAINT <name>` in both CREATE TABLE and ALTER TABLE ADD CONSTRAINT contexts. Validated against upstream fixtures; clippy -D warnings clean.