### PR TITLE
docs: remove references to unrelated external project

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ vp run release patch
 
 ## Port Targets
 
-`tools/port-targets.json` lists the ESLint plugins used by flyle-nexus that Oxlint does not yet support natively (`eslint-plugin-svelte` is excluded; it is handled by [rsvelte](https://github.com/baseballyama/rsvelte), and `eslint-plugin-vue` is excluded; it is handled by [vize](https://vizejs.dev/)). Their sources are vendored under `upstream/` as submodules.
+`tools/port-targets.json` lists the ESLint plugins that Oxlint does not yet support natively (`eslint-plugin-svelte` is excluded; it is handled by [rsvelte](https://github.com/baseballyama/rsvelte), and `eslint-plugin-vue` is excluded; it is handled by [vize](https://vizejs.dev/)). Their sources are vendored under `upstream/` as submodules.
 
 ```sh
 git submodule update --init --depth 1   # fetch upstream sources

--- a/docs/port-targets/README.md
+++ b/docs/port-targets/README.md
@@ -2,7 +2,7 @@
 
 # Port targets
 
-ESLint plugins and adjacent packages used by [flyle-nexus], collected here as port targets or upstream references. `eslint-plugin-svelte` is intentionally excluded — it is handled by [rsvelte](https://github.com/baseballyama/rsvelte). `eslint-plugin-vue` is intentionally excluded — it is handled by [vize](https://vizejs.dev/). Oxlint-supported plugins (`eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-unicorn`) are used directly via Oxlint and are not listed here.
+ESLint plugins and adjacent packages collected here as port targets or upstream references. `eslint-plugin-svelte` is intentionally excluded — it is handled by [rsvelte](https://github.com/baseballyama/rsvelte). `eslint-plugin-vue` is intentionally excluded — it is handled by [vize](https://vizejs.dev/). Oxlint-supported plugins (`eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-unicorn`) are used directly via Oxlint and are not listed here.
 
 Upstream source is vendored under `upstream/` as git submodules pinned to each plugin's baseline version. The per-rule inventory below is generated from that source.
 
@@ -36,5 +36,3 @@ Upstream source is vendored under `upstream/` as git submodules pinned to each p
 | [`eslint-plugin-postgresql`](./eslint-plugin-postgresql.md) | 89 | MIT | https://github.com/baseballyama/eslint-plugin-postgresql |
 | [`postgresql-eslint-parser`](./postgresql-eslint-parser.md) | 0 | MIT | https://github.com/baseballyama/postgresql-eslint-parser |
 | **Total** | **1157** | | |
-
-[flyle-nexus]: internal

--- a/docs/port-targets/unocss-eslint-plugin.md
+++ b/docs/port-targets/unocss-eslint-plugin.md
@@ -11,7 +11,7 @@
 | Oxlint native support | none — port target |
 | Rules to port | 4 |
 
-> Pulled in via @unocss/eslint-config in flyle-nexus.
+> Pulled in via @unocss/eslint-config.
 
 ## Rules
 

--- a/tools/port-targets.json
+++ b/tools/port-targets.json
@@ -1,5 +1,5 @@
 {
-  "$note": "Port-target manifest for ESLint plugins and adjacent upstream packages used by flyle-nexus (eslint-plugin-svelte is intentionally excluded; it is handled by rsvelte. eslint-plugin-vue is intentionally excluded; it is handled by vize). This file is the single source of truth for tools/tasks/enumerate-port-rules.ts (rule enumeration) and .github/workflows/track-upstream-releases.yml (release follow-up issues). baselineVersion is the upstream npm version flyle-nexus currently uses and the version the port should target first.",
+  "$note": "Port-target manifest for ESLint plugins and adjacent upstream packages (eslint-plugin-svelte is intentionally excluded; it is handled by rsvelte. eslint-plugin-vue is intentionally excluded; it is handled by vize). This file is the single source of truth for tools/tasks/enumerate-port-rules.ts (rule enumeration) and .github/workflows/track-upstream-releases.yml (release follow-up issues). baselineVersion is the upstream npm version the port should target first.",
   "submoduleRoot": "upstream",
   "plugins": [
     {
@@ -394,7 +394,7 @@
         "exclude": ["index.ts", ".test.ts", "_.ts", "uno.config.ts"]
       },
       "docsUrlTemplate": "https://unocss.dev/integrations/eslint",
-      "notes": "Pulled in via @unocss/eslint-config in flyle-nexus."
+      "notes": "Pulled in via @unocss/eslint-config."
     },
     {
       "id": "eslint-json",

--- a/tools/tasks/enumerate-port-rules.ts
+++ b/tools/tasks/enumerate-port-rules.ts
@@ -374,7 +374,7 @@ function renderIndex(
   lines.push('# Port targets');
   lines.push('');
   lines.push(
-    'ESLint plugins and adjacent packages used by [flyle-nexus], collected here as port targets or upstream references. ' +
+    'ESLint plugins and adjacent packages collected here as port targets or upstream references. ' +
       '`eslint-plugin-svelte` is intentionally excluded — it is handled by [rsvelte](https://github.com/baseballyama/rsvelte). ' +
       '`eslint-plugin-vue` is intentionally excluded — it is handled by [vize](https://vizejs.dev/). ' +
       'Oxlint-supported plugins (`eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-unicorn`) are used directly via Oxlint and are not listed here.',
@@ -393,8 +393,6 @@ function renderIndex(
     );
   }
   lines.push(`| **Total** | **${total}** | | |`);
-  lines.push('');
-  lines.push('[flyle-nexus]: internal');
   lines.push('');
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- Remove `flyle-nexus` mentions from the port-target manifest, docs, and rule-enumeration tooling. These plugins are tracked as general port targets and should not reference an unrelated downstream project.

## Changes
- `README.md` — drop "used by flyle-nexus" from the Port Targets section
- `tools/port-targets.json` — reword `$note` and the unocss `notes`
- `tools/tasks/enumerate-port-rules.ts` — drop the `[flyle-nexus]` text and link-def line from the generated index template
- `docs/port-targets/README.md`, `docs/port-targets/unocss-eslint-plugin.md` — regenerate-equivalent manual edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784033542&installation_id=136613492&pr_number=333&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F333&signature=db8bba4bc44bc7779d43e9faa3cf3710fed115f776f92d5579359a585289d0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->