### PR TITLE
fix(testing-library): honor consistent-data-testid options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "oxlint-plugins-_carton",
+ "regex",
 ]
 
 [[package]]

--- a/crates/testing_library/Cargo.toml
+++ b/crates/testing_library/Cargo.toml
@@ -13,6 +13,7 @@ oxc_allocator.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true
+regex.workspace = true
 
 [lints.rust]
 unused_must_use = "deny"

--- a/crates/testing_library/src/checks.rs
+++ b/crates/testing_library/src/checks.rs
@@ -1,33 +1,60 @@
 //! Targeted scan_* methods for testing-library rules, grouped here to keep the
 //! scanner driver file focused on dispatching.
 
-use oxc_span::Span;
+use std::fmt::Write as _;
 
-use crate::helpers::{
-    count_occurrences, find_all, is_kebab_case, line_prefix, quoted_value_after, span_for,
-};
+use oxc_span::Span;
+use oxlint_plugins_carton::CompactString;
+use regex::Regex;
+
+use crate::helpers::{count_occurrences, find_all, line_prefix, quoted_value_after, span_for};
 use crate::scanner::Scanner;
+
+const FILENAME_PLACEHOLDER: &str = "{fileName}";
 
 impl<'a> Scanner<'a> {
     pub(crate) fn scan_test_id_attributes(&mut self) {
         if !self.options.has_rule("consistent-data-testid") {
             return;
         }
-        let pattern = "data-testid=";
-        for index in find_all(self.source_text, pattern) {
-            let Some((value, value_start, value_end)) =
-                quoted_value_after(self.source_text, index + pattern.len())
-            else {
-                continue;
-            };
-            if !is_kebab_case(value) {
-                self.report(
-                    "consistent-data-testid",
-                    "data-testid should use a consistent kebab-case format.",
-                    Span::new(value_start as u32, value_end as u32),
-                );
-                return;
+        // Upstream defaults `testIdPattern` to "" which compiles to `//` and
+        // matches every value, so an unset pattern never reports.
+        if self.options.test_id_pattern.is_empty() {
+            return;
+        }
+        let file_name = derive_file_name(self.filename).unwrap_or_default();
+        let resolved = self
+            .options
+            .test_id_pattern
+            .replacen(FILENAME_PLACEHOLDER, file_name, 1);
+        let Ok(regex) = Regex::new(&resolved) else {
+            return;
+        };
+
+        // Collect first so the immutable borrows of `self` end before we report.
+        let mut reports: Vec<(CompactString, Span)> = Vec::new();
+        for attr in &self.options.test_id_attribute {
+            let mut needle = CompactString::new("");
+            let _ = write!(needle, "{attr}=");
+            for index in find_all(self.source_text, &needle) {
+                let Some((value, value_start, value_end)) =
+                    quoted_value_after(self.source_text, index + needle.len())
+                else {
+                    continue;
+                };
+                if regex.is_match(value) {
+                    continue;
+                }
+                let message = self.options.custom_message.clone().unwrap_or_else(|| {
+                    let mut message = CompactString::new("");
+                    let _ = write!(message, "`{attr}` \"{value}\" should match `/{resolved}/`");
+                    message
+                });
+                reports.push((message, Span::new(value_start as u32, value_end as u32)));
             }
+        }
+        for (message, span) in reports {
+            self.report_message("consistent-data-testid", message, span);
         }
     }
 
@@ -227,4 +254,19 @@ impl<'a> Scanner<'a> {
             }
         }
     }
+}
+
+/// Derive the `{fileName}` substitution the way upstream `consistent-data-testid`
+/// does: take the last path segment, drop its extension, and fall back to the
+/// parent directory when the file is `index`. Bracketed names (e.g. Next.js
+/// `[id].tsx`) yield no file name.
+fn derive_file_name(filename: &str) -> Option<&str> {
+    let mut segments: Vec<&str> = filename.split('/').collect();
+    let file_with_ext = segments.pop()?;
+    if file_with_ext.contains('[') || file_with_ext.contains(']') {
+        return None;
+    }
+    let parent = segments.pop();
+    let name = file_with_ext.split('.').next().unwrap_or("");
+    if name == "index" { parent } else { Some(name) }
 }

--- a/crates/testing_library/src/helpers.rs
+++ b/crates/testing_library/src/helpers.rs
@@ -30,16 +30,6 @@ pub(crate) fn quoted_value_after(source_text: &str, start: usize) -> Option<(&st
     Some((&source_text[value_start..value_end], value_start, value_end))
 }
 
-pub(crate) fn is_kebab_case(value: &str) -> bool {
-    !value.is_empty()
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-        && !value.starts_with('-')
-        && !value.ends_with('-')
-        && !value.contains("--")
-}
-
 pub(crate) fn count_occurrences(source_text: &str, pattern: &str) -> usize {
     source_text.match_indices(pattern).count()
 }

--- a/crates/testing_library/src/lib.rs
+++ b/crates/testing_library/src/lib.rs
@@ -74,6 +74,7 @@ pub fn scan_testing_library(
 
     let mut scanner = Scanner {
         source_text,
+        filename,
         line_index: LineIndex::new(source_text),
         diagnostics: SmallVec::new(),
         options,

--- a/crates/testing_library/src/scanner.rs
+++ b/crates/testing_library/src/scanner.rs
@@ -1,13 +1,14 @@
 //! Driver for testing-library rules. Heavy per-rule logic lives in `checks.rs`.
 
 use oxc_span::Span;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::helpers::{find_all, line_prefix, span_for};
 use crate::types::{Diagnostic, LineIndex, TestingLibraryOptions};
 
 pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,
+    pub(crate) filename: &'a str,
     pub(crate) line_index: LineIndex,
     pub(crate) diagnostics: SmallVec<[Diagnostic; 32]>,
     pub(crate) options: &'a TestingLibraryOptions,
@@ -117,10 +118,19 @@ impl<'a> Scanner<'a> {
     }
 
     pub(crate) fn report(&mut self, rule_name: &'static str, message: &'static str, span: Span) {
+        self.report_message(rule_name, message.into(), span);
+    }
+
+    pub(crate) fn report_message(
+        &mut self,
+        rule_name: &'static str,
+        message: CompactString,
+        span: Span,
+    ) {
         if self.options.has_rule(rule_name) {
             self.diagnostics.push(Diagnostic {
                 rule_name,
-                message: message.into(),
+                message,
                 loc: self.line_index.loc_for_span(self.source_text, span),
             });
         }

--- a/crates/testing_library/src/tests.rs
+++ b/crates/testing_library/src/tests.rs
@@ -30,7 +30,9 @@ const result = render(<Button />);
         .map(|diagnostic| diagnostic.rule_name)
         .collect();
     assert!(rules.contains(&"await-async-events"));
-    assert!(rules.contains(&"consistent-data-testid"));
+    // `consistent-data-testid` is a no-op unless a `testIdPattern` is configured
+    // (upstream default is the empty pattern), so it must not fire here.
+    assert!(!rules.contains(&"consistent-data-testid"));
     assert!(rules.contains(&"no-await-sync-events"));
     assert!(rules.contains(&"no-dom-import"));
     assert!(rules.contains(&"no-global-regexp-flag-in-query"));
@@ -44,6 +46,94 @@ const result = render(<Button />);
     assert!(rules.contains(&"prefer-user-event"));
     assert!(rules.contains(&"prefer-screen-queries"));
     assert!(rules.contains(&"render-result-naming-convention"));
+}
+
+fn consistent_data_testid_options(pattern: &str) -> TestingLibraryOptions {
+    TestingLibraryOptions {
+        rule_names: ["consistent-data-testid".into()].into_iter().collect(),
+        test_id_pattern: pattern.into(),
+        ..TestingLibraryOptions::default()
+    }
+}
+
+#[test]
+fn consistent_data_testid_honors_pattern() {
+    let source = r#"const a = <Button data-testid="kebab-id" />;"#;
+
+    // Matching value: no diagnostic.
+    assert!(
+        scan_testing_library(
+            source,
+            "fixture.test.tsx",
+            &consistent_data_testid_options("^[a-z-]+$"),
+        )
+        .is_empty()
+    );
+
+    // Non-matching value: one diagnostic, message echoes the resolved regex.
+    let diagnostics = scan_testing_library(
+        r#"const a = <Button data-testid="BadId" />;"#,
+        "fixture.test.tsx",
+        &consistent_data_testid_options("^[a-z-]+$"),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "consistent-data-testid");
+    assert!(diagnostics[0].message.contains("BadId"));
+    assert!(diagnostics[0].message.contains("/^[a-z-]+$/"));
+}
+
+#[test]
+fn consistent_data_testid_default_is_noop() {
+    let diagnostics = scan_testing_library(
+        r#"const a = <Button data-testid="BadId" />;"#,
+        "fixture.test.tsx",
+        &TestingLibraryOptions {
+            rule_names: ["consistent-data-testid".into()].into_iter().collect(),
+            ..TestingLibraryOptions::default()
+        },
+    );
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn consistent_data_testid_substitutes_filename() {
+    // `{fileName}` is replaced with the derived file name (`Button`), so a
+    // matching id passes and a mismatching one reports.
+    let options = consistent_data_testid_options("^{fileName}__[a-z]+$");
+    assert!(
+        scan_testing_library(
+            r#"const a = <Button data-testid="Button__primary" />;"#,
+            "src/Button.test.tsx",
+            &options,
+        )
+        .is_empty()
+    );
+    assert_eq!(
+        scan_testing_library(
+            r#"const a = <Button data-testid="Other__primary" />;"#,
+            "src/Button.test.tsx",
+            &options,
+        )
+        .len(),
+        1
+    );
+}
+
+#[test]
+fn consistent_data_testid_custom_message_and_attribute() {
+    let options = TestingLibraryOptions {
+        rule_names: ["consistent-data-testid".into()].into_iter().collect(),
+        test_id_pattern: "^[a-z-]+$".into(),
+        test_id_attribute: ["data-test-id".into()].into_iter().collect(),
+        custom_message: Some("use kebab-case".into()),
+    };
+    let diagnostics = scan_testing_library(
+        r#"const a = <Button data-test-id="BadId" data-testid="ignored" />;"#,
+        "fixture.test.tsx",
+        &options,
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message.as_str(), "use kebab-case");
 }
 
 #[test]

--- a/crates/testing_library/src/types.rs
+++ b/crates/testing_library/src/types.rs
@@ -23,7 +23,15 @@ pub struct Diagnostic {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TestingLibraryOptions {
     pub rule_names: SmallVec<[CompactString; 29]>,
+    /// `consistent-data-testid` regex source. Upstream defaults this to `""`,
+    /// which compiles to `//` and matches every value, so an unset pattern
+    /// never reports. `{fileName}` is substituted with the derived file name.
     pub test_id_pattern: CompactString,
+    /// Attribute name(s) checked by `consistent-data-testid` (upstream default
+    /// `["data-testid"]`).
+    pub test_id_attribute: SmallVec<[CompactString; 1]>,
+    /// Optional override message for `consistent-data-testid`.
+    pub custom_message: Option<CompactString>,
 }
 
 impl Default for TestingLibraryOptions {
@@ -33,7 +41,9 @@ impl Default for TestingLibraryOptions {
                 .iter()
                 .map(|rule_name| CompactString::from(*rule_name))
                 .collect(),
-            test_id_pattern: CompactString::from("kebab-case"),
+            test_id_pattern: CompactString::default(),
+            test_id_attribute: [CompactString::from("data-testid")].into_iter().collect(),
+            custom_message: None,
         }
     }
 }

--- a/npm/testing-library/api.js
+++ b/npm/testing-library/api.js
@@ -19,6 +19,10 @@ function scanTestingLibrary(sourceText, filename = 'file.test.tsx', options = {}
       ? raw.ruleNames.filter((ruleName) => typeof ruleName === 'string' && ruleName.length > 0)
       : undefined,
     testIdPattern: typeof raw.testIdPattern === 'string' ? raw.testIdPattern : undefined,
+    testIdAttribute: Array.isArray(raw.testIdAttribute)
+      ? raw.testIdAttribute.filter((value) => typeof value === 'string' && value.length > 0)
+      : undefined,
+    customMessage: typeof raw.customMessage === 'string' ? raw.customMessage : undefined,
   });
 }
 

--- a/npm/testing-library/index.js
+++ b/npm/testing-library/index.js
@@ -132,9 +132,34 @@ function createTestingLibraryRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
-  return diagnosticsForContext(context, { ruleNames: [ruleName] }).filter(
+  return diagnosticsForContext(context, scanOptionsForRule(ruleName, context.options)).filter(
     (diagnostic) => diagnostic.ruleName === ruleName,
   );
+}
+
+function scanOptionsForRule(ruleName, options) {
+  const scanOptions = { ruleNames: [ruleName] };
+  if (ruleName !== 'consistent-data-testid') {
+    return scanOptions;
+  }
+
+  const raw = options?.[0];
+  if (!raw || typeof raw !== 'object') {
+    return scanOptions;
+  }
+
+  if (typeof raw.testIdPattern === 'string') {
+    scanOptions.testIdPattern = raw.testIdPattern;
+  }
+  if (typeof raw.testIdAttribute === 'string') {
+    scanOptions.testIdAttribute = [raw.testIdAttribute];
+  } else if (Array.isArray(raw.testIdAttribute)) {
+    scanOptions.testIdAttribute = raw.testIdAttribute.filter((value) => typeof value === 'string');
+  }
+  if (typeof raw.customMessage === 'string') {
+    scanOptions.customMessage = raw.customMessage;
+  }
+  return scanOptions;
 }
 
 function diagnosticsForContext(context, options) {

--- a/npm/testing-library/src/lib.rs
+++ b/npm/testing-library/src/lib.rs
@@ -20,6 +20,8 @@ mod napi_abi {
     pub struct TestingLibraryScanOptions {
         pub rule_names: Option<Vec<String>>,
         pub test_id_pattern: Option<String>,
+        pub test_id_attribute: Option<Vec<String>>,
+        pub custom_message: Option<String>,
     }
 
     #[napi(object)]
@@ -59,9 +61,14 @@ mod napi_abi {
             rule_names: compact_rule_names(options.rule_names),
             test_id_pattern: options
                 .test_id_pattern
-                .filter(|value| !value.is_empty())
                 .map(CompactString::from)
                 .unwrap_or(default_options.test_id_pattern),
+            test_id_attribute: options
+                .test_id_attribute
+                .filter(|values| !values.is_empty())
+                .map(|values| values.into_iter().map(CompactString::from).collect())
+                .unwrap_or(default_options.test_id_attribute),
+            custom_message: options.custom_message.map(CompactString::from),
         };
 
         core::scan_testing_library(&source_text, &filename, &core_options)

--- a/npm/testing-library/test/api.test.mjs
+++ b/npm/testing-library/test/api.test.mjs
@@ -38,7 +38,11 @@ const focusedRuleCases = [
   ['await-async-events', 'userEvent.click(button);'],
   ['await-async-queries', 'screen.findByText("Save");'],
   ['await-async-utils', 'waitFor(() => screen.getByText("Save"));'],
-  ['consistent-data-testid', 'render(<button data-testid="BadId" />);'],
+  [
+    'consistent-data-testid',
+    'render(<button data-testid="BadId" />);',
+    { testIdPattern: '^[a-z-]+$' },
+  ],
   ['no-await-sync-events', 'await fireEvent.click(button);'],
   ['no-await-sync-queries', 'await screen.getByText("Save");'],
   ['no-container', 'container.querySelector(".save");'],
@@ -72,8 +76,11 @@ describe('testing-library native API', () => {
   });
 
   it('reports each ported rule with a focused fixture', () => {
-    for (const [ruleName, source] of focusedRuleCases) {
-      const diagnostics = scanTestingLibrary(source, 'fixture.test.tsx', { ruleNames: [ruleName] });
+    for (const [ruleName, source, ruleOptions] of focusedRuleCases) {
+      const diagnostics = scanTestingLibrary(source, 'fixture.test.tsx', {
+        ruleNames: [ruleName],
+        ...ruleOptions,
+      });
 
       expect(
         diagnostics.map((diagnostic) => diagnostic.ruleName),
@@ -104,7 +111,6 @@ describe('testing-library native API', () => {
       new Set([
         'await-async-events',
         'await-async-utils',
-        'consistent-data-testid',
         'no-await-sync-events',
         'no-container',
         'no-dom-import',

--- a/npm/testing-library/test/plugin.test.mjs
+++ b/npm/testing-library/test/plugin.test.mjs
@@ -12,7 +12,7 @@ const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = resolve(packageRoot, '../..');
 const expectedRuleNames = plugin.implementedTestingLibraryRuleNames;
 
-function runRule(ruleName, sourceText, filename = 'fixture.test.tsx') {
+function runRule(ruleName, sourceText, { filename = 'fixture.test.tsx', options = [] } = {}) {
   const reports = [];
   const sourceCode = {
     text: sourceText,
@@ -22,7 +22,7 @@ function runRule(ruleName, sourceText, filename = 'fixture.test.tsx') {
   };
   const visitor = plugin.rules[ruleName].createOnce({
     filename,
-    options: [],
+    options,
     sourceCode,
     report(descriptor) {
       reports.push(descriptor);
@@ -114,11 +114,29 @@ describe('testing-library rules through direct adapter harness', () => {
     expect(reports[0].data.message).toBe('Prefer userEvent over fireEvent.');
   });
 
-  it('passes source through the Rust scanner', () => {
-    const reports = runRule('consistent-data-testid', 'render(<button data-testid="BadId" />);');
+  it('forwards consistent-data-testid options to the Rust scanner', () => {
+    const reports = runRule('consistent-data-testid', 'render(<button data-testid="BadId" />);', {
+      options: [{ testIdPattern: '^[a-z-]+$' }],
+    });
 
     expect(reports).toHaveLength(1);
     expect(reports[0].data.message).toContain('data-testid');
+    expect(reports[0].data.message).toContain('/^[a-z-]+$/');
+  });
+
+  it('treats consistent-data-testid as a no-op without a configured pattern', () => {
+    const reports = runRule('consistent-data-testid', 'render(<button data-testid="BadId" />);');
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('honors a custom consistent-data-testid message', () => {
+    const reports = runRule('consistent-data-testid', 'render(<button data-testid="BadId" />);', {
+      options: [{ testIdPattern: '^[a-z-]+$', customMessage: 'use kebab-case' }],
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].data.message).toBe('use kebab-case');
   });
 });
 


### PR DESCRIPTION
## Summary
`consistent-data-testid` advertised an options schema but silently ignored user options: the Rust core had a `test_id_pattern` field it never read, the check hardcoded an `is_kebab_case` heuristic (matching neither upstream nor any config), and both `api.js` and `index.js` dropped `context.options`.

This faithfully reimplements the rule against upstream `eslint-plugin-testing-library`:

- **`testIdPattern`** — regex source with `{fileName}` placeholder substitution (filename derived the upstream way: last path segment sans extension, falling back to parent dir for `index`, `undefined` for bracketed names).
- **`testIdAttribute`** — `string | string[]`, default `["data-testid"]`.
- **`customMessage`** — overrides the default `` `{{attr}}` "{{value}}" should match `{{regex}}` `` message.
- **empty pattern is a no-op**, matching upstream's `""` default (which compiles to `//` and matches everything).

## Changes
- Core: read `test_id_pattern`/`test_id_attribute`/`custom_message`, wire `filename` into the scanner, add the `regex` dependency, drop the unused `is_kebab_case` helper.
- NAPI: extend `TestingLibraryScanOptions` with `testIdAttribute` + `customMessage`.
- Adapter: forward `context.options` through `index.js` and stop stripping fields in `api.js`.
- Tests: Rust unit tests (pattern, default no-op, `{fileName}`, custom message + attribute) and updated JS tests for the upstream-faithful default.

## Test
- `cargo test -p oxlint-plugins-testing-library` — 7 passed
- `vitest run npm/testing-library` — 11 passed
- clippy `-D warnings` + `cargo fmt --check` + `vp lint`/`vp fmt` clean

## Context
First of several PRs closing a class of "advertises an options schema but ignores user options" gaps (also affects perfectionist, angular-eslint, playwright; each tracked separately). A regression guard is coming in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038393&installation_id=136613492&pr_number=343&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F343&signature=6517b4084c39af526f512951ef249aedcf3cc0baf308c117d91fcd4d2d633d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->