### PR TITLE
feat(postgresql): port no-volatile-default-on-add-column

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -38,6 +38,7 @@ mod no_truncate_cascade;
 mod no_unlogged_table;
 mod no_update_without_from_binding;
 mod no_vacuum_full;
+mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
 mod prefer_exists_over_in_subquery;
 mod require_limit;
@@ -179,6 +180,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-unlogged-table",
     "no-update-without-from-binding",
     "no-vacuum-full",
+    "no-volatile-default-on-add-column",
     "no-with-recursive-without-limit",
     "prefer-exists-over-in-subquery",
     "require-limit",
@@ -365,6 +367,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-vacuum-full",
         run: no_vacuum_full::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-volatile-default-on-add-column",
+        run: no_volatile_default_on_add_column::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_volatile_default_on_add_column.rs
+++ b/crates/postgresql/src/rules/no_volatile_default_on_add_column.rs
@@ -1,0 +1,93 @@
+//! Port of `no-volatile-default-on-add-column`: disallow
+//! `ALTER TABLE ... ADD COLUMN ... DEFAULT <volatile>()` because volatile
+//! defaults force a full table rewrite under ACCESS EXCLUSIVE.
+//!
+//! Known volatile defaults: random, gen_random_uuid, uuid_generate_v1,
+//! uuid_generate_v1mc, uuid_generate_v4, clock_timestamp, timeofday.
+//! Stable defaults (now(), current_timestamp) are NOT in the list.
+
+use serde_json::Value;
+
+use crate::ast::{array_field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Functions whose value differs row-to-row when used as a column DEFAULT.
+/// Mirrors the upstream `VOLATILE_DEFAULTS` set.
+fn is_volatile_name(name: &str) -> bool {
+    matches!(
+        name,
+        "random"
+            | "gen_random_uuid"
+            | "uuid_generate_v1"
+            | "uuid_generate_v1mc"
+            | "uuid_generate_v4"
+            | "clock_timestamp"
+            | "timeofday"
+    )
+}
+
+/// Ported from upstream `isVolatileDefault`. Unwraps one level of `TypeCast`
+/// (e.g. `gen_random_uuid()::uuid`) then checks if the expression is a
+/// `FuncCall` whose last `funcname` element matches a volatile function name.
+/// Returns the function name if volatile, `None` otherwise.
+fn volatile_func_name(raw_expr: &Value) -> Option<&str> {
+    // Unwrap TypeCast → check its arg.
+    if is_type(raw_expr, "TypeCast") {
+        return raw_expr.get("arg").and_then(volatile_func_name);
+    }
+    if !is_type(raw_expr, "FuncCall") {
+        return None;
+    }
+    let funcname = array_field(raw_expr, "funcname")?;
+    // The last element is the unqualified function name; earlier elements are
+    // schema qualifiers.
+    let last = funcname.last()?;
+    let name = last.get("sval").and_then(Value::as_str)?;
+    if is_volatile_name(name) {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddColumn") {
+        return;
+    }
+
+    let constraints = match node
+        .get("def")
+        .and_then(|d| d.get("constraints"))
+        .and_then(Value::as_array)
+    {
+        Some(c) => c,
+        None => return,
+    };
+
+    for constraint in constraints {
+        if !is_type(constraint, "Constraint") {
+            continue;
+        }
+        if str_field(constraint, "contype") != Some("CONSTR_DEFAULT") {
+            continue;
+        }
+        let raw_expr = match constraint.get("raw_expr") {
+            Some(e) => e,
+            None => continue,
+        };
+        let fn_name = match volatile_func_name(raw_expr) {
+            Some(n) => n,
+            None => continue,
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("fn"),
+            value: CompactString::from(fn_name),
+        });
+        ctx.report_data(constraint, "noVolatileDefault", data);
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -433,6 +433,18 @@ const ruleMeta = Object.freeze({
         '`VACUUM FULL` takes `ACCESS EXCLUSIVE` and rewrites the whole table; the table is unavailable for the duration. For shrinking a bloated table on a live database, use `pg_repack` or `pg_squeeze`. A plain `VACUUM` (no `FULL`) is fine.',
     },
   },
+  'no-volatile-default-on-add-column': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ... ADD COLUMN ... DEFAULT <volatile>()`; volatile defaults force a full table rewrite under `ACCESS EXCLUSIVE` because the stable-default short-cut cannot be used',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noVolatileDefault:
+        '`{{fn}}()` is VOLATILE — using it as a column DEFAULT on `ADD COLUMN` forces PostgreSQL to rewrite the entire table under `ACCESS EXCLUSIVE`. Add the column without a default, then `UPDATE` rows in batches.',
+    },
+  },
   'no-with-recursive-without-limit': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5799,19 +5799,19 @@
       },
       {
         "name": "no-volatile-default-on-add-column",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-volatile-default-on-add-column."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-volatile-default-on-add-column; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-with-recursive-without-limit",


### PR DESCRIPTION
Part of #14. Ports `no-volatile-default-on-add-column`. Disallows `ALTER TABLE ... ADD COLUMN ... DEFAULT <volatile>()` by walking `AlterTableCmd` nodes, finding `CONSTR_DEFAULT` constraints, and checking the `raw_expr` for volatile function names (with one level of `TypeCast` unwrapping). Reports on the Constraint node with `data={fn}`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784032809&installation_id=136613492&pr_number=332&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F332&signature=679ab9c13f77bbeccfd0e5954b8a43ecb13c5213dc5e0814fdfa8c768d6406cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->