### PR TITLE
feat(postgresql): port no-add-column-not-null-without-default

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -4,6 +4,7 @@
 use crate::RuleDef;
 
 mod no_add_check_constraint_without_not_valid;
+mod no_add_column_not_null_without_default;
 mod no_add_unique_constraint_directly;
 mod no_alter_column_type;
 mod no_cluster;
@@ -153,6 +154,7 @@ pub const RULE_NAMES: [&str; 89] = [
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-add-check-constraint-without-not-valid",
+    "no-add-column-not-null-without-default",
     "no-add-unique-constraint-directly",
     "no-alter-column-type",
     "no-cluster",
@@ -211,6 +213,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-add-check-constraint-without-not-valid",
         run: no_add_check_constraint_without_not_valid::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-add-column-not-null-without-default",
+        run: no_add_column_not_null_without_default::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_add_column_not_null_without_default.rs
+++ b/crates/postgresql/src/rules/no_add_column_not_null_without_default.rs
@@ -1,0 +1,54 @@
+//! Port of `no-add-column-not-null-without-default`: disallow
+//! `ALTER TABLE ADD COLUMN ... NOT NULL` without a `DEFAULT` because
+//! the migration fails outright on any non-empty table.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+fn has_not_null(def: &Value) -> bool {
+    let Some(constraints) = array_field(def, "constraints") else {
+        return false;
+    };
+    constraints
+        .iter()
+        .any(|c| is_type(c, "Constraint") && str_field(c, "contype") == Some("CONSTR_NOTNULL"))
+}
+
+fn has_default(def: &Value) -> bool {
+    let Some(constraints) = array_field(def, "constraints") else {
+        return false;
+    };
+    constraints.iter().any(|c| {
+        if !is_type(c, "Constraint") {
+            return false;
+        }
+        matches!(
+            str_field(c, "contype"),
+            Some("CONSTR_DEFAULT") | Some("CONSTR_GENERATED") | Some("CONSTR_IDENTITY")
+        )
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddColumn") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "ColumnDef") {
+        return;
+    }
+    if !has_not_null(def) {
+        return;
+    }
+    if has_default(def) {
+        return;
+    }
+    ctx.report(node, "noAddColumnNotNullWithoutDefault");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -29,6 +29,18 @@ const ruleMeta = Object.freeze({
         'Add this CHECK constraint with `NOT VALID` and run `VALIDATE CONSTRAINT` separately, so the validating scan does not block writers under `ACCESS EXCLUSIVE`.',
     },
   },
+  'no-add-column-not-null-without-default': {
+    type: 'problem',
+    description:
+      'Disallow `ALTER TABLE ADD COLUMN ... NOT NULL` without a `DEFAULT` because the migration fails outright on any non-empty table',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noAddColumnNotNullWithoutDefault:
+        '`ADD COLUMN ... NOT NULL` without a `DEFAULT` aborts the migration on any table that already has rows. Either supply a `DEFAULT`, or add the column nullable first, backfill, and then `ALTER COLUMN ... SET NOT NULL` in a follow-up.',
+    },
+  },
   'no-add-unique-constraint-directly': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5079,19 +5079,19 @@
       },
       {
         "name": "no-add-column-not-null-without-default",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-add-column-not-null-without-default."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-add-column-not-null-without-default; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-add-unique-constraint-directly",


### PR DESCRIPTION
Part of #14. Ports `no-add-column-not-null-without-default`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038578&installation_id=136613492&pr_number=345&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F345&signature=ed9888906b03637dd45387da02367d6d783c166a633531a5a9e6e180c43ce085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->