### PR TITLE
feat(postgresql): port require-trailing-semicolon

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -44,6 +44,7 @@ mod require_limit;
 mod require_named_constraint;
 mod require_primary_key;
 mod require_schema_qualified_table;
+mod require_trailing_semicolon;
 mod require_where_in_delete;
 mod require_where_in_update;
 mod snake_case_table_name;
@@ -185,6 +186,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "require-named-constraint",
     "require-primary-key",
     "require-schema-qualified-table",
+    "require-trailing-semicolon",
     "require-where-in-delete",
     "require-where-in-update",
     "snake-case-table-name",
@@ -396,6 +398,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "require-schema-qualified-table",
         run: require_schema_qualified_table::run,
         uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-trailing-semicolon",
+        run: require_trailing_semicolon::run,
+        uses_parse_error: true,
     },
     RuleDef {
         name: "require-where-in-delete",

--- a/crates/postgresql/src/rules/require_trailing_semicolon.rs
+++ b/crates/postgresql/src/rules/require_trailing_semicolon.rs
@@ -1,0 +1,42 @@
+//! Port of `require-trailing-semicolon`: the last token in the file must be a
+//! semicolon. Produces an autofix that inserts `;` immediately after the last
+//! token. Operates on the token stream (not the AST).
+
+use serde_json::Value;
+
+use crate::tokenize::tokenize;
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Only execute on the one-time program-level trigger (Value::Null).
+    if !node.is_null() {
+        return;
+    }
+
+    let tokenized = tokenize(ctx.source);
+    let tokens = &tokenized.tokens;
+
+    let last = match tokens.last() {
+        Some(t) => t,
+        None => return,
+    };
+
+    if last.value == ";" {
+        return;
+    }
+
+    let loc = DiagnosticLoc {
+        start_line: last.start_pos.line,
+        start_column: last.start_pos.column,
+        end_line: last.end_pos.line,
+        end_column: last.end_pos.column,
+    };
+    // Insert `;` right after the last token (zero-length replacement = insert).
+    let fix = DiagnosticFix {
+        start: last.end,
+        end: last.end,
+        replacement: CompactString::from(";"),
+    };
+    ctx.report_loc(loc, "missingSemicolon", SmallVec::new(), Some(fix));
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -502,6 +502,16 @@ const ruleMeta = Object.freeze({
         '`CREATE TABLE` should specify a schema (e.g. `audit.events`). Without one, the target depends on `search_path` and may land in an unintended schema. The rule is off by default in `recommended` because many projects intentionally use the `public` schema.',
     },
   },
+  'require-trailing-semicolon': {
+    type: 'layout',
+    description: 'Require a trailing `;` at the end of the SQL file',
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingSemicolon: 'Missing trailing `;` at the end of the file.',
+    },
+  },
   'require-where-in-delete': {
     type: 'problem',
     description: 'Require a WHERE clause in DELETE statements',

--- a/npm/postgresql/test/fixtures/align-column-definitions.json
+++ b/npm/postgresql/test/fixtures/align-column-definitions.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "already-aligned",
-      "code": "CREATE TABLE document_ingest_stage_executions (\n  document_ingest_stage_execution_id  ulid                            PRIMARY KEY,\n  tenant_id                           ulid                            NOT NULL,\n  agent_id                            ulid                            NOT NULL,\n  status                              flygate_document_ingest_status  NOT NULL\n);\n"
+      "code": "CREATE TABLE document_ingest_stage_executions (\n  document_ingest_stage_execution_id  ulid                            PRIMARY KEY,\n  tenant_id                           ulid                            NOT NULL,\n  agent_id                            ulid                            NOT NULL,\n  status                              flygate_document_ingest_status  NOT NULL\n);"
     },
     {
       "name": "inline-comment-skipped-on-block-inside",
-      "code": "-- Block comment INSIDE a column definition would be clobbered by the\n-- realign; the rule must skip the whole table in that case.\nCREATE TABLE foo (\n  id /* see ticket */ ulid PRIMARY KEY,\n  name text NOT NULL\n);\n"
+      "code": "-- Block comment INSIDE a column definition would be clobbered by the\n-- realign; the rule must skip the whole table in that case.\nCREATE TABLE foo (\n  id /* see ticket */ ulid PRIMARY KEY,\n  name text NOT NULL\n);"
     },
     {
       "name": "single-column",
-      "code": "CREATE TABLE only_one (\n  id ulid PRIMARY KEY\n);\n"
+      "code": "CREATE TABLE only_one (\n  id ulid PRIMARY KEY\n);"
     }
   ],
   "invalid": [
     {
       "name": "array-type",
-      "code": "CREATE TABLE t (\n  a TEXT NOT NULL,\n  b non_blank_text_64[] NOT NULL,\n  c INTEGER NOT NULL\n);\n",
+      "code": "CREATE TABLE t (\n  a TEXT NOT NULL,\n  b non_blank_text_64[] NOT NULL,\n  c INTEGER NOT NULL\n);",
       "errors": [
         {
           "messageId": "misaligned",
@@ -38,7 +38,7 @@
     },
     {
       "name": "inline-comment",
-      "code": "CREATE TABLE foo (\n  id ulid PRIMARY KEY, -- the surrogate key\n  name text NOT NULL\n);\n",
+      "code": "CREATE TABLE foo (\n  id ulid PRIMARY KEY, -- the surrogate key\n  name text NOT NULL\n);",
       "errors": [
         {
           "messageId": "misaligned",
@@ -53,7 +53,7 @@
     },
     {
       "name": "misaligned",
-      "code": "CREATE TABLE document_ingest_stage_executions (\n  document_ingest_stage_execution_id ulid PRIMARY KEY,\n  tenant_id ulid NOT NULL,\n  agent_id ulid NOT NULL,\n  status flygate_document_ingest_status NOT NULL\n);\n",
+      "code": "CREATE TABLE document_ingest_stage_executions (\n  document_ingest_stage_execution_id ulid PRIMARY KEY,\n  tenant_id ulid NOT NULL,\n  agent_id ulid NOT NULL,\n  status flygate_document_ingest_status NOT NULL\n);",
       "errors": [
         {
           "messageId": "misaligned",
@@ -68,7 +68,7 @@
     },
     {
       "name": "mixed-constraints",
-      "code": "CREATE TABLE foo (\n  id ulid PRIMARY KEY,\n  description text,\n  created_at flygate_datetime NOT NULL\n);\n",
+      "code": "CREATE TABLE foo (\n  id ulid PRIMARY KEY,\n  description text,\n  created_at flygate_datetime NOT NULL\n);",
       "errors": [
         {
           "messageId": "misaligned",
@@ -83,7 +83,7 @@
     },
     {
       "name": "multi-keyword-constraint",
-      "code": "CREATE TABLE t (\n  id bigint GENERATED ALWAYS AS IDENTITY                     PRIMARY KEY,\n  name text NOT NULL\n);\n",
+      "code": "CREATE TABLE t (\n  id bigint GENERATED ALWAYS AS IDENTITY                     PRIMARY KEY,\n  name text NOT NULL\n);",
       "errors": [
         {
           "messageId": "misaligned",
@@ -98,7 +98,7 @@
     },
     {
       "name": "type-with-precision",
-      "code": "CREATE TABLE pgmigration_triggers (\n  id BIGSERIAL PRIMARY KEY,\n  name TEXT NOT NULL,\n  file_hash TEXT NOT NULL,\n  run_on TIMESTAMP(3) NOT NULL\n);\n",
+      "code": "CREATE TABLE pgmigration_triggers (\n  id BIGSERIAL PRIMARY KEY,\n  name TEXT NOT NULL,\n  file_hash TEXT NOT NULL,\n  run_on TIMESTAMP(3) NOT NULL\n);",
       "errors": [
         {
           "messageId": "misaligned",
@@ -113,7 +113,7 @@
     },
     {
       "name": "with-table-constraint",
-      "code": "CREATE TABLE foo (\n  id ulid,\n  name text,\n  email text,\n  PRIMARY KEY (id, email)\n);\n",
+      "code": "CREATE TABLE foo (\n  id ulid,\n  name text,\n  email text,\n  PRIMARY KEY (id, email)\n);",
       "errors": [
         {
           "messageId": "misaligned",

--- a/npm/postgresql/test/fixtures/align-values.json
+++ b/npm/postgresql/test/fixtures/align-values.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "already-aligned",
-      "code": "INSERT INTO t (a, b, c) VALUES\n  ('GPT-5',  1.25, CURRENT_TIMESTAMP),\n  ('Claude', 5,    CURRENT_TIMESTAMP);\n"
+      "code": "INSERT INTO t (a, b, c) VALUES\n  ('GPT-5',  1.25, CURRENT_TIMESTAMP),\n  ('Claude', 5,    CURRENT_TIMESTAMP);"
     },
     {
       "name": "single-row",
-      "code": "-- Single-row VALUES: nothing to align against; rule is a no-op.\nINSERT INTO t (a, b) VALUES ('GPT-5', 1.25);\n"
+      "code": "-- Single-row VALUES: nothing to align against; rule is a no-op.\nINSERT INTO t (a, b) VALUES ('GPT-5', 1.25);"
     }
   ],
   "invalid": [
     {
       "name": "over-padded",
-      "code": "INSERT INTO t (a, b, c) VALUES\n  ('GPT-5',                 1.25, CURRENT_TIMESTAMP),\n  ('Claude',                5,    CURRENT_TIMESTAMP),\n  ('Haiku',                 1,    CURRENT_TIMESTAMP);\n",
+      "code": "INSERT INTO t (a, b, c) VALUES\n  ('GPT-5',                 1.25, CURRENT_TIMESTAMP),\n  ('Claude',                5,    CURRENT_TIMESTAMP),\n  ('Haiku',                 1,    CURRENT_TIMESTAMP);",
       "errors": [
         {
           "messageId": "misaligned",

--- a/npm/postgresql/test/fixtures/consistent-as-for-column-alias.json
+++ b/npm/postgresql/test/fixtures/consistent-as-for-column-alias.json
@@ -9,15 +9,15 @@
   "valid": [
     {
       "name": "compound-expression-with-as",
-      "code": "-- TypeCast (`expr::type`), dotted ColumnRef (`t.col`) and CASE expressions\n-- expose parser ranges that stop in the middle of the value expression\n-- (e.g. on `::` between the inner expr and the type name, or on the\n-- first dotted segment). The rule must still see `AS` as present.\n-- (Regression: the rule used to look at the token immediately after the\n-- parser-reported value range and, when that token was `ulid` / `.` /\n-- `WHEN` instead of `AS`, it inserted `AS` in the middle of the\n-- expression, producing `()::AS ulid`, `uAS .col`, `CASE AS WHEN ...`.)\nSELECT\n  generate_ulid_plv8()::ulid AS some_id,\n  u.user_id AS created_by,\n  CASE WHEN x = 1 THEN 'a' WHEN x = 2 THEN 'b' ELSE 'c' END AS label\nFROM users u;\n"
+      "code": "-- TypeCast (`expr::type`), dotted ColumnRef (`t.col`) and CASE expressions\n-- expose parser ranges that stop in the middle of the value expression\n-- (e.g. on `::` between the inner expr and the type name, or on the\n-- first dotted segment). The rule must still see `AS` as present.\n-- (Regression: the rule used to look at the token immediately after the\n-- parser-reported value range and, when that token was `ulid` / `.` /\n-- `WHEN` instead of `AS`, it inserted `AS` in the middle of the\n-- expression, producing `()::AS ulid`, `uAS .col`, `CASE AS WHEN ...`.)\nSELECT\n  generate_ulid_plv8()::ulid AS some_id,\n  u.user_id AS created_by,\n  CASE WHEN x = 1 THEN 'a' WHEN x = 2 THEN 'b' ELSE 'c' END AS label\nFROM users u;"
     },
     {
       "name": "explicit-as",
-      "code": "SELECT id AS user_id, name AS full_name FROM users;\nSELECT id, name FROM users;\nSELECT * FROM users;\nINSERT INTO users (id, name) VALUES (1, 'a');\nUPDATE users SET name = 'b' WHERE id = 1;\n"
+      "code": "SELECT id AS user_id, name AS full_name FROM users;\nSELECT id, name FROM users;\nSELECT * FROM users;\nINSERT INTO users (id, name) VALUES (1, 'a');\nUPDATE users SET name = 'b' WHERE id = 1;"
     },
     {
       "name": "never-no-as",
-      "code": "SELECT id user_id FROM users;\n",
+      "code": "SELECT id user_id FROM users;",
       "options": [
         {
           "style": "never"
@@ -28,7 +28,7 @@
   "invalid": [
     {
       "name": "bare-alias",
-      "code": "SELECT id user_id, name full_name FROM users;\n",
+      "code": "SELECT id user_id, name full_name FROM users;",
       "errors": [
         {
           "messageId": "preferAs",
@@ -51,7 +51,7 @@
     },
     {
       "name": "compound-expression-without-as",
-      "code": "-- When the alias is omitted on a TypeCast value the rule's old logic\n-- would have corrupted `()::ulid id` into `()::AS ulid id` (parser range\n-- ends mid-cast). The defensive check requires the next token to match\n-- the alias name before inserting `AS`, so we only flag the bare ones\n-- whose next token actually is the alias.\nSELECT\n  COUNT(*) total,\n  id user_id\nFROM users;\n",
+      "code": "-- When the alias is omitted on a TypeCast value the rule's old logic\n-- would have corrupted `()::ulid id` into `()::AS ulid id` (parser range\n-- ends mid-cast). The defensive check requires the next token to match\n-- the alias name before inserting `AS`, so we only flag the bare ones\n-- whose next token actually is the alias.\nSELECT\n  COUNT(*) total,\n  id user_id\nFROM users;",
       "errors": [
         {
           "messageId": "preferAs",
@@ -66,7 +66,7 @@
     },
     {
       "name": "never-with-as",
-      "code": "SELECT id AS user_id FROM users;\n",
+      "code": "SELECT id AS user_id FROM users;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-as-for-table-alias.json
+++ b/npm/postgresql/test/fixtures/consistent-as-for-table-alias.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "explicit-as",
-      "code": "SELECT u.id FROM users AS u WHERE u.active = TRUE;\nSELECT u.id FROM public.users AS u JOIN orders AS o ON o.user_id = u.id;\nSELECT u.id FROM users WHERE active = TRUE;\n"
+      "code": "SELECT u.id FROM users AS u WHERE u.active = TRUE;\nSELECT u.id FROM public.users AS u JOIN orders AS o ON o.user_id = u.id;\nSELECT u.id FROM users WHERE active = TRUE;"
     },
     {
       "name": "never-no-as",
-      "code": "SELECT u.id FROM users u;\n",
+      "code": "SELECT u.id FROM users u;",
       "options": [
         {
           "style": "never"
@@ -24,7 +24,7 @@
   "invalid": [
     {
       "name": "bare-alias",
-      "code": "SELECT u.id FROM users u WHERE u.active = TRUE;\n",
+      "code": "SELECT u.id FROM users u WHERE u.active = TRUE;",
       "errors": [
         {
           "messageId": "preferAs",
@@ -39,7 +39,7 @@
     },
     {
       "name": "never-with-as",
-      "code": "SELECT u.id FROM users AS u;\n",
+      "code": "SELECT u.id FROM users AS u;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-between-over-and.json
+++ b/npm/postgresql/test/fixtures/consistent-between-over-and.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "already-between",
-      "code": "SELECT * FROM t WHERE x BETWEEN 1 AND 10;\n-- Strict inequalities are not equivalent to BETWEEN; do not flag.\nSELECT * FROM t WHERE x > 1 AND x < 10;\n-- Different lhs: not in scope.\nSELECT * FROM t WHERE x >= 1 AND y <= 10;\n-- More than two conjuncts: not in scope.\nSELECT * FROM t WHERE x >= 1 AND x <= 10 AND y > 0;\n"
+      "code": "SELECT * FROM t WHERE x BETWEEN 1 AND 10;\n-- Strict inequalities are not equivalent to BETWEEN; do not flag.\nSELECT * FROM t WHERE x > 1 AND x < 10;\n-- Different lhs: not in scope.\nSELECT * FROM t WHERE x >= 1 AND y <= 10;\n-- More than two conjuncts: not in scope.\nSELECT * FROM t WHERE x >= 1 AND x <= 10 AND y > 0;"
     },
     {
       "name": "never-and-pair",
-      "code": "SELECT 1 WHERE x >= 1 AND x <= 10;\n",
+      "code": "SELECT 1 WHERE x >= 1 AND x <= 10;",
       "options": [
         {
           "style": "never"
@@ -24,7 +24,7 @@
   "invalid": [
     {
       "name": "and-pair",
-      "code": "SELECT * FROM t WHERE x >= 1 AND x <= 10;\n",
+      "code": "SELECT * FROM t WHERE x >= 1 AND x <= 10;",
       "errors": [
         {
           "messageId": "preferBetween",
@@ -39,7 +39,7 @@
     },
     {
       "name": "cast-bounds",
-      "code": "SELECT 1 WHERE x >= '1900-01-01'::TIMESTAMPTZ AND x <= '2299-12-31'::TIMESTAMPTZ;\n",
+      "code": "SELECT 1 WHERE x >= '1900-01-01'::TIMESTAMPTZ AND x <= '2299-12-31'::TIMESTAMPTZ;",
       "errors": [
         {
           "messageId": "preferBetween",
@@ -54,7 +54,7 @@
     },
     {
       "name": "never-between",
-      "code": "SELECT 1 WHERE x BETWEEN 1 AND 10;\n",
+      "code": "SELECT 1 WHERE x BETWEEN 1 AND 10;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-create-index-concurrently.json
+++ b/npm/postgresql/test/fixtures/consistent-create-index-concurrently.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "concurrent",
-      "code": "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);\n"
+      "code": "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);"
     },
     {
       "name": "never-without-concurrently",
-      "code": "CREATE INDEX idx_users_email ON users (email);\nCREATE UNIQUE INDEX idx_users_uid ON users (uid);\n",
+      "code": "CREATE INDEX idx_users_email ON users (email);\nCREATE UNIQUE INDEX idx_users_uid ON users (uid);",
       "options": [
         {
           "style": "never"
@@ -24,7 +24,7 @@
   "invalid": [
     {
       "name": "missing-concurrently",
-      "code": "CREATE INDEX idx_users_email ON users (email);\n",
+      "code": "CREATE INDEX idx_users_email ON users (email);",
       "errors": [
         {
           "messageId": "preferConcurrently",
@@ -39,7 +39,7 @@
     },
     {
       "name": "never-with-concurrently",
-      "code": "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);\nCREATE UNIQUE INDEX CONCURRENTLY idx_users_uid ON users (uid);\n",
+      "code": "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);\nCREATE UNIQUE INDEX CONCURRENTLY idx_users_uid ON users (uid);",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-create-or-replace.json
+++ b/npm/postgresql/test/fixtures/consistent-create-or-replace.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "never-without-or-replace",
-      "code": "CREATE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE VIEW v AS SELECT 1;\n-- Other CREATE statements are out of scope.\nCREATE TABLE t (id integer);\nCREATE INDEX idx ON t (id);\n",
+      "code": "CREATE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE VIEW v AS SELECT 1;\n-- Other CREATE statements are out of scope.\nCREATE TABLE t (id integer);\nCREATE INDEX idx ON t (id);",
       "options": [
         {
           "style": "never"
@@ -18,13 +18,13 @@
     },
     {
       "name": "with-or-replace",
-      "code": "CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE OR REPLACE VIEW v AS SELECT 1;\n-- Other CREATE statements are out of scope (TABLE doesn't support OR REPLACE).\nCREATE TABLE t (id integer);\nCREATE INDEX idx ON t (id);\n"
+      "code": "CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE OR REPLACE VIEW v AS SELECT 1;\n-- Other CREATE statements are out of scope (TABLE doesn't support OR REPLACE).\nCREATE TABLE t (id integer);\nCREATE INDEX idx ON t (id);"
     }
   ],
   "invalid": [
     {
       "name": "missing-or-replace",
-      "code": "CREATE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE VIEW v AS SELECT 1;\n",
+      "code": "CREATE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE VIEW v AS SELECT 1;",
       "errors": [
         {
           "messageId": "preferOrReplace",
@@ -55,7 +55,7 @@
     },
     {
       "name": "never-with-or-replace",
-      "code": "CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE OR REPLACE VIEW v AS SELECT 1;\n",
+      "code": "CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';\nCREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS '';\nCREATE OR REPLACE VIEW v AS SELECT 1;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-drop-index-concurrently.json
+++ b/npm/postgresql/test/fixtures/consistent-drop-index-concurrently.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "concurrently",
-      "code": "DROP INDEX CONCURRENTLY idx_users;\nDROP INDEX CONCURRENTLY IF EXISTS idx_orders;\n-- Non-index DROPs are out of scope.\nDROP TABLE old_table;\n"
+      "code": "DROP INDEX CONCURRENTLY idx_users;\nDROP INDEX CONCURRENTLY IF EXISTS idx_orders;\n-- Non-index DROPs are out of scope.\nDROP TABLE old_table;"
     },
     {
       "name": "never-no-concurrently",
-      "code": "DROP INDEX idx_users;\n",
+      "code": "DROP INDEX idx_users;",
       "options": [
         {
           "style": "never"
@@ -24,7 +24,7 @@
   "invalid": [
     {
       "name": "never-concurrently",
-      "code": "DROP INDEX CONCURRENTLY idx_users;\n",
+      "code": "DROP INDEX CONCURRENTLY idx_users;",
       "options": [
         {
           "style": "never"
@@ -44,7 +44,7 @@
     },
     {
       "name": "no-concurrently",
-      "code": "DROP INDEX idx_users;\n",
+      "code": "DROP INDEX idx_users;",
       "errors": [
         {
           "messageId": "preferConcurrently",

--- a/npm/postgresql/test/fixtures/consistent-explicit-inner-join.json
+++ b/npm/postgresql/test/fixtures/consistent-explicit-inner-join.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "explicit-inner",
-      "code": "SELECT u.id FROM users u INNER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u CROSS JOIN regions r;\nSELECT u.id FROM users u NATURAL JOIN profiles p;\nSELECT u.id FROM users u LEFT JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u LEFT OUTER JOIN orders o ON o.user_id = u.id;\n"
+      "code": "SELECT u.id FROM users u INNER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u CROSS JOIN regions r;\nSELECT u.id FROM users u NATURAL JOIN profiles p;\nSELECT u.id FROM users u LEFT JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u LEFT OUTER JOIN orders o ON o.user_id = u.id;"
     },
     {
       "name": "never-bare-join",
-      "code": "SELECT a.id FROM a JOIN b ON a.id = b.id;\n",
+      "code": "SELECT a.id FROM a JOIN b ON a.id = b.id;",
       "options": [
         {
           "style": "never"
@@ -24,7 +24,7 @@
   "invalid": [
     {
       "name": "bare-join",
-      "code": "SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id;\n",
+      "code": "SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id;",
       "errors": [
         {
           "messageId": "preferInnerJoin",
@@ -39,7 +39,7 @@
     },
     {
       "name": "never-inner-join",
-      "code": "SELECT a.id FROM a INNER JOIN b ON a.id = b.id;\n",
+      "code": "SELECT a.id FROM a INNER JOIN b ON a.id = b.id;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-explicit-outer-join.json
+++ b/npm/postgresql/test/fixtures/consistent-explicit-outer-join.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "explicit-outer",
-      "code": "SELECT u.id FROM users u LEFT OUTER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u RIGHT OUTER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u FULL OUTER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u INNER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u CROSS JOIN regions r;\n"
+      "code": "SELECT u.id FROM users u LEFT OUTER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u RIGHT OUTER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u FULL OUTER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u INNER JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u CROSS JOIN regions r;"
     },
     {
       "name": "never-bare-side-join",
-      "code": "SELECT a.id FROM a LEFT JOIN b ON a.id = b.id;\n",
+      "code": "SELECT a.id FROM a LEFT JOIN b ON a.id = b.id;",
       "options": [
         {
           "style": "never"
@@ -24,7 +24,7 @@
   "invalid": [
     {
       "name": "left-join",
-      "code": "SELECT u.id FROM users u LEFT JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u RIGHT JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u FULL JOIN orders o ON o.user_id = u.id;\n",
+      "code": "SELECT u.id FROM users u LEFT JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u RIGHT JOIN orders o ON o.user_id = u.id;\nSELECT u.id FROM users u FULL JOIN orders o ON o.user_id = u.id;",
       "errors": [
         {
           "messageId": "preferOuterJoin",
@@ -55,7 +55,7 @@
     },
     {
       "name": "never-side-outer-join",
-      "code": "SELECT a.id FROM a LEFT OUTER JOIN b ON a.id = b.id;\n",
+      "code": "SELECT a.id FROM a LEFT OUTER JOIN b ON a.id = b.id;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-fk-not-valid.json
+++ b/npm/postgresql/test/fixtures/consistent-fk-not-valid.json
@@ -9,15 +9,15 @@
   "valid": [
     {
       "name": "add-check-without-fk",
-      "code": "ALTER TABLE orders ADD CONSTRAINT positive_amount CHECK (amount > 0);\n"
+      "code": "ALTER TABLE orders ADD CONSTRAINT positive_amount CHECK (amount > 0);"
     },
     {
       "name": "add-fk-not-valid",
-      "code": "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;\n"
+      "code": "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;"
     },
     {
       "name": "never-validating",
-      "code": "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES parent (id);\n",
+      "code": "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES parent (id);",
       "options": [
         {
           "style": "never"
@@ -26,13 +26,13 @@
     },
     {
       "name": "validate",
-      "code": "ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;\n"
+      "code": "ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;"
     }
   ],
   "invalid": [
     {
       "name": "add-fk",
-      "code": "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id);\n",
+      "code": "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id);",
       "errors": [
         {
           "messageId": "preferFkNotValid",
@@ -47,7 +47,7 @@
     },
     {
       "name": "never-not-valid",
-      "code": "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES parent (id) NOT VALID;\n",
+      "code": "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES parent (id) NOT VALID;",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/consistent-identity-over-serial.json
+++ b/npm/postgresql/test/fixtures/consistent-identity-over-serial.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "identity-column",
-      "code": "CREATE TABLE t (id INT GENERATED ALWAYS AS IDENTITY);\n"
+      "code": "CREATE TABLE t (id INT GENERATED ALWAYS AS IDENTITY);"
     },
     {
       "name": "never-serial",
-      "code": "CREATE TABLE t (id bigserial PRIMARY KEY);\n",
+      "code": "CREATE TABLE t (id bigserial PRIMARY KEY);",
       "options": [
         {
           "style": "never"
@@ -22,13 +22,13 @@
     },
     {
       "name": "plain-int",
-      "code": "CREATE TABLE t (id INT);\n"
+      "code": "CREATE TABLE t (id INT);"
     }
   ],
   "invalid": [
     {
       "name": "bigserial",
-      "code": "CREATE TABLE t (id BIGSERIAL);\n",
+      "code": "CREATE TABLE t (id BIGSERIAL);",
       "errors": [
         {
           "messageId": "preferIdentity",
@@ -43,7 +43,7 @@
     },
     {
       "name": "never-identity",
-      "code": "CREATE TABLE t (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY);\n",
+      "code": "CREATE TABLE t (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY);",
       "options": [
         {
           "style": "never"
@@ -63,7 +63,7 @@
     },
     {
       "name": "serial",
-      "code": "CREATE TABLE t (id SERIAL);\n",
+      "code": "CREATE TABLE t (id SERIAL);",
       "errors": [
         {
           "messageId": "preferIdentity",
@@ -78,7 +78,7 @@
     },
     {
       "name": "smallserial",
-      "code": "CREATE TABLE t (id SMALLSERIAL);\n",
+      "code": "CREATE TABLE t (id SMALLSERIAL);",
       "errors": [
         {
           "messageId": "preferIdentity",

--- a/npm/postgresql/test/fixtures/consistent-jsonb-over-json.json
+++ b/npm/postgresql/test/fixtures/consistent-jsonb-over-json.json
@@ -9,11 +9,11 @@
   "valid": [
     {
       "name": "jsonb-column",
-      "code": "CREATE TABLE events (payload JSONB);\n"
+      "code": "CREATE TABLE events (payload JSONB);"
     },
     {
       "name": "never-json",
-      "code": "CREATE TABLE t (payload json);\n",
+      "code": "CREATE TABLE t (payload json);",
       "options": [
         {
           "style": "never"
@@ -22,13 +22,13 @@
     },
     {
       "name": "other-column",
-      "code": "CREATE TABLE events (id INT);\n"
+      "code": "CREATE TABLE events (id INT);"
     }
   ],
   "invalid": [
     {
       "name": "json-column",
-      "code": "CREATE TABLE events (payload JSON);\n",
+      "code": "CREATE TABLE events (payload JSON);",
       "errors": [
         {
           "messageId": "preferJsonb",
@@ -43,7 +43,7 @@
     },
     {
       "name": "never-jsonb",
-      "code": "CREATE TABLE t (payload jsonb);\n",
+      "code": "CREATE TABLE t (payload jsonb);",
       "options": [
         {
           "style": "never"
@@ -63,7 +63,7 @@
     },
     {
       "name": "qualified-json",
-      "code": "CREATE TABLE events (payload pg_catalog.json);\n",
+      "code": "CREATE TABLE events (payload pg_catalog.json);",
       "errors": [
         {
           "messageId": "preferJsonb",

--- a/npm/postgresql/test/fixtures/consistent-reindex-concurrently.json
+++ b/npm/postgresql/test/fixtures/consistent-reindex-concurrently.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "never-no-concurrently",
-      "code": "REINDEX TABLE users;\n",
+      "code": "REINDEX TABLE users;",
       "options": [
         {
           "style": "never"
@@ -18,13 +18,13 @@
     },
     {
       "name": "reindex-concurrently",
-      "code": "REINDEX TABLE CONCURRENTLY users;\n"
+      "code": "REINDEX TABLE CONCURRENTLY users;"
     }
   ],
   "invalid": [
     {
       "name": "never-concurrently",
-      "code": "REINDEX TABLE CONCURRENTLY users;\n",
+      "code": "REINDEX TABLE CONCURRENTLY users;",
       "options": [
         {
           "style": "never"
@@ -44,7 +44,7 @@
     },
     {
       "name": "reindex-table",
-      "code": "REINDEX TABLE users;\n",
+      "code": "REINDEX TABLE users;",
       "errors": [
         {
           "messageId": "preferReindexConcurrently",

--- a/npm/postgresql/test/fixtures/consistent-text-over-varchar.json
+++ b/npm/postgresql/test/fixtures/consistent-text-over-varchar.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "never-varchar",
-      "code": "CREATE TABLE t (name varchar(255));\n",
+      "code": "CREATE TABLE t (name varchar(255));",
       "options": [
         {
           "style": "never"
@@ -18,17 +18,17 @@
     },
     {
       "name": "text-column",
-      "code": "CREATE TABLE users (name TEXT);\n"
+      "code": "CREATE TABLE users (name TEXT);"
     },
     {
       "name": "unlimited-varchar",
-      "code": "CREATE TABLE users (name VARCHAR);\n"
+      "code": "CREATE TABLE users (name VARCHAR);"
     }
   ],
   "invalid": [
     {
       "name": "never-text",
-      "code": "CREATE TABLE t (name text);\n",
+      "code": "CREATE TABLE t (name text);",
       "options": [
         {
           "style": "never"
@@ -48,7 +48,7 @@
     },
     {
       "name": "varchar-n",
-      "code": "CREATE TABLE users (name VARCHAR(255));\n",
+      "code": "CREATE TABLE users (name VARCHAR(255));",
       "errors": [
         {
           "messageId": "preferText",

--- a/npm/postgresql/test/fixtures/consistent-timestamptz.json
+++ b/npm/postgresql/test/fixtures/consistent-timestamptz.json
@@ -9,15 +9,15 @@
   "valid": [
     {
       "name": "always-timestamp-with-time-zone",
-      "code": "CREATE TABLE t (created_at TIMESTAMP WITH TIME ZONE);\n"
+      "code": "CREATE TABLE t (created_at TIMESTAMP WITH TIME ZONE);"
     },
     {
       "name": "always-timestamptz",
-      "code": "CREATE TABLE t (created_at TIMESTAMPTZ);\n"
+      "code": "CREATE TABLE t (created_at TIMESTAMPTZ);"
     },
     {
       "name": "never-timestamp",
-      "code": "CREATE TABLE t (created_at TIMESTAMP);\n",
+      "code": "CREATE TABLE t (created_at TIMESTAMP);",
       "options": [
         {
           "style": "never"
@@ -28,7 +28,7 @@
   "invalid": [
     {
       "name": "always-timestamp",
-      "code": "CREATE TABLE t (created_at TIMESTAMP);\n",
+      "code": "CREATE TABLE t (created_at TIMESTAMP);",
       "errors": [
         {
           "messageId": "preferTimestamptz",
@@ -43,7 +43,7 @@
     },
     {
       "name": "never-timestamptz",
-      "code": "CREATE TABLE t (created_at TIMESTAMPTZ);\nCREATE TABLE u (created_at TIMESTAMP WITH TIME ZONE);\n",
+      "code": "CREATE TABLE t (created_at TIMESTAMPTZ);\nCREATE TABLE u (created_at TIMESTAMP WITH TIME ZONE);",
       "options": [
         {
           "style": "never"

--- a/npm/postgresql/test/fixtures/no-add-check-constraint-without-not-valid.json
+++ b/npm/postgresql/test/fixtures/no-add-check-constraint-without-not-valid.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-not-valid",
-      "code": "ALTER TABLE t ADD CONSTRAINT c CHECK (x > 0) NOT VALID;\n-- Non-CHECK constraints are out of scope.\nALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (id);\n"
+      "code": "ALTER TABLE t ADD CONSTRAINT c CHECK (x > 0) NOT VALID;\n-- Non-CHECK constraints are out of scope.\nALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (id);"
     }
   ],
   "invalid": [
     {
       "name": "synchronous-check",
-      "code": "ALTER TABLE t ADD CONSTRAINT c CHECK (x > 0);\n",
+      "code": "ALTER TABLE t ADD CONSTRAINT c CHECK (x > 0);",
       "errors": [
         {
           "messageId": "checkNotValid",

--- a/npm/postgresql/test/fixtures/no-add-column-not-null-without-default.json
+++ b/npm/postgresql/test/fixtures/no-add-column-not-null-without-default.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "add-identity",
-      "code": "ALTER TABLE users ADD COLUMN id bigint GENERATED ALWAYS AS IDENTITY NOT NULL;\n"
+      "code": "ALTER TABLE users ADD COLUMN id bigint GENERATED ALWAYS AS IDENTITY NOT NULL;"
     },
     {
       "name": "add-not-null-with-default",
-      "code": "ALTER TABLE users ADD COLUMN status text NOT NULL DEFAULT 'active';\n"
+      "code": "ALTER TABLE users ADD COLUMN status text NOT NULL DEFAULT 'active';"
     },
     {
       "name": "add-nullable",
-      "code": "ALTER TABLE users ADD COLUMN status text;\n"
+      "code": "ALTER TABLE users ADD COLUMN status text;"
     }
   ],
   "invalid": [
     {
       "name": "add-not-null",
-      "code": "ALTER TABLE users ADD COLUMN status text NOT NULL;\n",
+      "code": "ALTER TABLE users ADD COLUMN status text NOT NULL;",
       "errors": [
         {
           "messageId": "noAddColumnNotNullWithoutDefault",

--- a/npm/postgresql/test/fixtures/no-add-unique-constraint-directly.json
+++ b/npm/postgresql/test/fixtures/no-add-unique-constraint-directly.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-using-index",
-      "code": "-- Build the index out-of-band, then promote it.\nCREATE UNIQUE INDEX CONCURRENTLY idx_t_email ON t (email);\nALTER TABLE t ADD CONSTRAINT uq_t_email UNIQUE USING INDEX idx_t_email;\n-- Non-UNIQUE constraints are out of scope.\nALTER TABLE t ADD CONSTRAINT c CHECK (x > 0);\n"
+      "code": "-- Build the index out-of-band, then promote it.\nCREATE UNIQUE INDEX CONCURRENTLY idx_t_email ON t (email);\nALTER TABLE t ADD CONSTRAINT uq_t_email UNIQUE USING INDEX idx_t_email;\n-- Non-UNIQUE constraints are out of scope.\nALTER TABLE t ADD CONSTRAINT c CHECK (x > 0);"
     }
   ],
   "invalid": [
     {
       "name": "inline-unique",
-      "code": "ALTER TABLE t ADD CONSTRAINT uq_t_email UNIQUE (email);\n",
+      "code": "ALTER TABLE t ADD CONSTRAINT uq_t_email UNIQUE (email);",
       "errors": [
         {
           "messageId": "useIndexFirst",

--- a/npm/postgresql/test/fixtures/no-alter-column-type.json
+++ b/npm/postgresql/test/fixtures/no-alter-column-type.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "add-column",
-      "code": "ALTER TABLE users ADD COLUMN id_new bigint;\n"
+      "code": "ALTER TABLE users ADD COLUMN id_new bigint;"
     },
     {
       "name": "alter-default",
-      "code": "ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active';\n"
+      "code": "ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active';"
     }
   ],
   "invalid": [
     {
       "name": "alter-type",
-      "code": "ALTER TABLE users ALTER COLUMN id TYPE bigint;\n",
+      "code": "ALTER TABLE users ALTER COLUMN id TYPE bigint;",
       "errors": [
         {
           "messageId": "noAlterColumnType",

--- a/npm/postgresql/test/fixtures/no-char-type.json
+++ b/npm/postgresql/test/fixtures/no-char-type.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "text",
-      "code": "CREATE TABLE t (code TEXT);\n"
+      "code": "CREATE TABLE t (code TEXT);"
     }
   ],
   "invalid": [
     {
       "name": "bpchar",
-      "code": "CREATE TABLE t (code BPCHAR(3));\n",
+      "code": "CREATE TABLE t (code BPCHAR(3));",
       "errors": [
         {
           "messageId": "noChar",
@@ -30,7 +30,7 @@
     },
     {
       "name": "char-n",
-      "code": "CREATE TABLE t (code CHAR(3));\n",
+      "code": "CREATE TABLE t (code CHAR(3));",
       "errors": [
         {
           "messageId": "noChar",

--- a/npm/postgresql/test/fixtures/no-cluster.json
+++ b/npm/postgresql/test/fixtures/no-cluster.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "vacuum",
-      "code": "VACUUM users;\n"
+      "code": "VACUUM users;"
     }
   ],
   "invalid": [
     {
       "name": "cluster",
-      "code": "CLUSTER users USING users_pkey;\n",
+      "code": "CLUSTER users USING users_pkey;",
       "errors": [
         {
           "messageId": "noCluster",

--- a/npm/postgresql/test/fixtures/no-composite-primary-key.json
+++ b/npm/postgresql/test/fixtures/no-composite-primary-key.json
@@ -9,25 +9,25 @@
   "valid": [
     {
       "name": "inline-pk",
-      "code": "CREATE TABLE t (id INT PRIMARY KEY, name TEXT);\n"
+      "code": "CREATE TABLE t (id INT PRIMARY KEY, name TEXT);"
     },
     {
       "name": "no-pk",
-      "code": "CREATE TABLE t (id INT, name TEXT, UNIQUE (id, name));\n"
+      "code": "CREATE TABLE t (id INT, name TEXT, UNIQUE (id, name));"
     },
     {
       "name": "single-col-alter-add-pk",
-      "code": "ALTER TABLE t ADD CONSTRAINT t_pkey PRIMARY KEY (id);\n"
+      "code": "ALTER TABLE t ADD CONSTRAINT t_pkey PRIMARY KEY (id);"
     },
     {
       "name": "single-col-table-level-pk",
-      "code": "CREATE TABLE t (id INT, name TEXT, PRIMARY KEY (id));\n"
+      "code": "CREATE TABLE t (id INT, name TEXT, PRIMARY KEY (id));"
     }
   ],
   "invalid": [
     {
       "name": "composite-pk-alter",
-      "code": "ALTER TABLE t ADD CONSTRAINT t_pkey PRIMARY KEY (a, b);\n",
+      "code": "ALTER TABLE t ADD CONSTRAINT t_pkey PRIMARY KEY (a, b);",
       "errors": [
         {
           "messageId": "noCompositePk",
@@ -42,7 +42,7 @@
     },
     {
       "name": "composite-pk-create",
-      "code": "CREATE TABLE t (a INT, b INT, name TEXT, PRIMARY KEY (a, b));\n",
+      "code": "CREATE TABLE t (a INT, b INT, name TEXT, PRIMARY KEY (a, b));",
       "errors": [
         {
           "messageId": "noCompositePk",

--- a/npm/postgresql/test/fixtures/no-create-role.json
+++ b/npm/postgresql/test/fixtures/no-create-role.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "grant",
-      "code": "GRANT SELECT ON users TO app_reader;\n"
+      "code": "GRANT SELECT ON users TO app_reader;"
     }
   ],
   "invalid": [
     {
       "name": "create-role",
-      "code": "CREATE ROLE app_writer LOGIN PASSWORD 'redacted';\n",
+      "code": "CREATE ROLE app_writer LOGIN PASSWORD 'redacted';",
       "errors": [
         {
           "messageId": "noCreateRole",

--- a/npm/postgresql/test/fixtures/no-cross-join.json
+++ b/npm/postgresql/test/fixtures/no-cross-join.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "inner-join-on",
-      "code": "SELECT 1 FROM a JOIN b ON a.id = b.id;\n"
+      "code": "SELECT 1 FROM a JOIN b ON a.id = b.id;"
     },
     {
       "name": "inner-join-using",
-      "code": "SELECT 1 FROM a INNER JOIN b USING (id);\n"
+      "code": "SELECT 1 FROM a INNER JOIN b USING (id);"
     }
   ],
   "invalid": [
     {
       "name": "cross-join",
-      "code": "SELECT 1 FROM a CROSS JOIN b;\n",
+      "code": "SELECT 1 FROM a CROSS JOIN b;",
       "errors": [
         {
           "messageId": "noCrossJoin",

--- a/npm/postgresql/test/fixtures/no-distinct-on-without-order-by.json
+++ b/npm/postgresql/test/fixtures/no-distinct-on-without-order-by.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "distinct-on-with-order",
-      "code": "SELECT DISTINCT ON (customer_id) customer_id, amount\nFROM orders\nORDER BY customer_id, created_at DESC;\n"
+      "code": "SELECT DISTINCT ON (customer_id) customer_id, amount\nFROM orders\nORDER BY customer_id, created_at DESC;"
     },
     {
       "name": "plain-distinct",
-      "code": "SELECT DISTINCT customer_id FROM orders;\n"
+      "code": "SELECT DISTINCT customer_id FROM orders;"
     }
   ],
   "invalid": [
     {
       "name": "distinct-on-no-order",
-      "code": "SELECT DISTINCT ON (customer_id) customer_id, amount FROM orders;\n",
+      "code": "SELECT DISTINCT ON (customer_id) customer_id, amount FROM orders;",
       "errors": [
         {
           "messageId": "noDistinctOnWithoutOrderBy",

--- a/npm/postgresql/test/fixtures/no-drop-column.json
+++ b/npm/postgresql/test/fixtures/no-drop-column.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "add-column",
-      "code": "ALTER TABLE users ADD COLUMN status text;\n"
+      "code": "ALTER TABLE users ADD COLUMN status text;"
     }
   ],
   "invalid": [
     {
       "name": "drop-column",
-      "code": "ALTER TABLE users DROP COLUMN legacy_flag;\n",
+      "code": "ALTER TABLE users DROP COLUMN legacy_flag;",
       "errors": [
         {
           "messageId": "noDropColumn",

--- a/npm/postgresql/test/fixtures/no-drop-database.json
+++ b/npm/postgresql/test/fixtures/no-drop-database.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "drop-table",
-      "code": "DROP TABLE archive;\n"
+      "code": "DROP TABLE archive;"
     }
   ],
   "invalid": [
     {
       "name": "drop-database",
-      "code": "DROP DATABASE archive_2023;\n",
+      "code": "DROP DATABASE archive_2023;",
       "errors": [
         {
           "messageId": "noDropDatabase",

--- a/npm/postgresql/test/fixtures/no-drop-not-null.json
+++ b/npm/postgresql/test/fixtures/no-drop-not-null.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "drop-default",
-      "code": "ALTER TABLE users ALTER COLUMN status DROP DEFAULT;\n"
+      "code": "ALTER TABLE users ALTER COLUMN status DROP DEFAULT;"
     }
   ],
   "invalid": [
     {
       "name": "drop-not-null",
-      "code": "ALTER TABLE users ALTER COLUMN email DROP NOT NULL;\n",
+      "code": "ALTER TABLE users ALTER COLUMN email DROP NOT NULL;",
       "errors": [
         {
           "messageId": "noDropNotNull",

--- a/npm/postgresql/test/fixtures/no-drop-schema-cascade.json
+++ b/npm/postgresql/test/fixtures/no-drop-schema-cascade.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "plain",
-      "code": "DROP SCHEMA staging;\n"
+      "code": "DROP SCHEMA staging;"
     },
     {
       "name": "restrict",
-      "code": "DROP SCHEMA staging RESTRICT;\n"
+      "code": "DROP SCHEMA staging RESTRICT;"
     }
   ],
   "invalid": [
     {
       "name": "cascade",
-      "code": "DROP SCHEMA staging CASCADE;\n",
+      "code": "DROP SCHEMA staging CASCADE;",
       "errors": [
         {
           "messageId": "noDropSchemaCascade",

--- a/npm/postgresql/test/fixtures/no-drop-table-cascade.json
+++ b/npm/postgresql/test/fixtures/no-drop-table-cascade.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "drop-schema-cascade",
-      "code": "DROP SCHEMA public CASCADE;\n"
+      "code": "DROP SCHEMA public CASCADE;"
     },
     {
       "name": "drop-table-restrict",
-      "code": "DROP TABLE users RESTRICT;\n"
+      "code": "DROP TABLE users RESTRICT;"
     },
     {
       "name": "drop-table",
-      "code": "DROP TABLE users;\n"
+      "code": "DROP TABLE users;"
     }
   ],
   "invalid": [
     {
       "name": "drop-table-cascade",
-      "code": "DROP TABLE users CASCADE;\n",
+      "code": "DROP TABLE users CASCADE;",
       "errors": [
         {
           "messageId": "noCascade",

--- a/npm/postgresql/test/fixtures/no-equality-with-null.json
+++ b/npm/postgresql/test/fixtures/no-equality-with-null.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "is-null",
-      "code": "SELECT * FROM t WHERE x IS NULL;\nSELECT * FROM t WHERE x IS NOT NULL;\nSELECT * FROM t WHERE x = 1;\n"
+      "code": "SELECT * FROM t WHERE x IS NULL;\nSELECT * FROM t WHERE x IS NOT NULL;\nSELECT * FROM t WHERE x = 1;"
     }
   ],
   "invalid": [
     {
       "name": "eq-null",
-      "code": "SELECT * FROM t WHERE x = NULL;\nSELECT * FROM t WHERE x <> NULL;\nSELECT * FROM t WHERE x != NULL;\nSELECT * FROM t WHERE NULL = x;\n",
+      "code": "SELECT * FROM t WHERE x = NULL;\nSELECT * FROM t WHERE x <> NULL;\nSELECT * FROM t WHERE x != NULL;\nSELECT * FROM t WHERE NULL = x;",
       "errors": [
         {
           "messageId": "useIsNull",

--- a/npm/postgresql/test/fixtures/no-grant-all.json
+++ b/npm/postgresql/test/fixtures/no-grant-all.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "explicit-privileges",
-      "code": "GRANT SELECT ON t TO u;\nGRANT SELECT, INSERT, UPDATE ON t TO u;\n-- REVOKE ALL is the safe direction; not flagged.\nREVOKE ALL ON t FROM u;\n"
+      "code": "GRANT SELECT ON t TO u;\nGRANT SELECT, INSERT, UPDATE ON t TO u;\n-- REVOKE ALL is the safe direction; not flagged.\nREVOKE ALL ON t FROM u;"
     }
   ],
   "invalid": [
     {
       "name": "grant-all",
-      "code": "GRANT ALL ON t TO u;\nGRANT ALL PRIVILEGES ON t TO PUBLIC;\n",
+      "code": "GRANT ALL ON t TO u;\nGRANT ALL PRIVILEGES ON t TO PUBLIC;",
       "errors": [
         {
           "messageId": "noGrantAll",

--- a/npm/postgresql/test/fixtures/no-grant-to-public.json
+++ b/npm/postgresql/test/fixtures/no-grant-to-public.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "grant-to-role",
-      "code": "GRANT SELECT ON users TO reporting;\n"
+      "code": "GRANT SELECT ON users TO reporting;"
     },
     {
       "name": "revoke-from-public",
-      "code": "REVOKE ALL ON users FROM PUBLIC;\n"
+      "code": "REVOKE ALL ON users FROM PUBLIC;"
     }
   ],
   "invalid": [
     {
       "name": "grant-to-public",
-      "code": "GRANT SELECT ON users TO PUBLIC;\n",
+      "code": "GRANT SELECT ON users TO PUBLIC;",
       "errors": [
         {
           "messageId": "noPublic",

--- a/npm/postgresql/test/fixtures/no-group-by-ordinal.json
+++ b/npm/postgresql/test/fixtures/no-group-by-ordinal.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "group-by-name",
-      "code": "SELECT category, count(*) FROM items GROUP BY category;\n"
+      "code": "SELECT category, count(*) FROM items GROUP BY category;"
     },
     {
       "name": "no-group-by",
-      "code": "SELECT id, name FROM users;\n"
+      "code": "SELECT id, name FROM users;"
     }
   ],
   "invalid": [
     {
       "name": "group-by-multiple-positions",
-      "code": "SELECT region, category, sum(amount) FROM sales GROUP BY 1, 2;\n",
+      "code": "SELECT region, category, sum(amount) FROM sales GROUP BY 1, 2;",
       "errors": [
         {
           "messageId": "noGroupByOrdinal",
@@ -42,7 +42,7 @@
     },
     {
       "name": "group-by-position",
-      "code": "SELECT category, count(*) FROM items GROUP BY 1;\n",
+      "code": "SELECT category, count(*) FROM items GROUP BY 1;",
       "errors": [
         {
           "messageId": "noGroupByOrdinal",

--- a/npm/postgresql/test/fixtures/no-having-without-group-by.json
+++ b/npm/postgresql/test/fixtures/no-having-without-group-by.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "having-with-group",
-      "code": "SELECT category, count(*) FROM items GROUP BY category HAVING count(*) > 1;\n"
+      "code": "SELECT category, count(*) FROM items GROUP BY category HAVING count(*) > 1;"
     },
     {
       "name": "no-having",
-      "code": "SELECT count(*) FROM users;\n"
+      "code": "SELECT count(*) FROM users;"
     }
   ],
   "invalid": [
     {
       "name": "having-without-group",
-      "code": "SELECT count(*) FROM users HAVING count(*) > 1;\n",
+      "code": "SELECT count(*) FROM users HAVING count(*) > 1;",
       "errors": [
         {
           "messageId": "noHavingWithoutGroupBy",

--- a/npm/postgresql/test/fixtures/no-identifier-too-long.json
+++ b/npm/postgresql/test/fixtures/no-identifier-too-long.json
@@ -9,15 +9,15 @@
   "valid": [
     {
       "name": "anonymous-index",
-      "code": "-- `CREATE INDEX ON foo (bar)` lets PostgreSQL pick the name — `idxname` is\n-- unset on the IndexStmt, so there is nothing for this rule to flag.\nCREATE INDEX ON aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (bar);\n"
+      "code": "-- `CREATE INDEX ON foo (bar)` lets PostgreSQL pick the name — `idxname` is\n-- unset on the IndexStmt, so there is nothing for this rule to flag.\nCREATE INDEX ON aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (bar);"
     },
     {
       "name": "at-limit",
-      "code": "-- Identifier at the exact 63-byte boundary is fine.\nCREATE TABLE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (\n  id BIGSERIAL PRIMARY KEY\n);\n"
+      "code": "-- Identifier at the exact 63-byte boundary is fine.\nCREATE TABLE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (\n  id BIGSERIAL PRIMARY KEY\n);"
     },
     {
       "name": "custom-max",
-      "code": "-- A user who compiled PostgreSQL with a larger NAMEDATALEN can raise `max`.\n-- This identifier is 64 bytes — over the default 63 but under the override.\nCREATE TABLE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (\n  id BIGSERIAL PRIMARY KEY\n);\n",
+      "code": "-- A user who compiled PostgreSQL with a larger NAMEDATALEN can raise `max`.\n-- This identifier is 64 bytes — over the default 63 but under the override.\nCREATE TABLE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (\n  id BIGSERIAL PRIMARY KEY\n);",
       "options": [
         {
           "max": 128
@@ -26,17 +26,17 @@
     },
     {
       "name": "short-names",
-      "code": "CREATE TABLE users (\n  id BIGSERIAL PRIMARY KEY,\n  email TEXT NOT NULL,\n  CONSTRAINT users_email_uniq UNIQUE (email)\n);\n\nCREATE INDEX idx_users_email ON users (email);\n\nCREATE SCHEMA app;\n\nCREATE SEQUENCE app.order_seq;\n\nCREATE OR REPLACE FUNCTION app.touch_updated_at() RETURNS trigger AS $$ BEGIN RETURN new; END; $$ LANGUAGE plpgsql;\n\nCREATE VIEW active_users AS SELECT id FROM users;\n\nCREATE TRIGGER trg_users_touch BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION app.touch_updated_at();\n\nALTER TABLE users RENAME TO accounts;\n"
+      "code": "CREATE TABLE users (\n  id BIGSERIAL PRIMARY KEY,\n  email TEXT NOT NULL,\n  CONSTRAINT users_email_uniq UNIQUE (email)\n);\n\nCREATE INDEX idx_users_email ON users (email);\n\nCREATE SCHEMA app;\n\nCREATE SEQUENCE app.order_seq;\n\nCREATE OR REPLACE FUNCTION app.touch_updated_at() RETURNS trigger AS $$ BEGIN RETURN new; END; $$ LANGUAGE plpgsql;\n\nCREATE VIEW active_users AS SELECT id FROM users;\n\nCREATE TRIGGER trg_users_touch BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION app.touch_updated_at();\n\nALTER TABLE users RENAME TO accounts;"
     },
     {
       "name": "unnamed-constraint",
-      "code": "-- An unnamed constraint has no user-supplied name to compare against the limit;\n-- PostgreSQL will generate one, separately covered by `require-named-constraint`.\nALTER TABLE items ADD CHECK (length(code) > 0);\n\nCREATE TABLE items2 (\n  id BIGSERIAL PRIMARY KEY,\n  code TEXT,\n  CHECK (length(code) > 0)\n);\n"
+      "code": "-- An unnamed constraint has no user-supplied name to compare against the limit;\n-- PostgreSQL will generate one, separately covered by `require-named-constraint`.\nALTER TABLE items ADD CHECK (length(code) > 0);\n\nCREATE TABLE items2 (\n  id BIGSERIAL PRIMARY KEY,\n  code TEXT,\n  CHECK (length(code) > 0)\n);"
     }
   ],
   "invalid": [
     {
       "name": "column-name",
-      "code": "CREATE TABLE users (\n  id BIGSERIAL PRIMARY KEY,\n  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TEXT\n);\n",
+      "code": "CREATE TABLE users (\n  id BIGSERIAL PRIMARY KEY,\n  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TEXT\n);",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -51,7 +51,7 @@
     },
     {
       "name": "constraint-alter-add",
-      "code": "ALTER TABLE items\n  ADD CONSTRAINT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n    CHECK (length(code) > 0);\n",
+      "code": "ALTER TABLE items\n  ADD CONSTRAINT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n    CHECK (length(code) > 0);",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -66,7 +66,7 @@
     },
     {
       "name": "constraint-table-level",
-      "code": "CREATE TABLE items (\n  id BIGSERIAL PRIMARY KEY,\n  code TEXT,\n  CONSTRAINT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa CHECK (length(code) > 0)\n);\n",
+      "code": "CREATE TABLE items (\n  id BIGSERIAL PRIMARY KEY,\n  code TEXT,\n  CONSTRAINT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa CHECK (length(code) > 0)\n);",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -81,7 +81,7 @@
     },
     {
       "name": "custom-max-stricter",
-      "code": "-- With `max: 10`, the 11-byte table name `looong_table` exceeds the limit.\nCREATE TABLE looong_table (\n  id BIGSERIAL PRIMARY KEY\n);\n",
+      "code": "-- With `max: 10`, the 11-byte table name `looong_table` exceeds the limit.\nCREATE TABLE looong_table (\n  id BIGSERIAL PRIMARY KEY\n);",
       "options": [
         {
           "max": 10
@@ -101,7 +101,7 @@
     },
     {
       "name": "function-name",
-      "code": "CREATE OR REPLACE FUNCTION aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa()\n  RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;\n",
+      "code": "CREATE OR REPLACE FUNCTION aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa()\n  RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -116,7 +116,7 @@
     },
     {
       "name": "index-name",
-      "code": "CREATE INDEX aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  ON items (code);\n",
+      "code": "CREATE INDEX aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  ON items (code);",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -131,7 +131,7 @@
     },
     {
       "name": "multibyte-overflow",
-      "code": "-- 22 instances of the 3-byte character '長' = 66 bytes, which is over the\n-- 63-byte limit even though it is only 22 characters long. The rule must\n-- count bytes, not characters.\nCREATE TABLE \"長長長長長長長長長長長長長長長長長長長長長長\" (\n  id BIGSERIAL PRIMARY KEY\n);\n",
+      "code": "-- 22 instances of the 3-byte character '長' = 66 bytes, which is over the\n-- 63-byte limit even though it is only 22 characters long. The rule must\n-- count bytes, not characters.\nCREATE TABLE \"長長長長長長長長長長長長長長長長長長長長長長\" (\n  id BIGSERIAL PRIMARY KEY\n);",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -146,7 +146,7 @@
     },
     {
       "name": "rename-to",
-      "code": "ALTER TABLE users\n  RENAME TO aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;\n",
+      "code": "ALTER TABLE users\n  RENAME TO aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -161,7 +161,7 @@
     },
     {
       "name": "schema-name",
-      "code": "CREATE SCHEMA aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;\n",
+      "code": "CREATE SCHEMA aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -176,7 +176,7 @@
     },
     {
       "name": "sequence-name",
-      "code": "CREATE SEQUENCE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;\n",
+      "code": "CREATE SEQUENCE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -191,7 +191,7 @@
     },
     {
       "name": "table-name",
-      "code": "-- 64-byte table name — one over the default 63-byte limit.\nCREATE TABLE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (\n  id BIGSERIAL PRIMARY KEY\n);\n",
+      "code": "-- 64-byte table name — one over the default 63-byte limit.\nCREATE TABLE aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (\n  id BIGSERIAL PRIMARY KEY\n);",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -206,7 +206,7 @@
     },
     {
       "name": "trigger-name",
-      "code": "CREATE TRIGGER aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  BEFORE INSERT ON items\n  FOR EACH ROW EXECUTE FUNCTION noop();\n",
+      "code": "CREATE TRIGGER aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  BEFORE INSERT ON items\n  FOR EACH ROW EXECUTE FUNCTION noop();",
       "errors": [
         {
           "messageId": "identifierTooLong",
@@ -221,7 +221,7 @@
     },
     {
       "name": "view-name",
-      "code": "CREATE VIEW aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS SELECT 1;\n",
+      "code": "CREATE VIEW aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS SELECT 1;",
       "errors": [
         {
           "messageId": "identifierTooLong",

--- a/npm/postgresql/test/fixtures/no-implicit-join.json
+++ b/npm/postgresql/test/fixtures/no-implicit-join.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "explicit-join",
-      "code": "SELECT a.id FROM a JOIN b ON a.id = b.id;\n"
+      "code": "SELECT a.id FROM a JOIN b ON a.id = b.id;"
     },
     {
       "name": "single-table",
-      "code": "SELECT id FROM a;\n"
+      "code": "SELECT id FROM a;"
     }
   ],
   "invalid": [
     {
       "name": "comma-join",
-      "code": "SELECT a.id FROM a, b WHERE a.id = b.id;\n",
+      "code": "SELECT a.id FROM a, b WHERE a.id = b.id;",
       "errors": [
         {
           "messageId": "noImplicitJoin",

--- a/npm/postgresql/test/fixtures/no-leading-wildcard-like.json
+++ b/npm/postgresql/test/fixtures/no-leading-wildcard-like.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "anchored-prefix",
-      "code": "SELECT id FROM users WHERE email LIKE 'admin@%';\n"
+      "code": "SELECT id FROM users WHERE email LIKE 'admin@%';"
     },
     {
       "name": "equals",
-      "code": "SELECT id FROM users WHERE email = 'admin@example.com';\n"
+      "code": "SELECT id FROM users WHERE email = 'admin@example.com';"
     }
   ],
   "invalid": [
     {
       "name": "leading-wildcard-ilike",
-      "code": "SELECT id FROM users WHERE name ILIKE '%smith%';\n",
+      "code": "SELECT id FROM users WHERE name ILIKE '%smith%';",
       "errors": [
         {
           "messageId": "noLeadingWildcardLike",
@@ -34,7 +34,7 @@
     },
     {
       "name": "leading-wildcard",
-      "code": "SELECT id FROM users WHERE email LIKE '%@example.com';\n",
+      "code": "SELECT id FROM users WHERE email LIKE '%@example.com';",
       "errors": [
         {
           "messageId": "noLeadingWildcardLike",

--- a/npm/postgresql/test/fixtures/no-money-type.json
+++ b/npm/postgresql/test/fixtures/no-money-type.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "numeric",
-      "code": "CREATE TABLE t (price NUMERIC(10, 2));\n"
+      "code": "CREATE TABLE t (price NUMERIC(10, 2));"
     }
   ],
   "invalid": [
     {
       "name": "money",
-      "code": "CREATE TABLE t (price MONEY);\n",
+      "code": "CREATE TABLE t (price MONEY);",
       "errors": [
         {
           "messageId": "noMoney",

--- a/npm/postgresql/test/fixtures/no-natural-join.json
+++ b/npm/postgresql/test/fixtures/no-natural-join.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "join-on",
-      "code": "SELECT 1 FROM a JOIN b ON a.id = b.id;\n"
+      "code": "SELECT 1 FROM a JOIN b ON a.id = b.id;"
     },
     {
       "name": "join-using",
-      "code": "SELECT 1 FROM a JOIN b USING (id);\n"
+      "code": "SELECT 1 FROM a JOIN b USING (id);"
     }
   ],
   "invalid": [
     {
       "name": "natural-join",
-      "code": "SELECT 1 FROM a NATURAL JOIN b;\n",
+      "code": "SELECT 1 FROM a NATURAL JOIN b;",
       "errors": [
         {
           "messageId": "noNaturalJoin",
@@ -34,7 +34,7 @@
     },
     {
       "name": "natural-left-join",
-      "code": "SELECT 1 FROM a NATURAL LEFT JOIN b;\n",
+      "code": "SELECT 1 FROM a NATURAL LEFT JOIN b;",
       "errors": [
         {
           "messageId": "noNaturalJoin",

--- a/npm/postgresql/test/fixtures/no-not-in-subquery.json
+++ b/npm/postgresql/test/fixtures/no-not-in-subquery.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "in-subquery",
-      "code": "SELECT 1 FROM users WHERE id IN (SELECT user_id FROM admins) LIMIT 100;\n"
+      "code": "SELECT 1 FROM users WHERE id IN (SELECT user_id FROM admins) LIMIT 100;"
     },
     {
       "name": "not-exists",
-      "code": "SELECT id FROM users u WHERE NOT EXISTS (SELECT 1 FROM blocks b WHERE b.user_id = u.id) LIMIT 100;\n"
+      "code": "SELECT id FROM users u WHERE NOT EXISTS (SELECT 1 FROM blocks b WHERE b.user_id = u.id) LIMIT 100;"
     },
     {
       "name": "not-in-list",
-      "code": "SELECT 1 FROM users WHERE id NOT IN (1, 2, 3) LIMIT 100;\n"
+      "code": "SELECT 1 FROM users WHERE id NOT IN (1, 2, 3) LIMIT 100;"
     }
   ],
   "invalid": [
     {
       "name": "not-in-subquery",
-      "code": "SELECT id FROM users WHERE id NOT IN (SELECT user_id FROM blocks) LIMIT 100;\n",
+      "code": "SELECT id FROM users WHERE id NOT IN (SELECT user_id FROM blocks) LIMIT 100;",
       "errors": [
         {
           "messageId": "noNotInSubquery",

--- a/npm/postgresql/test/fixtures/no-numeric-without-precision.json
+++ b/npm/postgresql/test/fixtures/no-numeric-without-precision.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "int-column",
-      "code": "CREATE TABLE products (id bigint PRIMARY KEY);\n"
+      "code": "CREATE TABLE products (id bigint PRIMARY KEY);"
     },
     {
       "name": "with-precision",
-      "code": "CREATE TABLE products (price numeric(10,2));\n"
+      "code": "CREATE TABLE products (price numeric(10,2));"
     }
   ],
   "invalid": [
     {
       "name": "bare-decimal",
-      "code": "CREATE TABLE products (price decimal);\n",
+      "code": "CREATE TABLE products (price decimal);",
       "errors": [
         {
           "messageId": "noNumericWithoutPrecision",
@@ -34,7 +34,7 @@
     },
     {
       "name": "bare-numeric",
-      "code": "CREATE TABLE products (price numeric);\n",
+      "code": "CREATE TABLE products (price numeric);",
       "errors": [
         {
           "messageId": "noNumericWithoutPrecision",

--- a/npm/postgresql/test/fixtures/no-on-delete-cascade.json
+++ b/npm/postgresql/test/fixtures/no-on-delete-cascade.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "no-cascade",
-      "code": "CREATE TABLE t (\n  id integer,\n  fid integer REFERENCES other(id),\n  fid2 integer REFERENCES other(id) ON DELETE RESTRICT,\n  fid3 integer REFERENCES other(id) ON DELETE SET NULL\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid) REFERENCES other(id) ON DELETE NO ACTION;\n"
+      "code": "CREATE TABLE t (\n  id integer,\n  fid integer REFERENCES other(id),\n  fid2 integer REFERENCES other(id) ON DELETE RESTRICT,\n  fid3 integer REFERENCES other(id) ON DELETE SET NULL\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid) REFERENCES other(id) ON DELETE NO ACTION;"
     }
   ],
   "invalid": [
     {
       "name": "cascade",
-      "code": "CREATE TABLE t (\n  id integer,\n  fid integer REFERENCES other(id) ON DELETE CASCADE\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid) REFERENCES other(id) ON DELETE CASCADE;\n",
+      "code": "CREATE TABLE t (\n  id integer,\n  fid integer REFERENCES other(id) ON DELETE CASCADE\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid) REFERENCES other(id) ON DELETE CASCADE;",
       "errors": [
         {
           "messageId": "noCascade",

--- a/npm/postgresql/test/fixtures/no-order-by-ordinal.json
+++ b/npm/postgresql/test/fixtures/no-order-by-ordinal.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "no-order-by",
-      "code": "SELECT id, name FROM users;\n"
+      "code": "SELECT id, name FROM users;"
     },
     {
       "name": "order-by-name",
-      "code": "SELECT id, name FROM users ORDER BY name;\n"
+      "code": "SELECT id, name FROM users ORDER BY name;"
     }
   ],
   "invalid": [
     {
       "name": "order-by-multiple-positions",
-      "code": "SELECT id, name, email FROM users ORDER BY 1, 2 DESC;\n",
+      "code": "SELECT id, name, email FROM users ORDER BY 1, 2 DESC;",
       "errors": [
         {
           "messageId": "noOrderByOrdinal",
@@ -42,7 +42,7 @@
     },
     {
       "name": "order-by-position",
-      "code": "SELECT id, name FROM users ORDER BY 1;\n",
+      "code": "SELECT id, name FROM users ORDER BY 1;",
       "errors": [
         {
           "messageId": "noOrderByOrdinal",

--- a/npm/postgresql/test/fixtures/no-rename-column.json
+++ b/npm/postgresql/test/fixtures/no-rename-column.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "add-column",
-      "code": "ALTER TABLE users ADD COLUMN email text;\n"
+      "code": "ALTER TABLE users ADD COLUMN email text;"
     }
   ],
   "invalid": [
     {
       "name": "rename-column",
-      "code": "ALTER TABLE users RENAME COLUMN email_address TO email;\n",
+      "code": "ALTER TABLE users RENAME COLUMN email_address TO email;",
       "errors": [
         {
           "messageId": "noRenameColumn",

--- a/npm/postgresql/test/fixtures/no-rename-table.json
+++ b/npm/postgresql/test/fixtures/no-rename-table.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "create-table",
-      "code": "CREATE TABLE users (id BIGINT PRIMARY KEY);\n"
+      "code": "CREATE TABLE users (id BIGINT PRIMARY KEY);"
     }
   ],
   "invalid": [
     {
       "name": "rename-table",
-      "code": "ALTER TABLE legacy_users RENAME TO users;\n",
+      "code": "ALTER TABLE legacy_users RENAME TO users;",
       "errors": [
         {
           "messageId": "noRenameTable",

--- a/npm/postgresql/test/fixtures/no-rule.json
+++ b/npm/postgresql/test/fixtures/no-rule.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "no-rule",
-      "code": "CREATE TRIGGER t_trg BEFORE UPDATE ON t FOR EACH ROW EXECUTE FUNCTION t_trg_fn();\nCREATE VIEW v AS SELECT * FROM t;\n"
+      "code": "CREATE TRIGGER t_trg BEFORE UPDATE ON t FOR EACH ROW EXECUTE FUNCTION t_trg_fn();\nCREATE VIEW v AS SELECT * FROM t;"
     }
   ],
   "invalid": [
     {
       "name": "create-rule",
-      "code": "CREATE RULE noop AS ON UPDATE TO t DO INSTEAD NOTHING;\n",
+      "code": "CREATE RULE noop AS ON UPDATE TO t DO INSTEAD NOTHING;",
       "errors": [
         {
           "messageId": "noRule",

--- a/npm/postgresql/test/fixtures/no-security-definer-without-search-path.json
+++ b/npm/postgresql/test/fixtures/no-security-definer-without-search-path.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-set",
-      "code": "CREATE FUNCTION fn() RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path = pg_catalog, pg_temp\nAS $$ BEGIN END $$;\n\n-- SECURITY INVOKER (the default) is fine.\nCREATE FUNCTION fn2() RETURNS void\nLANGUAGE plpgsql\nSECURITY INVOKER\nAS $$ BEGIN END $$;\n\n-- No SECURITY DEFINER → out of scope.\nCREATE FUNCTION fn3() RETURNS void\nLANGUAGE plpgsql\nAS $$ BEGIN END $$;\n"
+      "code": "CREATE FUNCTION fn() RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nSET search_path = pg_catalog, pg_temp\nAS $$ BEGIN END $$;\n\n-- SECURITY INVOKER (the default) is fine.\nCREATE FUNCTION fn2() RETURNS void\nLANGUAGE plpgsql\nSECURITY INVOKER\nAS $$ BEGIN END $$;\n\n-- No SECURITY DEFINER → out of scope.\nCREATE FUNCTION fn3() RETURNS void\nLANGUAGE plpgsql\nAS $$ BEGIN END $$;"
     }
   ],
   "invalid": [
     {
       "name": "missing-set",
-      "code": "CREATE FUNCTION fn() RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nAS $$ BEGIN END $$;\n",
+      "code": "CREATE FUNCTION fn() RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nAS $$ BEGIN END $$;",
       "errors": [
         {
           "messageId": "missingSearchPath",

--- a/npm/postgresql/test/fixtures/no-select-into.json
+++ b/npm/postgresql/test/fixtures/no-select-into.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "create-table-as",
-      "code": "CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;\n"
+      "code": "CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;"
     },
     {
       "name": "plain-select",
-      "code": "SELECT id, name FROM users WHERE inactive;\n"
+      "code": "SELECT id, name FROM users WHERE inactive;"
     }
   ],
   "invalid": [
     {
       "name": "select-into",
-      "code": "SELECT id, name INTO archived_users FROM users WHERE inactive;\n",
+      "code": "SELECT id, name INTO archived_users FROM users WHERE inactive;",
       "errors": [
         {
           "messageId": "noSelectInto",

--- a/npm/postgresql/test/fixtures/no-select-star.json
+++ b/npm/postgresql/test/fixtures/no-select-star.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "count-star-is-fine",
-      "code": "SELECT count(*) FROM users;\n"
+      "code": "SELECT count(*) FROM users;"
     },
     {
       "name": "explicit-columns",
-      "code": "SELECT id, name FROM users LIMIT 10;\n"
+      "code": "SELECT id, name FROM users LIMIT 10;"
     }
   ],
   "invalid": [
     {
       "name": "qualified-star",
-      "code": "SELECT u.* FROM users u;\n",
+      "code": "SELECT u.* FROM users u;",
       "errors": [
         {
           "messageId": "noSelectStar",
@@ -34,7 +34,7 @@
     },
     {
       "name": "select-star",
-      "code": "SELECT * FROM users;\n",
+      "code": "SELECT * FROM users;",
       "errors": [
         {
           "messageId": "noSelectStar",

--- a/npm/postgresql/test/fixtures/no-set-not-null.json
+++ b/npm/postgresql/test/fixtures/no-set-not-null.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "add-check-not-valid",
-      "code": "ALTER TABLE users ADD CONSTRAINT users_email_not_null CHECK (email IS NOT NULL) NOT VALID;\n"
+      "code": "ALTER TABLE users ADD CONSTRAINT users_email_not_null CHECK (email IS NOT NULL) NOT VALID;"
     },
     {
       "name": "create-with-not-null",
-      "code": "CREATE TABLE users (id int PRIMARY KEY, email text NOT NULL);\n"
+      "code": "CREATE TABLE users (id int PRIMARY KEY, email text NOT NULL);"
     }
   ],
   "invalid": [
     {
       "name": "set-not-null",
-      "code": "ALTER TABLE users ALTER COLUMN email SET NOT NULL;\n",
+      "code": "ALTER TABLE users ALTER COLUMN email SET NOT NULL;",
       "errors": [
         {
           "messageId": "noSetNotNull",

--- a/npm/postgresql/test/fixtures/no-set-search-path.json
+++ b/npm/postgresql/test/fixtures/no-set-search-path.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "other-set",
-      "code": "SET TIME ZONE 'UTC';\n"
+      "code": "SET TIME ZONE 'UTC';"
     },
     {
       "name": "qualified",
-      "code": "SELECT id FROM audit.events;\n"
+      "code": "SELECT id FROM audit.events;"
     }
   ],
   "invalid": [
     {
       "name": "set-search-path",
-      "code": "SET search_path TO audit, public;\n",
+      "code": "SET search_path TO audit, public;",
       "errors": [
         {
           "messageId": "noSetSearchPath",

--- a/npm/postgresql/test/fixtures/no-temporary-table.json
+++ b/npm/postgresql/test/fixtures/no-temporary-table.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "persistent",
-      "code": "CREATE TABLE staging (id int);\n"
+      "code": "CREATE TABLE staging (id int);"
     }
   ],
   "invalid": [
     {
       "name": "temp",
-      "code": "CREATE TEMP TABLE staging (id int);\n",
+      "code": "CREATE TEMP TABLE staging (id int);",
       "errors": [
         {
           "messageId": "noTemporaryTable",

--- a/npm/postgresql/test/fixtures/no-time-type.json
+++ b/npm/postgresql/test/fixtures/no-time-type.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "interval",
-      "code": "CREATE TABLE jobs (id int, duration interval);\n"
+      "code": "CREATE TABLE jobs (id int, duration interval);"
     },
     {
       "name": "timestamptz",
-      "code": "CREATE TABLE shifts (id int, start_at timestamptz);\n"
+      "code": "CREATE TABLE shifts (id int, start_at timestamptz);"
     }
   ],
   "invalid": [
     {
       "name": "time",
-      "code": "CREATE TABLE shifts (id int, start_at time);\n",
+      "code": "CREATE TABLE shifts (id int, start_at time);",
       "errors": [
         {
           "messageId": "noTimeType",
@@ -34,7 +34,7 @@
     },
     {
       "name": "timetz",
-      "code": "CREATE TABLE shifts (id int, start_at timetz);\n",
+      "code": "CREATE TABLE shifts (id int, start_at timetz);",
       "errors": [
         {
           "messageId": "noTimeType",

--- a/npm/postgresql/test/fixtures/no-truncate-cascade.json
+++ b/npm/postgresql/test/fixtures/no-truncate-cascade.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "truncate-restrict",
-      "code": "TRUNCATE users RESTRICT;\n"
+      "code": "TRUNCATE users RESTRICT;"
     },
     {
       "name": "truncate",
-      "code": "TRUNCATE users;\n"
+      "code": "TRUNCATE users;"
     }
   ],
   "invalid": [
     {
       "name": "truncate-cascade",
-      "code": "TRUNCATE users CASCADE;\n",
+      "code": "TRUNCATE users CASCADE;",
       "errors": [
         {
           "messageId": "noCascade",

--- a/npm/postgresql/test/fixtures/no-unlogged-table.json
+++ b/npm/postgresql/test/fixtures/no-unlogged-table.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "persistent",
-      "code": "CREATE TABLE session_cache (id text PRIMARY KEY);\n"
+      "code": "CREATE TABLE session_cache (id text PRIMARY KEY);"
     }
   ],
   "invalid": [
     {
       "name": "unlogged",
-      "code": "CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);\n",
+      "code": "CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);",
       "errors": [
         {
           "messageId": "noUnloggedTable",

--- a/npm/postgresql/test/fixtures/no-unnecessary-quoted-identifier.json
+++ b/npm/postgresql/test/fixtures/no-unnecessary-quoted-identifier.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "keep-required-quotes",
-      "code": "-- Reserved keyword: must stay quoted.\nSELECT \"select\" FROM users;\n-- COL_NAME_KEYWORD (cannot be function/type name without quoting): kept conservatively.\nSELECT \"between\" FROM users;\n-- Mixed case would case-fold to a different identifier when unquoted.\nSELECT \"MyColumn\" FROM \"MyTable\";\n-- Embedded double quote — cannot be unquoted.\nSELECT \"weird\"\"name\" FROM users;\n-- String literals (single quotes) are not identifiers and must be left alone.\nSELECT 'select' FROM users;\n"
+      "code": "-- Reserved keyword: must stay quoted.\nSELECT \"select\" FROM users;\n-- COL_NAME_KEYWORD (cannot be function/type name without quoting): kept conservatively.\nSELECT \"between\" FROM users;\n-- Mixed case would case-fold to a different identifier when unquoted.\nSELECT \"MyColumn\" FROM \"MyTable\";\n-- Embedded double quote — cannot be unquoted.\nSELECT \"weird\"\"name\" FROM users;\n-- String literals (single quotes) are not identifiers and must be left alone.\nSELECT 'select' FROM users;"
     }
   ],
   "invalid": [
     {
       "name": "redundant-quotes",
-      "code": "SELECT \"id\", \"name\" FROM \"users\" WHERE \"active\" = TRUE;\n",
+      "code": "SELECT \"id\", \"name\" FROM \"users\" WHERE \"active\" = TRUE;",
       "errors": [
         {
           "messageId": "unnecessaryQuoting",

--- a/npm/postgresql/test/fixtures/no-update-primary-key.json
+++ b/npm/postgresql/test/fixtures/no-update-primary-key.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "no-pk-update",
-      "code": "UPDATE users SET name = 'foo' WHERE id = 1;\nUPDATE orders SET total = 100, status = 'paid' WHERE id = 2;\n-- non-PK column happens to share a name with another table's PK pattern\n-- (orders.user_id is a foreign key, not the orders PK by the heuristic)\nUPDATE orders SET user_id = 5 WHERE id = 3;\n"
+      "code": "UPDATE users SET name = 'foo' WHERE id = 1;\nUPDATE orders SET total = 100, status = 'paid' WHERE id = 2;\n-- non-PK column happens to share a name with another table's PK pattern\n-- (orders.user_id is a foreign key, not the orders PK by the heuristic)\nUPDATE orders SET user_id = 5 WHERE id = 3;"
     }
   ],
   "invalid": [
     {
       "name": "custom-pk-name",
-      "code": "UPDATE users SET uuid = '...' WHERE name = 'a';\n",
+      "code": "UPDATE users SET uuid = '...' WHERE name = 'a';",
       "options": [
         {
           "pkColumnNames": ["uuid"]
@@ -35,7 +35,7 @@
     },
     {
       "name": "update-id",
-      "code": "UPDATE users SET id = 99 WHERE id = 1;\nUPDATE orders SET orders_id = 99 WHERE orders_id = 1;\n",
+      "code": "UPDATE users SET id = 99 WHERE id = 1;\nUPDATE orders SET orders_id = 99 WHERE orders_id = 1;",
       "errors": [
         {
           "messageId": "noUpdatePk",

--- a/npm/postgresql/test/fixtures/no-update-without-from-binding.json
+++ b/npm/postgresql/test/fixtures/no-update-without-from-binding.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-where",
-      "code": "UPDATE t SET x = u.x FROM u WHERE t.id = u.t_id;\n-- No FROM → out of scope.\nUPDATE t SET x = 1;\nUPDATE t SET x = 1 WHERE id = 5;\n"
+      "code": "UPDATE t SET x = u.x FROM u WHERE t.id = u.t_id;\n-- No FROM → out of scope.\nUPDATE t SET x = 1;\nUPDATE t SET x = 1 WHERE id = 5;"
     }
   ],
   "invalid": [
     {
       "name": "cartesian",
-      "code": "UPDATE t SET x = u.x FROM u;\n",
+      "code": "UPDATE t SET x = u.x FROM u;",
       "errors": [
         {
           "messageId": "missingJoin",

--- a/npm/postgresql/test/fixtures/no-vacuum-full.json
+++ b/npm/postgresql/test/fixtures/no-vacuum-full.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "analyze",
-      "code": "VACUUM ANALYZE users;\n"
+      "code": "VACUUM ANALYZE users;"
     },
     {
       "name": "plain-vacuum",
-      "code": "VACUUM users;\n"
+      "code": "VACUUM users;"
     }
   ],
   "invalid": [
     {
       "name": "full",
-      "code": "VACUUM FULL users;\n",
+      "code": "VACUUM FULL users;",
       "errors": [
         {
           "messageId": "noVacuumFull",

--- a/npm/postgresql/test/fixtures/no-volatile-default-on-add-column.json
+++ b/npm/postgresql/test/fixtures/no-volatile-default-on-add-column.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "stable-defaults",
-      "code": "-- Literals and STABLE defaults qualify for the PG10+ stable-default\n-- short-cut and do NOT trigger a table rewrite.\nALTER TABLE t ADD COLUMN x integer DEFAULT 1;\nALTER TABLE t ADD COLUMN y text DEFAULT 'literal';\nALTER TABLE t ADD COLUMN z timestamptz DEFAULT now();\nALTER TABLE t ADD COLUMN w timestamptz DEFAULT current_timestamp;\n-- ADD COLUMN with no default is also fine.\nALTER TABLE t ADD COLUMN id integer;\n"
+      "code": "-- Literals and STABLE defaults qualify for the PG10+ stable-default\n-- short-cut and do NOT trigger a table rewrite.\nALTER TABLE t ADD COLUMN x integer DEFAULT 1;\nALTER TABLE t ADD COLUMN y text DEFAULT 'literal';\nALTER TABLE t ADD COLUMN z timestamptz DEFAULT now();\nALTER TABLE t ADD COLUMN w timestamptz DEFAULT current_timestamp;\n-- ADD COLUMN with no default is also fine.\nALTER TABLE t ADD COLUMN id integer;"
     }
   ],
   "invalid": [
     {
       "name": "random-default",
-      "code": "ALTER TABLE t ADD COLUMN x integer DEFAULT random();\nALTER TABLE t ADD COLUMN id uuid DEFAULT gen_random_uuid();\n",
+      "code": "ALTER TABLE t ADD COLUMN x integer DEFAULT random();\nALTER TABLE t ADD COLUMN id uuid DEFAULT gen_random_uuid();",
       "errors": [
         {
           "messageId": "noVolatileDefault",

--- a/npm/postgresql/test/fixtures/no-with-recursive-without-limit.json
+++ b/npm/postgresql/test/fixtures/no-with-recursive-without-limit.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-limit",
-      "code": "WITH RECURSIVE r AS (\n  SELECT 1 AS n\n  UNION ALL\n  SELECT n + 1 FROM r\n) SELECT * FROM r LIMIT 10;\n-- Non-recursive CTEs are out of scope.\nWITH r AS (SELECT 1 AS n) SELECT * FROM r;\n"
+      "code": "WITH RECURSIVE r AS (\n  SELECT 1 AS n\n  UNION ALL\n  SELECT n + 1 FROM r\n) SELECT * FROM r LIMIT 10;\n-- Non-recursive CTEs are out of scope.\nWITH r AS (SELECT 1 AS n) SELECT * FROM r;"
     }
   ],
   "invalid": [
     {
       "name": "no-limit",
-      "code": "WITH RECURSIVE r AS (\n  SELECT 1 AS n\n  UNION ALL\n  SELECT n + 1 FROM r\n) SELECT * FROM r;\n",
+      "code": "WITH RECURSIVE r AS (\n  SELECT 1 AS n\n  UNION ALL\n  SELECT n + 1 FROM r\n) SELECT * FROM r;",
       "errors": [
         {
           "messageId": "noLimit",

--- a/npm/postgresql/test/fixtures/plpgsql-keyword-case.json
+++ b/npm/postgresql/test/fixtures/plpgsql-keyword-case.json
@@ -9,41 +9,41 @@
   "valid": [
     {
       "name": "diagnostic-names-as-identifiers",
-      "code": "CREATE FUNCTION example() RETURNS TRIGGER\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  row_count INTEGER;\n  column_name TEXT;\n  table_name TEXT;\n  schema_name TEXT;\n  message_text TEXT;\nBEGIN\n  SELECT COUNT(*) INTO row_count FROM some_table;\n  IF row_count > 0 THEN\n    RAISE NOTICE 'rows: %', row_count;\n  END IF;\n  SELECT 'a', 'b', 'c'\n    INTO column_name, table_name, schema_name;\n  RETURN NEW;\nEND;\n$$;\n"
+      "code": "CREATE FUNCTION example() RETURNS TRIGGER\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  row_count INTEGER;\n  column_name TEXT;\n  table_name TEXT;\n  schema_name TEXT;\n  message_text TEXT;\nBEGIN\n  SELECT COUNT(*) INTO row_count FROM some_table;\n  IF row_count > 0 THEN\n    RAISE NOTICE 'rows: %', row_count;\n  END IF;\n  SELECT 'a', 'b', 'c'\n    INTO column_name, table_name, schema_name;\n  RETURN NEW;\nEND;\n$$;"
     },
     {
       "name": "get-diagnostics-upper",
-      "code": "CREATE FUNCTION example() RETURNS void\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  affected INTEGER;\n  state TEXT;\nBEGIN\n  UPDATE some_table SET x = 1;\n  GET DIAGNOSTICS affected = ROW_COUNT;\n  GET STACKED DIAGNOSTICS state = RETURNED_SQLSTATE;\n  RAISE NOTICE '%, %', affected, state;\nEND;\n$$;\n"
+      "code": "CREATE FUNCTION example() RETURNS void\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  affected INTEGER;\n  state TEXT;\nBEGIN\n  UPDATE some_table SET x = 1;\n  GET DIAGNOSTICS affected = ROW_COUNT;\n  GET STACKED DIAGNOSTICS state = RETURNED_SQLSTATE;\n  RAISE NOTICE '%, %', affected, state;\nEND;\n$$;"
     },
     {
       "name": "identifier-clash-keywords-not-folded",
-      "code": "-- PostgreSQL has many UNRESERVED / COL_NAME / TYPE_FUNC_NAME keywords\n-- that can legitimately be used as column / variable names — `role`,\n-- `value`, `name`, `date`, `text`, `key`, `type`, etc. The rule must not\n-- case-fold them, because doing so silently corrupts the SQL.\n--\n-- Regression: previously this rule walked every word that matched the\n-- combined kwlist and PL/pgSQL kwlist, which uppercased `NEW.role` into\n-- `NEW.ROLE`, `NEW.value` into `NEW.VALUE`, and the column list of\n-- `INSERT INTO foo (role, value, name)` inside PL/pgSQL bodies. The fix\n-- restricts case-folding to the reserved subset of keywords.\nCREATE FUNCTION fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$\nBEGIN\n  IF NEW.role IS NOT NULL THEN\n    INSERT INTO foo (id, role, value, name, date, text)\n    VALUES (NEW.id, NEW.role, NEW.value, NEW.name, NEW.date, NEW.text);\n  END IF;\n  RETURN NEW;\nEND;\n$$;\n"
+      "code": "-- PostgreSQL has many UNRESERVED / COL_NAME / TYPE_FUNC_NAME keywords\n-- that can legitimately be used as column / variable names — `role`,\n-- `value`, `name`, `date`, `text`, `key`, `type`, etc. The rule must not\n-- case-fold them, because doing so silently corrupts the SQL.\n--\n-- Regression: previously this rule walked every word that matched the\n-- combined kwlist and PL/pgSQL kwlist, which uppercased `NEW.role` into\n-- `NEW.ROLE`, `NEW.value` into `NEW.VALUE`, and the column list of\n-- `INSERT INTO foo (role, value, name)` inside PL/pgSQL bodies. The fix\n-- restricts case-folding to the reserved subset of keywords.\nCREATE FUNCTION fn() RETURNS TRIGGER LANGUAGE plpgsql AS $$\nBEGIN\n  IF NEW.role IS NOT NULL THEN\n    INSERT INTO foo (id, role, value, name, date, text)\n    VALUES (NEW.id, NEW.role, NEW.value, NEW.name, NEW.date, NEW.text);\n  END IF;\n  RETURN NEW;\nEND;\n$$;"
     },
     {
       "name": "non-plpgsql-language",
-      "code": "-- The rule only touches plpgsql bodies. A SQL function body's keyword\n-- casing is not in scope here.\nCREATE FUNCTION add_one(n integer) RETURNS integer AS $$\n  select n + 1;\n$$ LANGUAGE sql;\n"
+      "code": "-- The rule only touches plpgsql bodies. A SQL function body's keyword\n-- casing is not in scope here.\nCREATE FUNCTION add_one(n integer) RETURNS integer AS $$\n  select n + 1;\n$$ LANGUAGE sql;"
     },
     {
       "name": "upper-default",
-      "code": "CREATE FUNCTION foo() RETURNS void AS $$\nDECLARE\n  user_count INTEGER;\nBEGIN\n  IF user_count IS NULL THEN\n    RAISE NOTICE 'select from where stays alone';\n  END IF;\n  -- the comment also stays alone: select from where\nEND;\n$$ LANGUAGE plpgsql;\n"
+      "code": "CREATE FUNCTION foo() RETURNS void AS $$\nDECLARE\n  user_count INTEGER;\nBEGIN\n  IF user_count IS NULL THEN\n    RAISE NOTICE 'select from where stays alone';\n  END IF;\n  -- the comment also stays alone: select from where\nEND;\n$$ LANGUAGE plpgsql;"
     }
   ],
   "invalid": [
     {
       "name": "get-diagnostics-lower-output.expected",
-      "code": "CREATE FUNCTION example() RETURNS void\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  affected INTEGER;\nBEGIN\n  UPDATE some_table SET x = 1;\n  GET DIAGNOSTICS affected = ROW_COUNT;\nEND;\n$$;\n",
+      "code": "CREATE FUNCTION example() RETURNS void\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  affected INTEGER;\nBEGIN\n  UPDATE some_table SET x = 1;\n  GET DIAGNOSTICS affected = ROW_COUNT;\nEND;\n$$;",
       "errors": [],
       "output": null
     },
     {
       "name": "get-diagnostics-lower",
-      "code": "CREATE FUNCTION example() RETURNS void\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  affected INTEGER;\nBEGIN\n  UPDATE some_table SET x = 1;\n  GET DIAGNOSTICS affected = row_count;\nEND;\n$$;\n",
+      "code": "CREATE FUNCTION example() RETURNS void\nLANGUAGE PLPGSQL\nAS $$\nDECLARE\n  affected INTEGER;\nBEGIN\n  UPDATE some_table SET x = 1;\n  GET DIAGNOSTICS affected = row_count;\nEND;\n$$;",
       "errors": [],
       "output": null
     },
     {
       "name": "lowercase-keywords",
-      "code": "CREATE FUNCTION foo() RETURNS void AS $$\ndeclare\n  user_count integer;\nbegin\n  if user_count is null then\n    raise notice 'hello';\n  end if;\nend;\n$$ LANGUAGE plpgsql;\n",
+      "code": "CREATE FUNCTION foo() RETURNS void AS $$\ndeclare\n  user_count integer;\nbegin\n  if user_count is null then\n    raise notice 'hello';\n  end if;\nend;\n$$ LANGUAGE plpgsql;",
       "errors": [
         {
           "messageId": "expectedUpper",

--- a/npm/postgresql/test/fixtures/prefer-add-constraint-not-valid.json
+++ b/npm/postgresql/test/fixtures/prefer-add-constraint-not-valid.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-not-valid",
-      "code": "ALTER TABLE t ADD CONSTRAINT c_check CHECK (x > 0) NOT VALID;\nALTER TABLE t ADD CONSTRAINT c_fk FOREIGN KEY (other_id) REFERENCES other(id) NOT VALID;\n-- NOT NULL and PRIMARY KEY do not benefit from NOT VALID.\nALTER TABLE t ADD CONSTRAINT c_pk PRIMARY KEY (id);\nALTER TABLE t ADD CONSTRAINT c_uq UNIQUE (email);\n"
+      "code": "ALTER TABLE t ADD CONSTRAINT c_check CHECK (x > 0) NOT VALID;\nALTER TABLE t ADD CONSTRAINT c_fk FOREIGN KEY (other_id) REFERENCES other(id) NOT VALID;\n-- NOT NULL and PRIMARY KEY do not benefit from NOT VALID.\nALTER TABLE t ADD CONSTRAINT c_pk PRIMARY KEY (id);\nALTER TABLE t ADD CONSTRAINT c_uq UNIQUE (email);"
     }
   ],
   "invalid": [
     {
       "name": "missing-not-valid",
-      "code": "ALTER TABLE t ADD CONSTRAINT c_check CHECK (x > 0);\nALTER TABLE t ADD CONSTRAINT c_fk FOREIGN KEY (other_id) REFERENCES other(id);\n",
+      "code": "ALTER TABLE t ADD CONSTRAINT c_check CHECK (x > 0);\nALTER TABLE t ADD CONSTRAINT c_fk FOREIGN KEY (other_id) REFERENCES other(id);",
       "errors": [
         {
           "messageId": "notValid",

--- a/npm/postgresql/test/fixtures/prefer-bigint-id.json
+++ b/npm/postgresql/test/fixtures/prefer-bigint-id.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "bigint-pk",
-      "code": "CREATE TABLE users (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name text);\n"
+      "code": "CREATE TABLE users (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name text);"
     },
     {
       "name": "int-not-pk",
-      "code": "-- An int `id` column that is not a primary key is not flagged.\nCREATE TABLE event_count (id int, count int);\n"
+      "code": "-- An int `id` column that is not a primary key is not flagged.\nCREATE TABLE event_count (id int, count int);"
     },
     {
       "name": "uuid-pk",
-      "code": "CREATE TABLE users (id uuid PRIMARY KEY, name text);\n"
+      "code": "CREATE TABLE users (id uuid PRIMARY KEY, name text);"
     }
   ],
   "invalid": [
     {
       "name": "int-pk",
-      "code": "CREATE TABLE users (id int PRIMARY KEY, name text);\n",
+      "code": "CREATE TABLE users (id int PRIMARY KEY, name text);",
       "errors": [
         {
           "messageId": "preferBigintId",
@@ -38,7 +38,7 @@
     },
     {
       "name": "serial-pk",
-      "code": "CREATE TABLE users (id serial PRIMARY KEY, name text);\n",
+      "code": "CREATE TABLE users (id serial PRIMARY KEY, name text);",
       "errors": [
         {
           "messageId": "preferBigintId",
@@ -53,7 +53,7 @@
     },
     {
       "name": "table-pk",
-      "code": "CREATE TABLE users (id int, name text, PRIMARY KEY (id));\n",
+      "code": "CREATE TABLE users (id int, name text, PRIMARY KEY (id));",
       "errors": [
         {
           "messageId": "preferBigintId",

--- a/npm/postgresql/test/fixtures/prefer-cast-operator.json
+++ b/npm/postgresql/test/fixtures/prefer-cast-operator.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "operator-default",
-      "code": "SELECT x::integer FROM t;\nSELECT x::public.my_type FROM t;\nSELECT x::numeric(10, 2) FROM t;\n"
+      "code": "SELECT x::integer FROM t;\nSELECT x::public.my_type FROM t;\nSELECT x::numeric(10, 2) FROM t;"
     }
   ],
   "invalid": [
     {
       "name": "cast-to-operator",
-      "code": "SELECT CAST(x AS integer) FROM t;\nSELECT CAST(x AS public.my_type) FROM t;\nSELECT CAST(x AS varchar(255)) FROM t;\n",
+      "code": "SELECT CAST(x AS integer) FROM t;\nSELECT CAST(x AS public.my_type) FROM t;\nSELECT CAST(x AS varchar(255)) FROM t;",
       "errors": [
         {
           "messageId": "preferOperator",
@@ -46,7 +46,7 @@
     },
     {
       "name": "operator-to-cast",
-      "code": "SELECT x::integer FROM t;\nSELECT x::numeric(10, 2) FROM t;\n",
+      "code": "SELECT x::integer FROM t;\nSELECT x::numeric(10, 2) FROM t;",
       "options": [
         {
           "form": "function"

--- a/npm/postgresql/test/fixtures/prefer-coalesce-over-case.json
+++ b/npm/postgresql/test/fixtures/prefer-coalesce-over-case.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "coalesce",
-      "code": "SELECT COALESCE(nickname, full_name) AS display FROM users;\n"
+      "code": "SELECT COALESCE(nickname, full_name) AS display FROM users;"
     },
     {
       "name": "different-branches",
-      "code": "SELECT CASE WHEN created_at IS NULL THEN 'unknown' ELSE 'set' END AS status\nFROM users;\n"
+      "code": "SELECT CASE WHEN created_at IS NULL THEN 'unknown' ELSE 'set' END AS status\nFROM users;"
     },
     {
       "name": "multi-arm",
-      "code": "SELECT CASE\n  WHEN nickname IS NULL THEN full_name\n  WHEN length(nickname) = 0 THEN full_name\n  ELSE nickname\nEND AS display\nFROM users;\n"
+      "code": "SELECT CASE\n  WHEN nickname IS NULL THEN full_name\n  WHEN length(nickname) = 0 THEN full_name\n  ELSE nickname\nEND AS display\nFROM users;"
     }
   ],
   "invalid": [
     {
       "name": "is-not-null",
-      "code": "SELECT CASE WHEN nickname IS NOT NULL THEN nickname ELSE full_name END AS display\nFROM users;\n",
+      "code": "SELECT CASE WHEN nickname IS NOT NULL THEN nickname ELSE full_name END AS display\nFROM users;",
       "errors": [
         {
           "messageId": "preferCoalesceOverCase",
@@ -38,7 +38,7 @@
     },
     {
       "name": "is-null",
-      "code": "SELECT CASE WHEN nickname IS NULL THEN full_name ELSE nickname END AS display\nFROM users;\n",
+      "code": "SELECT CASE WHEN nickname IS NULL THEN full_name ELSE nickname END AS display\nFROM users;",
       "errors": [
         {
           "messageId": "preferCoalesceOverCase",

--- a/npm/postgresql/test/fixtures/prefer-current-timestamp-over-now.json
+++ b/npm/postgresql/test/fixtures/prefer-current-timestamp-over-now.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "standard-timestamp",
-      "code": "INSERT INTO events (created_at) VALUES (CURRENT_TIMESTAMP);\nSELECT now FROM noise_metric_table;\n"
+      "code": "INSERT INTO events (created_at) VALUES (CURRENT_TIMESTAMP);\nSELECT now FROM noise_metric_table;"
     }
   ],
   "invalid": [
     {
       "name": "local-timestamp",
-      "code": "SELECT LOCALTIMESTAMP, LOCALTIME FROM t;\n",
+      "code": "SELECT LOCALTIMESTAMP, LOCALTIME FROM t;",
       "errors": [
         {
           "messageId": "preferCurrentTimestampOverLocal",
@@ -38,7 +38,7 @@
     },
     {
       "name": "now-call",
-      "code": "INSERT INTO events (created_at) VALUES (now());\n",
+      "code": "INSERT INTO events (created_at) VALUES (now());",
       "errors": [
         {
           "messageId": "preferCurrentTimestamp",

--- a/npm/postgresql/test/fixtures/prefer-exists-over-in-subquery.json
+++ b/npm/postgresql/test/fixtures/prefer-exists-over-in-subquery.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "exists-form",
-      "code": "SELECT * FROM t WHERE EXISTS (SELECT 1 FROM other WHERE other.id = t.x);\nSELECT * FROM t WHERE x IN (1, 2, 3);\nSELECT * FROM t WHERE x = 1;\n"
+      "code": "SELECT * FROM t WHERE EXISTS (SELECT 1 FROM other WHERE other.id = t.x);\nSELECT * FROM t WHERE x IN (1, 2, 3);\nSELECT * FROM t WHERE x = 1;"
     }
   ],
   "invalid": [
     {
       "name": "in-subquery",
-      "code": "SELECT * FROM t WHERE x IN (SELECT id FROM other);\nSELECT * FROM t WHERE x = ANY (SELECT id FROM other);\n",
+      "code": "SELECT * FROM t WHERE x IN (SELECT id FROM other);\nSELECT * FROM t WHERE x = ANY (SELECT id FROM other);",
       "errors": [
         {
           "messageId": "preferExists",

--- a/npm/postgresql/test/fixtures/prefer-explicit-null-ordering.json
+++ b/npm/postgresql/test/fixtures/prefer-explicit-null-ordering.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "no-direction",
-      "code": "-- No explicit ASC/DESC: rule does not fire.\nSELECT id FROM users ORDER BY created_at;\n"
+      "code": "-- No explicit ASC/DESC: rule does not fire.\nSELECT id FROM users ORDER BY created_at;"
     },
     {
       "name": "with-nulls-last",
-      "code": "SELECT id FROM users ORDER BY created_at DESC NULLS LAST;\n"
+      "code": "SELECT id FROM users ORDER BY created_at DESC NULLS LAST;"
     }
   ],
   "invalid": [
     {
       "name": "desc",
-      "code": "SELECT id FROM users ORDER BY created_at DESC;\n",
+      "code": "SELECT id FROM users ORDER BY created_at DESC;",
       "errors": [
         {
           "messageId": "preferExplicitNullOrdering",

--- a/npm/postgresql/test/fixtures/prefer-in-list-over-or.json
+++ b/npm/postgresql/test/fixtures/prefer-in-list-over-or.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "already-in",
-      "code": "SELECT * FROM t WHERE x IN (1, 2, 3);\n-- Mixed lhs: cannot collapse.\nSELECT * FROM t WHERE x = 1 OR y = 2;\n-- Single equality: nothing to combine.\nSELECT * FROM t WHERE x = 1;\n-- AND chain: not in scope.\nSELECT * FROM t WHERE x = 1 AND y = 2;\n"
+      "code": "SELECT * FROM t WHERE x IN (1, 2, 3);\n-- Mixed lhs: cannot collapse.\nSELECT * FROM t WHERE x = 1 OR y = 2;\n-- Single equality: nothing to combine.\nSELECT * FROM t WHERE x = 1;\n-- AND chain: not in scope.\nSELECT * FROM t WHERE x = 1 AND y = 2;"
     }
   ],
   "invalid": [
     {
       "name": "or-chain",
-      "code": "SELECT * FROM t WHERE x = 1 OR x = 2 OR x = 3;\n",
+      "code": "SELECT * FROM t WHERE x = 1 OR x = 2 OR x = 3;",
       "errors": [
         {
           "messageId": "preferIn",

--- a/npm/postgresql/test/fixtures/prefer-keyword-case.json
+++ b/npm/postgresql/test/fixtures/prefer-keyword-case.json
@@ -9,33 +9,33 @@
   "valid": [
     {
       "name": "builtin-type-name-untouched",
-      "code": "-- Regression for #145: built-in type names in function signatures,\n-- column types, and casts must not be uppercased — uppercasing them\n-- mixes case with user-defined types like `ulid` that the rule cannot\n-- touch.\nCREATE FUNCTION fn(\n  ulid,\n  text,\n  int\n) RETURNS void LANGUAGE SQL AS '';\n\nCREATE TABLE t (\n  id    ulid,\n  name  text\n);\n\nSELECT x::text FROM t;\nSELECT CAST(x AS int) FROM t;\n"
+      "code": "-- Regression for #145: built-in type names in function signatures,\n-- column types, and casts must not be uppercased — uppercasing them\n-- mixes case with user-defined types like `ulid` that the rule cannot\n-- touch.\nCREATE FUNCTION fn(\n  ulid,\n  text,\n  int\n) RETURNS void LANGUAGE SQL AS '';\n\nCREATE TABLE t (\n  id    ulid,\n  name  text\n);\n\nSELECT x::text FROM t;\nSELECT CAST(x AS int) FROM t;"
     },
     {
       "name": "identifier-collides-with-keyword",
-      "code": "-- Regression for #144: column / table / constraint identifiers whose\n-- spelling collides with a SQL keyword (`trigger`, `user`, `order`,\n-- ...) must NOT be uppercased — they are identifiers in this position,\n-- not keywords.\nCREATE TABLE t (\n  id       BIGINT  NOT NULL,\n  trigger  TEXT    NOT NULL,\n  \"user\"   TEXT    NOT NULL\n);\n"
+      "code": "-- Regression for #144: column / table / constraint identifiers whose\n-- spelling collides with a SQL keyword (`trigger`, `user`, `order`,\n-- ...) must NOT be uppercased — they are identifiers in this position,\n-- not keywords.\nCREATE TABLE t (\n  id       BIGINT  NOT NULL,\n  trigger  TEXT    NOT NULL,\n  \"user\"   TEXT    NOT NULL\n);"
     },
     {
       "name": "identifier-positions-not-folded",
-      "code": "-- Regression: previously this rule walked every Keyword token and\n-- case-folded it, which uppercased identifiers like `date`, `role`,\n-- `value`, etc. wherever PostgreSQL's tokenizer happens to tag them as\n-- keywords — column references, dotted ColumnRef field names, INSERT\n-- column lists, IndexElem column references, Constraint key columns,\n-- and identifier String nodes (e.g. `LANGUAGE plpgsql`).\n--\n-- The fix collects AST node ranges and resolves scoped identifier names\n-- (IndexElem.name, Constraint.keys[*].sval) into concrete token\n-- positions, then exempts those tokens from case-folding.\nCREATE TABLE bar (\n  id   BIGSERIAL  PRIMARY KEY,\n  date date       NOT NULL,\n  role text       NOT NULL,\n  value text      NOT NULL\n);\n\nCREATE UNIQUE INDEX index_bar_date ON bar (date DESC, role);\n\nALTER TABLE bar ADD CONSTRAINT uq_bar_date UNIQUE (date);\n\nINSERT INTO bar (date, role, value) VALUES ('2025-01-01', 'admin', 'x');\nSELECT date, role, value FROM bar WHERE date > '2024-01-01';\nUPDATE bar SET role = 'y' WHERE date = '2024-01-01';\n\n-- Dotted field access: PostgreSQL's ColumnRef range only covers the\n-- first dotted segment, so the rule's range-contains check doesn't see\n-- the trailing field. The after-dot token guard catches it.\nSELECT kv.key, kv.value FROM jsonb_each('{}') AS kv;\nSELECT t.date, t.role, t.text FROM bar AS t WHERE t.date > '2024-01-01';\n"
+      "code": "-- Regression: previously this rule walked every Keyword token and\n-- case-folded it, which uppercased identifiers like `date`, `role`,\n-- `value`, etc. wherever PostgreSQL's tokenizer happens to tag them as\n-- keywords — column references, dotted ColumnRef field names, INSERT\n-- column lists, IndexElem column references, Constraint key columns,\n-- and identifier String nodes (e.g. `LANGUAGE plpgsql`).\n--\n-- The fix collects AST node ranges and resolves scoped identifier names\n-- (IndexElem.name, Constraint.keys[*].sval) into concrete token\n-- positions, then exempts those tokens from case-folding.\nCREATE TABLE bar (\n  id   BIGSERIAL  PRIMARY KEY,\n  date date       NOT NULL,\n  role text       NOT NULL,\n  value text      NOT NULL\n);\n\nCREATE UNIQUE INDEX index_bar_date ON bar (date DESC, role);\n\nALTER TABLE bar ADD CONSTRAINT uq_bar_date UNIQUE (date);\n\nINSERT INTO bar (date, role, value) VALUES ('2025-01-01', 'admin', 'x');\nSELECT date, role, value FROM bar WHERE date > '2024-01-01';\nUPDATE bar SET role = 'y' WHERE date = '2024-01-01';\n\n-- Dotted field access: PostgreSQL's ColumnRef range only covers the\n-- first dotted segment, so the rule's range-contains check doesn't see\n-- the trailing field. The after-dot token guard catches it.\nSELECT kv.key, kv.value FROM jsonb_each('{}') AS kv;\nSELECT t.date, t.role, t.text FROM bar AS t WHERE t.date > '2024-01-01';"
     },
     {
       "name": "upper-default",
-      "code": "SELECT id, name FROM users WHERE active = TRUE LIMIT 10;\n"
+      "code": "SELECT id, name FROM users WHERE active = TRUE LIMIT 10;"
     },
     {
       "name": "upper-string-literal",
-      "code": "SELECT 'select from where' AS phrase FROM users;\n"
+      "code": "SELECT 'select from where' AS phrase FROM users;"
     },
     {
       "name": "upper-with-comment",
-      "code": "-- the keyword 'select' inside a comment must not be touched\nSELECT id FROM users;\n"
+      "code": "-- the keyword 'select' inside a comment must not be touched\nSELECT id FROM users;"
     }
   ],
   "invalid": [
     {
       "name": "lowercase-keywords",
-      "code": "select id, name from users where active = true limit 10;\n",
+      "code": "select id, name from users where active = true limit 10;",
       "errors": [
         {
           "messageId": "expectedUpper",
@@ -82,7 +82,7 @@
     },
     {
       "name": "mixed-case",
-      "code": "Select id From users Where active = True;\n",
+      "code": "Select id From users Where active = True;",
       "errors": [
         {
           "messageId": "expectedUpper",
@@ -121,7 +121,7 @@
     },
     {
       "name": "types-upper",
-      "code": "CREATE TABLE t (\n  id    bigint  NOT NULL,\n  body  text    NOT NULL\n);\n\nCREATE FUNCTION fn(arr text[]) RETURNS BOOLEAN LANGUAGE SQL AS '';\nDROP FUNCTION IF EXISTS fn(text[]);\n",
+      "code": "CREATE TABLE t (\n  id    bigint  NOT NULL,\n  body  text    NOT NULL\n);\n\nCREATE FUNCTION fn(arr text[]) RETURNS BOOLEAN LANGUAGE SQL AS '';\nDROP FUNCTION IF EXISTS fn(text[]);",
       "options": [
         {
           "types": "upper"

--- a/npm/postgresql/test/fixtures/prefer-not-equals-operator.json
+++ b/npm/postgresql/test/fixtures/prefer-not-equals-operator.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "angle-default",
-      "code": "SELECT id FROM users WHERE status <> 'inactive';\n"
+      "code": "SELECT id FROM users WHERE status <> 'inactive';"
     }
   ],
   "invalid": [
     {
       "name": "bang-not-equals",
-      "code": "SELECT id FROM users WHERE status != 'inactive';\n",
+      "code": "SELECT id FROM users WHERE status != 'inactive';",
       "errors": [
         {
           "messageId": "preferAngle",

--- a/npm/postgresql/test/fixtures/require-fk-include-columns.json
+++ b/npm/postgresql/test/fixtures/require-fk-include-columns.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "alter-table-add-fk",
-      "code": "-- ALTER TABLE ADD CONSTRAINT FK that includes `tenant_id`.\nALTER TABLE orders\n  ADD CONSTRAINT orders_user_fk\n  FOREIGN KEY (tenant_id, user_id) REFERENCES users (tenant_id, id);\n",
+      "code": "-- ALTER TABLE ADD CONSTRAINT FK that includes `tenant_id`.\nALTER TABLE orders\n  ADD CONSTRAINT orders_user_fk\n  FOREIGN KEY (tenant_id, user_id) REFERENCES users (tenant_id, id);",
       "options": [
         {
           "columns": ["tenant_id"]
@@ -18,7 +18,7 @@
     },
     {
       "name": "composite-fk-includes-tenant",
-      "code": "-- Table-level composite FK that includes `tenant_id`.\nCREATE TABLE orders (\n  tenant_id bigint NOT NULL,\n  id        bigint NOT NULL,\n  user_id   bigint NOT NULL,\n  PRIMARY KEY (tenant_id, id),\n  FOREIGN KEY (tenant_id, user_id) REFERENCES users (tenant_id, id)\n);\n",
+      "code": "-- Table-level composite FK that includes `tenant_id`.\nCREATE TABLE orders (\n  tenant_id bigint NOT NULL,\n  id        bigint NOT NULL,\n  user_id   bigint NOT NULL,\n  PRIMARY KEY (tenant_id, id),\n  FOREIGN KEY (tenant_id, user_id) REFERENCES users (tenant_id, id)\n);",
       "options": [
         {
           "columns": ["tenant_id"]
@@ -27,7 +27,7 @@
     },
     {
       "name": "excluded-by-referenced-table-pattern",
-      "code": "-- The referenced table `tenants` is shared across tenants by definition,\n-- so an FK to it does not need to carry `tenant_id`.\nCREATE TABLE orders (\n  id        bigserial PRIMARY KEY,\n  tenant_id bigint NOT NULL REFERENCES tenants (id)\n);\n",
+      "code": "-- The referenced table `tenants` is shared across tenants by definition,\n-- so an FK to it does not need to carry `tenant_id`.\nCREATE TABLE orders (\n  id        bigserial PRIMARY KEY,\n  tenant_id bigint NOT NULL REFERENCES tenants (id)\n);",
       "options": [
         {
           "columns": ["tenant_id"],
@@ -37,7 +37,7 @@
     },
     {
       "name": "excluded-by-table-pattern",
-      "code": "-- `audit_*` tables are excluded by `excludeTablePattern`, so a missing\n-- `tenant_id` is not reported.\nCREATE TABLE audit_events (\n  id      bigserial PRIMARY KEY,\n  user_id bigint REFERENCES users (id)\n);\n",
+      "code": "-- `audit_*` tables are excluded by `excludeTablePattern`, so a missing\n-- `tenant_id` is not reported.\nCREATE TABLE audit_events (\n  id      bigserial PRIMARY KEY,\n  user_id bigint REFERENCES users (id)\n);",
       "options": [
         {
           "columns": ["tenant_id"],
@@ -47,7 +47,7 @@
     },
     {
       "name": "no-fk",
-      "code": "-- No FK constraints — nothing to flag.\nCREATE TABLE orders (\n  id        bigserial PRIMARY KEY,\n  tenant_id bigint NOT NULL,\n  amount    numeric(10, 2)\n);\n",
+      "code": "-- No FK constraints — nothing to flag.\nCREATE TABLE orders (\n  id        bigserial PRIMARY KEY,\n  tenant_id bigint NOT NULL,\n  amount    numeric(10, 2)\n);",
       "options": [
         {
           "columns": ["tenant_id"]
@@ -58,7 +58,7 @@
   "invalid": [
     {
       "name": "alter-table-add-fk-missing-tenant",
-      "code": "-- ALTER TABLE ADD CONSTRAINT FK without `tenant_id`.\nALTER TABLE orders\n  ADD CONSTRAINT orders_user_fk\n  FOREIGN KEY (user_id) REFERENCES users (id);\n",
+      "code": "-- ALTER TABLE ADD CONSTRAINT FK without `tenant_id`.\nALTER TABLE orders\n  ADD CONSTRAINT orders_user_fk\n  FOREIGN KEY (user_id) REFERENCES users (id);",
       "options": [
         {
           "columns": ["tenant_id"]
@@ -78,7 +78,7 @@
     },
     {
       "name": "inline-fk-on-non-tenant-column",
-      "code": "-- Column-level (inline) FK on a non-tenant column — the FK's referencing\n-- column list is just `[user_id]`, which is missing `tenant_id`.\nCREATE TABLE orders (\n  tenant_id bigint NOT NULL,\n  id        bigserial PRIMARY KEY,\n  user_id   bigint REFERENCES users (id)\n);\n",
+      "code": "-- Column-level (inline) FK on a non-tenant column — the FK's referencing\n-- column list is just `[user_id]`, which is missing `tenant_id`.\nCREATE TABLE orders (\n  tenant_id bigint NOT NULL,\n  id        bigserial PRIMARY KEY,\n  user_id   bigint REFERENCES users (id)\n);",
       "options": [
         {
           "columns": ["tenant_id"]
@@ -98,7 +98,7 @@
     },
     {
       "name": "table-level-fk-missing-tenant",
-      "code": "-- Table-level FK that does not include `tenant_id`.\nCREATE TABLE orders (\n  tenant_id bigint NOT NULL,\n  id        bigint NOT NULL,\n  user_id   bigint NOT NULL,\n  PRIMARY KEY (tenant_id, id),\n  FOREIGN KEY (user_id) REFERENCES users (id)\n);\n",
+      "code": "-- Table-level FK that does not include `tenant_id`.\nCREATE TABLE orders (\n  tenant_id bigint NOT NULL,\n  id        bigint NOT NULL,\n  user_id   bigint NOT NULL,\n  PRIMARY KEY (tenant_id, id),\n  FOREIGN KEY (user_id) REFERENCES users (id)\n);",
       "options": [
         {
           "columns": ["tenant_id"]

--- a/npm/postgresql/test/fixtures/require-if-exists.json
+++ b/npm/postgresql/test/fixtures/require-if-exists.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "alter-table-drop-constraint-not-targeted",
-      "code": "-- `ALTER TABLE ... DROP CONSTRAINT` / `DROP COLUMN` are part of an\n-- `AlterTableStmt`, not a `DropStmt`. The rule must not match them.\n-- (Regression: previously the rule scanned all DROP keywords in the file\n-- and inserted `IF EXISTS` inside the ALTER TABLE statement, producing\n-- `DROP CONSTRAINT IF EXISTS IF EXISTS ...` syntax errors.)\nALTER TABLE users DROP CONSTRAINT chk_users_email;\nALTER TABLE users DROP COLUMN nickname;\n-- A subsequent DropStmt should still be flagged.\nDROP TABLE IF EXISTS old_users;\n"
+      "code": "-- `ALTER TABLE ... DROP CONSTRAINT` / `DROP COLUMN` are part of an\n-- `AlterTableStmt`, not a `DropStmt`. The rule must not match them.\n-- (Regression: previously the rule scanned all DROP keywords in the file\n-- and inserted `IF EXISTS` inside the ALTER TABLE statement, producing\n-- `DROP CONSTRAINT IF EXISTS IF EXISTS ...` syntax errors.)\nALTER TABLE users DROP CONSTRAINT chk_users_email;\nALTER TABLE users DROP COLUMN nickname;\n-- A subsequent DropStmt should still be flagged.\nDROP TABLE IF EXISTS old_users;"
     },
     {
       "name": "with-if-exists",
-      "code": "DROP TABLE IF EXISTS foo;\nDROP INDEX IF EXISTS idx_foo;\nDROP FUNCTION IF EXISTS fn();\nDROP TRIGGER IF EXISTS t ON foo;\nDROP DATABASE IF EXISTS bar;\nDROP SCHEMA IF EXISTS s;\nDROP ROLE IF EXISTS r;\n-- Other statements are not in scope.\nCREATE TABLE foo (id integer);\nSELECT * FROM users LIMIT 1;\n"
+      "code": "DROP TABLE IF EXISTS foo;\nDROP INDEX IF EXISTS idx_foo;\nDROP FUNCTION IF EXISTS fn();\nDROP TRIGGER IF EXISTS t ON foo;\nDROP DATABASE IF EXISTS bar;\nDROP SCHEMA IF EXISTS s;\nDROP ROLE IF EXISTS r;\n-- Other statements are not in scope.\nCREATE TABLE foo (id integer);\nSELECT * FROM users LIMIT 1;"
     }
   ],
   "invalid": [
     {
       "name": "drop-after-alter-table-drop-constraint",
-      "code": "-- The bare `DROP TABLE` below must be flagged, but the `DROP CONSTRAINT`\n-- / `DROP COLUMN` inside the `ALTER TABLE` statements above must be\n-- left untouched. (Regression: the previous token-cursor scan landed\n-- the `IF EXISTS` insertion on the first `DROP` keyword in the file,\n-- i.e. inside the ALTER TABLE, and ESLint's --fix loop ran the rule\n-- again, producing `DROP CONSTRAINT IF EXISTS IF EXISTS ...`.)\nALTER TABLE users DROP CONSTRAINT chk_users_email;\nALTER TABLE users DROP COLUMN nickname;\nDROP TABLE old_users;\n",
+      "code": "-- The bare `DROP TABLE` below must be flagged, but the `DROP CONSTRAINT`\n-- / `DROP COLUMN` inside the `ALTER TABLE` statements above must be\n-- left untouched. (Regression: the previous token-cursor scan landed\n-- the `IF EXISTS` insertion on the first `DROP` keyword in the file,\n-- i.e. inside the ALTER TABLE, and ESLint's --fix loop ran the rule\n-- again, producing `DROP CONSTRAINT IF EXISTS IF EXISTS ...`.)\nALTER TABLE users DROP CONSTRAINT chk_users_email;\nALTER TABLE users DROP COLUMN nickname;\nDROP TABLE old_users;",
       "errors": [
         {
           "messageId": "missingIfExists",
@@ -34,7 +34,7 @@
     },
     {
       "name": "missing-if-exists",
-      "code": "DROP TABLE foo;\nDROP INDEX idx_foo;\nDROP FUNCTION fn();\nDROP DATABASE bar;\n",
+      "code": "DROP TABLE foo;\nDROP INDEX idx_foo;\nDROP FUNCTION fn();\nDROP DATABASE bar;",
       "errors": [
         {
           "messageId": "missingIfExists",

--- a/npm/postgresql/test/fixtures/require-index-on-fk-column.json
+++ b/npm/postgresql/test/fixtures/require-index-on-fk-column.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "with-index",
-      "code": "-- FK column has a covering CREATE INDEX in the same file.\nCREATE TABLE t (\n  id integer PRIMARY KEY,\n  fid integer REFERENCES other(id)\n);\nCREATE INDEX idx_t_fid ON t (fid);\n\n-- Inline FK on the PRIMARY KEY column needs no extra index.\nCREATE TABLE u (\n  id integer PRIMARY KEY REFERENCES other(id)\n);\n\n-- ALTER TABLE ADD FK + matching CREATE INDEX in same file.\nCREATE TABLE w (id integer);\nCREATE INDEX idx_w_id ON w (id);\nALTER TABLE w ADD CONSTRAINT fk FOREIGN KEY (id) REFERENCES other(id);\n"
+      "code": "-- FK column has a covering CREATE INDEX in the same file.\nCREATE TABLE t (\n  id integer PRIMARY KEY,\n  fid integer REFERENCES other(id)\n);\nCREATE INDEX idx_t_fid ON t (fid);\n\n-- Inline FK on the PRIMARY KEY column needs no extra index.\nCREATE TABLE u (\n  id integer PRIMARY KEY REFERENCES other(id)\n);\n\n-- ALTER TABLE ADD FK + matching CREATE INDEX in same file.\nCREATE TABLE w (id integer);\nCREATE INDEX idx_w_id ON w (id);\nALTER TABLE w ADD CONSTRAINT fk FOREIGN KEY (id) REFERENCES other(id);"
     }
   ],
   "invalid": [
     {
       "name": "missing-index",
-      "code": "CREATE TABLE t (\n  id integer PRIMARY KEY,\n  fid integer REFERENCES other(id)\n);\n-- No CREATE INDEX on t.fid in this file.\n",
+      "code": "CREATE TABLE t (\n  id integer PRIMARY KEY,\n  fid integer REFERENCES other(id)\n);\n-- No CREATE INDEX on t.fid in this file.",
       "errors": [
         {
           "messageId": "missingIndex",

--- a/npm/postgresql/test/fixtures/require-limit.json
+++ b/npm/postgresql/test/fixtures/require-limit.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "insert-values-not-flagged",
-      "code": "-- Regression for #159: INSERT ... VALUES (...) is rewritten by\n-- libpg-query into a SelectStmt with `valuesLists`, but LIMIT has no\n-- meaning there.\nINSERT INTO t (id, name) VALUES\n  (1, 'alpha'),\n  (2, 'beta');\n"
+      "code": "-- Regression for #159: INSERT ... VALUES (...) is rewritten by\n-- libpg-query into a SelectStmt with `valuesLists`, but LIMIT has no\n-- meaning there.\nINSERT INTO t (id, name) VALUES\n  (1, 'alpha'),\n  (2, 'beta');"
     },
     {
       "name": "select-with-limit-and-offset",

--- a/npm/postgresql/test/fixtures/require-named-constraint.json
+++ b/npm/postgresql/test/fixtures/require-named-constraint.json
@@ -9,21 +9,21 @@
   "valid": [
     {
       "name": "column-not-null",
-      "code": "-- NOT NULL on a column is allowed without an explicit name.\nCREATE TABLE items (id int PRIMARY KEY, code text NOT NULL);\n"
+      "code": "-- NOT NULL on a column is allowed without an explicit name.\nCREATE TABLE items (id int PRIMARY KEY, code text NOT NULL);"
     },
     {
       "name": "named-add-fk",
-      "code": "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk\n  FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;\n"
+      "code": "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk\n  FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;"
     },
     {
       "name": "named-unique",
-      "code": "CREATE TABLE items (\n  id int,\n  code text,\n  CONSTRAINT items_code_unique UNIQUE (code)\n);\n"
+      "code": "CREATE TABLE items (\n  id int,\n  code text,\n  CONSTRAINT items_code_unique UNIQUE (code)\n);"
     }
   ],
   "invalid": [
     {
       "name": "alter-add-check",
-      "code": "ALTER TABLE items ADD CHECK (length(code) > 0);\n",
+      "code": "ALTER TABLE items ADD CHECK (length(code) > 0);",
       "errors": [
         {
           "messageId": "requireNamedConstraint",
@@ -38,7 +38,7 @@
     },
     {
       "name": "create-table-unique",
-      "code": "CREATE TABLE items (id int, code text, UNIQUE (code));\n",
+      "code": "CREATE TABLE items (id int, code text, UNIQUE (code));",
       "errors": [
         {
           "messageId": "requireNamedConstraint",

--- a/npm/postgresql/test/fixtures/require-on-delete-action.json
+++ b/npm/postgresql/test/fixtures/require-on-delete-action.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "allowed-restrict-only",
-      "code": "ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE RESTRICT;\nALTER TABLE child2 ADD FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE NO ACTION;\n",
+      "code": "ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE RESTRICT;\nALTER TABLE child2 ADD FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE NO ACTION;",
       "options": [
         {
           "allowed": ["RESTRICT", "NO ACTION"]
@@ -18,13 +18,13 @@
     },
     {
       "name": "explicit-actions",
-      "code": "CREATE TABLE t (\n  id integer,\n  fid1 integer REFERENCES other(id) ON DELETE NO ACTION,\n  fid2 integer REFERENCES other(id) ON DELETE RESTRICT,\n  fid3 integer REFERENCES other(id) ON DELETE SET NULL,\n  fid4 integer REFERENCES other(id) ON DELETE SET DEFAULT\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid1) REFERENCES other(id) ON DELETE RESTRICT;\nALTER TABLE t ADD CONSTRAINT fk2 FOREIGN KEY (fid2) REFERENCES other(id) ON UPDATE CASCADE ON DELETE SET NULL;\n"
+      "code": "CREATE TABLE t (\n  id integer,\n  fid1 integer REFERENCES other(id) ON DELETE NO ACTION,\n  fid2 integer REFERENCES other(id) ON DELETE RESTRICT,\n  fid3 integer REFERENCES other(id) ON DELETE SET NULL,\n  fid4 integer REFERENCES other(id) ON DELETE SET DEFAULT\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid1) REFERENCES other(id) ON DELETE RESTRICT;\nALTER TABLE t ADD CONSTRAINT fk2 FOREIGN KEY (fid2) REFERENCES other(id) ON UPDATE CASCADE ON DELETE SET NULL;"
     }
   ],
   "invalid": [
     {
       "name": "allowed-disallows-cascade",
-      "code": "ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE CASCADE;\n",
+      "code": "ALTER TABLE child ADD FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE CASCADE;",
       "options": [
         {
           "allowed": ["RESTRICT", "NO ACTION"]
@@ -44,7 +44,7 @@
     },
     {
       "name": "missing-on-delete",
-      "code": "CREATE TABLE t (\n  fid integer REFERENCES other(id)\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid) REFERENCES other(id);\n",
+      "code": "CREATE TABLE t (\n  fid integer REFERENCES other(id)\n);\nALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (fid) REFERENCES other(id);",
       "errors": [
         {
           "messageId": "missingOnDelete",

--- a/npm/postgresql/test/fixtures/require-primary-key.json
+++ b/npm/postgresql/test/fixtures/require-primary-key.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "inline-pk",
-      "code": "CREATE TABLE t (id INT PRIMARY KEY);\n"
+      "code": "CREATE TABLE t (id INT PRIMARY KEY);"
     },
     {
       "name": "table-level-pk",
-      "code": "CREATE TABLE t (id INT, name TEXT, PRIMARY KEY (id));\n"
+      "code": "CREATE TABLE t (id INT, name TEXT, PRIMARY KEY (id));"
     }
   ],
   "invalid": [
     {
       "name": "no-pk",
-      "code": "CREATE TABLE t (id INT, name TEXT);\n",
+      "code": "CREATE TABLE t (id INT, name TEXT);",
       "errors": [
         {
           "messageId": "missingPrimaryKey",

--- a/npm/postgresql/test/fixtures/require-schema-qualified-table.json
+++ b/npm/postgresql/test/fixtures/require-schema-qualified-table.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "qualified",
-      "code": "CREATE TABLE app.users (id bigint PRIMARY KEY);\n"
+      "code": "CREATE TABLE app.users (id bigint PRIMARY KEY);"
     }
   ],
   "invalid": [
     {
       "name": "unqualified",
-      "code": "CREATE TABLE users (id bigint PRIMARY KEY);\n",
+      "code": "CREATE TABLE users (id bigint PRIMARY KEY);",
       "errors": [
         {
           "messageId": "requireSchemaQualifiedTable",

--- a/npm/postgresql/test/fixtures/require-table-columns.json
+++ b/npm/postgresql/test/fixtures/require-table-columns.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "excluded-table",
-      "code": "-- Matches `exclude` pattern (`^audit_`) — no check is performed.\nCREATE TABLE audit_events (\n  id   bigserial PRIMARY KEY,\n  data jsonb\n);\n",
+      "code": "-- Matches `exclude` pattern (`^audit_`) — no check is performed.\nCREATE TABLE audit_events (\n  id   bigserial PRIMARY KEY,\n  data jsonb\n);",
       "options": [
         {
           "columns": ["tenant_id", "created_at", "updated_at"],
@@ -19,7 +19,7 @@
     },
     {
       "name": "has-all-required",
-      "code": "-- All required columns are present.\nCREATE TABLE orders (\n  id         bigserial PRIMARY KEY,\n  tenant_id  bigint NOT NULL,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  created_by bigint NOT NULL,\n  updated_at timestamptz NOT NULL DEFAULT current_timestamp,\n  updated_by bigint NOT NULL\n);\n",
+      "code": "-- All required columns are present.\nCREATE TABLE orders (\n  id         bigserial PRIMARY KEY,\n  tenant_id  bigint NOT NULL,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  created_by bigint NOT NULL,\n  updated_at timestamptz NOT NULL DEFAULT current_timestamp,\n  updated_by bigint NOT NULL\n);",
       "options": [
         {
           "columns": ["tenant_id", "created_at", "created_by", "updated_at", "updated_by"]
@@ -28,7 +28,7 @@
     },
     {
       "name": "override-temporal",
-      "code": "-- `*_temporal` tables follow an override that only requires\n-- `tenant_id`, `created_at`, `created_by`, `updated_at` (no\n-- `updated_by`), because rows are append-only.\nCREATE TABLE orders_temporal (\n  id         bigserial PRIMARY KEY,\n  tenant_id  bigint NOT NULL,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  created_by bigint NOT NULL,\n  updated_at timestamptz NOT NULL DEFAULT current_timestamp\n);\n",
+      "code": "-- `*_temporal` tables follow an override that only requires\n-- `tenant_id`, `created_at`, `created_by`, `updated_at` (no\n-- `updated_by`), because rows are append-only.\nCREATE TABLE orders_temporal (\n  id         bigserial PRIMARY KEY,\n  tenant_id  bigint NOT NULL,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  created_by bigint NOT NULL,\n  updated_at timestamptz NOT NULL DEFAULT current_timestamp\n);",
       "options": [
         {
           "columns": ["tenant_id", "created_at", "created_by", "updated_at", "updated_by"],
@@ -45,7 +45,7 @@
   "invalid": [
     {
       "name": "missing-multiple-columns",
-      "code": "-- Missing `tenant_id`, `created_by`, and `updated_by`.\nCREATE TABLE orders (\n  id         bigserial PRIMARY KEY,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  updated_at timestamptz NOT NULL DEFAULT current_timestamp\n);\n",
+      "code": "-- Missing `tenant_id`, `created_by`, and `updated_by`.\nCREATE TABLE orders (\n  id         bigserial PRIMARY KEY,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  updated_at timestamptz NOT NULL DEFAULT current_timestamp\n);",
       "options": [
         {
           "columns": ["tenant_id", "created_at", "created_by", "updated_at", "updated_by"]
@@ -81,7 +81,7 @@
     },
     {
       "name": "override-temporal-missing-column",
-      "code": "-- `*_temporal` override requires `[tenant_id, created_at, created_by,\n-- updated_at]`. This table is missing `updated_at`.\nCREATE TABLE orders_temporal (\n  id         bigserial PRIMARY KEY,\n  tenant_id  bigint NOT NULL,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  created_by bigint NOT NULL\n);\n",
+      "code": "-- `*_temporal` override requires `[tenant_id, created_at, created_by,\n-- updated_at]`. This table is missing `updated_at`.\nCREATE TABLE orders_temporal (\n  id         bigserial PRIMARY KEY,\n  tenant_id  bigint NOT NULL,\n  created_at timestamptz NOT NULL DEFAULT current_timestamp,\n  created_by bigint NOT NULL\n);",
       "options": [
         {
           "columns": ["tenant_id", "created_at", "created_by", "updated_at", "updated_by"],

--- a/npm/postgresql/test/fixtures/require-trailing-semicolon.json
+++ b/npm/postgresql/test/fixtures/require-trailing-semicolon.json
@@ -9,25 +9,25 @@
   "valid": [
     {
       "name": "create-table-with-not-null",
-      "code": "-- Regression for #143: the parser's per-statement range[1] for a\n-- single CREATE TABLE pointed mid-NOT-NULL on the last column. The\n-- rule used to insert `;` between NOT and NULL there. The rewrite to\n-- a file-level check makes this fixture a no-op.\nCREATE TABLE t (\n  a  TEXT     NOT NULL,\n  b  TEXT     NOT NULL,\n  c  INTEGER  NOT NULL\n);\n"
+      "code": "-- Regression for #143: the parser's per-statement range[1] for a\n-- single CREATE TABLE pointed mid-NOT-NULL on the last column. The\n-- rule used to insert `;` between NOT and NULL there. The rewrite to\n-- a file-level check makes this fixture a no-op.\nCREATE TABLE t (\n  a  TEXT     NOT NULL,\n  b  TEXT     NOT NULL,\n  c  INTEGER  NOT NULL\n);"
     },
     {
       "name": "multi-statement",
-      "code": "SELECT id FROM users;\nINSERT INTO events (kind) VALUES ('login');\nUPDATE users SET active = FALSE WHERE id = 1;\n"
+      "code": "SELECT id FROM users;\nINSERT INTO events (kind) VALUES ('login');\nUPDATE users SET active = FALSE WHERE id = 1;"
     },
     {
       "name": "parse-error-stays-untouched",
-      "code": "-- Regression test for #136: SET ... = NULL is rejected by libpg-query.\n-- The rule must skip parse-error stmts so autofix does not append a\n-- run of `;` characters to the file.\nSET LOCAL app.admin = 'true';\nSET plv8.start_proc = NULL;\n"
+      "code": "-- Regression test for #136: SET ... = NULL is rejected by libpg-query.\n-- The rule must skip parse-error stmts so autofix does not append a\n-- run of `;` characters to the file.\nSET LOCAL app.admin = 'true';\nSET plv8.start_proc = NULL;"
     },
     {
       "name": "with-semicolons",
-      "code": "SELECT id FROM users;\nINSERT INTO events (kind) VALUES ('login');\nUPDATE users SET active = FALSE WHERE id = 1;\n"
+      "code": "SELECT id FROM users;\nINSERT INTO events (kind) VALUES ('login');\nUPDATE users SET active = FALSE WHERE id = 1;"
     }
   ],
   "invalid": [
     {
       "name": "missing-semicolon",
-      "code": "SELECT id FROM users\n",
+      "code": "SELECT id FROM users",
       "errors": [
         {
           "messageId": "missingSemicolon",

--- a/npm/postgresql/test/fixtures/require-where-in-delete.json
+++ b/npm/postgresql/test/fixtures/require-where-in-delete.json
@@ -9,17 +9,17 @@
   "valid": [
     {
       "name": "delete-with-returning",
-      "code": "DELETE FROM users WHERE created_at < now() - interval '30 days' RETURNING id;\n"
+      "code": "DELETE FROM users WHERE created_at < now() - interval '30 days' RETURNING id;"
     },
     {
       "name": "delete-with-where",
-      "code": "DELETE FROM users WHERE id = 1;\n"
+      "code": "DELETE FROM users WHERE id = 1;"
     }
   ],
   "invalid": [
     {
       "name": "delete-without-where",
-      "code": "DELETE FROM users;\n",
+      "code": "DELETE FROM users;",
       "errors": [
         {
           "messageId": "missingWhere",

--- a/npm/postgresql/test/fixtures/require-where-in-update.json
+++ b/npm/postgresql/test/fixtures/require-where-in-update.json
@@ -9,13 +9,13 @@
   "valid": [
     {
       "name": "update-with-where",
-      "code": "UPDATE users SET name = 'a' WHERE id = 1;\n"
+      "code": "UPDATE users SET name = 'a' WHERE id = 1;"
     }
   ],
   "invalid": [
     {
       "name": "update-without-where",
-      "code": "UPDATE users SET active = false;\n",
+      "code": "UPDATE users SET active = false;",
       "errors": [
         {
           "messageId": "missingWhere",

--- a/npm/postgresql/test/fixtures/snake-case-column-name.json
+++ b/npm/postgresql/test/fixtures/snake-case-column-name.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "allow-list",
-      "code": "CREATE TABLE t (\n  \"userId\" int,\n  \"createdAt\" timestamptz\n);\n",
+      "code": "CREATE TABLE t (\n  \"userId\" int,\n  \"createdAt\" timestamptz\n);",
       "options": [
         {
           "allow": ["userId", "createdAt"]
@@ -18,17 +18,17 @@
     },
     {
       "name": "case-folded",
-      "code": "CREATE TABLE t (CamelCol INT);\n"
+      "code": "CREATE TABLE t (CamelCol INT);"
     },
     {
       "name": "snake",
-      "code": "CREATE TABLE t (id INT PRIMARY KEY, created_at TIMESTAMPTZ);\n"
+      "code": "CREATE TABLE t (id INT PRIMARY KEY, created_at TIMESTAMPTZ);"
     }
   ],
   "invalid": [
     {
       "name": "allow-list-partial",
-      "code": "CREATE TABLE t (\n  \"userId\" int,\n  \"createdAt\" timestamptz\n);\n",
+      "code": "CREATE TABLE t (\n  \"userId\" int,\n  \"createdAt\" timestamptz\n);",
       "options": [
         {
           "allow": ["userId"]
@@ -48,7 +48,7 @@
     },
     {
       "name": "quoted-camel",
-      "code": "CREATE TABLE t (\"CamelCol\" INT);\n",
+      "code": "CREATE TABLE t (\"CamelCol\" INT);",
       "errors": [
         {
           "messageId": "notSnakeCase",

--- a/npm/postgresql/test/fixtures/snake-case-table-name.json
+++ b/npm/postgresql/test/fixtures/snake-case-table-name.json
@@ -9,7 +9,7 @@
   "valid": [
     {
       "name": "allow-list",
-      "code": "CREATE TABLE LegacyOrders (id int);\n",
+      "code": "CREATE TABLE LegacyOrders (id int);",
       "options": [
         {
           "allow": ["LegacyOrders"]
@@ -18,17 +18,17 @@
     },
     {
       "name": "case-folded",
-      "code": "CREATE TABLE UserAccounts (id INT PRIMARY KEY);\n"
+      "code": "CREATE TABLE UserAccounts (id INT PRIMARY KEY);"
     },
     {
       "name": "snake",
-      "code": "CREATE TABLE user_accounts (id INT PRIMARY KEY);\n"
+      "code": "CREATE TABLE user_accounts (id INT PRIMARY KEY);"
     }
   ],
   "invalid": [
     {
       "name": "quoted-camel",
-      "code": "CREATE TABLE \"UserAccounts\" (id INT PRIMARY KEY);\n",
+      "code": "CREATE TABLE \"UserAccounts\" (id INT PRIMARY KEY);",
       "errors": [
         {
           "messageId": "notSnakeCase",

--- a/status.json
+++ b/status.json
@@ -6151,19 +6151,19 @@
       },
       {
         "name": "require-trailing-semicolon",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-trailing-semicolon."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-trailing-semicolon; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-where-in-delete",

--- a/tools/tasks/sync-postgresql-tests.ts
+++ b/tools/tasks/sync-postgresql-tests.ts
@@ -60,7 +60,10 @@ type Case = {
 };
 
 function readText(path: string): string {
-  return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+  // Trim matches upstream test-utils.ts (`readSql(...).trim()`) so that
+  // `code` and the YAML-derived `output` share the same baseline (no trailing
+  // newline), making autofix output comparisons exact.
+  return readFileSync(path, 'utf8').replace(/\r\n/g, '\n').trim();
 }
 
 function readMeta(path: string): FixtureMeta {


### PR DESCRIPTION
## Summary
- Ports `require-trailing-semicolon` from `eslint-plugin-postgresql` as a token-stream rule
- Uses `uses_parse_error: true` trigger (fires once with `Value::Null`, tokenizes the source)
- Checks that the last token in the file is `;`; reports at the last token's loc if not
- Fix inserts `;` immediately after the last token via a zero-length `DiagnosticFix` (start=end=last.end)
- Also carries the `sync-postgresql-tests.ts` trim fix from PR #335 for correct autofix output comparison

## Validation
- `cargo clippy`: zero warnings
- `pnpm run build:debug` (debug NAPI): success
- Fixture test (canonical error+output check): ALL MATCH (1 invalid, 4 valid)
- `pnpm exec vitest run npm/postgresql/test/upstream.test.mjs`: 131 passed / 44 skipped

## Test plan
- [ ] Verify last-token check and zero-length insert fix
- [ ] Confirm all 4 valid cases (with-semicolons, multi-statement, create-table, parse-error) pass with no errors
- [ ] Confirm fix produces correct output for missing-semicolon case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784034742&installation_id=136613492&pr_number=337&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F337&signature=2b28c70aaefdd4521a96d8e9d2f6ed4d23aa406e68faf4095d114ae0a6e7591c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->