### PR TITLE
feat(postgresql): port 54 more rules to Rust (87/89 implemented)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "oxlint-plugins-_carton",
  "pg_query",
  "phf",
+ "regex",
  "serde_json",
 ]
 

--- a/crates/postgresql/Cargo.toml
+++ b/crates/postgresql/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 oxlint-plugins-carton.workspace = true
 pg_query.workspace = true
 phf.workspace = true
+regex.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/postgresql/src/ast.rs
+++ b/crates/postgresql/src/ast.rs
@@ -33,3 +33,19 @@ pub fn array_field<'a>(node: &'a Value, key: &str) -> Option<&'a [Value]> {
 pub fn str_field<'a>(node: &'a Value, key: &str) -> Option<&'a str> {
     node.get(key).and_then(Value::as_str)
 }
+
+/// The name of a `TypeName` node, mirroring upstream `getTypeName`: the enriched
+/// AST keys the `names` list as `"0"`, `"1"`, … of `String` nodes; the type is
+/// the last segment's `sval` (`"1"` if present, else `"0"`), so `varchar`'s
+/// `pg_catalog.varchar` resolves to `varchar` and a bare `money` to `money`.
+#[allow(dead_code, reason = "shared accessor used by rules added in later PRs")]
+pub fn type_name(type_name: Option<&Value>) -> Option<&str> {
+    let names = type_name?;
+    let sval = |key: &str| {
+        names
+            .get(key)
+            .and_then(|segment| segment.get("sval"))
+            .and_then(Value::as_str)
+    };
+    sval("1").or_else(|| sval("0"))
+}

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,39 +3,93 @@
 
 use crate::RuleDef;
 
+mod align_column_definitions;
+mod align_values;
+mod consistent_as_for_column_alias;
+mod consistent_as_for_table_alias;
+mod consistent_between_over_and;
+mod consistent_create_index_concurrently;
+mod consistent_create_or_replace;
+mod consistent_drop_index_concurrently;
+mod consistent_explicit_inner_join;
+mod consistent_explicit_outer_join;
+mod consistent_fk_not_valid;
+mod consistent_identity_over_serial;
+mod consistent_jsonb_over_json;
+mod consistent_reindex_concurrently;
+mod consistent_text_over_varchar;
+mod consistent_timestamptz;
+mod no_add_check_constraint_without_not_valid;
+mod no_add_column_not_null_without_default;
+mod no_add_unique_constraint_directly;
 mod no_alter_column_type;
+mod no_char_type;
 mod no_cluster;
+mod no_composite_primary_key;
 mod no_create_role;
 mod no_cross_join;
 mod no_distinct_on_without_order_by;
 mod no_drop_column;
 mod no_drop_database;
 mod no_drop_not_null;
+mod no_drop_schema_cascade;
+mod no_drop_table_cascade;
 mod no_equality_with_null;
 mod no_grant_all;
 mod no_grant_to_public;
 mod no_group_by_ordinal;
 mod no_having_without_group_by;
+mod no_identifier_too_long;
 mod no_implicit_join;
 mod no_leading_wildcard_like;
+mod no_money_type;
 mod no_natural_join;
+mod no_not_in_subquery;
+mod no_numeric_without_precision;
 mod no_on_delete_cascade;
 mod no_order_by_ordinal;
 mod no_rename_column;
 mod no_rename_table;
 mod no_rule;
+mod no_security_definer_without_search_path;
 mod no_select_into;
 mod no_select_star;
 mod no_set_not_null;
 mod no_set_search_path;
 mod no_temporary_table;
+mod no_time_type;
 mod no_truncate_cascade;
 mod no_unlogged_table;
+mod no_unnecessary_quoted_identifier;
+mod no_update_primary_key;
+mod no_update_without_from_binding;
 mod no_vacuum_full;
+mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
+mod plpgsql_keyword_case;
+mod prefer_add_constraint_not_valid;
+mod prefer_bigint_id;
+mod prefer_cast_operator;
+mod prefer_coalesce_over_case;
+mod prefer_current_timestamp_over_now;
+mod prefer_exists_over_in_subquery;
+mod prefer_explicit_null_ordering;
+mod prefer_in_list_over_or;
+mod prefer_keyword_case;
+mod prefer_not_equals_operator;
+mod require_fk_include_columns;
+mod require_if_exists;
 mod require_limit;
+mod require_named_constraint;
+mod require_on_delete_action;
+mod require_primary_key;
+mod require_schema_qualified_table;
+mod require_table_columns;
+mod require_trailing_semicolon;
 mod require_where_in_delete;
 mod require_where_in_update;
+mod snake_case_column_name;
+mod snake_case_table_name;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
 /// know the full surface even while only a subset is implemented.
@@ -133,51 +187,210 @@ pub const RULE_NAMES: [&str; 89] = [
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "align-column-definitions",
+    "align-values",
+    "consistent-as-for-column-alias",
+    "consistent-as-for-table-alias",
+    "consistent-between-over-and",
+    "consistent-create-index-concurrently",
+    "consistent-create-or-replace",
+    "consistent-drop-index-concurrently",
+    "consistent-explicit-inner-join",
+    "consistent-explicit-outer-join",
+    "consistent-fk-not-valid",
+    "consistent-identity-over-serial",
+    "consistent-jsonb-over-json",
+    "consistent-reindex-concurrently",
+    "consistent-text-over-varchar",
+    "consistent-timestamptz",
+    "no-add-check-constraint-without-not-valid",
+    "no-add-column-not-null-without-default",
+    "no-add-unique-constraint-directly",
     "no-alter-column-type",
+    "no-char-type",
     "no-cluster",
+    "no-composite-primary-key",
     "no-create-role",
     "no-cross-join",
     "no-distinct-on-without-order-by",
     "no-drop-column",
     "no-drop-database",
     "no-drop-not-null",
+    "no-drop-schema-cascade",
+    "no-drop-table-cascade",
     "no-equality-with-null",
     "no-grant-all",
     "no-grant-to-public",
     "no-group-by-ordinal",
     "no-having-without-group-by",
+    "no-identifier-too-long",
     "no-implicit-join",
     "no-leading-wildcard-like",
+    "no-money-type",
     "no-natural-join",
+    "no-not-in-subquery",
+    "no-numeric-without-precision",
     "no-on-delete-cascade",
     "no-order-by-ordinal",
     "no-rename-column",
     "no-rename-table",
     "no-rule",
+    "no-security-definer-without-search-path",
     "no-select-into",
     "no-select-star",
     "no-set-not-null",
     "no-set-search-path",
     "no-temporary-table",
+    "no-time-type",
     "no-truncate-cascade",
     "no-unlogged-table",
+    "no-unnecessary-quoted-identifier",
+    "no-update-primary-key",
+    "no-update-without-from-binding",
     "no-vacuum-full",
+    "no-volatile-default-on-add-column",
     "no-with-recursive-without-limit",
+    "plpgsql-keyword-case",
+    "prefer-add-constraint-not-valid",
+    "prefer-bigint-id",
+    "prefer-cast-operator",
+    "prefer-coalesce-over-case",
+    "prefer-current-timestamp-over-now",
+    "prefer-exists-over-in-subquery",
+    "prefer-explicit-null-ordering",
+    "prefer-in-list-over-or",
+    "prefer-keyword-case",
+    "prefer-not-equals-operator",
+    "require-fk-include-columns",
+    "require-if-exists",
     "require-limit",
+    "require-named-constraint",
+    "require-on-delete-action",
+    "require-primary-key",
+    "require-schema-qualified-table",
+    "require-table-columns",
+    "require-trailing-semicolon",
     "require-where-in-delete",
     "require-where-in-update",
+    "snake-case-column-name",
+    "snake-case-table-name",
 ];
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "align-column-definitions",
+        run: align_column_definitions::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "align-values",
+        run: align_values::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-as-for-column-alias",
+        run: consistent_as_for_column_alias::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-as-for-table-alias",
+        run: consistent_as_for_table_alias::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-between-over-and",
+        run: consistent_between_over_and::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-create-index-concurrently",
+        run: consistent_create_index_concurrently::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-create-or-replace",
+        run: consistent_create_or_replace::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "consistent-drop-index-concurrently",
+        run: consistent_drop_index_concurrently::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-explicit-inner-join",
+        run: consistent_explicit_inner_join::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "consistent-explicit-outer-join",
+        run: consistent_explicit_outer_join::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "consistent-fk-not-valid",
+        run: consistent_fk_not_valid::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-identity-over-serial",
+        run: consistent_identity_over_serial::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-jsonb-over-json",
+        run: consistent_jsonb_over_json::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-reindex-concurrently",
+        run: consistent_reindex_concurrently::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-text-over-varchar",
+        run: consistent_text_over_varchar::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-timestamptz",
+        run: consistent_timestamptz::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-add-check-constraint-without-not-valid",
+        run: no_add_check_constraint_without_not_valid::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-add-column-not-null-without-default",
+        run: no_add_column_not_null_without_default::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-add-unique-constraint-directly",
+        run: no_add_unique_constraint_directly::run,
+        uses_parse_error: false,
+    },
     RuleDef {
         name: "no-alter-column-type",
         run: no_alter_column_type::run,
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-char-type",
+        run: no_char_type::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "no-cluster",
         run: no_cluster::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-composite-primary-key",
+        run: no_composite_primary_key::run,
         uses_parse_error: false,
     },
     RuleDef {
@@ -211,6 +424,16 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-drop-schema-cascade",
+        run: no_drop_schema_cascade::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-drop-table-cascade",
+        run: no_drop_table_cascade::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "no-equality-with-null",
         run: no_equality_with_null::run,
         uses_parse_error: false,
@@ -236,6 +459,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-identifier-too-long",
+        run: no_identifier_too_long::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
         name: "no-implicit-join",
         run: no_implicit_join::run,
         uses_parse_error: false,
@@ -246,8 +474,23 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-money-type",
+        run: no_money_type::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "no-natural-join",
         run: no_natural_join::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-not-in-subquery",
+        run: no_not_in_subquery::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-numeric-without-precision",
+        run: no_numeric_without_precision::run,
         uses_parse_error: false,
     },
     RuleDef {
@@ -276,6 +519,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-security-definer-without-search-path",
+        run: no_security_definer_without_search_path::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "no-select-into",
         run: no_select_into::run,
         uses_parse_error: false,
@@ -301,6 +549,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-time-type",
+        run: no_time_type::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "no-truncate-cascade",
         run: no_truncate_cascade::run,
         uses_parse_error: false,
@@ -311,8 +564,28 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "no-unnecessary-quoted-identifier",
+        run: no_unnecessary_quoted_identifier::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "no-update-primary-key",
+        run: no_update_primary_key::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-update-without-from-binding",
+        run: no_update_without_from_binding::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "no-vacuum-full",
         run: no_vacuum_full::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-volatile-default-on-add-column",
+        run: no_volatile_default_on_add_column::run,
         uses_parse_error: false,
     },
     RuleDef {
@@ -321,9 +594,104 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         uses_parse_error: false,
     },
     RuleDef {
+        name: "plpgsql-keyword-case",
+        run: plpgsql_keyword_case::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "prefer-add-constraint-not-valid",
+        run: prefer_add_constraint_not_valid::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-bigint-id",
+        run: prefer_bigint_id::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-cast-operator",
+        run: prefer_cast_operator::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-coalesce-over-case",
+        run: prefer_coalesce_over_case::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-current-timestamp-over-now",
+        run: prefer_current_timestamp_over_now::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "prefer-exists-over-in-subquery",
+        run: prefer_exists_over_in_subquery::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-explicit-null-ordering",
+        run: prefer_explicit_null_ordering::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-in-list-over-or",
+        run: prefer_in_list_over_or::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-keyword-case",
+        run: prefer_keyword_case::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "prefer-not-equals-operator",
+        run: prefer_not_equals_operator::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "require-fk-include-columns",
+        run: require_fk_include_columns::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-if-exists",
+        run: require_if_exists::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
         name: "require-limit",
         run: require_limit::run,
         uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-named-constraint",
+        run: require_named_constraint::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-on-delete-action",
+        run: require_on_delete_action::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-primary-key",
+        run: require_primary_key::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-schema-qualified-table",
+        run: require_schema_qualified_table::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-table-columns",
+        run: require_table_columns::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-trailing-semicolon",
+        run: require_trailing_semicolon::run,
+        uses_parse_error: true,
     },
     RuleDef {
         name: "require-where-in-delete",
@@ -333,6 +701,16 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-where-in-update",
         run: require_where_in_update::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "snake-case-column-name",
+        run: snake_case_column_name::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "snake-case-table-name",
+        run: snake_case_table_name::run,
         uses_parse_error: false,
     },
 ];

--- a/crates/postgresql/src/rules/align_column_definitions.rs
+++ b/crates/postgresql/src/rules/align_column_definitions.rs
@@ -1,0 +1,254 @@
+//! Port of `align-column-definitions`: vertically align `name type constraints`
+//! across the single-line `ColumnDef` rows of a `CREATE TABLE`.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "Layout rule that reconstructs and pads source text for column alignment, working with serde_json's owned String/Vec at the rule/source-text boundary."
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, is_type};
+use crate::text::Source;
+use crate::tokenize::{Token, tokenize};
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+const DEFAULT_GAP: usize = 2;
+
+struct Slot {
+    name: String,
+    type_text: String,
+    constraints_text: String,
+    rewrite_start: u32,
+    rewrite_end: u32,
+}
+
+fn range_of(node: &Value) -> Option<(u32, u32)> {
+    let arr = node.get("range")?.as_array()?;
+    let a = arr.first()?.as_u64()? as u32;
+    let b = arr.get(1)?.as_u64()? as u32;
+    Some((a, b))
+}
+
+fn gap_option(options: &Value, default: usize) -> usize {
+    options
+        .get(0)
+        .and_then(|o| o.get("gap"))
+        .and_then(Value::as_u64)
+        .map_or(default, |g| g as usize)
+}
+
+fn pad_end(s: &str, width: usize) -> String {
+    let len = s.chars().count();
+    let mut out = s.to_owned();
+    if len < width {
+        out.push_str(&" ".repeat(width - len));
+    }
+    out
+}
+
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::new();
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.push(ch);
+            prev_space = false;
+        }
+    }
+    out.trim().to_owned()
+}
+
+fn consume_array_suffix(source: &Source, start: u32) -> u32 {
+    let mut p = start;
+    loop {
+        if source.ascii_at(p) == Some(b'[') {
+            let mut q = p + 1;
+            while source.ascii_at(q).is_some_and(|c| c.is_ascii_digit()) {
+                q += 1;
+            }
+            if source.ascii_at(q) == Some(b']') {
+                p = q + 1;
+                continue;
+            }
+        }
+        break;
+    }
+    p
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let gap = gap_option(ctx.options, DEFAULT_GAP);
+    let Some(elts) = array_field(node, "tableElts") else {
+        return;
+    };
+    if elts.is_empty() {
+        return;
+    }
+
+    let mut slots: Vec<Slot> = Vec::new();
+    let mut seen_lines: Vec<u32> = Vec::new();
+    let mut tokens: Option<Vec<Token>> = None;
+
+    for elt in elts {
+        if !is_type(elt, "ColumnDef") {
+            continue;
+        }
+        let Some(col_range) = range_of(elt) else {
+            return;
+        };
+        let type_name = elt.get("typeName");
+        let Some(base_type_range) = type_name.and_then(range_of) else {
+            return;
+        };
+        let mut type_end = base_type_range.1;
+
+        if let Some(last_typmod_range) = type_name
+            .and_then(|t| t.get("typmods"))
+            .and_then(Value::as_array)
+            .and_then(|typmods| typmods.last())
+            .and_then(range_of)
+        {
+            if tokens.is_none() {
+                tokens = Some(tokenize(ctx.source).tokens);
+            }
+            if let Some(toks) = &tokens
+                && let Some(close) = toks
+                    .iter()
+                    .find(|t| t.start >= last_typmod_range.1 && t.value == ")")
+            {
+                type_end = close.end;
+            }
+        }
+
+        if type_name
+            .and_then(|t| t.get("arrayBounds"))
+            .and_then(Value::as_array)
+            .is_some_and(|a| !a.is_empty())
+        {
+            type_end = consume_array_suffix(ctx.source, type_end);
+        }
+
+        let type_range = (base_type_range.0, type_end);
+
+        let constraints: Vec<&Value> = elt
+            .get("constraints")
+            .and_then(Value::as_array)
+            .map(|cs| cs.iter().filter(|c| is_type(c, "Constraint")).collect())
+            .unwrap_or_default();
+        let last_constraint_range = constraints.last().and_then(|c| range_of(c));
+        let rewrite_end = last_constraint_range.map_or(type_range.1, |r| r.1);
+
+        let start_loc = ctx.source.position(col_range.0);
+        let end_loc = ctx.source.position(rewrite_end);
+        if start_loc.line != end_loc.line {
+            return;
+        }
+        if seen_lines.contains(&start_loc.line) {
+            return;
+        }
+        seen_lines.push(start_loc.line);
+
+        let rewrite_span = ctx.source.slice(col_range.0, rewrite_end);
+        if rewrite_span.contains("--") || rewrite_span.contains("/*") {
+            return;
+        }
+
+        let type_text = ctx.source.slice(type_range.0, type_range.1);
+        let constraints_text = match last_constraint_range {
+            Some(r) => collapse_ws(&ctx.source.slice(type_range.1, r.1)),
+            None => String::new(),
+        };
+        let name = elt
+            .get("colname")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+
+        slots.push(Slot {
+            name,
+            type_text,
+            constraints_text,
+            rewrite_start: col_range.0,
+            rewrite_end,
+        });
+    }
+
+    if slots.len() < 2 {
+        return;
+    }
+
+    let max_name = slots
+        .iter()
+        .map(|s| s.name.chars().count())
+        .max()
+        .unwrap_or(0);
+    let max_type = slots
+        .iter()
+        .map(|s| s.type_text.chars().count())
+        .max()
+        .unwrap_or(0);
+    let gap_spaces = " ".repeat(gap);
+
+    let mut rewrites: Vec<(u32, u32, String)> = Vec::new();
+    for slot in &slots {
+        let name_part = pad_end(&slot.name, max_name);
+        let mut expected = String::new();
+        expected.push_str(&name_part);
+        expected.push_str(&gap_spaces);
+        if slot.constraints_text.is_empty() {
+            expected.push_str(&slot.type_text);
+        } else {
+            expected.push_str(&pad_end(&slot.type_text, max_type));
+            expected.push_str(&gap_spaces);
+            expected.push_str(&slot.constraints_text);
+        }
+        let current = ctx.source.slice(slot.rewrite_start, slot.rewrite_end);
+        if current == expected {
+            continue;
+        }
+        rewrites.push((slot.rewrite_start, slot.rewrite_end, expected));
+    }
+
+    if rewrites.is_empty() {
+        return;
+    }
+
+    let first = &rewrites[0];
+    let sp = ctx.source.position(first.0);
+    let ep = ctx.source.position(first.1);
+    let loc = DiagnosticLoc {
+        start_line: sp.line,
+        start_column: sp.column,
+        end_line: ep.line,
+        end_column: ep.column,
+    };
+
+    let min_start = rewrites[0].0;
+    let max_end = rewrites[rewrites.len() - 1].1;
+    let mut replacement = String::new();
+    let mut cursor = min_start;
+    for (s, e, r) in &rewrites {
+        replacement.push_str(&ctx.source.slice(cursor, *s));
+        replacement.push_str(r);
+        cursor = *e;
+    }
+    replacement.push_str(&ctx.source.slice(cursor, max_end));
+
+    let fix = Some(DiagnosticFix {
+        start: min_start,
+        end: max_end,
+        replacement: CompactString::from(replacement.as_str()),
+    });
+    ctx.report_loc(loc, "misaligned", SmallVec::new(), fix);
+}

--- a/crates/postgresql/src/rules/align_values.rs
+++ b/crates/postgresql/src/rules/align_values.rs
@@ -1,0 +1,230 @@
+//! Port of `align-values`: vertically align tuple positions across the rows of
+//! a multi-row `INSERT ... VALUES (...)`.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "Layout rule that reconstructs and pads source text for VALUES alignment, working with serde_json's owned String/Vec at the rule/source-text boundary."
+)]
+#![allow(clippy::needless_range_loop)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::text::Source;
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+const DEFAULT_GAP: usize = 1;
+
+struct Row {
+    item_texts: Vec<String>,
+    rewrite_start: u32,
+    rewrite_end: u32,
+}
+
+fn gap_option(options: &Value, default: usize) -> usize {
+    options
+        .get(0)
+        .and_then(|o| o.get("gap"))
+        .and_then(Value::as_u64)
+        .map_or(default, |g| g as usize)
+}
+
+fn pad_end(s: &str, width: usize) -> String {
+    let len = s.chars().count();
+    let mut out = s.to_owned();
+    if len < width {
+        out.push_str(&" ".repeat(width - len));
+    }
+    out
+}
+
+fn visit_range(node: &Value, min: &mut Option<u32>, max: &mut Option<u32>) {
+    match node {
+        Value::Object(map) => {
+            if let Some(arr) = map.get("range").and_then(Value::as_array)
+                && let (Some(a), Some(b)) = (
+                    arr.first().and_then(Value::as_u64),
+                    arr.get(1).and_then(Value::as_u64),
+                )
+                && a != 0
+            {
+                let a = a as u32;
+                let b = b as u32;
+                if min.is_none_or(|m| a < m) {
+                    *min = Some(a);
+                }
+                if max.is_none_or(|m| b > m) {
+                    *max = Some(b);
+                }
+            }
+            for (k, v) in map {
+                if !matches!(k.as_str(), "parent" | "range" | "loc") {
+                    visit_range(v, min, max);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                visit_range(item, min, max);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn full_source_range(node: &Value) -> Option<(u32, u32)> {
+    let mut min = None;
+    let mut max = None;
+    visit_range(node, &mut min, &mut max);
+    match (min, max) {
+        (Some(a), Some(b)) => Some((a, b)),
+        _ => None,
+    }
+}
+
+fn line_text(source: &Source, offset: u32) -> String {
+    let len = source.len();
+    let clamped = offset.min(len);
+    let mut s = clamped;
+    while s > 0 && source.ascii_at(s - 1) != Some(b'\n') {
+        s -= 1;
+    }
+    let mut e = clamped;
+    while e < len && source.ascii_at(e) != Some(b'\n') {
+        e += 1;
+    }
+    source.slice(s, e)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "InsertStmt") {
+        return;
+    }
+    let Some(select) = node.get("selectStmt") else {
+        return;
+    };
+    let Some(lists) = select.get("valuesLists").and_then(Value::as_array) else {
+        return;
+    };
+    if lists.len() < 2 {
+        return;
+    }
+    let gap = gap_option(ctx.options, DEFAULT_GAP);
+
+    let mut rows: Vec<Row> = Vec::new();
+    let mut column_count: Option<usize> = None;
+    for list in lists {
+        let Some(items) = list.get("items").and_then(Value::as_array) else {
+            return;
+        };
+        if items.is_empty() {
+            return;
+        }
+        match column_count {
+            None => column_count = Some(items.len()),
+            Some(c) => {
+                if items.len() != c {
+                    return;
+                }
+            }
+        }
+        let mut ranges: Vec<(u32, u32)> = Vec::new();
+        for it in items {
+            let Some(r) = full_source_range(it) else {
+                return;
+            };
+            ranges.push(r);
+        }
+        let first = ranges[0];
+        let last = ranges[ranges.len() - 1];
+        let start_loc = ctx.source.position(first.0);
+        let end_loc = ctx.source.position(last.1);
+        if start_loc.line != end_loc.line {
+            return;
+        }
+        let line = line_text(ctx.source, first.0);
+        if line.contains("--") || line.contains("/*") {
+            return;
+        }
+        let item_texts: Vec<String> = ranges
+            .iter()
+            .map(|(s, e)| ctx.source.slice(*s, *e))
+            .collect();
+        rows.push(Row {
+            item_texts,
+            rewrite_start: first.0,
+            rewrite_end: last.1,
+        });
+    }
+    let Some(column_count) = column_count else {
+        return;
+    };
+    if rows.len() < 2 {
+        return;
+    }
+
+    let mut widths: Vec<usize> = vec![0; column_count];
+    for row in &rows {
+        for i in 0..column_count {
+            let w = row.item_texts[i].chars().count();
+            if w > widths[i] {
+                widths[i] = w;
+            }
+        }
+    }
+
+    let mut rewrites: Vec<(u32, u32, String)> = Vec::new();
+    for row in &rows {
+        let mut expected = String::new();
+        for i in 0..column_count {
+            let text = &row.item_texts[i];
+            if i == column_count - 1 {
+                expected.push_str(text);
+            } else {
+                let pad_to = widths[i] + 1 + gap;
+                let mut seg = String::new();
+                seg.push_str(text);
+                seg.push(',');
+                expected.push_str(&pad_end(&seg, pad_to));
+            }
+        }
+        let current = ctx.source.slice(row.rewrite_start, row.rewrite_end);
+        if current == expected {
+            continue;
+        }
+        rewrites.push((row.rewrite_start, row.rewrite_end, expected));
+    }
+    if rewrites.is_empty() {
+        return;
+    }
+
+    let first = &rewrites[0];
+    let sp = ctx.source.position(first.0);
+    let ep = ctx.source.position(first.1);
+    let loc = DiagnosticLoc {
+        start_line: sp.line,
+        start_column: sp.column,
+        end_line: ep.line,
+        end_column: ep.column,
+    };
+
+    let min_start = rewrites[0].0;
+    let max_end = rewrites[rewrites.len() - 1].1;
+    let mut replacement = String::new();
+    let mut cursor = min_start;
+    for (s, e, r) in &rewrites {
+        replacement.push_str(&ctx.source.slice(cursor, *s));
+        replacement.push_str(r);
+        cursor = *e;
+    }
+    replacement.push_str(&ctx.source.slice(cursor, max_end));
+
+    let fix = Some(DiagnosticFix {
+        start: min_start,
+        end: max_end,
+        replacement: CompactString::from(replacement.as_str()),
+    });
+    ctx.report_loc(loc, "misaligned", SmallVec::new(), fix);
+}

--- a/crates/postgresql/src/rules/consistent_as_for_column_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_column_alias.rs
@@ -1,0 +1,130 @@
+//! Port of `consistent-as-for-column-alias`: require (or forbid) the `AS`
+//! keyword before column aliases in `SELECT`. Token-driven, like upstream: the
+//! parser exposes the alias only as `ResTarget.name`, so the alias token is
+//! located by walking forward from the value expression's reported range end.
+//! The defensive name-match guards against parser ranges that stop mid-expression
+//! (TypeCast `::`, dotted ColumnRef, CASE), so `AS` is never inserted inside an
+//! expression.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "autofix boundary: builds fix replacement text and consumes the owned tokenizer output"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+// Strip surrounding double quotes from a quoted identifier so it can be compared
+// against `ResTarget.name` (which holds the unquoted identifier).
+fn token_identifier_text(token: &Token) -> &str {
+    let v = token.value.as_str();
+    if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
+        &v[1..v.len() - 1]
+    } else {
+        v
+    }
+}
+
+fn report(
+    ctx: &mut RuleContext,
+    token: &Token,
+    message_id: &'static str,
+    alias: &str,
+    fix: Option<DiagnosticFix>,
+) {
+    let loc = DiagnosticLoc {
+        start_line: token.start_pos.line,
+        start_column: token.start_pos.column,
+        end_line: token.end_pos.line,
+        end_column: token.end_pos.column,
+    };
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("alias"),
+        value: CompactString::from(alias),
+    });
+    ctx.report_loc(loc, message_id, data, fix);
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Only SELECT target lists; the same ResTarget type is used for INSERT column
+    // lists and UPDATE SET clauses where `AS` would be a syntax error.
+    if !is_type(node, "SelectStmt") {
+        return;
+    }
+    let Some(target_list) = array_field(node, "targetList") else {
+        return;
+    };
+    let s = style(ctx);
+    let tokens = tokenize(ctx.source).tokens;
+    for target in target_list {
+        if !is_type(target, "ResTarget") {
+            continue;
+        }
+        let Some(alias) = str_field(target, "name") else {
+            continue;
+        };
+        let Some(val) = field(target, "val") else {
+            continue;
+        };
+        let Some(val_end) = val
+            .get("range")
+            .and_then(Value::as_array)
+            .and_then(|r| r.get(1))
+            .and_then(Value::as_u64)
+        else {
+            continue;
+        };
+        let val_end = val_end as u32;
+        let Some(next_index) = tokens.iter().position(|t| t.start >= val_end) else {
+            continue;
+        };
+        let next = &tokens[next_index];
+        let has_as = next.kind == TokenKind::Keyword && next.value.eq_ignore_ascii_case("AS");
+        if s == "always" {
+            if has_as {
+                continue;
+            }
+            if token_identifier_text(next) != alias {
+                continue;
+            }
+            let fix = DiagnosticFix {
+                start: next.start,
+                end: next.start,
+                replacement: CompactString::from("AS "),
+            };
+            report(ctx, next, "preferAs", alias, Some(fix));
+            continue;
+        }
+        // style === "never"
+        if !has_as {
+            continue;
+        }
+        let Some(after) = tokens.get(next_index + 1) else {
+            continue;
+        };
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: after.start,
+            replacement: CompactString::default(),
+        };
+        report(ctx, next, "unexpectedAs", alias, Some(fix));
+    }
+}

--- a/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
@@ -1,0 +1,112 @@
+//! Port of `consistent-as-for-table-alias`: require (or forbid) the `AS`
+//! keyword before table aliases. The parser exposes the alias as
+//! `RangeVar.alias.aliasname`; the alias token is located by walking forward
+//! from the table reference's reported range end. The name-match guard ensures
+//! the next token really is the alias (not `WHERE`/`JOIN`/a column list).
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "autofix boundary: builds fix replacement text and consumes the owned tokenizer output"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{field, is_type, str_field};
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+fn report(
+    ctx: &mut RuleContext,
+    token: &Token,
+    message_id: &'static str,
+    alias: &str,
+    fix: Option<DiagnosticFix>,
+) {
+    let loc = DiagnosticLoc {
+        start_line: token.start_pos.line,
+        start_column: token.start_pos.column,
+        end_line: token.end_pos.line,
+        end_column: token.end_pos.column,
+    };
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("alias"),
+        value: CompactString::from(alias),
+    });
+    ctx.report_loc(loc, message_id, data, fix);
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "RangeVar") {
+        return;
+    }
+    let Some(alias) = field(node, "alias").and_then(|a| str_field(a, "aliasname")) else {
+        return;
+    };
+    let Some(table_end) = node
+        .get("range")
+        .and_then(Value::as_array)
+        .and_then(|r| r.get(1))
+        .and_then(Value::as_u64)
+    else {
+        return;
+    };
+    let table_end = table_end as u32;
+    let tokens = tokenize(ctx.source).tokens;
+    let Some(next_index) = tokens.iter().position(|t| t.start >= table_end) else {
+        return;
+    };
+    let next = &tokens[next_index];
+    let has_as = next.kind == TokenKind::Keyword && next.value.eq_ignore_ascii_case("AS");
+    if style(ctx) == "always" {
+        if has_as {
+            return;
+        }
+        if next.kind != TokenKind::Identifier {
+            return;
+        }
+        if next.value.as_str() != alias {
+            return;
+        }
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: next.start,
+            replacement: CompactString::from("AS "),
+        };
+        report(ctx, next, "preferAs", alias, Some(fix));
+        return;
+    }
+    // style === "never"
+    if !has_as {
+        return;
+    }
+    let Some(after) = tokens.get(next_index + 1) else {
+        return;
+    };
+    if after.kind != TokenKind::Identifier {
+        return;
+    }
+    if after.value.as_str() != alias {
+        return;
+    }
+    let fix = DiagnosticFix {
+        start: next.start,
+        end: after.start,
+        replacement: CompactString::default(),
+    };
+    report(ctx, next, "unexpectedAs", alias, Some(fix));
+}

--- a/crates/postgresql/src/rules/consistent_between_over_and.rs
+++ b/crates/postgresql/src/rules/consistent_between_over_and.rs
@@ -1,0 +1,241 @@
+//! Port of `consistent-between-over-and`: `always` rewrites `x >= a AND x <= b`
+//! into `x BETWEEN a AND b`; `never` rewrites `BETWEEN` into the two explicit
+//! comparisons. Source spans are computed with a full-subtree range union
+//! (`getFullSourceRange`) because TypeCast/ColumnRef node ranges are partial.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "autofix boundary: slices source text and builds fix replacement strings"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+// A single-operator `A_Expr` (kind AEXPR_OP, one name segment): its operator.
+fn op_name(node: &Value) -> Option<&str> {
+    if !is_type(node, "A_Expr") {
+        return None;
+    }
+    if str_field(node, "kind") != Some("AEXPR_OP") {
+        return None;
+    }
+    let name = array_field(node, "name")?;
+    if name.len() != 1 {
+        return None;
+    }
+    name[0].get("sval").and_then(Value::as_str)
+}
+
+fn visit(node: &Value, min: &mut i64, max: &mut i64) {
+    match node {
+        Value::Object(map) => {
+            if let Some(r) = map.get("range").and_then(Value::as_array)
+                && let (Some(a), Some(b)) = (
+                    r.first().and_then(Value::as_i64),
+                    r.get(1).and_then(Value::as_i64),
+                )
+                && a != 0
+            {
+                if a < *min {
+                    *min = a;
+                }
+                if b > *max {
+                    *max = b;
+                }
+            }
+            for (k, v) in map {
+                if matches!(k.as_str(), "parent" | "range" | "loc") {
+                    continue;
+                }
+                visit(v, min, max);
+            }
+        }
+        Value::Array(items) => {
+            for it in items {
+                visit(it, min, max);
+            }
+        }
+        _ => {}
+    }
+}
+
+// Union of all descendant `range`s (skipping the [0,0] no-location placeholder).
+fn full_source_range(node: &Value) -> Option<(u32, u32)> {
+    let mut min: i64 = i64::MAX;
+    let mut max: i64 = -1;
+    visit(node, &mut min, &mut max);
+    if max < 0 || min == i64::MAX {
+        None
+    } else {
+        Some((min as u32, max as u32))
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "shared report helper for both message variants"
+)]
+fn report_range(
+    ctx: &mut RuleContext,
+    start: u32,
+    end: u32,
+    message_id: &'static str,
+    lhs: &str,
+    lower: &str,
+    upper: &str,
+    replacement: CompactString,
+) {
+    let sp = ctx.source.position(start);
+    let ep = ctx.source.position(end);
+    let loc = DiagnosticLoc {
+        start_line: sp.line,
+        start_column: sp.column,
+        end_line: ep.line,
+        end_column: ep.column,
+    };
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("lhs"),
+        value: CompactString::from(lhs),
+    });
+    data.push(DiagnosticDatum {
+        key: CompactString::from("lower"),
+        value: CompactString::from(lower),
+    });
+    data.push(DiagnosticDatum {
+        key: CompactString::from("upper"),
+        value: CompactString::from(upper),
+    });
+    ctx.report_loc(
+        loc,
+        message_id,
+        data,
+        Some(DiagnosticFix {
+            start,
+            end,
+            replacement,
+        }),
+    );
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    let s = style(ctx);
+    if s == "always" && is_type(node, "BoolExpr") {
+        if str_field(node, "boolop") != Some("AND_EXPR") {
+            return;
+        }
+        let Some(args) = array_field(node, "args") else {
+            return;
+        };
+        if args.len() != 2 {
+            return;
+        }
+        let a = &args[0];
+        let b = &args[1];
+        if op_name(a) != Some(">=") || op_name(b) != Some("<=") {
+            return;
+        }
+        let (Some(a_lex), Some(a_rex), Some(b_lex), Some(b_rex)) = (
+            field(a, "lexpr"),
+            field(a, "rexpr"),
+            field(b, "lexpr"),
+            field(b, "rexpr"),
+        ) else {
+            return;
+        };
+        let (Some(al), Some(ar), Some(bl), Some(br)) = (
+            full_source_range(a_lex),
+            full_source_range(a_rex),
+            full_source_range(b_lex),
+            full_source_range(b_rex),
+        ) else {
+            return;
+        };
+        let a_lex_src = ctx.source.slice(al.0, al.1);
+        let b_lex_src = ctx.source.slice(bl.0, bl.1);
+        if a_lex_src != b_lex_src {
+            return;
+        }
+        let lower = ctx.source.slice(ar.0, ar.1);
+        let upper = ctx.source.slice(br.0, br.1);
+        let mut replacement = CompactString::default();
+        replacement.push_str(&a_lex_src);
+        replacement.push_str(" BETWEEN ");
+        replacement.push_str(&lower);
+        replacement.push_str(" AND ");
+        replacement.push_str(&upper);
+        report_range(
+            ctx,
+            al.0,
+            br.1,
+            "preferBetween",
+            &a_lex_src,
+            &lower,
+            &upper,
+            replacement,
+        );
+        return;
+    }
+    if s == "never" && is_type(node, "A_Expr") {
+        let kind = str_field(node, "kind");
+        if kind != Some("AEXPR_BETWEEN") && kind != Some("AEXPR_BETWEEN_SYM") {
+            return;
+        }
+        let Some(lexpr) = field(node, "lexpr") else {
+            return;
+        };
+        let Some(rexpr) = field(node, "rexpr") else {
+            return;
+        };
+        let Some(items) = array_field(rexpr, "items") else {
+            return;
+        };
+        if items.len() != 2 {
+            return;
+        }
+        let (Some(lhs), Some(lo), Some(hi)) = (
+            full_source_range(lexpr),
+            full_source_range(&items[0]),
+            full_source_range(&items[1]),
+        ) else {
+            return;
+        };
+        let lhs_src = ctx.source.slice(lhs.0, lhs.1);
+        let lower = ctx.source.slice(lo.0, lo.1);
+        let upper = ctx.source.slice(hi.0, hi.1);
+        let mut replacement = CompactString::default();
+        replacement.push_str(&lhs_src);
+        replacement.push_str(" >= ");
+        replacement.push_str(&lower);
+        replacement.push_str(" AND ");
+        replacement.push_str(&lhs_src);
+        replacement.push_str(" <= ");
+        replacement.push_str(&upper);
+        report_range(
+            ctx,
+            lhs.0,
+            hi.1,
+            "unexpectedBetween",
+            &lhs_src,
+            &lower,
+            &upper,
+            replacement,
+        );
+    }
+}

--- a/crates/postgresql/src/rules/consistent_create_index_concurrently.rs
+++ b/crates/postgresql/src/rules/consistent_create_index_concurrently.rs
@@ -1,0 +1,31 @@
+//! Port of `consistent-create-index-concurrently`: enforce a consistent
+//! stance on `CONCURRENTLY` for `CREATE INDEX` (either always require it, or
+//! always forbid it).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+fn style(options: &Value) -> &str {
+    options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "IndexStmt") {
+        return;
+    }
+    let has_concurrently = node.get("concurrent") == Some(&Value::Bool(true));
+    let opt = style(ctx.options);
+    let always = opt == "always";
+    let never = opt == "never";
+    if always && !has_concurrently {
+        ctx.report(node, "preferConcurrently");
+    } else if never && has_concurrently {
+        ctx.report(node, "unexpectedConcurrently");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_create_or_replace.rs
+++ b/crates/postgresql/src/rules/consistent_create_or_replace.rs
@@ -1,0 +1,89 @@
+//! Port of `consistent-create-or-replace`: enforce a consistent stance on
+//! `CREATE OR REPLACE` for `FUNCTION` / `PROCEDURE` / `VIEW` (always require it,
+//! or always forbid it). No autofix: toggling `OR REPLACE` changes runtime
+//! semantics, so the linter must not do it.
+//!
+//! Upstream walks `CreateFunctionStmt` / `ViewStmt` nodes and matches each to a
+//! `CREATE` token via a per-file cursor (the parser can emit `[0, 0]` ranges).
+//! This port scans the token stream directly: for every `CREATE` keyword it
+//! reads the (optional) `OR REPLACE` and the object kind keyword, which yields
+//! the same reports and the same `CREATE`-keyword report location. It runs once
+//! per file via the `usesParseError` entry point.
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
+
+fn style(options: &Value) -> &str {
+    options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Program-level token scan: act only on the single parse-error entry call.
+    if !node.is_null() {
+        return;
+    }
+    let opt = style(ctx.options);
+    let always = opt == "always";
+    let never = opt == "never";
+
+    let tokens = tokenize(ctx.source).tokens;
+    let n = tokens.len();
+    for i in 0..n {
+        let create = &tokens[i];
+        if !matches!(create.kind, TokenKind::Keyword)
+            || !create.value.eq_ignore_ascii_case("CREATE")
+        {
+            continue;
+        }
+        let mut j = i + 1;
+        let mut has_or_replace = false;
+        if j + 1 < n
+            && matches!(tokens[j].kind, TokenKind::Keyword)
+            && tokens[j].value.eq_ignore_ascii_case("OR")
+            && tokens[j + 1].value.eq_ignore_ascii_case("REPLACE")
+        {
+            has_or_replace = true;
+            j += 2;
+        }
+        let Some(kind_tok) = tokens.get(j) else {
+            continue;
+        };
+        let kind = if kind_tok.value.eq_ignore_ascii_case("FUNCTION") {
+            "FUNCTION"
+        } else if kind_tok.value.eq_ignore_ascii_case("PROCEDURE") {
+            "PROCEDURE"
+        } else if kind_tok.value.eq_ignore_ascii_case("VIEW") {
+            "VIEW"
+        } else {
+            continue;
+        };
+
+        let message_id = if always && !has_or_replace {
+            "preferOrReplace"
+        } else if never && has_or_replace {
+            "unexpectedOrReplace"
+        } else {
+            continue;
+        };
+        let loc = DiagnosticLoc {
+            start_line: create.start_pos.line,
+            start_column: create.start_pos.column,
+            end_line: create.end_pos.line,
+            end_column: create.end_pos.column,
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("kind"),
+            value: CompactString::from(kind),
+        });
+        ctx.report_loc(loc, message_id, data, None);
+    }
+}

--- a/crates/postgresql/src/rules/consistent_drop_index_concurrently.rs
+++ b/crates/postgresql/src/rules/consistent_drop_index_concurrently.rs
@@ -1,0 +1,34 @@
+//! Port of `consistent-drop-index-concurrently`: enforce a consistent stance
+//! on `CONCURRENTLY` for `DROP INDEX` (either always require it, or always
+//! forbid it). Non-index `DROP`s are out of scope.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+fn style(options: &Value) -> &str {
+    options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "DropStmt") {
+        return;
+    }
+    if str_field(node, "removeType") != Some("OBJECT_INDEX") {
+        return;
+    }
+    let is_concurrent = node.get("concurrent") == Some(&Value::Bool(true));
+    let opt = style(ctx.options);
+    let always = opt == "always";
+    let never = opt == "never";
+    if always && !is_concurrent {
+        ctx.report(node, "preferConcurrently");
+    } else if never && is_concurrent {
+        ctx.report(node, "unexpectedConcurrently");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_explicit_inner_join.rs
+++ b/crates/postgresql/src/rules/consistent_explicit_inner_join.rs
@@ -1,0 +1,86 @@
+//! Port of `consistent-explicit-inner-join`: enforce a consistent stance on the
+//! explicit `INNER` keyword in `INNER JOIN` (always require it, or always forbid
+//! it). Token-driven, with an autofix that inserts/removes the `INNER` keyword.
+//! Runs once per file via the `usesParseError` entry point.
+#![allow(
+    clippy::disallowed_methods,
+    reason = "autofix boundary: builds fix replacement text"
+)]
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn style(options: &Value) -> &str {
+    options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always")
+}
+
+// Keywords that already declare a join's kind when they immediately precede
+// `JOIN`. A bare `JOIN` (none of these before it) is what `always` rewrites.
+fn is_join_kind_keyword(token: &Token) -> bool {
+    matches!(token.kind, TokenKind::Keyword)
+        && matches!(
+            token.value.to_ascii_uppercase().as_str(),
+            "INNER" | "OUTER" | "LEFT" | "RIGHT" | "FULL" | "CROSS" | "NATURAL"
+        )
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let always = style(ctx.options) == "always";
+
+    let tokens = tokenize(ctx.source).tokens;
+    for i in 0..tokens.len() {
+        let token = &tokens[i];
+        if !matches!(token.kind, TokenKind::Keyword) || !token.value.eq_ignore_ascii_case("JOIN") {
+            continue;
+        }
+        let prev = if i > 0 { Some(&tokens[i - 1]) } else { None };
+        if always {
+            if prev.is_some_and(is_join_kind_keyword) {
+                continue;
+            }
+            let loc = DiagnosticLoc {
+                start_line: token.start_pos.line,
+                start_column: token.start_pos.column,
+                end_line: token.end_pos.line,
+                end_column: token.end_pos.column,
+            };
+            let fix = DiagnosticFix {
+                start: token.start,
+                end: token.start,
+                replacement: CompactString::from("INNER "),
+            };
+            ctx.report_loc(loc, "preferInnerJoin", SmallVec::new(), Some(fix));
+            continue;
+        }
+        // style === "never": flag an explicit `INNER JOIN`.
+        let Some(prev) = prev else {
+            continue;
+        };
+        if !matches!(prev.kind, TokenKind::Keyword) || !prev.value.eq_ignore_ascii_case("INNER") {
+            continue;
+        }
+        let loc = DiagnosticLoc {
+            start_line: prev.start_pos.line,
+            start_column: prev.start_pos.column,
+            end_line: token.end_pos.line,
+            end_column: token.end_pos.column,
+        };
+        let fix = DiagnosticFix {
+            start: prev.start,
+            end: token.start,
+            replacement: CompactString::from(""),
+        };
+        ctx.report_loc(loc, "unexpectedInnerJoin", SmallVec::new(), Some(fix));
+    }
+}

--- a/crates/postgresql/src/rules/consistent_explicit_outer_join.rs
+++ b/crates/postgresql/src/rules/consistent_explicit_outer_join.rs
@@ -1,0 +1,101 @@
+//! Port of `consistent-explicit-outer-join`: enforce a consistent stance on the
+//! explicit `OUTER` keyword in `LEFT`/`RIGHT`/`FULL OUTER JOIN` (always require
+//! it, or always forbid it). Token-driven with an autofix. Runs once per file
+//! via the `usesParseError` entry point.
+#![allow(
+    clippy::disallowed_methods,
+    reason = "autofix boundary: builds fix replacement text"
+)]
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn style(options: &Value) -> &str {
+    options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always")
+}
+
+fn is_side_keyword(upper: &str) -> bool {
+    matches!(upper, "LEFT" | "RIGHT" | "FULL")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let always = style(ctx.options) == "always";
+
+    let tokens = tokenize(ctx.source).tokens;
+    let len = tokens.len();
+    for i in 0..len.saturating_sub(1) {
+        let side = &tokens[i];
+        let next = &tokens[i + 1];
+        if !matches!(side.kind, TokenKind::Keyword) {
+            continue;
+        }
+        let side_upper = side.value.to_ascii_uppercase();
+        if !is_side_keyword(&side_upper) {
+            continue;
+        }
+        if !matches!(next.kind, TokenKind::Keyword) {
+            continue;
+        }
+        if always {
+            if !next.value.eq_ignore_ascii_case("JOIN") {
+                continue;
+            }
+            let loc = DiagnosticLoc {
+                start_line: side.start_pos.line,
+                start_column: side.start_pos.column,
+                end_line: next.end_pos.line,
+                end_column: next.end_pos.column,
+            };
+            let fix = DiagnosticFix {
+                start: next.start,
+                end: next.start,
+                replacement: CompactString::from("OUTER "),
+            };
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("side"),
+                value: CompactString::from(side_upper),
+            });
+            ctx.report_loc(loc, "preferOuterJoin", data, Some(fix));
+            continue;
+        }
+        // style === "never": flag `LEFT/RIGHT/FULL OUTER JOIN`.
+        if !next.value.eq_ignore_ascii_case("OUTER") {
+            continue;
+        }
+        let Some(after) = tokens.get(i + 2) else {
+            continue;
+        };
+        if !matches!(after.kind, TokenKind::Keyword) || !after.value.eq_ignore_ascii_case("JOIN") {
+            continue;
+        }
+        let loc = DiagnosticLoc {
+            start_line: side.start_pos.line,
+            start_column: side.start_pos.column,
+            end_line: after.end_pos.line,
+            end_column: after.end_pos.column,
+        };
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: after.start,
+            replacement: CompactString::from(""),
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("side"),
+            value: CompactString::from(side_upper),
+        });
+        ctx.report_loc(loc, "unexpectedOuterJoin", data, Some(fix));
+    }
+}

--- a/crates/postgresql/src/rules/consistent_fk_not_valid.rs
+++ b/crates/postgresql/src/rules/consistent_fk_not_valid.rs
@@ -1,0 +1,39 @@
+//! Port of `consistent-fk-not-valid`: enforce a consistent stance on
+//! `NOT VALID` for `ALTER TABLE ... ADD FOREIGN KEY`. `NOT VALID` sets
+//! `skip_validation: true`; option `style` is `always` (default, require it) or
+//! `never` (forbid it).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    if str_field(def, "contype") != Some("CONSTR_FOREIGN") {
+        return;
+    }
+    let skips = def.get("skip_validation") == Some(&Value::Bool(true));
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+    if style == "always" && !skips {
+        ctx.report(node, "preferFkNotValid");
+    } else if style == "never" && skips {
+        ctx.report(node, "unexpectedFkNotValid");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_identity_over_serial.rs
+++ b/crates/postgresql/src/rules/consistent_identity_over_serial.rs
@@ -1,0 +1,50 @@
+//! Port of `consistent-identity-over-serial`: enforce a consistent stance on
+//! `GENERATED ... AS IDENTITY` vs the `serial` / `bigserial` / `smallserial`
+//! pseudo-types on column definitions.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field, type_name};
+use crate::{DiagnosticDatum, RuleContext};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+fn has_identity(node: &Value) -> bool {
+    array_field(node, "constraints").is_some_and(|cs| {
+        cs.iter()
+            .any(|c| is_type(c, "Constraint") && str_field(c, "contype") == Some("CONSTR_IDENTITY"))
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    if style(ctx) == "always" {
+        if let Some(t) = type_name(field(node, "typeName"))
+            && matches!(t, "smallserial" | "serial" | "bigserial")
+        {
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("type"),
+                value: CompactString::from(t),
+            });
+            ctx.report_data(node, "preferIdentity", data);
+        }
+        return;
+    }
+    if has_identity(node) {
+        ctx.report(node, "unexpectedIdentity");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_jsonb_over_json.rs
+++ b/crates/postgresql/src/rules/consistent_jsonb_over_json.rs
@@ -1,0 +1,35 @@
+//! Port of `consistent-jsonb-over-json`: enforce a consistent stance on `jsonb`
+//! vs `json` for column types.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, type_name};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let t = type_name(field(node, "typeName"));
+    if style(ctx) == "always" {
+        if t == Some("json") {
+            ctx.report(node, "preferJsonb");
+        }
+        return;
+    }
+    if t == Some("jsonb") {
+        ctx.report(node, "unexpectedJsonb");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_reindex_concurrently.rs
+++ b/crates/postgresql/src/rules/consistent_reindex_concurrently.rs
@@ -1,0 +1,36 @@
+//! Port of `consistent-reindex-concurrently`: enforce a consistent stance on
+//! `CONCURRENTLY` for `REINDEX` (either always require it, or always forbid it).
+//! `CONCURRENTLY` is carried as a `DefElem { defname: "concurrently" }` in the
+//! statement's `params` list.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, is_type, str_field};
+
+fn style(options: &Value) -> &str {
+    options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ReindexStmt") {
+        return;
+    }
+    let concurrent = array_field(node, "params").is_some_and(|params| {
+        params
+            .iter()
+            .any(|p| is_type(p, "DefElem") && str_field(p, "defname") == Some("concurrently"))
+    });
+    let opt = style(ctx.options);
+    let always = opt == "always";
+    let never = opt == "never";
+    if always && !concurrent {
+        ctx.report(node, "preferReindexConcurrently");
+    } else if never && concurrent {
+        ctx.report(node, "unexpectedReindexConcurrently");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_text_over_varchar.rs
+++ b/crates/postgresql/src/rules/consistent_text_over_varchar.rs
@@ -1,0 +1,42 @@
+//! Port of `consistent-text-over-varchar`: enforce a consistent stance on `text`
+//! vs `varchar(n)` for string columns. The `always` style only flags
+//! length-bounded `varchar(n)` (i.e. typeName carries `typmods`), never the
+//! unbounded `varchar`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, type_name};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let type_name_node = field(node, "typeName");
+    let name = type_name(type_name_node);
+    if style(ctx) == "always" {
+        let has_typmods = type_name_node
+            .and_then(|t| t.get("typmods"))
+            .and_then(Value::as_array)
+            .is_some();
+        if name == Some("varchar") && has_typmods {
+            ctx.report(node, "preferText");
+        }
+        return;
+    }
+    if name == Some("text") {
+        ctx.report(node, "unexpectedText");
+    }
+}

--- a/crates/postgresql/src/rules/consistent_timestamptz.rs
+++ b/crates/postgresql/src/rules/consistent_timestamptz.rs
@@ -1,0 +1,36 @@
+//! Port of `consistent-timestamptz`: enforce a consistent stance on `timestamptz`
+//! vs `timestamp` (without time zone). `TIMESTAMP WITH TIME ZONE` parses as
+//! `timestamptz`, so it is treated identically.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, type_name};
+
+fn style(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+    {
+        Some("never") => "never",
+        _ => "always",
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let t = type_name(field(node, "typeName"));
+    if style(ctx) == "always" {
+        if t == Some("timestamp") {
+            ctx.report(node, "preferTimestamptz");
+        }
+        return;
+    }
+    if t == Some("timestamptz") {
+        ctx.report(node, "unexpectedTimestamptz");
+    }
+}

--- a/crates/postgresql/src/rules/no_add_check_constraint_without_not_valid.rs
+++ b/crates/postgresql/src/rules/no_add_check_constraint_without_not_valid.rs
@@ -1,0 +1,31 @@
+//! Port of `no-add-check-constraint-without-not-valid`: disallow
+//! `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` without `NOT VALID`; the
+//! synchronous form holds `ACCESS EXCLUSIVE` on the table for the entire
+//! validating scan. `NOT VALID` sets `skip_validation: true` on the Constraint.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    if str_field(def, "contype") != Some("CONSTR_CHECK") {
+        return;
+    }
+    if def.get("skip_validation") == Some(&Value::Bool(true)) {
+        return;
+    }
+    ctx.report(node, "checkNotValid");
+}

--- a/crates/postgresql/src/rules/no_add_column_not_null_without_default.rs
+++ b/crates/postgresql/src/rules/no_add_column_not_null_without_default.rs
@@ -1,0 +1,43 @@
+//! Port of `no-add-column-not-null-without-default`: disallow
+//! `ALTER TABLE ADD COLUMN ... NOT NULL` without a `DEFAULT` because the
+//! migration fails outright on any non-empty table. A DEFAULT, GENERATED, or
+//! IDENTITY constraint on the new column makes it safe.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+fn has_any_contype(constraints: &[Value], wanted: &[&str]) -> bool {
+    constraints.iter().any(|c| {
+        is_type(c, "Constraint") && str_field(c, "contype").is_some_and(|t| wanted.contains(&t))
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddColumn") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "ColumnDef") {
+        return;
+    }
+    let Some(constraints) = array_field(def, "constraints") else {
+        return;
+    };
+    if !has_any_contype(constraints, &["CONSTR_NOTNULL"]) {
+        return;
+    }
+    if has_any_contype(
+        constraints,
+        &["CONSTR_DEFAULT", "CONSTR_GENERATED", "CONSTR_IDENTITY"],
+    ) {
+        return;
+    }
+    ctx.report(node, "noAddColumnNotNullWithoutDefault");
+}

--- a/crates/postgresql/src/rules/no_add_unique_constraint_directly.rs
+++ b/crates/postgresql/src/rules/no_add_unique_constraint_directly.rs
@@ -1,0 +1,32 @@
+//! Port of `no-add-unique-constraint-directly`: disallow
+//! `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (...)` written inline. The
+//! `USING INDEX <name>` form populates the constraint's `indexname`; its
+//! absence means the user wrote the inline form that builds the index
+//! synchronously under `ACCESS EXCLUSIVE`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    if str_field(def, "contype") != Some("CONSTR_UNIQUE") {
+        return;
+    }
+    if str_field(def, "indexname").is_some() {
+        return;
+    }
+    ctx.report(node, "useIndexFirst");
+}

--- a/crates/postgresql/src/rules/no_char_type.rs
+++ b/crates/postgresql/src/rules/no_char_type.rs
@@ -1,0 +1,15 @@
+//! Port of `no-char-type`: disallow the blank-padded `char(n)` / `bpchar`
+//! column type. PostgreSQL pads stored values to `n` with trailing spaces and
+//! trims on read, surprising every comparison and round-trip. Reports the
+//! `ColumnDef` whose type resolves to `bpchar` (both `CHAR(n)` and `BPCHAR`).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, type_name};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "ColumnDef") && type_name(field(node, "typeName")) == Some("bpchar") {
+        ctx.report(node, "noChar");
+    }
+}

--- a/crates/postgresql/src/rules/no_composite_primary_key.rs
+++ b/crates/postgresql/src/rules/no_composite_primary_key.rs
@@ -1,0 +1,35 @@
+//! Port of `no-composite-primary-key`: disallow composite (multi-column)
+//! PRIMARY KEY constraints. Mirrors upstream's two visitors: a table-level
+//! `Constraint` inside `CREATE TABLE (... PRIMARY KEY (a, b))` is reported at
+//! the constraint node, while `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY
+//! (a, b)` is reported at the `AlterTableCmd`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+fn is_composite_primary_key(def: &Value) -> bool {
+    is_type(def, "Constraint")
+        && str_field(def, "contype") == Some("CONSTR_PRIMARY")
+        && array_field(def, "keys").is_some_and(|keys| keys.len() > 1)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "CreateStmt") {
+        if let Some(elts) = array_field(node, "tableElts") {
+            for elt in elts {
+                if is_composite_primary_key(elt) {
+                    ctx.report(elt, "noCompositePk");
+                }
+            }
+        }
+        return;
+    }
+    if is_type(node, "AlterTableCmd")
+        && str_field(node, "subtype") == Some("AT_AddConstraint")
+        && field(node, "def").is_some_and(is_composite_primary_key)
+    {
+        ctx.report(node, "noCompositePk");
+    }
+}

--- a/crates/postgresql/src/rules/no_drop_schema_cascade.rs
+++ b/crates/postgresql/src/rules/no_drop_schema_cascade.rs
@@ -1,0 +1,16 @@
+//! Port of `no-drop-schema-cascade`: disallow `DROP SCHEMA ... CASCADE`, which
+//! silently removes every object in the schema.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "DropStmt")
+        && str_field(node, "removeType") == Some("OBJECT_SCHEMA")
+        && str_field(node, "behavior") == Some("DROP_CASCADE")
+    {
+        ctx.report(node, "noDropSchemaCascade");
+    }
+}

--- a/crates/postgresql/src/rules/no_drop_table_cascade.rs
+++ b/crates/postgresql/src/rules/no_drop_table_cascade.rs
@@ -1,0 +1,16 @@
+//! Port of `no-drop-table-cascade`: disallow `DROP TABLE ... CASCADE`, which
+//! silently removes dependent objects (views, foreign keys, sequences).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "DropStmt")
+        && str_field(node, "removeType") == Some("OBJECT_TABLE")
+        && str_field(node, "behavior") == Some("DROP_CASCADE")
+    {
+        ctx.report(node, "noCascade");
+    }
+}

--- a/crates/postgresql/src/rules/no_identifier_too_long.rs
+++ b/crates/postgresql/src/rules/no_identifier_too_long.rs
@@ -1,0 +1,76 @@
+//! Port of `no-identifier-too-long`: flag identifiers longer than PostgreSQL's
+//! `NAMEDATALEN - 1` byte limit (default 63). libpg_query silently truncates
+//! over-length names at parse time, so the rule walks the token stream once at
+//! program level (invoked with the null node via `uses_parse_error`), where the
+//! raw user text survives. Byte length is measured in UTF-8 to match the
+//! server's fixed-width `name` column.
+#![allow(
+    clippy::disallowed_methods,
+    reason = "the byte count and configured limit are formatted into diagnostic interpolation data — a presentation boundary, not rule hot-state"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
+
+const DEFAULT_MAX: u64 = 63;
+
+/// `"a""b"` is the SQL escape for the identifier `a"b`; PostgreSQL truncates the
+/// post-unescape form, so that is what we measure.
+fn unquote_identifier(value: &str) -> CompactString {
+    CompactString::from(value[1..value.len() - 1].replace("\"\"", "\"").as_str())
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let max = ctx
+        .options
+        .as_array()
+        .and_then(|opts| opts.first())
+        .and_then(|opt| opt.get("max"))
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_MAX);
+
+    for token in tokenize(ctx.source).tokens {
+        let name: CompactString = match token.kind {
+            TokenKind::Identifier => CompactString::from(token.value.as_str()),
+            TokenKind::String => {
+                let value = token.value.as_str();
+                if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+                    unquote_identifier(value)
+                } else {
+                    continue;
+                }
+            }
+            _ => continue,
+        };
+        let length = name.len();
+        if length as u64 <= max {
+            continue;
+        }
+        let loc = DiagnosticLoc {
+            start_line: token.start_pos.line,
+            start_column: token.start_pos.column,
+            end_line: token.end_pos.line,
+            end_column: token.end_pos.column,
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("name"),
+            value: name,
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("length"),
+            value: CompactString::from(length.to_string().as_str()),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("max"),
+            value: CompactString::from(max.to_string().as_str()),
+        });
+        ctx.report_loc(loc, "identifierTooLong", data, None);
+    }
+}

--- a/crates/postgresql/src/rules/no_money_type.rs
+++ b/crates/postgresql/src/rules/no_money_type.rs
@@ -1,0 +1,14 @@
+//! Port of `no-money-type`: disallow the `money` column type — its output
+//! format and precision depend on `lc_monetary`, so the same row renders
+//! differently across servers. Reports the `ColumnDef` whose type is `money`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, type_name};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "ColumnDef") && type_name(field(node, "typeName")) == Some("money") {
+        ctx.report(node, "noMoney");
+    }
+}

--- a/crates/postgresql/src/rules/no_not_in_subquery.rs
+++ b/crates/postgresql/src/rules/no_not_in_subquery.rs
@@ -1,0 +1,40 @@
+//! Port of `no-not-in-subquery`: disallow `NOT IN (subquery)` because NULLs in
+//! the subquery silently return zero rows.
+//!
+//! libpg_query encodes `NOT IN (subq)` as a `BoolExpr` with `boolop = NOT_EXPR`
+//! whose single arg is a `SubLink` of `ANY_SUBLINK` kind, with a `testexpr` and
+//! no `operName` (the `= ANY(...)` form sets `operName`).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "BoolExpr") {
+        return;
+    }
+    if str_field(node, "boolop") != Some("NOT_EXPR") {
+        return;
+    }
+    let Some(args) = array_field(node, "args") else {
+        return;
+    };
+    if args.len() != 1 {
+        return;
+    }
+    let arg = &args[0];
+    if !is_type(arg, "SubLink") {
+        return;
+    }
+    if str_field(arg, "subLinkType") != Some("ANY_SUBLINK") {
+        return;
+    }
+    if field(arg, "operName").is_some() {
+        return;
+    }
+    if field(arg, "testexpr").is_none() {
+        return;
+    }
+    ctx.report(node, "noNotInSubquery");
+}

--- a/crates/postgresql/src/rules/no_numeric_without_precision.rs
+++ b/crates/postgresql/src/rules/no_numeric_without_precision.rs
@@ -1,0 +1,29 @@
+//! Port of `no-numeric-without-precision`: require an explicit precision (and
+//! scale) on `NUMERIC` / `DECIMAL` columns. A bare `numeric` accepts unbounded
+//! magnitude and encodes nothing about the column's domain. Reports the
+//! `ColumnDef` whose type resolves to `numeric` and carries no typmods.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, type_name};
+
+fn has_typmods(type_name_node: Option<&Value>) -> bool {
+    type_name_node
+        .and_then(|t| array_field(t, "typmods"))
+        .is_some_and(|mods| !mods.is_empty())
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let type_name_node = field(node, "typeName");
+    if type_name(type_name_node) != Some("numeric") {
+        return;
+    }
+    if has_typmods(type_name_node) {
+        return;
+    }
+    ctx.report(node, "noNumericWithoutPrecision");
+}

--- a/crates/postgresql/src/rules/no_security_definer_without_search_path.rs
+++ b/crates/postgresql/src/rules/no_security_definer_without_search_path.rs
@@ -1,0 +1,40 @@
+//! Port of `no-security-definer-without-search-path`: disallow
+//! `SECURITY DEFINER` functions that do not pin `search_path`.
+//!
+//! libpg_query lists function attributes as `DefElem` options: `SECURITY
+//! DEFINER` is `defname = "security"` with a Boolean `arg.boolval = true`, and a
+//! `SET ...` clause is `defname = "set"`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateFunctionStmt") {
+        return;
+    }
+    let mut is_definer = false;
+    let mut has_set = false;
+    if let Some(options) = array_field(node, "options") {
+        for opt in options {
+            match str_field(opt, "defname") {
+                Some("security") => {
+                    if opt
+                        .get("arg")
+                        .and_then(|a| a.get("boolval"))
+                        .and_then(Value::as_bool)
+                        == Some(true)
+                    {
+                        is_definer = true;
+                    }
+                }
+                Some("set") => has_set = true,
+                _ => {}
+            }
+        }
+    }
+    if is_definer && !has_set {
+        ctx.report(node, "missingSearchPath");
+    }
+}

--- a/crates/postgresql/src/rules/no_time_type.rs
+++ b/crates/postgresql/src/rules/no_time_type.rs
@@ -1,0 +1,18 @@
+//! Port of `no-time-type`: disallow `TIME` / `TIME WITH TIME ZONE` columns.
+//! `time` has no date (cannot disambiguate around DST) and `timetz` stores an
+//! offset that is meaningless without a date. Reports the `ColumnDef` whose
+//! type resolves to `time` or `timetz`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, type_name};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    if matches!(type_name(field(node, "typeName")), Some("time" | "timetz")) {
+        ctx.report(node, "noTimeType");
+    }
+}

--- a/crates/postgresql/src/rules/no_unnecessary_quoted_identifier.rs
+++ b/crates/postgresql/src/rules/no_unnecessary_quoted_identifier.rs
@@ -1,0 +1,103 @@
+//! Port of `no-unnecessary-quoted-identifier`: flag double-quoted identifiers
+//! that would mean the same thing unquoted (e.g. `"users"` -> `users`). The
+//! parser folds the quotes away, so the rule walks the token stream once at
+//! program level (invoked with the null node via `uses_parse_error`).
+//!
+//! PostgreSQL case-folds unquoted identifiers to lowercase, so only an already
+//! all-lowercase inner text can be unquoted without renaming the object;
+//! doubled quotes (an embedded `"`) and keywords that require quoting are left
+//! alone.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+/// Mirror upstream `/^[a-z_][a-z0-9_$]*$/`.
+fn is_safe_unquoted(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '$')
+}
+
+/// Keywords that require double-quoting as an identifier in any context
+/// (RESERVED / COL_NAME / TYPE_FUNC_NAME from PostgreSQL REL_17 kwlist.h),
+/// ported verbatim from upstream `src/utils/pg-keywords.ts`.
+static PG_KEYWORDS_REQUIRING_QUOTES: phf::Set<&'static str> = phf::phf_set! {
+    "all", "analyse", "analyze", "and", "any", "array", "as", "asc",
+    "asymmetric", "authorization", "between", "bigint", "binary", "bit",
+    "boolean", "both", "case", "cast", "char", "character", "check",
+    "coalesce", "collate", "collation", "column", "concurrently", "constraint",
+    "create", "cross", "current_catalog", "current_date", "current_role",
+    "current_schema", "current_time", "current_timestamp", "current_user",
+    "dec", "decimal", "default", "deferrable", "desc", "distinct", "do",
+    "else", "end", "except", "exists", "extract", "false", "fetch", "float",
+    "for", "foreign", "freeze", "from", "full", "grant", "greatest", "group",
+    "grouping", "having", "ilike", "in", "initially", "inner", "inout", "int",
+    "integer", "intersect", "interval", "into", "is", "isnull", "join", "json",
+    "json_array", "json_arrayagg", "json_exists", "json_object",
+    "json_objectagg", "json_query", "json_scalar", "json_serialize",
+    "json_table", "json_value", "lateral", "leading", "least", "left", "like",
+    "limit", "localtime", "localtimestamp", "merge_action", "national",
+    "natural", "nchar", "none", "normalize", "not", "notnull", "null",
+    "nullif", "numeric", "offset", "on", "only", "or", "order", "out",
+    "outer", "overlaps", "overlay", "placing", "position", "precision",
+    "primary", "real", "references", "returning", "right", "row", "select",
+    "session_user", "setof", "similar", "smallint", "some", "substring",
+    "symmetric", "system_user", "table", "tablesample", "then", "time",
+    "timestamp", "to", "trailing", "treat", "trim", "true", "union", "unique",
+    "user", "using", "values", "varchar", "variadic", "verbose", "when",
+    "where", "window", "with", "xmlattributes", "xmlconcat", "xmlelement",
+    "xmlexists", "xmlforest", "xmlnamespaces", "xmlparse", "xmlpi", "xmlroot",
+    "xmlserialize", "xmltable",
+};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Program-level rule: only act on the single null-node invocation.
+    if !node.is_null() {
+        return;
+    }
+    for token in tokenize(ctx.source).tokens {
+        // The lexer emits both `'...'` and `"..."` as `String`; a quoted
+        // identifier is the double-quoted form.
+        if token.kind != TokenKind::String {
+            continue;
+        }
+        let value = token.value.as_str();
+        if value.len() < 2 || !value.starts_with('"') || !value.ends_with('"') {
+            continue;
+        }
+        let raw = &value[1..value.len() - 1];
+        // An embedded `"` (written `""`) cannot be unquoted.
+        if raw.contains("\"\"") {
+            continue;
+        }
+        if !is_safe_unquoted(raw) {
+            continue;
+        }
+        if PG_KEYWORDS_REQUIRING_QUOTES.contains(raw) {
+            continue;
+        }
+        let loc = DiagnosticLoc {
+            start_line: token.start_pos.line,
+            start_column: token.start_pos.column,
+            end_line: token.end_pos.line,
+            end_column: token.end_pos.column,
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("inner"),
+            value: CompactString::from(raw),
+        });
+        let fix = DiagnosticFix {
+            start: token.start,
+            end: token.end,
+            replacement: CompactString::from(raw),
+        };
+        ctx.report_loc(loc, "unnecessaryQuoting", data, Some(fix));
+    }
+}

--- a/crates/postgresql/src/rules/no_update_primary_key.rs
+++ b/crates/postgresql/src/rules/no_update_primary_key.rs
@@ -1,0 +1,61 @@
+//! Port of `no-update-primary-key`: disallow `UPDATE ... SET <pk> = ...` for
+//! columns the rule treats as primary keys. Default heuristic is any column
+//! named `id` plus a per-statement `<table>_id`; the `pkColumnNames` option
+//! replaces the default `id` list.
+
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "rule helpers operate on arbitrary-length identifier/column lists and reconstructed source text at the rule boundary, where owned String/Vec and per-rule formatting are appropriate"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "UpdateStmt") {
+        return;
+    }
+    let mut names: Vec<String> = match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("pkColumnNames"))
+        .and_then(Value::as_array)
+    {
+        Some(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect(),
+        None => vec![String::from("id")],
+    };
+    if let Some(relname) = field(node, "relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+    {
+        names.push(format!("{relname}_id"));
+    }
+    let Some(targets) = array_field(node, "targetList") else {
+        return;
+    };
+    for target in targets {
+        if !is_type(target, "ResTarget") {
+            continue;
+        }
+        let Some(name) = str_field(target, "name") else {
+            continue;
+        };
+        if !names.iter().any(|n| n == name) {
+            continue;
+        }
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("name"),
+            value: CompactString::from(name),
+        });
+        ctx.report_data(target, "noUpdatePk", data);
+    }
+}

--- a/crates/postgresql/src/rules/no_update_without_from_binding.rs
+++ b/crates/postgresql/src/rules/no_update_without_from_binding.rs
@@ -1,0 +1,21 @@
+//! Port of `no-update-without-from-binding`: disallow `UPDATE ... FROM other`
+//! without a `WHERE` clause (a Cartesian product with the target table).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "UpdateStmt") {
+        return;
+    }
+    let has_from = array_field(node, "fromClause").is_some_and(|f| !f.is_empty());
+    if !has_from {
+        return;
+    }
+    if field(node, "whereClause").is_some() {
+        return;
+    }
+    ctx.report(node, "missingJoin");
+}

--- a/crates/postgresql/src/rules/no_volatile_default_on_add_column.rs
+++ b/crates/postgresql/src/rules/no_volatile_default_on_add_column.rs
@@ -1,0 +1,73 @@
+//! Port of `no-volatile-default-on-add-column`: disallow
+//! `ALTER TABLE ... ADD COLUMN ... DEFAULT <volatile>()`; volatile defaults
+//! force a full table rewrite under `ACCESS EXCLUSIVE`. `now()` /
+//! `current_timestamp` / `current_date` are STABLE and excluded.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, node_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+const VOLATILE_DEFAULTS: &[&str] = &[
+    "random",
+    "gen_random_uuid",
+    "uuid_generate_v1",
+    "uuid_generate_v1mc",
+    "uuid_generate_v4",
+    "clock_timestamp",
+    "timeofday",
+];
+
+/// Returns the unqualified volatile function name when `raw_expr` is a volatile
+/// FuncCall (optionally wrapped in a single TypeCast, e.g. `gen_random_uuid()::uuid`).
+fn volatile_default_name(raw_expr: &Value) -> Option<&str> {
+    match node_type(raw_expr) {
+        Some("TypeCast") => raw_expr.get("arg").and_then(volatile_default_name),
+        Some("FuncCall") => {
+            let funcname = raw_expr.get("funcname")?.as_array()?;
+            let name = funcname.last()?.get("sval")?.as_str()?;
+            if VOLATILE_DEFAULTS.contains(&name) {
+                Some(name)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddColumn") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    let Some(constraints) = array_field(def, "constraints") else {
+        return;
+    };
+    for c in constraints {
+        if !is_type(c, "Constraint") {
+            continue;
+        }
+        if str_field(c, "contype") != Some("CONSTR_DEFAULT") {
+            continue;
+        }
+        let Some(raw_expr) = c.get("raw_expr") else {
+            continue;
+        };
+        let Some(name) = volatile_default_name(raw_expr) else {
+            continue;
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("fn"),
+            value: CompactString::from(name),
+        });
+        ctx.report_data(c, "noVolatileDefault", data);
+    }
+}

--- a/crates/postgresql/src/rules/plpgsql_keyword_case.rs
+++ b/crates/postgresql/src/rules/plpgsql_keyword_case.rs
@@ -1,0 +1,311 @@
+//! Port of `plpgsql-keyword-case`: enforce a consistent case for reserved
+//! SQL / PL/pgSQL keywords inside `plpgsql` function bodies.
+//!
+//! Program-level: the scan engine does not attach `EmbeddedCode` to the
+//! per-statement tree it walks (that only happens on the ESLint parse path), so
+//! when invoked once with `node == null` (uses_parse_error) this rule re-derives
+//! the bodies by re-parsing and running `attach_embedded_code`, then scans each
+//! plpgsql body's UTF-16 units exactly like upstream's regex word scan.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "Program-level keyword-case rule: reconstructs source text, re-derives embedded PL/pgSQL bodies, and scans them as UTF-16 units, mirroring upstream's JS string manipulation over serde_json's owned String/Vec."
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::{Value, json};
+
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+/// RESERVED_KEYWORD (kwlist.h) + PL/pgSQL reserved kwlist, lower-cased.
+const RESERVED: &[&str] = &[
+    "all",
+    "analyse",
+    "analyze",
+    "and",
+    "any",
+    "array",
+    "as",
+    "asc",
+    "asymmetric",
+    "begin",
+    "both",
+    "by",
+    "case",
+    "cast",
+    "check",
+    "collate",
+    "column",
+    "constraint",
+    "create",
+    "current_catalog",
+    "current_date",
+    "current_role",
+    "current_time",
+    "current_timestamp",
+    "current_user",
+    "declare",
+    "default",
+    "deferrable",
+    "desc",
+    "distinct",
+    "do",
+    "else",
+    "end",
+    "except",
+    "execute",
+    "false",
+    "fetch",
+    "for",
+    "foreach",
+    "foreign",
+    "from",
+    "grant",
+    "group",
+    "having",
+    "if",
+    "in",
+    "initially",
+    "intersect",
+    "into",
+    "lateral",
+    "leading",
+    "limit",
+    "localtime",
+    "localtimestamp",
+    "loop",
+    "not",
+    "null",
+    "offset",
+    "on",
+    "only",
+    "or",
+    "order",
+    "placing",
+    "primary",
+    "references",
+    "returning",
+    "select",
+    "session_user",
+    "some",
+    "strict",
+    "symmetric",
+    "system_user",
+    "table",
+    "then",
+    "to",
+    "trailing",
+    "true",
+    "union",
+    "unique",
+    "user",
+    "using",
+    "variadic",
+    "when",
+    "where",
+    "while",
+    "window",
+    "with",
+];
+
+const QUOTE: u16 = b'\'' as u16;
+const DASH: u16 = b'-' as u16;
+const SLASH: u16 = b'/' as u16;
+const STAR: u16 = b'*' as u16;
+const NL: u16 = b'\n' as u16;
+const SP: u16 = b' ' as u16;
+const TAB: u16 = b'\t' as u16;
+const DOT: u16 = b'.' as u16;
+
+fn is_word_start(u: u16) -> bool {
+    u < 128 && {
+        let b = u as u8;
+        b.is_ascii_alphabetic() || b == b'_'
+    }
+}
+
+fn is_word(u: u16) -> bool {
+    u < 128 && {
+        let b = u as u8;
+        b.is_ascii_alphanumeric() || b == b'_'
+    }
+}
+
+fn in_skip(off: u32, skip: &[(u32, u32)]) -> bool {
+    skip.iter().any(|&(s, e)| off >= s && off < e)
+}
+
+fn collect_skip(u: &[u16]) -> Vec<(u32, u32)> {
+    let n = u.len();
+    let mut skip: Vec<(u32, u32)> = Vec::new();
+    let mut i = 0usize;
+    while i < n {
+        let c = u[i];
+        if c == QUOTE {
+            let start = i;
+            i += 1;
+            while i < n {
+                if u[i] == QUOTE {
+                    if i + 1 < n && u[i + 1] == QUOTE {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            skip.push((start as u32, i as u32));
+        } else if c == DASH && i + 1 < n && u[i + 1] == DASH {
+            let start = i;
+            while i < n && u[i] != NL {
+                i += 1;
+            }
+            skip.push((start as u32, i as u32));
+        } else if c == SLASH && i + 1 < n && u[i + 1] == STAR {
+            let start = i;
+            i += 2;
+            while i + 1 < n && !(u[i] == STAR && u[i + 1] == SLASH) {
+                i += 1;
+            }
+            i += 2;
+            let end = i.min(n);
+            skip.push((start as u32, end as u32));
+        } else {
+            i += 1;
+        }
+    }
+    skip
+}
+
+fn is_field_access(u: &[u16], start: usize) -> bool {
+    if start == 0 {
+        return false;
+    }
+    let mut i = start as isize - 1;
+    while i >= 0 && (u[i as usize] == SP || u[i as usize] == TAB) {
+        i -= 1;
+    }
+    if i < 0 || u[i as usize] != DOT {
+        return false;
+    }
+    if i > 0 && u[(i - 1) as usize] == DOT {
+        return false;
+    }
+    true
+}
+
+fn scan_body(ctx: &mut RuleContext, source: &str, base: u32, upper: bool) {
+    let units: Vec<u16> = source.encode_utf16().collect();
+    let n = units.len();
+    let skip = collect_skip(&units);
+    let mut i = 0usize;
+    while i < n {
+        if !is_word_start(units[i]) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < n && is_word(units[i]) {
+            i += 1;
+        }
+        let start_u = start as u32;
+        if in_skip(start_u, &skip) || is_field_access(&units, start) {
+            continue;
+        }
+        let word = String::from_utf16_lossy(&units[start..i]);
+        let lower = word.to_lowercase();
+        if !RESERVED.contains(&lower.as_str()) {
+            continue;
+        }
+        let expected = if upper {
+            word.to_uppercase()
+        } else {
+            word.to_lowercase()
+        };
+        if word == expected {
+            continue;
+        }
+        let abs_start = base + start_u;
+        let abs_end = abs_start + (i - start) as u32;
+        let sp = ctx.source.position(abs_start);
+        let ep = ctx.source.position(abs_end);
+        let loc = DiagnosticLoc {
+            start_line: sp.line,
+            start_column: sp.column,
+            end_line: ep.line,
+            end_column: ep.column,
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("actual"),
+            value: CompactString::from(word.as_str()),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("expected"),
+            value: CompactString::from(expected.as_str()),
+        });
+        let message_id = if upper {
+            "expectedUpper"
+        } else {
+            "expectedLower"
+        };
+        let fix = Some(DiagnosticFix {
+            start: abs_start,
+            end: abs_end,
+            replacement: CompactString::from(expected.as_str()),
+        });
+        ctx.report_loc(loc, message_id, data, fix);
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let upper = !matches!(
+        ctx.options
+            .get(0)
+            .and_then(|o| o.get("case"))
+            .and_then(Value::as_str),
+        Some("lower")
+    );
+    let src = ctx.source.slice(0, ctx.source.len());
+    let crate::parse::Parsed {
+        tokens,
+        statements,
+        source: parsed_source,
+        ..
+    } = crate::parse::parse(&src);
+    let mut program = json!({ "type": "Program", "body": statements });
+    crate::embedded_code::attach_embedded_code(&mut program, &tokens, &parsed_source);
+
+    let Some(body) = program.get("body").and_then(Value::as_array) else {
+        return;
+    };
+    let mut jobs: Vec<(String, u32)> = Vec::new();
+    for stmt in body {
+        let Some(ec) = stmt.get("embeddedCode") else {
+            continue;
+        };
+        if ec.get("language").and_then(Value::as_str) != Some("plpgsql") {
+            continue;
+        }
+        let Some(base) = ec
+            .get("range")
+            .and_then(Value::as_array)
+            .and_then(|r| r.first())
+            .and_then(Value::as_u64)
+        else {
+            continue;
+        };
+        let Some(source) = ec.get("source").and_then(Value::as_str) else {
+            continue;
+        };
+        jobs.push((source.to_owned(), base as u32));
+    }
+    for (source, base) in jobs {
+        scan_body(ctx, &source, base, upper);
+    }
+}

--- a/crates/postgresql/src/rules/prefer_add_constraint_not_valid.rs
+++ b/crates/postgresql/src/rules/prefer_add_constraint_not_valid.rs
@@ -1,0 +1,33 @@
+//! Port of `prefer-add-constraint-not-valid`: prefer
+//! `ADD CONSTRAINT ... NOT VALID` + a separate `VALIDATE CONSTRAINT` for the
+//! validating constraint kinds (FOREIGN KEY, CHECK) so the validating scan
+//! does not hold `ACCESS EXCLUSIVE`. `skip_validation: true` means the user
+//! already wrote `NOT VALID`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    match str_field(def, "contype") {
+        Some("CONSTR_FOREIGN") | Some("CONSTR_CHECK") => {}
+        _ => return,
+    }
+    if def.get("skip_validation") == Some(&Value::Bool(true)) {
+        return;
+    }
+    ctx.report(node, "notValid");
+}

--- a/crates/postgresql/src/rules/prefer_bigint_id.rs
+++ b/crates/postgresql/src/rules/prefer_bigint_id.rs
@@ -1,0 +1,54 @@
+//! Port of `prefer-bigint-id`: prefer `bigint` for primary-key `id` columns.
+//! Flags an `id` column whose type is a 32-bit-or-smaller integer (`int2`,
+//! `int4`, `smallserial`, `serial`) when it is the primary key, either through a
+//! column constraint or a table-level `PRIMARY KEY (id)`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field, type_name};
+
+fn is_primary_key(col: &Value) -> bool {
+    array_field(col, "constraints").is_some_and(|cs| {
+        cs.iter()
+            .any(|c| is_type(c, "Constraint") && str_field(c, "contype") == Some("CONSTR_PRIMARY"))
+    })
+}
+
+fn table_primary_key_on(elts: &[Value], colname: &str) -> bool {
+    elts.iter().any(|elt| {
+        is_type(elt, "Constraint")
+            && str_field(elt, "contype") == Some("CONSTR_PRIMARY")
+            && array_field(elt, "keys").is_some_and(|keys| {
+                keys.iter()
+                    .any(|k| k.get("sval").and_then(Value::as_str) == Some(colname))
+            })
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let Some(elts) = array_field(node, "tableElts") else {
+        return;
+    };
+    for elt in elts {
+        if !is_type(elt, "ColumnDef") {
+            continue;
+        }
+        if str_field(elt, "colname") != Some("id") {
+            continue;
+        }
+        let Some(t) = type_name(field(elt, "typeName")) else {
+            continue;
+        };
+        if !matches!(t, "int2" | "int4" | "smallserial" | "serial") {
+            continue;
+        }
+        if !is_primary_key(elt) && !table_primary_key_on(elts, "id") {
+            continue;
+        }
+        ctx.report(elt, "preferBigintId");
+    }
+}

--- a/crates/postgresql/src/rules/prefer_cast_operator.rs
+++ b/crates/postgresql/src/rules/prefer_cast_operator.rs
@@ -1,0 +1,211 @@
+//! Port of `prefer-cast-operator`: enforce a single cast style — `x::type`
+//! operator form (default) vs `CAST(x AS type)` function form. The cast's source
+//! form is identified by the token at the node's start (`CAST` keyword vs `::`
+//! operator); the type expression's end is found by walking qualifier dots and a
+//! single matched typmod `(...)` group.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "autofix boundary: slices source text and builds fix replacement strings"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{field, is_type};
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn form(ctx: &RuleContext) -> &'static str {
+    match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("form"))
+        .and_then(Value::as_str)
+    {
+        Some("function") => "function",
+        _ => "operator",
+    }
+}
+
+// Walk forward through tokens while they look like a type expression (qualifier
+// `schema.name` chains, then a single matched `(...)` typmod group). Returns the
+// end offset, or None if the shape doesn't fit.
+fn find_type_end(tokens: &[Token], start_index: usize) -> Option<u32> {
+    let mut i = start_index;
+    let first = tokens.get(i)?;
+    if !matches!(first.kind, TokenKind::Identifier | TokenKind::Keyword) {
+        return None;
+    }
+    let mut end = first.end;
+    i += 1;
+    while i + 1 < tokens.len() {
+        let dot = &tokens[i];
+        let next = &tokens[i + 1];
+        if dot.kind == TokenKind::Punctuator
+            && dot.value == "."
+            && matches!(next.kind, TokenKind::Identifier | TokenKind::Keyword)
+        {
+            end = next.end;
+            i += 2;
+        } else {
+            break;
+        }
+    }
+    if let Some(t) = tokens.get(i)
+        && t.kind == TokenKind::Punctuator
+        && t.value == "("
+    {
+        let mut depth = 1;
+        i += 1;
+        while i < tokens.len() && depth > 0 {
+            let t = &tokens[i];
+            if t.kind == TokenKind::Punctuator && t.value == "(" {
+                depth += 1;
+            } else if t.kind == TokenKind::Punctuator && t.value == ")" {
+                depth -= 1;
+            }
+            end = t.end;
+            i += 1;
+        }
+        if depth != 0 {
+            return None;
+        }
+    }
+    Some(end)
+}
+
+fn report_replace(
+    ctx: &mut RuleContext,
+    start: u32,
+    end: u32,
+    message_id: &'static str,
+    replacement: CompactString,
+) {
+    let sp = ctx.source.position(start);
+    let ep = ctx.source.position(end);
+    let loc = DiagnosticLoc {
+        start_line: sp.line,
+        start_column: sp.column,
+        end_line: ep.line,
+        end_column: ep.column,
+    };
+    ctx.report_loc(
+        loc,
+        message_id,
+        SmallVec::new(),
+        Some(DiagnosticFix {
+            start,
+            end,
+            replacement,
+        }),
+    );
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "TypeCast") {
+        return;
+    }
+    let Some(tc_start) = node
+        .get("range")
+        .and_then(Value::as_array)
+        .and_then(|r| r.first())
+        .and_then(Value::as_u64)
+    else {
+        return;
+    };
+    let tc_start = tc_start as u32;
+    let Some(arg) = field(node, "arg") else {
+        return;
+    };
+    let Some(arg_range) = arg.get("range").and_then(Value::as_array) else {
+        return;
+    };
+    let (Some(arg_start), Some(arg_end)) = (
+        arg_range.first().and_then(Value::as_u64),
+        arg_range.get(1).and_then(Value::as_u64),
+    ) else {
+        return;
+    };
+    let arg_start = arg_start as u32;
+    let arg_end = arg_end as u32;
+    let target = form(ctx);
+    let tokens = tokenize(ctx.source).tokens;
+    let Some(head_index) = tokens.iter().position(|t| t.start == tc_start) else {
+        return;
+    };
+    let head = &tokens[head_index];
+    let is_function = head.kind == TokenKind::Keyword && head.value.eq_ignore_ascii_case("CAST");
+    let is_operator = head.kind == TokenKind::Operator && head.value == "::";
+    if !is_function && !is_operator {
+        return;
+    }
+    if (is_function && target == "function") || (is_operator && target == "operator") {
+        return;
+    }
+
+    if is_function {
+        // CAST ( arg AS type ) — find the matching `)` and the top-level `AS`.
+        let head_start = head.start;
+        let Some(open) = tokens.get(head_index + 1) else {
+            return;
+        };
+        if !(open.kind == TokenKind::Punctuator && open.value == "(") {
+            return;
+        }
+        let mut depth = 1i32;
+        let mut close_idx: Option<usize> = None;
+        let mut as_idx: Option<usize> = None;
+        let mut i = head_index + 2;
+        while i < tokens.len() {
+            let t = &tokens[i];
+            if t.kind == TokenKind::Punctuator && t.value == "(" {
+                depth += 1;
+            } else if t.kind == TokenKind::Punctuator && t.value == ")" {
+                depth -= 1;
+                if depth == 0 {
+                    close_idx = Some(i);
+                    break;
+                }
+            } else if depth == 1
+                && t.kind == TokenKind::Keyword
+                && t.value.eq_ignore_ascii_case("AS")
+            {
+                as_idx = Some(i);
+            }
+            i += 1;
+        }
+        let (Some(as_idx), Some(close_idx)) = (as_idx, close_idx) else {
+            return;
+        };
+        let close_end = tokens[close_idx].end;
+        let type_start_idx = as_idx + 1;
+        let Some(type_end) = find_type_end(&tokens, type_start_idx) else {
+            return;
+        };
+        let arg_src = ctx.source.slice(arg_start, arg_end);
+        let type_src = ctx.source.slice(tokens[type_start_idx].start, type_end);
+        let mut replacement = CompactString::default();
+        replacement.push_str(&arg_src);
+        replacement.push_str("::");
+        replacement.push_str(&type_src);
+        report_replace(ctx, head_start, close_end, "preferOperator", replacement);
+        return;
+    }
+
+    // Operator form: arg :: type
+    let type_start_idx = head_index + 1;
+    let Some(type_end) = find_type_end(&tokens, type_start_idx) else {
+        return;
+    };
+    let arg_src = ctx.source.slice(arg_start, arg_end);
+    let type_src = ctx.source.slice(tokens[type_start_idx].start, type_end);
+    let mut replacement = CompactString::default();
+    replacement.push_str("CAST(");
+    replacement.push_str(&arg_src);
+    replacement.push_str(" AS ");
+    replacement.push_str(&type_src);
+    replacement.push(')');
+    report_replace(ctx, arg_start, type_end, "preferFunction", replacement);
+}

--- a/crates/postgresql/src/rules/prefer_coalesce_over_case.rs
+++ b/crates/postgresql/src/rules/prefer_coalesce_over_case.rs
@@ -1,0 +1,89 @@
+//! Port of `prefer-coalesce-over-case`: flag the verbose `COALESCE` written as
+//! `CASE WHEN x IS NULL THEN y ELSE x END` (and its `IS NOT NULL` mirror).
+//! Only the searched single-arm form with a matching `ELSE` collapses to a
+//! two-argument `COALESCE`, so the structural shape is checked exactly.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+// Position/identity keys ignored when comparing two subtrees for equality
+// (mirrors upstream NOISE_KEYS). `type` is intentionally NOT ignored.
+fn is_noise_key(key: &str) -> bool {
+    matches!(key, "parent" | "loc" | "range")
+}
+
+fn same_node(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Object(ao), Value::Object(bo)) => {
+            let a_len = ao.keys().filter(|k| !is_noise_key(k.as_str())).count();
+            let b_len = bo.keys().filter(|k| !is_noise_key(k.as_str())).count();
+            if a_len != b_len {
+                return false;
+            }
+            ao.iter()
+                .filter(|(k, _)| !is_noise_key(k.as_str()))
+                .all(|(k, av)| match bo.get(k.as_str()) {
+                    Some(bv) => same_node(av, bv),
+                    None => false,
+                })
+        }
+        (Value::Array(aa), Value::Array(ba)) => {
+            aa.len() == ba.len() && aa.iter().zip(ba.iter()).all(|(x, y)| same_node(x, y))
+        }
+        _ => a == b,
+    }
+}
+
+fn is_null_test(node: &Value, kind: &str) -> bool {
+    is_type(node, "NullTest") && node.get("nulltesttype").and_then(Value::as_str) == Some(kind)
+}
+
+fn is_coalesce_shape(node: &Value) -> bool {
+    // Only the searched `CASE WHEN ... END` form (no `CASE expr WHEN ...`).
+    if node.get("arg").is_some() {
+        return false;
+    }
+    let Some(args) = node.get("args").and_then(Value::as_array) else {
+        return false;
+    };
+    if args.len() != 1 {
+        return false;
+    }
+    let branch = &args[0];
+    let Some(expr) = branch.get("expr") else {
+        return false;
+    };
+    let Some(defresult) = node.get("defresult") else {
+        return false;
+    };
+    let result = branch.get("result").unwrap_or(&Value::Null);
+
+    // CASE WHEN x IS NULL THEN y ELSE x END  ->  COALESCE(x, y)
+    if is_null_test(expr, "IS_NULL")
+        && let Some(arg) = expr.get("arg")
+        && same_node(arg, defresult)
+        && !same_node(arg, result)
+    {
+        return true;
+    }
+    // CASE WHEN x IS NOT NULL THEN x ELSE y END  ->  COALESCE(x, y)
+    if is_null_test(expr, "IS_NOT_NULL")
+        && let Some(arg) = expr.get("arg")
+        && same_node(arg, result)
+        && !same_node(arg, defresult)
+    {
+        return true;
+    }
+    false
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CaseExpr") {
+        return;
+    }
+    if is_coalesce_shape(node) {
+        ctx.report(node, "preferCoalesceOverCase");
+    }
+}

--- a/crates/postgresql/src/rules/prefer_current_timestamp_over_now.rs
+++ b/crates/postgresql/src/rules/prefer_current_timestamp_over_now.rs
@@ -1,0 +1,81 @@
+//! Port of `prefer-current-timestamp-over-now`: prefer the SQL-standard
+//! `CURRENT_TIMESTAMP` / `CURRENT_TIME` over PostgreSQL's `now()` and the
+//! timezone-naive `LOCALTIMESTAMP` / `LOCALTIME`. Token-driven with autofix.
+//! Runs once per file via the `usesParseError` entry point.
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let tokens = tokenize(ctx.source).tokens;
+    let n = tokens.len();
+    for i in 0..n {
+        let tok = &tokens[i];
+        // `now()` — three-token sequence Identifier "(" ")".
+        if matches!(tok.kind, TokenKind::Identifier)
+            && tok.value.eq_ignore_ascii_case("now")
+            && i + 2 < n
+        {
+            let open = &tokens[i + 1];
+            let close = &tokens[i + 2];
+            if open.value == "(" && close.value == ")" {
+                let loc = DiagnosticLoc {
+                    start_line: tok.start_pos.line,
+                    start_column: tok.start_pos.column,
+                    end_line: close.end_pos.line,
+                    end_column: close.end_pos.column,
+                };
+                let fix = DiagnosticFix {
+                    start: tok.start,
+                    end: close.end,
+                    replacement: CompactString::from("CURRENT_TIMESTAMP"),
+                };
+                ctx.report_loc(loc, "preferCurrentTimestamp", SmallVec::new(), Some(fix));
+            }
+            continue;
+        }
+        // `LOCALTIMESTAMP` / `LOCALTIME` — bareword keyword tokens.
+        if !matches!(tok.kind, TokenKind::Keyword) {
+            continue;
+        }
+        let upper = tok.value.to_ascii_uppercase();
+        let loc = DiagnosticLoc {
+            start_line: tok.start_pos.line,
+            start_column: tok.start_pos.column,
+            end_line: tok.end_pos.line,
+            end_column: tok.end_pos.column,
+        };
+        if upper == "LOCALTIMESTAMP" {
+            let fix = DiagnosticFix {
+                start: tok.start,
+                end: tok.end,
+                replacement: CompactString::from("CURRENT_TIMESTAMP"),
+            };
+            ctx.report_loc(
+                loc,
+                "preferCurrentTimestampOverLocal",
+                SmallVec::new(),
+                Some(fix),
+            );
+        } else if upper == "LOCALTIME" {
+            let fix = DiagnosticFix {
+                start: tok.start,
+                end: tok.end,
+                replacement: CompactString::from("CURRENT_TIME"),
+            };
+            ctx.report_loc(
+                loc,
+                "preferCurrentTimeOverLocal",
+                SmallVec::new(),
+                Some(fix),
+            );
+        }
+    }
+}

--- a/crates/postgresql/src/rules/prefer_exists_over_in_subquery.rs
+++ b/crates/postgresql/src/rules/prefer_exists_over_in_subquery.rs
@@ -1,0 +1,19 @@
+//! Port of `prefer-exists-over-in-subquery`: prefer `EXISTS (...)` over
+//! `... IN (subquery)` (and the equivalent `= ANY (subquery)`). Both forms parse
+//! to a `SubLink` of `ANY_SUBLINK` kind, reported at the SubLink's operator span.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SubLink") {
+        return;
+    }
+    // ANY_SUBLINK covers both `x IN (subquery)` and `x = ANY (subquery)`.
+    if str_field(node, "subLinkType") != Some("ANY_SUBLINK") {
+        return;
+    }
+    ctx.report(node, "preferExists");
+}

--- a/crates/postgresql/src/rules/prefer_explicit_null_ordering.rs
+++ b/crates/postgresql/src/rules/prefer_explicit_null_ordering.rs
@@ -1,0 +1,23 @@
+//! Port of `prefer-explicit-null-ordering`: when `ORDER BY` specifies an
+//! explicit direction (`ASC`/`DESC`/`USING`), require an explicit
+//! `NULLS FIRST` / `NULLS LAST`. A `SortBy` with a non-default direction and a
+//! default nulls ordering is reported.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SortBy") {
+        return;
+    }
+    match str_field(node, "sortby_dir") {
+        Some("SORTBY_ASC" | "SORTBY_DESC" | "SORTBY_USING") => {}
+        _ => return,
+    }
+    if str_field(node, "sortby_nulls") != Some("SORTBY_NULLS_DEFAULT") {
+        return;
+    }
+    ctx.report(node, "preferExplicitNullOrdering");
+}

--- a/crates/postgresql/src/rules/prefer_in_list_over_or.rs
+++ b/crates/postgresql/src/rules/prefer_in_list_over_or.rs
@@ -1,0 +1,154 @@
+//! Port of `prefer-in-list-over-or`: rewrite a chain of `x = a OR x = b OR ...`
+//! (same left-hand side, compared by source text) into `x IN (a, b, ...)`.
+//! Source ranges are computed with a full-subtree range union because a
+//! `TypeCast` node's own `range` is partial.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "autofix boundary: slices source text and builds fix replacement strings"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+fn visit(node: &Value, min: &mut i64, max: &mut i64) {
+    match node {
+        Value::Object(map) => {
+            if let Some(r) = map.get("range").and_then(Value::as_array)
+                && let (Some(a), Some(b)) = (
+                    r.first().and_then(Value::as_i64),
+                    r.get(1).and_then(Value::as_i64),
+                )
+                && a != 0
+            {
+                if a < *min {
+                    *min = a;
+                }
+                if b > *max {
+                    *max = b;
+                }
+            }
+            for (k, v) in map {
+                if matches!(k.as_str(), "parent" | "range" | "loc") {
+                    continue;
+                }
+                visit(v, min, max);
+            }
+        }
+        Value::Array(items) => {
+            for it in items {
+                visit(it, min, max);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn full_source_range(node: &Value) -> Option<(u32, u32)> {
+    let mut min: i64 = i64::MAX;
+    let mut max: i64 = -1;
+    visit(node, &mut min, &mut max);
+    if max < 0 || min == i64::MAX {
+        None
+    } else {
+        Some((min as u32, max as u32))
+    }
+}
+
+fn is_equality(node: &Value) -> bool {
+    is_type(node, "A_Expr")
+        && str_field(node, "kind") == Some("AEXPR_OP")
+        && array_field(node, "name").is_some_and(|name| {
+            name.len() == 1 && name[0].get("sval").and_then(Value::as_str) == Some("=")
+        })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "BoolExpr") {
+        return;
+    }
+    if str_field(node, "boolop") != Some("OR_EXPR") {
+        return;
+    }
+    let Some(args) = array_field(node, "args") else {
+        return;
+    };
+    if args.len() < 2 {
+        return;
+    }
+
+    let mut rhs_ranges: Vec<(u32, u32)> = Vec::new();
+    let mut lhs_text: Option<String> = None;
+    let mut chain_start = u32::MAX;
+    let mut chain_end: i64 = -1;
+    for arg in args {
+        if !is_equality(arg) {
+            return;
+        }
+        let (Some(lexpr), Some(rexpr)) = (field(arg, "lexpr"), field(arg, "rexpr")) else {
+            return;
+        };
+        let (Some(lhs_r), Some(rhs_r)) = (full_source_range(lexpr), full_source_range(rexpr))
+        else {
+            return;
+        };
+        let lhs_src = ctx.source.slice(lhs_r.0, lhs_r.1);
+        match &lhs_text {
+            None => lhs_text = Some(lhs_src),
+            Some(existing) if *existing != lhs_src => return,
+            _ => {}
+        }
+        rhs_ranges.push(rhs_r);
+        if lhs_r.0 < chain_start {
+            chain_start = lhs_r.0;
+        }
+        if (rhs_r.1 as i64) > chain_end {
+            chain_end = rhs_r.1 as i64;
+        }
+    }
+    let Some(lhs_text) = lhs_text else {
+        return;
+    };
+    if chain_end < 0 {
+        return;
+    }
+    let chain_end = chain_end as u32;
+
+    let rhs_texts: Vec<String> = rhs_ranges
+        .iter()
+        .map(|(s, e)| ctx.source.slice(*s, *e))
+        .collect();
+    let mut replacement = CompactString::default();
+    replacement.push_str(&lhs_text);
+    replacement.push_str(" IN (");
+    replacement.push_str(&rhs_texts.join(", "));
+    replacement.push(')');
+
+    let sp = ctx.source.position(chain_start);
+    let ep = ctx.source.position(chain_end);
+    let loc = DiagnosticLoc {
+        start_line: sp.line,
+        start_column: sp.column,
+        end_line: ep.line,
+        end_column: ep.column,
+    };
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("lhs"),
+        value: CompactString::from(lhs_text.as_str()),
+    });
+    ctx.report_loc(
+        loc,
+        "preferIn",
+        data,
+        Some(DiagnosticFix {
+            start: chain_start,
+            end: chain_end,
+            replacement,
+        }),
+    );
+}

--- a/crates/postgresql/src/rules/prefer_keyword_case.rs
+++ b/crates/postgresql/src/rules/prefer_keyword_case.rs
@@ -1,0 +1,241 @@
+//! Port of `prefer-keyword-case`: enforce a consistent case for SQL keyword
+//! tokens, exempting identifier-positioned tokens (column/table/constraint
+//! names, type names by default, dotted field access, INSERT column lists,
+//! IndexElem / Constraint key columns).
+//!
+//! This is a program-level rule: the scan engine walks per-statement nodes and
+//! does not expose the token stream or a `Program` node to rules, so when
+//! invoked once with `node == null` (uses_parse_error) it re-derives both by
+//! calling `crate::parse::parse` on the reconstructed source. Tokens exist even
+//! on a parse error (matching upstream `sourceCode.ast.tokens`); the AST-derived
+//! exemptions simply collapse to nothing then, as upstream.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "Program-level keyword-case rule: reconstructs source text and re-derives the AST/token stream, mirroring upstream's JS source-text manipulation over serde_json's owned String/Vec."
+)]
+#![allow(clippy::if_same_then_else)]
+
+use oxlint_plugins_carton::{CompactString, FastHashSet, SmallVec};
+use serde_json::{Value, json};
+
+use crate::tokenize::TokenKind;
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+const START_TYPES: [&str; 2] = ["ColumnDef", "Constraint"];
+const RANGE_TYPES: [&str; 2] = ["ColumnRef", "RangeVar"];
+const TYPE_NAME_TYPES: [&str; 2] = ["names", "TypeName"];
+
+struct Positions {
+    start_ids: FastHashSet<u32>,
+    range_ids: Vec<(u32, u32)>,
+    scoped: Vec<(String, (u32, u32))>,
+    type_starts: FastHashSet<u32>,
+}
+
+fn range_of(map: &serde_json::Map<String, Value>) -> Option<(u32, u32)> {
+    let arr = map.get("range")?.as_array()?;
+    let a = arr.first()?.as_u64()? as u32;
+    let b = arr.get(1)?.as_u64()? as u32;
+    Some((a, b))
+}
+
+fn collect(
+    node: &Value,
+    parent_type: Option<&str>,
+    stmt_range: Option<(u32, u32)>,
+    pos: &mut Positions,
+) {
+    if let Value::Array(items) = node {
+        for item in items {
+            collect(item, parent_type, stmt_range, pos);
+        }
+        return;
+    }
+    let Value::Object(map) = node else {
+        return;
+    };
+    let ty = map.get("type").and_then(Value::as_str);
+    let mut next_stmt = stmt_range;
+    if let Some(t) = ty
+        && let Some((s, e)) = range_of(map)
+    {
+        let scoped = (s, e);
+        if stmt_range.is_none() && parent_type == Some("Program") {
+            next_stmt = Some(scoped);
+        }
+        if START_TYPES.contains(&t) {
+            pos.start_ids.insert(s);
+        } else if RANGE_TYPES.contains(&t) {
+            pos.range_ids.push(scoped);
+        } else if TYPE_NAME_TYPES.contains(&t) {
+            pos.type_starts.insert(s);
+        } else if t == "String" && parent_type != Some("A_Const") {
+            pos.range_ids.push(scoped);
+        } else if t == "ResTarget" && map.get("val").is_none_or(Value::is_null) {
+            pos.range_ids.push(scoped);
+        } else if t == "IndexElem" {
+            if let (Some(name), Some(sr)) = (map.get("name").and_then(Value::as_str), stmt_range) {
+                pos.scoped.push((name.to_owned(), sr));
+            }
+        } else if t == "Constraint"
+            && let Some(sr) = stmt_range
+        {
+            for key in ["keys", "pk_attrs", "fk_attrs"] {
+                if let Some(arr) = map.get(key).and_then(Value::as_array) {
+                    for item in arr {
+                        if item.get("type").and_then(Value::as_str) == Some("String")
+                            && let Some(sv) = item.get("sval").and_then(Value::as_str)
+                        {
+                            pos.scoped.push((sv.to_owned(), sr));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let current = ty.or(parent_type);
+    for (k, v) in map {
+        if !matches!(k.as_str(), "parent" | "range" | "loc") {
+            collect(v, current, next_stmt, pos);
+        }
+    }
+}
+
+fn in_range(s: u32, e: u32, ranges: &[(u32, u32)]) -> bool {
+    ranges.iter().any(|&(a, b)| s >= a && e <= b)
+}
+
+fn transform(value: &str, upper: bool) -> String {
+    if upper {
+        value.to_uppercase()
+    } else {
+        value.to_lowercase()
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let case_upper = !matches!(
+        ctx.options
+            .get(0)
+            .and_then(|o| o.get("case"))
+            .and_then(Value::as_str),
+        Some("lower")
+    );
+    let types_upper: Option<bool> = match ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("types"))
+        .and_then(Value::as_str)
+    {
+        Some("upper") => Some(true),
+        Some("lower") => Some(false),
+        _ => None,
+    };
+
+    let src = ctx.source.slice(0, ctx.source.len());
+    let len = ctx.source.len();
+    let crate::parse::Parsed {
+        tokens, statements, ..
+    } = crate::parse::parse(&src);
+    let program = json!({ "type": "Program", "range": [0, len], "body": statements });
+
+    let mut pos = Positions {
+        start_ids: FastHashSet::default(),
+        range_ids: Vec::new(),
+        scoped: Vec::new(),
+        type_starts: FastHashSet::default(),
+    };
+    collect(&program, Some("Program"), None, &mut pos);
+
+    let mut scoped_starts: FastHashSet<u32> = FastHashSet::default();
+    if !pos.scoped.is_empty() {
+        for token in &tokens {
+            if token.kind != TokenKind::Keyword {
+                continue;
+            }
+            let tv = token.value.to_lowercase();
+            for (name, range) in &pos.scoped {
+                if *name == tv && token.start >= range.0 && token.end <= range.1 {
+                    scoped_starts.insert(token.start);
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut field_starts: FastHashSet<u32> = FastHashSet::default();
+    for i in 1..tokens.len() {
+        let token = &tokens[i];
+        if token.kind != TokenKind::Keyword {
+            continue;
+        }
+        let prev = &tokens[i - 1];
+        if prev.kind == TokenKind::Punctuator
+            && prev.value == "."
+            && (i < 2 || tokens[i - 2].kind != TokenKind::Punctuator || tokens[i - 2].value != ".")
+        {
+            field_starts.insert(token.start);
+        }
+    }
+
+    for token in &tokens {
+        if token.kind != TokenKind::Keyword {
+            continue;
+        }
+        if pos.start_ids.contains(&token.start) {
+            continue;
+        }
+        if in_range(token.start, token.end, &pos.range_ids) {
+            continue;
+        }
+        if scoped_starts.contains(&token.start) {
+            continue;
+        }
+        if field_starts.contains(&token.start) {
+            continue;
+        }
+
+        let (desired, is_upper_msg) = if pos.type_starts.contains(&token.start) {
+            match types_upper {
+                None => continue,
+                Some(up) => (transform(&token.value, up), up),
+            }
+        } else {
+            (transform(&token.value, case_upper), case_upper)
+        };
+        if token.value == desired {
+            continue;
+        }
+        let loc = DiagnosticLoc {
+            start_line: token.start_pos.line,
+            start_column: token.start_pos.column,
+            end_line: token.end_pos.line,
+            end_column: token.end_pos.column,
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("actual"),
+            value: CompactString::from(token.value.as_str()),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("expected"),
+            value: CompactString::from(desired.as_str()),
+        });
+        let message_id = if is_upper_msg {
+            "expectedUpper"
+        } else {
+            "expectedLower"
+        };
+        let fix = Some(DiagnosticFix {
+            start: token.start,
+            end: token.end,
+            replacement: CompactString::from(desired.as_str()),
+        });
+        ctx.report_loc(loc, message_id, data, fix);
+    }
+}

--- a/crates/postgresql/src/rules/prefer_not_equals_operator.rs
+++ b/crates/postgresql/src/rules/prefer_not_equals_operator.rs
@@ -1,0 +1,50 @@
+//! Port of `prefer-not-equals-operator`: enforce a single spelling for the
+//! not-equal operator (`<>` or `!=`). Token-driven with autofix. Runs once per
+//! file via the `usesParseError` entry point.
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::tokenize::tokenize;
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let target_is_angle = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("operator"))
+        .and_then(Value::as_str)
+        .unwrap_or("<>")
+        == "<>";
+    let (wrong, target, message_id) = if target_is_angle {
+        ("!=", "<>", "preferAngle")
+    } else {
+        ("<>", "!=", "preferBang")
+    };
+
+    let tokens = tokenize(ctx.source).tokens;
+    for tok in &tokens {
+        // The lexer emits `<>` / `!=` only as Operator tokens (string contents
+        // are wrapped in quotes, comments are not tokens), so matching on the
+        // literal value is sufficient.
+        if tok.value != wrong {
+            continue;
+        }
+        let loc = DiagnosticLoc {
+            start_line: tok.start_pos.line,
+            start_column: tok.start_pos.column,
+            end_line: tok.end_pos.line,
+            end_column: tok.end_pos.column,
+        };
+        let fix = DiagnosticFix {
+            start: tok.start,
+            end: tok.end,
+            replacement: CompactString::from(target),
+        };
+        ctx.report_loc(loc, message_id, SmallVec::new(), Some(fix));
+    }
+}

--- a/crates/postgresql/src/rules/require_fk_include_columns.rs
+++ b/crates/postgresql/src/rules/require_fk_include_columns.rs
@@ -1,0 +1,183 @@
+//! Port of `require-fk-include-columns`: require every foreign-key constraint
+//! to include a configured set of columns (e.g. `tenant_id`).
+
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    reason = "rule helpers operate on arbitrary-length identifier/column lists and reconstructed source text at the rule boundary, where owned String/Vec and per-rule formatting are appropriate"
+)]
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use regex::Regex;
+
+use crate::ast::{array_field, field, is_type, node_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+fn collect_fk_attrs(fk_attrs: Option<&[Value]>) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(arr) = fk_attrs {
+        for a in arr {
+            if let Some(s) = a.get("sval").and_then(Value::as_str) {
+                out.push(s.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn referenced_table_name(constraint: &Value) -> Option<String> {
+    constraint
+        .get("pktable")
+        .and_then(|p| p.get("relname"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check(
+    ctx: &mut RuleContext,
+    report_node: &Value,
+    table_name: Option<&str>,
+    constraint: &Value,
+    fk_columns: &[String],
+    required: &[String],
+    table_exclude: &Option<Regex>,
+    ref_exclude: &Option<Regex>,
+) {
+    if let (Some(t), Some(re)) = (table_name, table_exclude)
+        && re.is_match(t)
+    {
+        return;
+    }
+    let ref_table = referenced_table_name(constraint);
+    if let (Some(rt), Some(re)) = (ref_table.as_deref(), ref_exclude)
+        && re.is_match(rt)
+    {
+        return;
+    }
+    for col in required {
+        if fk_columns.iter().any(|c| c == col) {
+            continue;
+        }
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("table"),
+            value: CompactString::from(table_name.unwrap_or("(unknown)")),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("refTable"),
+            value: CompactString::from(ref_table.as_deref().unwrap_or("(unknown)")),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("missing"),
+            value: CompactString::from(col.as_str()),
+        });
+        ctx.report_data(report_node, "missingFkColumn", data);
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    let option = ctx.options.get(0);
+    let required: Vec<String> = option
+        .and_then(|o| o.get("columns"))
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if required.is_empty() {
+        return;
+    }
+    let table_exclude = option
+        .and_then(|o| o.get("excludeTablePattern"))
+        .and_then(Value::as_str)
+        .and_then(|p| Regex::new(p).ok());
+    let ref_exclude = option
+        .and_then(|o| o.get("excludeReferencedTablePattern"))
+        .and_then(Value::as_str)
+        .and_then(|p| Regex::new(p).ok());
+
+    if is_type(node, "CreateStmt") {
+        let table_name = node
+            .get("relation")
+            .and_then(|r| r.get("relname"))
+            .and_then(Value::as_str);
+        let Some(elts) = array_field(node, "tableElts") else {
+            return;
+        };
+        for elt in elts {
+            match node_type(elt) {
+                Some("ColumnDef") => {
+                    if let Some(colname) = str_field(elt, "colname")
+                        && let Some(cons) = array_field(elt, "constraints")
+                    {
+                        for c in cons {
+                            if is_type(c, "Constraint")
+                                && str_field(c, "contype") == Some("CONSTR_FOREIGN")
+                            {
+                                check(
+                                    ctx,
+                                    c,
+                                    table_name,
+                                    c,
+                                    &[colname.to_string()],
+                                    &required,
+                                    &table_exclude,
+                                    &ref_exclude,
+                                );
+                            }
+                        }
+                    }
+                }
+                Some("Constraint") if str_field(elt, "contype") == Some("CONSTR_FOREIGN") => {
+                    let cols = collect_fk_attrs(array_field(elt, "fk_attrs"));
+                    check(
+                        ctx,
+                        elt,
+                        table_name,
+                        elt,
+                        &cols,
+                        &required,
+                        &table_exclude,
+                        &ref_exclude,
+                    );
+                }
+                _ => {}
+            }
+        }
+    } else if is_type(node, "AlterTableStmt") {
+        let table_name = node
+            .get("relation")
+            .and_then(|r| r.get("relname"))
+            .and_then(Value::as_str);
+        let Some(cmds) = array_field(node, "cmds") else {
+            return;
+        };
+        for cmd in cmds {
+            if str_field(cmd, "subtype") != Some("AT_AddConstraint") {
+                continue;
+            }
+            let Some(def) = field(cmd, "def") else {
+                continue;
+            };
+            if !is_type(def, "Constraint") || str_field(def, "contype") != Some("CONSTR_FOREIGN") {
+                continue;
+            }
+            let cols = collect_fk_attrs(array_field(def, "fk_attrs"));
+            check(
+                ctx,
+                cmd,
+                table_name,
+                def,
+                &cols,
+                &required,
+                &table_exclude,
+                &ref_exclude,
+            );
+        }
+    }
+}

--- a/crates/postgresql/src/rules/require_if_exists.rs
+++ b/crates/postgresql/src/rules/require_if_exists.rs
@@ -1,0 +1,120 @@
+//! Port of `require-if-exists`: require `IF EXISTS` on every `DROP` statement.
+//!
+//! Upstream walks the statement's token stream to find the `DROP` keyword and
+//! the object-type keyword that follows it, reporting that span. This engine
+//! exposes no token stream to rules, so the span is reconstructed from the
+//! node's source `range` via `ctx.source`: skip leading trivia/comments to the
+//! `DROP` keyword, then take the next word (the object-type keyword) and report
+//! `DROP <KEYWORD>`.
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::SmallVec;
+
+use crate::ast::node_type;
+use crate::text::Source;
+use crate::{DiagnosticLoc, RuleContext};
+
+fn is_drop_node(node: &Value) -> bool {
+    matches!(
+        node_type(node),
+        Some("DropStmt" | "DropdbStmt" | "DropRoleStmt" | "DropSubscriptionStmt")
+    )
+}
+
+fn skip_trivia(src: &Source, mut i: u32, end: u32) -> u32 {
+    while i < end {
+        match src.ascii_at(i) {
+            Some(b' ') | Some(b'\t') | Some(b'\r') | Some(b'\n') => i += 1,
+            Some(b'-') if src.ascii_at(i + 1) == Some(b'-') => {
+                i += 2;
+                while i < end && src.ascii_at(i) != Some(b'\n') {
+                    i += 1;
+                }
+            }
+            Some(b'/') if src.ascii_at(i + 1) == Some(b'*') => {
+                i += 2;
+                while i < end {
+                    if src.ascii_at(i) == Some(b'*') && src.ascii_at(i + 1) == Some(b'/') {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            _ => break,
+        }
+    }
+    i
+}
+
+/// The next identifier-ish word `[start, end)`, skipping leading trivia.
+fn read_word(src: &Source, start: u32, end: u32) -> Option<(u32, u32)> {
+    let ws = skip_trivia(src, start, end);
+    let mut j = ws;
+    while j < end {
+        match src.ascii_at(j) {
+            Some(c) if c.is_ascii_alphanumeric() || c == b'_' => j += 1,
+            _ => break,
+        }
+    }
+    if j > ws { Some((ws, j)) } else { None }
+}
+
+fn word_eq_ignore_case(src: &Source, s: u32, e: u32, target: &[u8]) -> bool {
+    if (e - s) as usize != target.len() {
+        return false;
+    }
+    for (k, t) in target.iter().enumerate() {
+        match src.ascii_at(s + k as u32) {
+            Some(c) if c.eq_ignore_ascii_case(t) => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_drop_node(node) {
+        return;
+    }
+    if node.get("missing_ok").and_then(Value::as_bool) == Some(true) {
+        return;
+    }
+    let Some(range) = node.get("range").and_then(Value::as_array) else {
+        return;
+    };
+    let (Some(start), Some(end)) = (
+        range.first().and_then(Value::as_u64),
+        range.get(1).and_then(Value::as_u64),
+    ) else {
+        return;
+    };
+    let (start, end) = (start as u32, end as u32);
+    if end <= start {
+        return;
+    }
+    let src = ctx.source;
+    let Some((drop_s, drop_e)) = read_word(src, start, end) else {
+        return;
+    };
+    if !word_eq_ignore_case(src, drop_s, drop_e, b"drop") {
+        return;
+    }
+    let Some((_kind_s, kind_e)) = read_word(src, drop_e, end) else {
+        return;
+    };
+    let sp = src.position(drop_s);
+    let ep = src.position(kind_e);
+    ctx.report_loc(
+        DiagnosticLoc {
+            start_line: sp.line,
+            start_column: sp.column,
+            end_line: ep.line,
+            end_column: ep.column,
+        },
+        "missingIfExists",
+        SmallVec::new(),
+        None,
+    );
+}

--- a/crates/postgresql/src/rules/require_named_constraint.rs
+++ b/crates/postgresql/src/rules/require_named_constraint.rs
@@ -1,0 +1,51 @@
+//! Port of `require-named-constraint`: require an explicit name on table-level
+//! CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints, whether declared in
+//! `CREATE TABLE (..., <constraint>)` or via `ALTER TABLE ... ADD ...`.
+//! Column-level constraints (nested in a ColumnDef) are out of scope, so the
+//! rule matches only the CreateStmt table-element list and the
+//! AT_AddConstraint command, mirroring upstream.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+const NAMED_CONSTRAINT_TYPES: &[&str] = &[
+    "CONSTR_CHECK",
+    "CONSTR_UNIQUE",
+    "CONSTR_FOREIGN",
+    "CONSTR_EXCLUSION",
+];
+
+fn is_unnamed_named_kind(c: &Value) -> bool {
+    let Some(contype) = str_field(c, "contype") else {
+        return false;
+    };
+    if !NAMED_CONSTRAINT_TYPES.contains(&contype) {
+        return false;
+    }
+    // Unnamed when `conname` is absent or empty.
+    str_field(c, "conname").is_none_or(str::is_empty)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if is_type(node, "CreateStmt") {
+        let Some(elts) = array_field(node, "tableElts") else {
+            return;
+        };
+        for elt in elts {
+            if is_type(elt, "Constraint") && is_unnamed_named_kind(elt) {
+                ctx.report(elt, "requireNamedConstraint");
+            }
+        }
+        return;
+    }
+    if is_type(node, "AlterTableCmd") && str_field(node, "subtype") == Some("AT_AddConstraint") {
+        let Some(def) = field(node, "def") else {
+            return;
+        };
+        if is_type(def, "Constraint") && is_unnamed_named_kind(def) {
+            ctx.report(node, "requireNamedConstraint");
+        }
+    }
+}

--- a/crates/postgresql/src/rules/require_on_delete_action.rs
+++ b/crates/postgresql/src/rules/require_on_delete_action.rs
@@ -1,0 +1,253 @@
+//! Port of `require-on-delete-action`: require an explicit `ON DELETE` clause
+//! on every foreign-key constraint, and (when `allowed` is set) restrict which
+//! action is used.
+//!
+//! libpg_query reports `fk_del_action: "a"` for both an omitted `ON DELETE`
+//! and an explicit `ON DELETE NO ACTION`, so the AST alone cannot tell them
+//! apart. Upstream walks the token stream; this port reproduces that by
+//! scanning the source text forward from the FK Constraint's range start —
+//! tracking paren depth to find the end of the FK clause (a `,`/`;` at depth 0
+//! or a closing `)` that drops below depth 0), then locating the `ON DELETE`
+//! keyword pair and the action that follows it. Spans are emitted in UTF-16
+//! unit space via `ctx.source.position`.
+
+#![allow(
+    clippy::disallowed_types,
+    reason = "rule helpers operate on arbitrary-length identifier/column lists and reconstructed source text at the rule boundary, where owned String/Vec and per-rule formatting are appropriate"
+)]
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{is_type, str_field};
+use crate::text::Source;
+use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
+
+struct ActionSpan {
+    name: &'static str,
+    start: u32,
+    end: u32,
+}
+
+struct FkScan {
+    /// End offset (UTF-16 units) of the last token in the FK clause.
+    clause_end: u32,
+    has_on_delete: bool,
+    action: Option<ActionSpan>,
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn scan_fk_clause(src: &Source, start: u32) -> FkScan {
+    let len = src.len();
+    let mut i = start;
+    let mut depth: i32 = 0;
+    let mut last_end = start;
+    let mut words: Vec<(u32, u32, String)> = Vec::new();
+    while i < len {
+        match src.ascii_at(i) {
+            Some(b) if b.is_ascii_whitespace() => i += 1,
+            // line comment `-- ...`
+            Some(b'-') if src.ascii_at(i + 1) == Some(b'-') => {
+                i += 2;
+                while i < len && src.ascii_at(i) != Some(b'\n') {
+                    i += 1;
+                }
+            }
+            // block comment `/* ... */`
+            Some(b'/') if src.ascii_at(i + 1) == Some(b'*') => {
+                i += 2;
+                while i < len
+                    && !(src.ascii_at(i) == Some(b'*') && src.ascii_at(i + 1) == Some(b'/'))
+                {
+                    i += 1;
+                }
+                i = (i + 2).min(len);
+            }
+            // single-quoted string literal ('' escapes an inner quote)
+            Some(b'\'') => {
+                i += 1;
+                while i < len {
+                    if src.ascii_at(i) == Some(b'\'') {
+                        if src.ascii_at(i + 1) == Some(b'\'') {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+                last_end = i;
+            }
+            // double-quoted identifier ("" escapes an inner quote)
+            Some(b'"') => {
+                i += 1;
+                while i < len {
+                    if src.ascii_at(i) == Some(b'"') {
+                        if src.ascii_at(i + 1) == Some(b'"') {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+                last_end = i;
+            }
+            Some(b'(') => {
+                depth += 1;
+                last_end = i + 1;
+                i += 1;
+            }
+            Some(b')') => {
+                if depth == 0 {
+                    break;
+                }
+                depth -= 1;
+                last_end = i + 1;
+                i += 1;
+            }
+            Some(b',') | Some(b';') if depth == 0 => break,
+            Some(b) if is_word_byte(b) => {
+                let s = i;
+                while i < len {
+                    match src.ascii_at(i) {
+                        Some(x) if is_word_byte(x) => i += 1,
+                        _ => break,
+                    }
+                }
+                words.push((s, i, src.slice(s, i).to_ascii_uppercase()));
+                last_end = i;
+            }
+            // any other punctuation/operator, or a non-ASCII unit
+            _ => {
+                i += 1;
+                last_end = i;
+            }
+        }
+    }
+
+    let mut idx = None;
+    if words.len() >= 2 {
+        for k in 0..words.len() - 1 {
+            if words[k].2 == "ON" && words[k + 1].2 == "DELETE" {
+                idx = Some(k);
+                break;
+            }
+        }
+    }
+
+    let action = idx.and_then(|k| {
+        let (s, e, a) = words.get(k + 2)?;
+        let second = words.get(k + 3).map(|w| w.2.as_str());
+        match (a.as_str(), second) {
+            ("CASCADE", _) => Some(ActionSpan {
+                name: "CASCADE",
+                start: *s,
+                end: *e,
+            }),
+            ("RESTRICT", _) => Some(ActionSpan {
+                name: "RESTRICT",
+                start: *s,
+                end: *e,
+            }),
+            ("NO", Some("ACTION")) => Some(ActionSpan {
+                name: "NO ACTION",
+                start: *s,
+                end: words[k + 3].1,
+            }),
+            ("SET", Some("NULL")) => Some(ActionSpan {
+                name: "SET NULL",
+                start: *s,
+                end: words[k + 3].1,
+            }),
+            ("SET", Some("DEFAULT")) => Some(ActionSpan {
+                name: "SET DEFAULT",
+                start: *s,
+                end: words[k + 3].1,
+            }),
+            _ => None,
+        }
+    });
+
+    FkScan {
+        clause_end: last_end,
+        has_on_delete: idx.is_some(),
+        action,
+    }
+}
+
+fn loc(src: &Source, start: u32, end: u32) -> DiagnosticLoc {
+    let sp = src.position(start);
+    let ep = src.position(end);
+    DiagnosticLoc {
+        start_line: sp.line,
+        start_column: sp.column,
+        end_line: ep.line,
+        end_column: ep.column,
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "Constraint") {
+        return;
+    }
+    if str_field(node, "contype") != Some("CONSTR_FOREIGN") {
+        return;
+    }
+    let Some(start) = node
+        .get("range")
+        .and_then(Value::as_array)
+        .and_then(|r| r.first())
+        .and_then(Value::as_u64)
+    else {
+        return;
+    };
+    let start = start as u32;
+
+    let scan = scan_fk_clause(ctx.source, start);
+
+    if !scan.has_on_delete {
+        let l = loc(ctx.source, start, scan.clause_end);
+        ctx.report_loc(l, "missingOnDelete", SmallVec::new(), None);
+        return;
+    }
+
+    let allowed: Option<Vec<String>> = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("allowed"))
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        });
+    let Some(allowed) = allowed else {
+        return;
+    };
+    let Some(act) = scan.action else {
+        return;
+    };
+    if allowed.iter().any(|a| a == act.name) {
+        return;
+    }
+
+    let l = loc(ctx.source, act.start, act.end);
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("action"),
+        value: CompactString::from(act.name),
+    });
+    data.push(DiagnosticDatum {
+        key: CompactString::from("allowedList"),
+        value: CompactString::from(allowed.join(", ").as_str()),
+    });
+    ctx.report_loc(l, "disallowedAction", data, None);
+}

--- a/crates/postgresql/src/rules/require_primary_key.rs
+++ b/crates/postgresql/src/rules/require_primary_key.rs
@@ -1,0 +1,52 @@
+//! Port of `require-primary-key`: require every `CREATE TABLE` to declare a
+//! primary key, either as a column constraint or a table-level constraint.
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::ast::{array_field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+fn has_primary_key(elts: &[Value]) -> bool {
+    elts.iter().any(|elt| {
+        if is_type(elt, "Constraint") && str_field(elt, "contype") == Some("CONSTR_PRIMARY") {
+            return true;
+        }
+        if is_type(elt, "ColumnDef")
+            && let Some(constraints) = array_field(elt, "constraints")
+        {
+            return constraints.iter().any(|c| {
+                is_type(c, "Constraint") && str_field(c, "contype") == Some("CONSTR_PRIMARY")
+            });
+        }
+        false
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    // No tableElts means CREATE TABLE ... PARTITION OF or similar; skip.
+    let Some(elts) = array_field(node, "tableElts") else {
+        return;
+    };
+    if elts.is_empty() {
+        return;
+    }
+    if has_primary_key(elts) {
+        return;
+    }
+    let relname = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("table"),
+        value: CompactString::from(relname),
+    });
+    ctx.report_data(node, "missingPrimaryKey", data);
+}

--- a/crates/postgresql/src/rules/require_schema_qualified_table.rs
+++ b/crates/postgresql/src/rules/require_schema_qualified_table.rs
@@ -1,0 +1,22 @@
+//! Port of `require-schema-qualified-table`: require `CREATE TABLE` to use a
+//! schema-qualified name (e.g. `audit.events`).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let has_schema = node
+        .get("relation")
+        .and_then(|r| r.get("schemaname"))
+        .and_then(Value::as_str)
+        .is_some_and(|s| !s.is_empty());
+    if has_schema {
+        return;
+    }
+    ctx.report(node, "requireSchemaQualifiedTable");
+}

--- a/crates/postgresql/src/rules/require_table_columns.rs
+++ b/crates/postgresql/src/rules/require_table_columns.rs
@@ -1,0 +1,114 @@
+//! Port of `require-table-columns`: require every `CREATE TABLE` to include a
+//! configured set of columns (with optional per-pattern overrides).
+
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    reason = "rule helpers operate on arbitrary-length identifier/column lists and reconstructed source text at the rule boundary, where owned String/Vec and per-rule formatting are appropriate"
+)]
+
+use serde_json::Value;
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use regex::Regex;
+
+use crate::ast::{array_field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+fn string_list(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let option = ctx.options.get(0);
+    let base = string_list(option.and_then(|o| o.get("columns")));
+    if base.is_empty() {
+        return;
+    }
+    let Some(table_name) = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    if let Some(ex) = option
+        .and_then(|o| o.get("exclude"))
+        .and_then(Value::as_str)
+        && Regex::new(ex).is_ok_and(|re| re.is_match(table_name))
+    {
+        return;
+    }
+
+    // First matching override wins.
+    let mut chosen: Option<(String, Vec<String>)> = None;
+    if let Some(overrides) = option
+        .and_then(|o| o.get("overrides"))
+        .and_then(Value::as_array)
+    {
+        for o in overrides {
+            if let Some(pat) = o.get("pattern").and_then(Value::as_str)
+                && Regex::new(pat).is_ok_and(|re| re.is_match(table_name))
+            {
+                chosen = Some((pat.to_string(), string_list(o.get("columns"))));
+                break;
+            }
+        }
+    }
+
+    let (required, rationale) = match &chosen {
+        Some((pat, cols)) => (
+            cols.clone(),
+            format!("Required by the override for pattern `{pat}`."),
+        ),
+        None => (
+            base.clone(),
+            "Required by the default column list.".to_string(),
+        ),
+    };
+    if required.is_empty() {
+        return;
+    }
+
+    let mut present: Vec<&str> = Vec::new();
+    if let Some(elts) = array_field(node, "tableElts") {
+        for elt in elts {
+            if is_type(elt, "ColumnDef")
+                && let Some(colname) = str_field(elt, "colname")
+            {
+                present.push(colname);
+            }
+        }
+    }
+
+    for col in &required {
+        if present.contains(&col.as_str()) {
+            continue;
+        }
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("table"),
+            value: CompactString::from(table_name),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("missing"),
+            value: CompactString::from(col.as_str()),
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("rationale"),
+            value: CompactString::from(rationale.as_str()),
+        });
+        ctx.report_data(node, "missingColumn", data);
+    }
+}

--- a/crates/postgresql/src/rules/require_trailing_semicolon.rs
+++ b/crates/postgresql/src/rules/require_trailing_semicolon.rs
@@ -1,0 +1,37 @@
+//! Port of `require-trailing-semicolon`: require a trailing `;` at the end of
+//! the SQL file. Operates at file level on the token stream (invoked with the
+//! null node via `uses_parse_error`): the last source token must be `;`. The
+//! autofix replaces any trailing whitespace after the last token with `;`, so a
+//! file ending in `\n` is fixed to end in `;` (matching upstream, whose harness
+//! trims the source before linting).
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::tokenize::tokenize;
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let tokens = tokenize(ctx.source).tokens;
+    let Some(last) = tokens.last() else {
+        return;
+    };
+    if last.value == ";" {
+        return;
+    }
+    let loc = DiagnosticLoc {
+        start_line: last.start_pos.line,
+        start_column: last.start_pos.column,
+        end_line: last.end_pos.line,
+        end_column: last.end_pos.column,
+    };
+    let fix = DiagnosticFix {
+        start: last.end,
+        end: ctx.source.len(),
+        replacement: CompactString::from(";"),
+    };
+    ctx.report_loc(loc, "missingSemicolon", SmallVec::new(), Some(fix));
+}

--- a/crates/postgresql/src/rules/snake_case_column_name.rs
+++ b/crates/postgresql/src/rules/snake_case_column_name.rs
@@ -1,0 +1,41 @@
+//! Port of `snake-case-column-name`: require column names to match
+//! `^[a-z][a-z0-9_]*$`. The `allow` option exempts specific names.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::{is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+
+fn is_snake_case(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(name) = str_field(node, "colname") else {
+        return;
+    };
+    let allowed = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("allow"))
+        .and_then(Value::as_array)
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(name)));
+    if allowed || is_snake_case(name) {
+        return;
+    }
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("name"),
+        value: CompactString::from(name),
+    });
+    ctx.report_data(node, "notSnakeCase", data);
+}

--- a/crates/postgresql/src/rules/snake_case_table_name.rs
+++ b/crates/postgresql/src/rules/snake_case_table_name.rs
@@ -1,0 +1,45 @@
+//! Port of `snake-case-table-name`: require table names to match
+//! `^[a-z][a-z0-9_]*$`. The `allow` option exempts specific names.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::{DiagnosticDatum, RuleContext};
+
+fn is_snake_case(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let Some(name) = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    let allowed = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("allow"))
+        .and_then(Value::as_array)
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(name)));
+    if allowed || is_snake_case(name) {
+        return;
+    }
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("name"),
+        value: CompactString::from(name),
+    });
+    ctx.report_data(node, "notSnakeCase", data);
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,346 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'align-column-definitions': {
+    type: 'layout',
+    description:
+      'Align column definitions vertically inside `CREATE TABLE` so that name, type, and constraints share consistent column offsets',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { gap: { type: 'integer', minimum: 1 } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      misaligned: 'Column definitions in this CREATE TABLE are not vertically aligned.',
+    },
+  },
+  'align-values': {
+    type: 'layout',
+    description:
+      'Align column values vertically inside multi-row `INSERT ... VALUES (...)` so that each tuple position shares a consistent width across rows',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { gap: { type: 'integer', minimum: 1 } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      misaligned:
+        'VALUES rows are not vertically aligned: column widths can shrink to fit the current rows.',
+    },
+  },
+  'consistent-as-for-column-alias': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the `AS` keyword before column aliases in `SELECT` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferAs: 'Use `AS` before the column alias `{{alias}}`.',
+      unexpectedAs: 'Omit `AS` before the column alias `{{alias}}`.',
+    },
+  },
+  'consistent-as-for-table-alias': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the `AS` keyword before table aliases (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferAs: 'Use `AS` before the table alias `{{alias}}`.',
+      unexpectedAs: 'Omit `AS` before the table alias `{{alias}}`.',
+    },
+  },
+  'consistent-between-over-and': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `x BETWEEN a AND b` vs `x >= a AND x <= b` for closed-interval range checks',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferBetween: 'Use `{{lhs}} BETWEEN {{lower}} AND {{upper}}` instead of `>= ... AND <=`.',
+      unexpectedBetween:
+        'Use `{{lhs}} >= {{lower}} AND {{lhs}} <= {{upper}}` instead of `BETWEEN`. Some teams prefer explicit comparisons so the inclusive bounds are obvious to readers.',
+    },
+  },
+  'consistent-create-index-concurrently': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `CONCURRENTLY` for `CREATE INDEX` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferConcurrently:
+        'Use `CREATE INDEX CONCURRENTLY`. A plain `CREATE INDEX` takes a `SHARE` lock on the target table for the duration of the build — readers are unaffected, but every writer is blocked. Concurrent index builds cannot run inside a transaction, so a migration tool that wraps each step in BEGIN/COMMIT needs an explicit opt-out here.',
+      unexpectedConcurrently:
+        'Avoid `CREATE INDEX CONCURRENTLY`. Concurrent index builds cannot run inside a transaction, so they conflict with migration tools that wrap each step in BEGIN/COMMIT; drop the keyword and use a plain `CREATE INDEX`.',
+    },
+  },
+  'consistent-create-or-replace': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `CREATE OR REPLACE` for `FUNCTION` / `PROCEDURE` / `VIEW` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOrReplace:
+        'Use `CREATE OR REPLACE {{kind}}` so re-running this migration does not abort with `relation already exists`.',
+      unexpectedOrReplace:
+        'Avoid `CREATE OR REPLACE {{kind}}`; drop and re-create the object explicitly so unintended overwrites are surfaced.',
+    },
+  },
+  'consistent-drop-index-concurrently': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `CONCURRENTLY` for `DROP INDEX` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferConcurrently:
+        'Use `DROP INDEX CONCURRENTLY` to avoid an `ACCESS EXCLUSIVE` lock on the table for the entire drop.',
+      unexpectedConcurrently:
+        'Avoid `DROP INDEX CONCURRENTLY`. Concurrent drops cannot run inside a transaction, so they conflict with migration tools that wrap each step in BEGIN/COMMIT.',
+    },
+  },
+  'consistent-explicit-inner-join': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the explicit `INNER` keyword in `INNER JOIN` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferInnerJoin: 'Write `INNER JOIN` explicitly instead of bare `JOIN`.',
+      unexpectedInnerJoin: 'Omit the redundant `INNER`; use bare `JOIN` for inner joins.',
+    },
+  },
+  'consistent-explicit-outer-join': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the explicit `OUTER` keyword in `LEFT/RIGHT/FULL OUTER JOIN` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOuterJoin: 'Write `{{side}} OUTER JOIN` explicitly instead of `{{side}} JOIN`.',
+      unexpectedOuterJoin:
+        'Omit the redundant `OUTER`; use `{{side}} JOIN` instead of `{{side}} OUTER JOIN`.',
+    },
+  },
+  'consistent-fk-not-valid': {
+    type: 'problem',
+    description:
+      'Enforce a consistent stance on `NOT VALID` for `ALTER TABLE ... ADD FOREIGN KEY` (either always require it, or always forbid it)',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferFkNotValid:
+        'Adding a foreign key without `NOT VALID` validates every existing row under an `ACCESS EXCLUSIVE` lock that blocks writers. Use `ADD CONSTRAINT ... FOREIGN KEY (...) REFERENCES ... NOT VALID`, then `ALTER TABLE ... VALIDATE CONSTRAINT` in a separate migration (`VALIDATE` only takes a `SHARE UPDATE EXCLUSIVE` lock).',
+      unexpectedFkNotValid:
+        "Avoid `NOT VALID` on foreign keys. The constraint is added in a non-validated state and won't reject existing violations until you remember to run `VALIDATE CONSTRAINT`; some projects prefer to fail loudly at constraint-add time instead.",
+    },
+  },
+  'consistent-identity-over-serial': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `GENERATED ... AS IDENTITY` vs `SERIAL` / `BIGSERIAL` / `SMALLSERIAL`',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferIdentity:
+        'Use `GENERATED ALWAYS AS IDENTITY` (SQL standard) instead of `{{type}}`. The serial pseudo-types create a separately-owned sequence that breaks under pg_dump round-trips and does not honor column privileges.',
+      unexpectedIdentity:
+        'Use a serial pseudo-type (e.g. `bigserial`) instead of `GENERATED ... AS IDENTITY`. Useful for projects that need to keep compatibility with tooling that does not understand identity columns.',
+    },
+  },
+  'consistent-jsonb-over-json': {
+    type: 'suggestion',
+    description: 'Enforce a consistent stance on `jsonb` vs `json` for column types',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferJsonb:
+        'Use `jsonb` instead of `json`. `jsonb` stores the parsed representation, supports indexing, and is what almost every application actually wants.',
+      unexpectedJsonb:
+        "Use `json` instead of `jsonb`. Useful when the project intentionally relies on `json`'s preservation of key order, whitespace, and duplicate keys.",
+    },
+  },
+  'consistent-reindex-concurrently': {
+    type: 'problem',
+    description:
+      'Enforce a consistent stance on `CONCURRENTLY` for `REINDEX` (either always require it, or always forbid it)',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferReindexConcurrently:
+        '`REINDEX` without `CONCURRENTLY` takes a `SHARE` lock (table) or `ACCESS EXCLUSIVE` (index), blocking writers for the rebuild. Use `REINDEX (TABLE|INDEX) CONCURRENTLY ...` (PG ≥ 12) so writers keep working.',
+      unexpectedReindexConcurrently:
+        'Avoid `REINDEX CONCURRENTLY`. Concurrent reindex cannot run inside a transaction; use plain `REINDEX` when the migration tool wraps each step in BEGIN/COMMIT.',
+    },
+  },
+  'consistent-text-over-varchar': {
+    type: 'suggestion',
+    description: 'Enforce a consistent stance on `text` vs `varchar(n)` for string columns',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferText:
+        'Use `text` instead of `varchar(n)`. PostgreSQL stores both the same way; the length cap is enforced by a constraint that you cannot relax without a full table rewrite. Move the limit into a CHECK constraint.',
+      unexpectedText:
+        "Use `varchar(n)` (or another bounded string type) instead of `text`. Useful for projects that intentionally cap every string column's length at the type level.",
+    },
+  },
+  'consistent-timestamptz': {
+    type: 'suggestion',
+    description: 'Enforce a consistent stance on `timestamptz` vs `timestamp` (without time zone)',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { style: { enum: ['always', 'never'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferTimestamptz:
+        'Use `timestamptz` (or `TIMESTAMP WITH TIME ZONE`) instead of `timestamp`. `timestamp` is timezone-naive: it stores the wall-clock value you handed in and assumes every reader and writer share the same convention, so two clients on different `TimeZone` settings will disagree on which instant the row represents.',
+      unexpectedTimestamptz:
+        "Use `timestamp` instead of `timestamptz` (or `TIMESTAMP WITH TIME ZONE`). When the project treats every timestamp as UTC at the application layer, `timestamp` avoids the implicit conversions `timestamptz` performs against each session's `TimeZone` setting.",
+    },
+  },
+  'no-add-check-constraint-without-not-valid': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` without `NOT VALID`; the synchronous form holds `ACCESS EXCLUSIVE` on the table for the entire validating scan',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      checkNotValid:
+        'Add this CHECK constraint with `NOT VALID` and run `VALIDATE CONSTRAINT` separately, so the validating scan does not block writers under `ACCESS EXCLUSIVE`.',
+    },
+  },
+  'no-add-column-not-null-without-default': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ADD COLUMN ... NOT NULL` without a `DEFAULT` because the migration fails outright on any non-empty table',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noAddColumnNotNullWithoutDefault:
+        '`ADD COLUMN ... NOT NULL` without a `DEFAULT` aborts the migration on any table that already has rows. Either supply a `DEFAULT`, or add the column nullable first, backfill, and then `ALTER COLUMN ... SET NOT NULL` in a follow-up.',
+    },
+  },
+  'no-add-unique-constraint-directly': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (...)` written inline; build the index with `CREATE UNIQUE INDEX CONCURRENTLY` first, then promote it via `ADD CONSTRAINT ... UNIQUE USING INDEX <name>`',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      useIndexFirst:
+        "Build this UNIQUE constraint's index with `CREATE UNIQUE INDEX CONCURRENTLY` first, then promote it via `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE USING INDEX <name>`. The inline form blocks writers under `ACCESS EXCLUSIVE` for the entire index build.",
+    },
+  },
   'no-alter-column-type': {
     type: 'problem',
     description:
@@ -29,6 +369,17 @@ const ruleMeta = Object.freeze({
         '`ALTER COLUMN ... TYPE` can rewrite the entire table under an ACCESS EXCLUSIVE lock. For non-trivial tables, add a new column, dual-write, backfill, and swap — or use `USING` only for known-safe conversions in a separate migration.',
     },
   },
+  'no-char-type': {
+    type: 'suggestion',
+    description: 'Disallow the blank-padded `char(n)` / `bpchar` column type',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noChar:
+        'Avoid `char(n)`. PostgreSQL pads stored values to `n` with trailing spaces and trims on read, which surprises every comparison and round-trip. Use `text` instead.',
+    },
+  },
   'no-cluster': {
     type: 'problem',
     description:
@@ -39,6 +390,18 @@ const ruleMeta = Object.freeze({
     messages: {
       noCluster:
         '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
+    },
+  },
+  'no-composite-primary-key': {
+    type: 'problem',
+    description:
+      'Disallow composite (multi-column) PRIMARY KEY constraints; use a single surrogate key and a UNIQUE constraint on the natural columns instead',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCompositePk:
+        'Composite PRIMARY KEY is not allowed. Use a single-column surrogate key (e.g. `id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY`) and enforce the natural key with a `UNIQUE` constraint. Composite primary keys complicate joins, ORM mapping, and foreign-key references.',
     },
   },
   'no-create-role': {
@@ -112,6 +475,29 @@ const ruleMeta = Object.freeze({
         '`DROP NOT NULL` lets the column store NULLs again — every consumer that already assumes the column is non-null (joins, COALESCE coverage, app-level types) silently breaks. If a row genuinely needs no value, model it with a sentinel or a separate optional table.',
     },
   },
+  'no-drop-schema-cascade': {
+    type: 'problem',
+    description:
+      'Disallow `DROP SCHEMA ... CASCADE`; it silently removes every object in the schema',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDropSchemaCascade:
+        "`DROP SCHEMA ... CASCADE` removes every table, view, function, and sequence in the schema with no preview. List the objects you actually want to drop instead, or drop the schema only when it's already empty.",
+    },
+  },
+  'no-drop-table-cascade': {
+    type: 'problem',
+    description: 'Disallow `DROP TABLE ... CASCADE` because it silently removes dependent objects',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCascade:
+        'Avoid `DROP TABLE ... CASCADE`. CASCADE silently removes dependent objects (views, foreign keys, sequences); list them explicitly so reviewers can see the blast radius.',
+    },
+  },
   'no-equality-with-null': {
     type: 'problem',
     description:
@@ -171,6 +557,24 @@ const ruleMeta = Object.freeze({
         '`HAVING` without `GROUP BY` collapses the query to one aggregate row over the whole table. If that is intended, put the predicate in `WHERE`. Otherwise, add a `GROUP BY`.',
     },
   },
+  'no-identifier-too-long': {
+    type: 'problem',
+    description:
+      "Disallow identifiers longer than PostgreSQL's `NAMEDATALEN - 1` limit (default 63 bytes)",
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { max: { type: 'integer', minimum: 1 } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      identifierTooLong:
+        'Identifier `{{name}}` is {{length}} bytes, which exceeds the {{max}}-byte limit. PostgreSQL silently truncates over-length identifiers at parse time, so the object will be created (or looked up) under a different name than written — every later `DROP` / `ALTER` / `\\d` that uses the original name will then fail with `does not exist`.',
+    },
+  },
   'no-select-star': {
     type: 'suggestion',
     description:
@@ -207,6 +611,17 @@ const ruleMeta = Object.freeze({
         '`LIKE`/`ILIKE` patterns that begin with `%` cannot use a B-tree index and force a sequential scan. If you need substring search, use a `pg_trgm` GIN index, full-text search, or rework the schema so the prefix is indexable.',
     },
   },
+  'no-money-type': {
+    type: 'problem',
+    description: 'Disallow the `money` column type',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noMoney:
+        'Avoid `money`. Its output format and precision depend on `lc_monetary`, so the same row looks different on different servers and round-trips badly. Store amounts as `numeric` and keep the currency in a separate column.',
+    },
+  },
   'no-natural-join': {
     type: 'problem',
     description: 'Disallow `NATURAL JOIN`',
@@ -216,6 +631,29 @@ const ruleMeta = Object.freeze({
     messages: {
       noNaturalJoin:
         'Avoid `NATURAL JOIN`. The join columns are implicit — any future column with a matching name on both sides silently changes the result. Use `JOIN ... USING (...)` or `JOIN ... ON ...` and name the columns.',
+    },
+  },
+  'no-not-in-subquery': {
+    type: 'problem',
+    description:
+      'Disallow `NOT IN (subquery)` because NULL values in the subquery silently return zero rows',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNotInSubquery:
+        '`NOT IN (subquery)` returns no rows if the subquery yields any NULL — almost certainly not what you want. Use `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` instead; it handles NULL correctly.',
+    },
+  },
+  'no-numeric-without-precision': {
+    type: 'suggestion',
+    description: 'Require an explicit precision (and scale) on `NUMERIC` / `DECIMAL` columns',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNumericWithoutPrecision:
+        "`NUMERIC` / `DECIMAL` without precision accepts unbounded magnitude and rejects nothing — it's a missed opportunity to encode the column's domain. Declare `NUMERIC(precision, scale)`.",
     },
   },
   'no-on-delete-cascade': {
@@ -278,6 +716,18 @@ const ruleMeta = Object.freeze({
         "Avoid `CREATE RULE`. PostgreSQL's rule system has surprising semantics around row counts, RETURNING, and updatable views; use a trigger or an updatable view instead.",
     },
   },
+  'no-security-definer-without-search-path': {
+    type: 'problem',
+    description:
+      "Disallow `SECURITY DEFINER` functions that do not pin `search_path`; an attacker who controls a schema in the caller's `search_path` can shadow built-in objects and escalate privileges",
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingSearchPath:
+        "`SECURITY DEFINER` function must `SET search_path = ...` (e.g. `pg_catalog, pg_temp`) so an attacker-controlled schema in the caller's `search_path` cannot shadow built-in objects called from inside the function body.",
+    },
+  },
   'no-select-into': {
     type: 'suggestion',
     description:
@@ -326,6 +776,18 @@ const ruleMeta = Object.freeze({
         '`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.',
     },
   },
+  'no-time-type': {
+    type: 'suggestion',
+    description:
+      'Disallow `TIME` / `TIME WITH TIME ZONE` columns; they rarely model a real-world value correctly',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noTimeType:
+        '`TIME` and `TIME WITH TIME ZONE` rarely model anything correctly: `time` has no date so cannot disambiguate around DST, and `timetz` stores an offset that is meaningless without a date. Use `timestamptz` for points in time, `interval` for durations, or store an opaque `text` if all you need is a display value.',
+    },
+  },
   'no-truncate-cascade': {
     type: 'problem',
     description:
@@ -350,6 +812,49 @@ const ruleMeta = Object.freeze({
         '`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file.',
     },
   },
+  'no-unnecessary-quoted-identifier': {
+    type: 'layout',
+    description:
+      'Disallow unnecessary double-quoting of identifiers (e.g. `"users"` when `users` would mean the same thing)',
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      unnecessaryQuoting:
+        'The identifier `"{{inner}}"` does not need quoting; `{{inner}}` means the same thing.',
+    },
+  },
+  'no-update-primary-key': {
+    type: 'problem',
+    description: 'Disallow `UPDATE ... SET <pk> = ...` for columns the rule treats as primary keys',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          pkColumnNames: { type: 'array', items: { type: 'string' }, uniqueItems: true },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noUpdatePk:
+        'Avoid `UPDATE` on the primary-key column `{{name}}`. Primary keys are intended to be immutable; FK references and external systems can hold the old value.',
+    },
+  },
+  'no-update-without-from-binding': {
+    type: 'problem',
+    description:
+      'Disallow `UPDATE ... FROM other_table` without a `WHERE` clause; without a join condition the FROM table forms a Cartesian product with the target table and updates every row of the target as many times as `other_table` has rows',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingJoin:
+        '`UPDATE ... FROM` without a `WHERE` clause produces a Cartesian product with the target table; add a `WHERE t.x = other.x` condition to bind the rows.',
+    },
+  },
   'no-vacuum-full': {
     type: 'problem',
     description:
@@ -360,6 +865,18 @@ const ruleMeta = Object.freeze({
     messages: {
       noVacuumFull:
         '`VACUUM FULL` takes `ACCESS EXCLUSIVE` and rewrites the whole table; the table is unavailable for the duration. For shrinking a bloated table on a live database, use `pg_repack` or `pg_squeeze`. A plain `VACUUM` (no `FULL`) is fine.',
+    },
+  },
+  'no-volatile-default-on-add-column': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ... ADD COLUMN ... DEFAULT <volatile>()`; volatile defaults force a full table rewrite under `ACCESS EXCLUSIVE` because the stable-default short-cut cannot be used',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noVolatileDefault:
+        '`{{fn}}()` is VOLATILE — using it as a column DEFAULT on `ADD COLUMN` forces PostgreSQL to rewrite the entire table under `ACCESS EXCLUSIVE`. Add the column without a default, then `UPDATE` rows in batches.',
     },
   },
   'no-with-recursive-without-limit': {
@@ -374,6 +891,199 @@ const ruleMeta = Object.freeze({
         'Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.',
     },
   },
+  'plpgsql-keyword-case': {
+    type: 'layout',
+    description:
+      'Enforce a consistent case (upper or lower) for SQL and PL/pgSQL keywords inside PL/pgSQL function bodies',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { case: { enum: ['upper', 'lower'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      expectedUpper: "PL/pgSQL keyword '{{actual}}' should be uppercase: '{{expected}}'.",
+      expectedLower: "PL/pgSQL keyword '{{actual}}' should be lowercase: '{{expected}}'.",
+    },
+  },
+  'prefer-add-constraint-not-valid': {
+    type: 'suggestion',
+    description:
+      'Prefer `ADD CONSTRAINT ... NOT VALID` followed by a separate `VALIDATE CONSTRAINT` to avoid an `ACCESS EXCLUSIVE` lock on the full table while it is being scanned',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      notValid:
+        'Add this constraint with `NOT VALID` and run `VALIDATE CONSTRAINT` separately, so the validating scan does not hold `ACCESS EXCLUSIVE` on the table.',
+    },
+  },
+  'prefer-bigint-id': {
+    type: 'suggestion',
+    description:
+      'Prefer `bigint` for primary-key `id` columns; `int` / `smallint` primary keys risk silent overflow on growing tables',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferBigintId:
+        'Primary-key `id` columns should be `bigint`. `int` overflows at 2.1 billion rows and the migration to widen it later requires a table rewrite under `ACCESS EXCLUSIVE`. Declare the column as `bigint GENERATED ALWAYS AS IDENTITY` from the start.',
+    },
+  },
+  'prefer-cast-operator': {
+    type: 'layout',
+    description:
+      'Enforce a single style for type casts (`x::int` operator form vs `CAST(x AS int)` function form)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { form: { enum: ['operator', 'function'] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOperator: 'Use `<expr>::type` operator form instead of `CAST(...)`.',
+      preferFunction: 'Use `CAST(<expr> AS type)` instead of the `::` operator.',
+    },
+  },
+  'prefer-coalesce-over-case': {
+    type: 'suggestion',
+    description:
+      'Prefer `COALESCE(x, y)` over `CASE WHEN x IS NULL THEN y ELSE x END` (and its IS NOT NULL mirror)',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferCoalesceOverCase:
+        '`CASE WHEN ... IS NULL THEN ... ELSE ... END` is a verbose `COALESCE`. Use `COALESCE(x, fallback)` instead.',
+    },
+  },
+  'prefer-current-timestamp-over-now': {
+    type: 'layout',
+    description:
+      "Prefer SQL-standard `CURRENT_TIMESTAMP` / `CURRENT_TIME` over PostgreSQL's `now()` and the timezone-naive `LOCALTIMESTAMP` / `LOCALTIME`",
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferCurrentTimestamp: 'Use the SQL-standard `CURRENT_TIMESTAMP` instead of `now()`.',
+      preferCurrentTimestampOverLocal:
+        'Use `CURRENT_TIMESTAMP` instead of `LOCALTIMESTAMP`. `LOCALTIMESTAMP` returns a timezone-naive `timestamp`; `CURRENT_TIMESTAMP` returns `timestamptz`, which is what most apps actually want.',
+      preferCurrentTimeOverLocal:
+        'Use `CURRENT_TIME` instead of `LOCALTIME`. `LOCALTIME` returns a timezone-naive `time`; `CURRENT_TIME` returns `timetz`.',
+    },
+  },
+  'prefer-exists-over-in-subquery': {
+    type: 'suggestion',
+    description:
+      'Prefer `EXISTS (...)` over `... IN (subquery)` so NULL handling is unambiguous and the planner can use a semi-join',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferExists:
+        'Use `EXISTS (...)` instead of `IN (subquery)`. `IN` returns NULL when the subquery has any NULL row, which silently turns the row into a no-match; `EXISTS` is unambiguously boolean.',
+    },
+  },
+  'prefer-explicit-null-ordering': {
+    type: 'suggestion',
+    description:
+      'When `ORDER BY` specifies an explicit direction, require an explicit `NULLS FIRST` / `NULLS LAST` so null ordering is not implicit',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferExplicitNullOrdering:
+        "`ORDER BY ... ASC|DESC` without `NULLS FIRST` / `NULLS LAST` relies on PostgreSQL's implicit ordering (NULLS LAST for ASC, NULLS FIRST for DESC), which trips up cross-database readers. Add an explicit `NULLS FIRST` / `NULLS LAST`.",
+    },
+  },
+  'prefer-in-list-over-or': {
+    type: 'suggestion',
+    description: 'Prefer `x IN (a, b, c)` over a chain of `x = a OR x = b OR x = c`',
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferIn: 'Combine these `=` checks on `{{lhs}}` into a single `IN (...)` clause.',
+    },
+  },
+  'prefer-keyword-case': {
+    type: 'layout',
+    description: 'Enforce a consistent case (upper or lower) for SQL keywords',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          case: { enum: ['upper', 'lower'] },
+          types: { enum: ['upper', 'lower', 'skip'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      expectedUpper: "SQL keyword '{{actual}}' should be uppercase: '{{expected}}'.",
+      expectedLower: "SQL keyword '{{actual}}' should be lowercase: '{{expected}}'.",
+    },
+  },
+  'prefer-not-equals-operator': {
+    type: 'layout',
+    description: 'Enforce a single style for the not-equal operator (`<>` or `!=`)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: { operator: { enum: ['<>', '!='] } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferAngle: 'Use `<>` instead of `!=`.',
+      preferBang: 'Use `!=` instead of `<>`.',
+    },
+  },
+  'require-fk-include-columns': {
+    type: 'problem',
+    description:
+      'Require every foreign-key constraint to include a configured set of columns (e.g. `tenant_id` in a multi-tenant database)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          columns: { type: 'array', items: { type: 'string' }, uniqueItems: true, minItems: 1 },
+          excludeTablePattern: { type: 'string' },
+          excludeReferencedTablePattern: { type: 'string' },
+        },
+        required: ['columns'],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingFkColumn:
+        'Foreign-key constraint on `{{table}}` references `{{refTable}}` but does not include `{{missing}}`. In a multi-tenant database every FK should carry the tenant key so a child row cannot point at a parent in a different tenant.',
+    },
+  },
+  'require-if-exists': {
+    type: 'suggestion',
+    description:
+      'Require `IF EXISTS` on every `DROP` statement so re-running a migration on a database that already lost the object does not error',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingIfExists:
+        'Add `IF EXISTS` to this `DROP` so re-running the migration on a database that already lost the object does not abort.',
+    },
+  },
   'require-limit': {
     type: 'suggestion',
     description: 'Require LIMIT clause in SELECT statements',
@@ -383,6 +1093,110 @@ const ruleMeta = Object.freeze({
     messages: {
       missingLimit:
         'SELECT statement should include a LIMIT clause to prevent excessive data retrieval',
+    },
+  },
+  'require-named-constraint': {
+    type: 'suggestion',
+    description:
+      'Require an explicit name on table-level CHECK, UNIQUE, FOREIGN KEY, and EXCLUSION constraints',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      requireNamedConstraint:
+        'Table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints should be named with `CONSTRAINT <name>`. Auto-generated names are unpredictable across environments and make later `DROP CONSTRAINT` / `ALTER CONSTRAINT` migrations brittle.',
+    },
+  },
+  'require-on-delete-action': {
+    type: 'suggestion',
+    description: 'Require an explicit `ON DELETE` clause on every foreign-key constraint',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowed: {
+            type: 'array',
+            items: { enum: ['CASCADE', 'RESTRICT', 'NO ACTION', 'SET NULL', 'SET DEFAULT'] },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingOnDelete:
+        'Foreign-key constraint is missing an explicit `ON DELETE` clause; the implicit default is `NO ACTION`. Make the choice explicit so reviewers can see what happens to dependent rows.',
+      disallowedAction:
+        "`ON DELETE {{action}}` is not in the `allowed` list ({{allowedList}}). Either change the action or extend the rule's `allowed` option.",
+    },
+  },
+  'require-primary-key': {
+    type: 'suggestion',
+    description: 'Require every `CREATE TABLE` to declare a primary key',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingPrimaryKey:
+        'Table `{{table}}` has no PRIMARY KEY. Tables without one cannot be replicated cleanly, cannot be sharded predictably, and break almost every ORM. Add one as either a column constraint or a table-level constraint.',
+    },
+  },
+  'require-schema-qualified-table': {
+    type: 'suggestion',
+    description:
+      'Require `CREATE TABLE` to use a schema-qualified name (e.g. `audit.events`) so the target schema is explicit',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      requireSchemaQualifiedTable:
+        '`CREATE TABLE` should specify a schema (e.g. `audit.events`). Without one, the target depends on `search_path` and may land in an unintended schema. The rule is off by default in `recommended` because many projects intentionally use the `public` schema.',
+    },
+  },
+  'require-table-columns': {
+    type: 'problem',
+    description:
+      'Require every `CREATE TABLE` to include a configured set of columns (e.g. multi-tenant / audit columns like `tenant_id`, `created_at`, `updated_by`)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          columns: { type: 'array', items: { type: 'string' }, uniqueItems: true, minItems: 1 },
+          overrides: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                pattern: { type: 'string' },
+                columns: { type: 'array', items: { type: 'string' }, uniqueItems: true },
+              },
+              required: ['pattern', 'columns'],
+              additionalProperties: false,
+            },
+          },
+          exclude: { type: 'string' },
+        },
+        required: ['columns'],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingColumn:
+        '`CREATE TABLE {{table}}` is missing required column `{{missing}}`. {{rationale}}',
+    },
+  },
+  'require-trailing-semicolon': {
+    type: 'layout',
+    description: 'Require a trailing `;` at the end of the SQL file',
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingSemicolon: 'Missing trailing `;` at the end of the file.',
     },
   },
   'require-where-in-delete': {
@@ -405,6 +1219,40 @@ const ruleMeta = Object.freeze({
     messages: {
       missingWhere:
         'UPDATE without WHERE rewrites every row in the table. Add a WHERE clause to scope the change.',
+    },
+  },
+  'snake-case-column-name': {
+    type: 'suggestion',
+    description: 'Require column names to be snake_case',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { allow: { type: 'array', items: { type: 'string' }, uniqueItems: true } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      notSnakeCase:
+        'Column name `{{name}}` is not snake_case. PostgreSQL preserves the case of quoted identifiers; using a mixed-case quoted name forces every consumer to quote-match it.',
+    },
+  },
+  'snake-case-table-name': {
+    type: 'suggestion',
+    description: 'Require table names to be snake_case',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: { allow: { type: 'array', items: { type: 'string' }, uniqueItems: true } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      notSnakeCase:
+        'Table name `{{name}}` is not snake_case. PostgreSQL folds unquoted identifiers to lower case but preserves the case of quoted identifiers; mixing the two leads to `relation "BadName" does not exist` errors that are confusing to debug.',
     },
   },
 });

--- a/npm/postgresql/test/harness.mjs
+++ b/npm/postgresql/test/harness.mjs
@@ -94,7 +94,10 @@ export function runRule(ruleName, testCase) {
     throw new Error(`Unknown rule: ${ruleName}`);
   }
 
-  const code = testCase.code;
+  // Upstream's RuleTester lints `readSql(...).trim()`, so the captured fixture
+  // `code` (which keeps its trailing newline) must be trimmed to reproduce the
+  // expected error columns and autofix `output` exactly.
+  const code = testCase.code.trim();
   const sourceCode = {
     text: code,
     getText() {

--- a/status.json
+++ b/status.json
@@ -4807,307 +4807,307 @@
     "rules": [
       {
         "name": "align-column-definitions",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule align-column-definitions."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/align-column-definitions; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "align-values",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule align-values."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/align-values; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-as-for-column-alias",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-as-for-column-alias."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-as-for-column-alias; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-as-for-table-alias",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-as-for-table-alias."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-as-for-table-alias; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-between-over-and",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-between-over-and."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-between-over-and; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-create-index-concurrently",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-create-index-concurrently."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-create-index-concurrently; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-create-or-replace",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-create-or-replace."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-create-or-replace; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-drop-index-concurrently",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-drop-index-concurrently."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-drop-index-concurrently; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-explicit-inner-join",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-explicit-inner-join."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-explicit-inner-join; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-explicit-outer-join",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-explicit-outer-join."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-explicit-outer-join; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-fk-not-valid",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-fk-not-valid."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-fk-not-valid; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-identity-over-serial",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-identity-over-serial."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-identity-over-serial; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-jsonb-over-json",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-jsonb-over-json."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-jsonb-over-json; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-reindex-concurrently",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-reindex-concurrently."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-reindex-concurrently; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-text-over-varchar",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-text-over-varchar."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-text-over-varchar; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-timestamptz",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-timestamptz."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-timestamptz; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-add-check-constraint-without-not-valid",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-add-check-constraint-without-not-valid."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-add-check-constraint-without-not-valid; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-add-column-not-null-without-default",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-add-column-not-null-without-default."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-add-column-not-null-without-default; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-add-unique-constraint-directly",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-add-unique-constraint-directly."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-add-unique-constraint-directly; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-alter-column-type",
@@ -5127,19 +5127,19 @@
       },
       {
         "name": "no-char-type",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-char-type."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-char-type; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-cluster",
@@ -5159,19 +5159,19 @@
       },
       {
         "name": "no-composite-primary-key",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-composite-primary-key."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-composite-primary-key; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-create-role",
@@ -5271,35 +5271,35 @@
       },
       {
         "name": "no-drop-schema-cascade",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-drop-schema-cascade."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-drop-schema-cascade; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-drop-table-cascade",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-drop-table-cascade."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-drop-table-cascade; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-equality-with-null",
@@ -5383,19 +5383,19 @@
       },
       {
         "name": "no-identifier-too-long",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-identifier-too-long."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-identifier-too-long; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-implicit-join",
@@ -5431,19 +5431,19 @@
       },
       {
         "name": "no-money-type",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-money-type."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-money-type; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-natural-join",
@@ -5463,35 +5463,35 @@
       },
       {
         "name": "no-not-in-subquery",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-not-in-subquery."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-not-in-subquery; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-numeric-without-precision",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-numeric-without-precision."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-numeric-without-precision; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-on-delete-cascade",
@@ -5575,19 +5575,19 @@
       },
       {
         "name": "no-security-definer-without-search-path",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-security-definer-without-search-path."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-security-definer-without-search-path; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-select-into",
@@ -5687,19 +5687,19 @@
       },
       {
         "name": "no-time-type",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-time-type."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-time-type; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-truncate-cascade",
@@ -5735,51 +5735,51 @@
       },
       {
         "name": "no-unnecessary-quoted-identifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-unnecessary-quoted-identifier."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-unnecessary-quoted-identifier; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-update-primary-key",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-update-primary-key."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-update-primary-key; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-update-without-from-binding",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-update-without-from-binding."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-update-without-from-binding; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-vacuum-full",
@@ -5799,19 +5799,19 @@
       },
       {
         "name": "no-volatile-default-on-add-column",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-volatile-default-on-add-column."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-volatile-default-on-add-column; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-with-recursive-without-limit",
@@ -5831,211 +5831,211 @@
       },
       {
         "name": "plpgsql-keyword-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule plpgsql-keyword-case."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/plpgsql-keyword-case; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-add-constraint-not-valid",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-add-constraint-not-valid."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-add-constraint-not-valid; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-bigint-id",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-bigint-id."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-bigint-id; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-cast-operator",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-cast-operator."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-cast-operator; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-coalesce-over-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-coalesce-over-case."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-coalesce-over-case; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-current-timestamp-over-now",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-current-timestamp-over-now."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-current-timestamp-over-now; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-exists-over-in-subquery",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-exists-over-in-subquery."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-exists-over-in-subquery; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-explicit-null-ordering",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-explicit-null-ordering."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-explicit-null-ordering; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-in-list-over-or",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-in-list-over-or."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-in-list-over-or; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-keyword-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-keyword-case."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-keyword-case; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-not-equals-operator",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-not-equals-operator."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-not-equals-operator; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-fk-include-columns",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-fk-include-columns."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-fk-include-columns; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-if-exists",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-if-exists."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-if-exists; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-index-on-fk-column",
@@ -6071,99 +6071,99 @@
       },
       {
         "name": "require-named-constraint",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-named-constraint."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-named-constraint; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-on-delete-action",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-on-delete-action."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-on-delete-action; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-primary-key",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-primary-key."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-primary-key; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-schema-qualified-table",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-schema-qualified-table."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-schema-qualified-table; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-table-columns",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-table-columns."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-table-columns; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-trailing-semicolon",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-trailing-semicolon."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-trailing-semicolon; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-where-in-delete",
@@ -6199,35 +6199,35 @@
       },
       {
         "name": "snake-case-column-name",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule snake-case-column-name."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/snake-case-column-name; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "snake-case-table-name",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule snake-case-table-name."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/snake-case-table-name; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       }
     ]
   },


### PR DESCRIPTION
## What

Ports the remaining **54** `eslint-plugin-postgresql` rules to the Rust/libpg_query core, bringing the plugin from 33 → **87 of 89** rules implemented. Every rule is verified at **exact upstream-fixture parity** (messageId, 1-indexed location, and autofix `output`).

### Coverage by group
- **Column-type / DDL**: `no-char-type`, `no-time-type`, `no-numeric-without-precision`, `no-money-type`, `no-composite-primary-key`, `no-drop-table-cascade`, `no-drop-schema-cascade`, `no-unnecessary-quoted-identifier`, `no-identifier-too-long`, `require-trailing-semicolon`
- **Constraint / ALTER**: `no-add-check-constraint-without-not-valid`, `no-add-column-not-null-without-default`, `no-add-unique-constraint-directly`, `consistent-fk-not-valid`, `prefer-add-constraint-not-valid`, `require-named-constraint`, `no-update-primary-key`, `no-volatile-default-on-add-column`, `require-on-delete-action`
- **Table / key requirements**: `require-primary-key`, `require-fk-include-columns`, `require-schema-qualified-table`, `require-table-columns`, `require-if-exists`, `no-update-without-from-binding`, `no-not-in-subquery`, `no-security-definer-without-search-path`
- **Consistency / preference**: the `consistent-*` family (identity/jsonb/text/timestamptz, AS-for-aliases, between-over-and, *-concurrently, create-or-replace, explicit inner/outer join), the `prefer-*` family (bigint-id, cast-operator, coalesce-over-case, current-timestamp-over-now, not-equals, exists-over-in-subquery, explicit-null-ordering, in-list-over-or, keyword-case), `snake-case-{column,table}-name`, `align-{column-definitions,values}`, `plpgsql-keyword-case`

## Notes
- Token / whitespace / keyword-case rules run once per file via the parse-error program hook (`uses_parse_error`).
- Adds a shared `type_name` AST helper and the `regex` workspace dependency.
- The postgresql fixture harness now trims input SQL to match upstream's `RuleTester` (`readSql(...).trim()`), which the npm test-sync tool did not — required for the first batch of fixable rules' autofix `output` to match.

## Still pending (2)
- `require-index-on-fk-column` — needs a cross-statement `Program:exit` hook the per-node scan engine does not expose.
- `no-syntax-error` — one fixture's expected message is a JS `JSON.parse` artifact of upstream's `@libpg-query` binding that the Rust C-FFI path cannot reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784033966&installation_id=136613492&pr_number=334&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F334&signature=f6a332eb23cd713503e67491a4c5bed9cdaf8b7cf2f7747de6d7fc4dd1aac83a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->