### PR TITLE
feat(postgresql): port no-update-primary-key

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -36,6 +36,7 @@ mod no_set_search_path;
 mod no_temporary_table;
 mod no_truncate_cascade;
 mod no_unlogged_table;
+mod no_update_primary_key;
 mod no_update_without_from_binding;
 mod no_vacuum_full;
 mod no_with_recursive_without_limit;
@@ -177,6 +178,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-temporary-table",
     "no-truncate-cascade",
     "no-unlogged-table",
+    "no-update-primary-key",
     "no-update-without-from-binding",
     "no-vacuum-full",
     "no-with-recursive-without-limit",
@@ -355,6 +357,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-unlogged-table",
         run: no_unlogged_table::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-update-primary-key",
+        run: no_update_primary_key::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_update_primary_key.rs
+++ b/crates/postgresql/src/rules/no_update_primary_key.rs
@@ -1,0 +1,74 @@
+//! Port of `no-update-primary-key`: disallow `UPDATE ... SET <pk> = ...` for
+//! columns the rule treats as primary keys.
+//!
+//! Default heuristic: any column literally named `id`. The option
+//! `pkColumnNames` lets a project add its own names. Additionally, for each
+//! statement the `<table>_id` column (derived from the relation being updated)
+//! is added to the per-statement set.
+
+use serde_json::Value;
+
+use crate::ast::{array_field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+const DEFAULT_PK_COLUMN_NAMES: &[&str] = &["id"];
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "UpdateStmt") {
+        return;
+    }
+
+    // Derive the table name from node.relation.relname (if present) to build
+    // the <table>_id heuristic on top of the configured global names.
+    let relname: Option<&str> = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str);
+
+    // Build the set of PK column names: options[0].pkColumnNames ?? DEFAULT, +
+    // relname_id if we have a relname. Use SmallVec to stay in the carton
+    // allocation policy.
+    let configured: SmallVec<[&str; 8]> = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("pkColumnNames"))
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_else(|| DEFAULT_PK_COLUMN_NAMES.iter().copied().collect());
+
+    // Build the <relname>_id derived name using CompactString to avoid String.
+    let derived: Option<CompactString> = relname.map(|r| {
+        let mut cs = CompactString::from(r);
+        cs.push_str("_id");
+        cs
+    });
+
+    let target_list = match array_field(node, "targetList") {
+        Some(list) => list,
+        None => return,
+    };
+
+    for target in target_list {
+        if !is_type(target, "ResTarget") {
+            continue;
+        }
+        let name = match str_field(target, "name") {
+            Some(n) => n,
+            None => continue,
+        };
+
+        let is_pk = configured.contains(&name) || derived.as_deref().is_some_and(|d| d == name);
+
+        if !is_pk {
+            continue;
+        }
+
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("name"),
+            value: CompactString::from(name),
+        });
+        ctx.report_data(target, "noUpdatePk", data);
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -409,6 +409,29 @@ const ruleMeta = Object.freeze({
         '`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file.',
     },
   },
+  'no-update-primary-key': {
+    type: 'problem',
+    description: 'Disallow `UPDATE ... SET <pk> = ...` for columns the rule treats as primary keys',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          pkColumnNames: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noUpdatePk:
+        'Avoid `UPDATE` on the primary-key column `{{name}}`. Primary keys are intended to be immutable; FK references and external systems can hold the old value.',
+    },
+  },
   'no-update-without-from-binding': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5751,19 +5751,19 @@
       },
       {
         "name": "no-update-primary-key",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-update-primary-key."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-update-primary-key; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-update-without-from-binding",


### PR DESCRIPTION
Part of #14. Ports `no-update-primary-key`. Disallows UPDATE on primary-key columns by walking UpdateStmt nodes and checking each ResTarget against the configured PK name set (default: "id" + <table>_id heuristic). Reports on the ResTarget node with data={name}. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784032666&installation_id=136613492&pr_number=331&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F331&signature=52ab0df06b22a77d000ba25e3aee9dcfc07ce27e9ac17ffeef34c7f0ec8302b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->