### PR TITLE
feat(postgresql): port require-schema-qualified-table

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -41,6 +41,7 @@ mod prefer_exists_over_in_subquery;
 mod require_limit;
 mod require_named_constraint;
 mod require_primary_key;
+mod require_schema_qualified_table;
 mod require_where_in_delete;
 mod require_where_in_update;
 mod snake_case_table_name;
@@ -179,6 +180,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "require-limit",
     "require-named-constraint",
     "require-primary-key",
+    "require-schema-qualified-table",
     "require-where-in-delete",
     "require-where-in-update",
     "snake-case-table-name",
@@ -374,6 +376,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-primary-key",
         run: require_primary_key::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-schema-qualified-table",
+        run: require_schema_qualified_table::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/require_schema_qualified_table.rs
+++ b/crates/postgresql/src/rules/require_schema_qualified_table.rs
@@ -1,0 +1,21 @@
+//! Port of `require-schema-qualified-table`: every `CREATE TABLE` should
+//! specify an explicit schema to avoid depending on `search_path`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let schemaname = node
+        .get("relation")
+        .and_then(|r| r.get("schemaname"))
+        .and_then(Value::as_str);
+    match schemaname {
+        Some(s) if !s.is_empty() => {} // qualified — OK
+        _ => ctx.report(node, "requireSchemaQualifiedTable"),
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -466,6 +466,18 @@ const ruleMeta = Object.freeze({
         'Table `{{table}}` has no PRIMARY KEY. Tables without one cannot be replicated cleanly, cannot be sharded predictably, and break almost every ORM. Add one as either a column constraint or a table-level constraint.',
     },
   },
+  'require-schema-qualified-table': {
+    type: 'suggestion',
+    description:
+      'Require `CREATE TABLE` to specify an explicit schema to avoid `search_path` dependence',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      requireSchemaQualifiedTable:
+        '`CREATE TABLE` should specify a schema (e.g. `audit.events`). Without one, the target depends on `search_path` and may land in an unintended schema. The rule is off by default in `recommended` because many projects intentionally use the `public` schema.',
+    },
+  },
   'require-where-in-delete': {
     type: 'problem',
     description: 'Require a WHERE clause in DELETE statements',

--- a/status.json
+++ b/status.json
@@ -6119,19 +6119,19 @@
       },
       {
         "name": "require-schema-qualified-table",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-schema-qualified-table."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-schema-qualified-table; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-table-columns",


### PR DESCRIPTION
Part of #14. Ports `require-schema-qualified-table`. Flags `CREATE TABLE` statements that do not include an explicit schema qualifier; tables without one depend on `search_path` and may land in an unintended schema. The rule is off by default in `recommended`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784029066&installation_id=136613492&pr_number=325&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F325&signature=ad08aa98c26274f5134ca5276903b7b81537828dfb0619c5de4be6e143dfda16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->