### PR TITLE
feat(postgresql): port no-composite-primary-key

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -5,6 +5,7 @@ use crate::RuleDef;
 
 mod no_alter_column_type;
 mod no_cluster;
+mod no_composite_primary_key;
 mod no_create_role;
 mod no_cross_join;
 mod no_distinct_on_without_order_by;
@@ -135,6 +136,7 @@ pub const RULE_NAMES: [&str; 89] = [
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-alter-column-type",
     "no-cluster",
+    "no-composite-primary-key",
     "no-create-role",
     "no-cross-join",
     "no-distinct-on-without-order-by",
@@ -178,6 +180,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-cluster",
         run: no_cluster::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-composite-primary-key",
+        run: no_composite_primary_key::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_composite_primary_key.rs
+++ b/crates/postgresql/src/rules/no_composite_primary_key.rs
@@ -1,0 +1,46 @@
+//! Port of `no-composite-primary-key`: disallow composite PRIMARY KEY
+//! constraints (more than one column). Use a single-column surrogate key and
+//! a UNIQUE constraint for the natural key instead.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+fn is_composite_primary_key(elt: &Value) -> bool {
+    if !is_type(elt, "Constraint") {
+        return false;
+    }
+    if str_field(elt, "contype") != Some("CONSTR_PRIMARY") {
+        return false;
+    }
+    array_field(elt, "keys").is_some_and(|k| k.len() > 1)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "CreateStmt") {
+        let elts = match array_field(node, "tableElts") {
+            Some(e) => e,
+            None => return,
+        };
+        for elt in elts {
+            if is_composite_primary_key(elt) {
+                ctx.report(elt, "noCompositePk");
+            }
+        }
+        return;
+    }
+
+    if is_type(node, "AlterTableCmd") {
+        if str_field(node, "subtype") != Some("AT_AddConstraint") {
+            return;
+        }
+        let def = match field(node, "def") {
+            Some(d) => d,
+            None => return,
+        };
+        if is_composite_primary_key(def) {
+            ctx.report(node, "noCompositePk");
+        }
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -41,6 +41,17 @@ const ruleMeta = Object.freeze({
         '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
     },
   },
+  'no-composite-primary-key': {
+    type: 'problem',
+    description: 'Disallow composite PRIMARY KEY constraints (more than one column)',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCompositePk:
+        'Composite PRIMARY KEY is not allowed. Use a single-column surrogate key (e.g. `id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY`) and enforce the natural key with a `UNIQUE` constraint. Composite primary keys complicate joins, ORM mapping, and foreign-key references.',
+    },
+  },
   'no-create-role': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5159,19 +5159,19 @@
       },
       {
         "name": "no-composite-primary-key",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-composite-primary-key."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-composite-primary-key; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-create-role",


### PR DESCRIPTION
Part of #14. Ports `no-composite-primary-key`. Flags PRIMARY KEY constraints with more than one column in both CREATE TABLE (reports the Constraint elt) and ALTER TABLE ADD CONSTRAINT (reports the AlterTableCmd) contexts. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784029387&installation_id=136613492&pr_number=328&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F328&signature=8cec37a5fc1d2edcc832e5959b67cb97c87ece27ff768f9fdd5927083732366d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->