### PR TITLE
feat(postgresql): port no-drop-schema-cascade

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -14,6 +14,7 @@ mod no_distinct_on_without_order_by;
 mod no_drop_column;
 mod no_drop_database;
 mod no_drop_not_null;
+mod no_drop_schema_cascade;
 mod no_drop_table_cascade;
 mod no_equality_with_null;
 mod no_grant_all;
@@ -163,6 +164,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-drop-column",
     "no-drop-database",
     "no-drop-not-null",
+    "no-drop-schema-cascade",
     "no-drop-table-cascade",
     "no-equality-with-null",
     "no-grant-all",
@@ -261,6 +263,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-drop-not-null",
         run: no_drop_not_null::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-drop-schema-cascade",
+        run: no_drop_schema_cascade::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_drop_schema_cascade.rs
+++ b/crates/postgresql/src/rules/no_drop_schema_cascade.rs
@@ -1,0 +1,20 @@
+//! Port of `no-drop-schema-cascade`: disallow `DROP SCHEMA ... CASCADE`
+//! because it silently removes every object in the schema.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "DropStmt") {
+        return;
+    }
+    if str_field(node, "removeType") != Some("OBJECT_SCHEMA") {
+        return;
+    }
+    if str_field(node, "behavior") != Some("DROP_CASCADE") {
+        return;
+    }
+    ctx.report(node, "noDropSchemaCascade");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -147,6 +147,18 @@ const ruleMeta = Object.freeze({
         '`DROP NOT NULL` lets the column store NULLs again — every consumer that already assumes the column is non-null (joins, COALESCE coverage, app-level types) silently breaks. If a row genuinely needs no value, model it with a sentinel or a separate optional table.',
     },
   },
+  'no-drop-schema-cascade': {
+    type: 'problem',
+    description:
+      'Disallow `DROP SCHEMA ... CASCADE`; it silently removes every object in the schema',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDropSchemaCascade:
+        "`DROP SCHEMA ... CASCADE` removes every table, view, function, and sequence in the schema with no preview. List the objects you actually want to drop instead, or drop the schema only when it's already empty.",
+    },
+  },
   'no-drop-table-cascade': {
     type: 'problem',
     description: 'Disallow `DROP TABLE ... CASCADE` because it silently removes dependent objects',

--- a/status.json
+++ b/status.json
@@ -5271,19 +5271,19 @@
       },
       {
         "name": "no-drop-schema-cascade",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-drop-schema-cascade."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-drop-schema-cascade; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-drop-table-cascade",


### PR DESCRIPTION
Part of #14. Ports `no-drop-schema-cascade`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038437&installation_id=136613492&pr_number=344&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F344&signature=cba9e794ba410c2487e28d98399fb6c38498af70434e68587bb724a862071542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->