### PR TITLE
feat(postgresql): port snake-case-table-name

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -36,6 +36,7 @@ mod no_with_recursive_without_limit;
 mod require_limit;
 mod require_where_in_delete;
 mod require_where_in_update;
+mod snake_case_table_name;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
 /// know the full surface even while only a subset is implemented.
@@ -166,6 +167,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "require-limit",
     "require-where-in-delete",
     "require-where-in-update",
+    "snake-case-table-name",
 ];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
@@ -333,6 +335,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-where-in-update",
         run: require_where_in_update::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "snake-case-table-name",
+        run: snake_case_table_name::run,
         uses_parse_error: false,
     },
 ];

--- a/crates/postgresql/src/rules/snake_case_table_name.rs
+++ b/crates/postgresql/src/rules/snake_case_table_name.rs
@@ -1,0 +1,56 @@
+//! Port of `snake-case-table-name`: table names must be snake_case.
+//! Unquoted identifiers are folded to lowercase by PostgreSQL; quoted
+//! identifiers preserve case and can introduce inconsistencies.
+
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+fn is_snake_case(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let relname = match node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+    {
+        Some(n) => n,
+        None => return,
+    };
+
+    if is_snake_case(relname) {
+        return;
+    }
+
+    // Check the allow list from options
+    let allowed = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("allow"))
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(relname)));
+    if allowed {
+        return;
+    }
+
+    ctx.report_data(
+        node,
+        "notSnakeCase",
+        SmallVec::from_iter([DiagnosticDatum {
+            key: CompactString::from("name"),
+            value: CompactString::from(relname),
+        }]),
+    );
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -407,6 +407,29 @@ const ruleMeta = Object.freeze({
         'UPDATE without WHERE rewrites every row in the table. Add a WHERE clause to scope the change.',
     },
   },
+  'snake-case-table-name': {
+    type: 'suggestion',
+    description: 'Require table names to be snake_case',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      notSnakeCase:
+        'Table name `{{name}}` is not snake_case. PostgreSQL folds unquoted identifiers to lower case but preserves the case of quoted identifiers; mixing the two leads to `relation "BadName" does not exist` errors that are confusing to debug.',
+    },
+  },
 });
 
 const implementedRuleNames = Object.freeze(implementedPostgresqlRuleNames());

--- a/status.json
+++ b/status.json
@@ -6215,19 +6215,19 @@
       },
       {
         "name": "snake-case-table-name",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule snake-case-table-name."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/snake-case-table-name; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       }
     ]
   },


### PR DESCRIPTION
Part of #14. Ports `snake-case-table-name`. Flags `CREATE TABLE` when the table name is not snake_case (i.e. does not match `^[a-z][a-z0-9_]*$`). Supports an `allow` option array to whitelist legacy names. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784029220&installation_id=136613492&pr_number=326&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F326&signature=bb8f32396672480e74378f0f5a84c8f0ae7c0d5bbf99219cdeb50e19fca73632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->