### PR TITLE
feat(postgresql): port require-primary-key

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -39,6 +39,7 @@ mod no_with_recursive_without_limit;
 mod prefer_exists_over_in_subquery;
 mod require_limit;
 mod require_named_constraint;
+mod require_primary_key;
 mod require_where_in_delete;
 mod require_where_in_update;
 mod snake_case_table_name;
@@ -175,6 +176,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "prefer-exists-over-in-subquery",
     "require-limit",
     "require-named-constraint",
+    "require-primary-key",
     "require-where-in-delete",
     "require-where-in-update",
     "snake-case-table-name",
@@ -360,6 +362,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-named-constraint",
         run: require_named_constraint::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-primary-key",
+        run: require_primary_key::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/require_primary_key.rs
+++ b/crates/postgresql/src/rules/require_primary_key.rs
@@ -1,0 +1,55 @@
+//! Port of `require-primary-key`: every `CREATE TABLE` should have a PRIMARY
+//! KEY (either a column constraint or a table-level constraint).
+
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+fn has_primary_key(elts: &[Value]) -> bool {
+    for elt in elts {
+        // Table-level PRIMARY KEY constraint
+        if is_type(elt, "Constraint") && str_field(elt, "contype") == Some("CONSTR_PRIMARY") {
+            return true;
+        }
+        // Column-level PRIMARY KEY constraint (inside a ColumnDef)
+        if is_type(elt, "ColumnDef")
+            && let Some(constraints) = array_field(elt, "constraints")
+        {
+            for constraint in constraints {
+                if is_type(constraint, "Constraint")
+                    && str_field(constraint, "contype") == Some("CONSTR_PRIMARY")
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let elts = match array_field(node, "tableElts") {
+        Some(e) if !e.is_empty() => e,
+        _ => return,
+    };
+    if has_primary_key(elts) {
+        return;
+    }
+    let relname = field(node, "relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    ctx.report_data(
+        node,
+        "missingPrimaryKey",
+        SmallVec::from_iter([DiagnosticDatum {
+            key: CompactString::from("table"),
+            value: CompactString::from(relname),
+        }]),
+    );
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -443,6 +443,17 @@ const ruleMeta = Object.freeze({
         'Table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints should be named with `CONSTRAINT <name>`. Auto-generated names are unpredictable across environments and make later `DROP CONSTRAINT` / `ALTER CONSTRAINT` migrations brittle.',
     },
   },
+  'require-primary-key': {
+    type: 'suggestion',
+    description: 'Require every `CREATE TABLE` to have a PRIMARY KEY',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingPrimaryKey:
+        'Table `{{table}}` has no PRIMARY KEY. Tables without one cannot be replicated cleanly, cannot be sharded predictably, and break almost every ORM. Add one as either a column constraint or a table-level constraint.',
+    },
+  },
   'require-where-in-delete': {
     type: 'problem',
     description: 'Require a WHERE clause in DELETE statements',

--- a/status.json
+++ b/status.json
@@ -6103,19 +6103,19 @@
       },
       {
         "name": "require-primary-key",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-primary-key."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-primary-key; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-schema-qualified-table",


### PR DESCRIPTION
Part of #14. Ports `require-primary-key`. Flags CREATE TABLE statements that have no PRIMARY KEY (neither column-level nor table-level). Reports the CreateStmt with the table name interpolated into the message. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784028938&installation_id=136613492&pr_number=324&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F324&signature=bf7e095f37d452bdc35e00ecb9c894ba63321f331bebee9ab11a892b144ec366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->