### PR TITLE
feat(postgresql): port no-drop-table-cascade

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -14,6 +14,7 @@ mod no_distinct_on_without_order_by;
 mod no_drop_column;
 mod no_drop_database;
 mod no_drop_not_null;
+mod no_drop_table_cascade;
 mod no_equality_with_null;
 mod no_grant_all;
 mod no_grant_to_public;
@@ -155,6 +156,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-drop-column",
     "no-drop-database",
     "no-drop-not-null",
+    "no-drop-table-cascade",
     "no-equality-with-null",
     "no-grant-all",
     "no-grant-to-public",
@@ -245,6 +247,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-drop-not-null",
         run: no_drop_not_null::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-drop-table-cascade",
+        run: no_drop_table_cascade::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_drop_table_cascade.rs
+++ b/crates/postgresql/src/rules/no_drop_table_cascade.rs
@@ -1,0 +1,20 @@
+//! Port of `no-drop-table-cascade`: disallow `DROP TABLE ... CASCADE` because
+//! it silently removes dependent objects (views, foreign keys, sequences).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "DropStmt") {
+        return;
+    }
+    if str_field(node, "behavior") != Some("DROP_CASCADE") {
+        return;
+    }
+    if str_field(node, "removeType") != Some("OBJECT_TABLE") {
+        return;
+    }
+    ctx.report(node, "noCascade");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -147,6 +147,17 @@ const ruleMeta = Object.freeze({
         '`DROP NOT NULL` lets the column store NULLs again — every consumer that already assumes the column is non-null (joins, COALESCE coverage, app-level types) silently breaks. If a row genuinely needs no value, model it with a sentinel or a separate optional table.',
     },
   },
+  'no-drop-table-cascade': {
+    type: 'problem',
+    description: 'Disallow `DROP TABLE ... CASCADE` because it silently removes dependent objects',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCascade:
+        'Avoid `DROP TABLE ... CASCADE`. CASCADE silently removes dependent objects (views, foreign keys, sequences); list them explicitly so reviewers can see the blast radius.',
+    },
+  },
   'no-equality-with-null': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5287,19 +5287,19 @@
       },
       {
         "name": "no-drop-table-cascade",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-drop-table-cascade."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-drop-table-cascade; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-equality-with-null",


### PR DESCRIPTION
Part of #14. Ports `no-drop-table-cascade`. Disallows `DROP TABLE ... CASCADE` by matching `DropStmt` nodes where `behavior=DROP_CASCADE` and `removeType=OBJECT_TABLE`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784032490&installation_id=136613492&pr_number=330&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F330&signature=45ccf7caf835373b9c6b7fc99c7d4a530a5a57e869523b935ac7fcc541139881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->