### PR TITLE
feat(postgresql): port prefer-explicit-null-ordering

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -45,6 +45,7 @@ mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
 mod prefer_current_timestamp_over_now;
 mod prefer_exists_over_in_subquery;
+mod prefer_explicit_null_ordering;
 mod prefer_not_equals_operator;
 mod require_if_exists;
 mod require_limit;
@@ -194,6 +195,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-with-recursive-without-limit",
     "prefer-current-timestamp-over-now",
     "prefer-exists-over-in-subquery",
+    "prefer-explicit-null-ordering",
     "prefer-not-equals-operator",
     "require-if-exists",
     "require-limit",
@@ -416,6 +418,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "prefer-exists-over-in-subquery",
         run: prefer_exists_over_in_subquery::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-explicit-null-ordering",
+        run: prefer_explicit_null_ordering::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/prefer_explicit_null_ordering.rs
+++ b/crates/postgresql/src/rules/prefer_explicit_null_ordering.rs
@@ -1,0 +1,25 @@
+//! Port of `prefer-explicit-null-ordering`: when `ORDER BY` specifies an
+//! explicit direction, require an explicit `NULLS FIRST` / `NULLS LAST` so
+//! null ordering is not implicit.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{is_type, str_field};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SortBy") {
+        return;
+    }
+    let dir = str_field(node, "sortby_dir");
+    if !matches!(
+        dir,
+        Some("SORTBY_ASC") | Some("SORTBY_DESC") | Some("SORTBY_USING")
+    ) {
+        return;
+    }
+    if str_field(node, "sortby_nulls") != Some("SORTBY_NULLS_DEFAULT") {
+        return;
+    }
+    ctx.report(node, "preferExplicitNullOrdering");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -537,6 +537,18 @@ const ruleMeta = Object.freeze({
         'Use `EXISTS (...)` instead of `IN (subquery)`. `IN` returns NULL when the subquery has any NULL row, which silently turns the row into a no-match; `EXISTS` is unambiguously boolean.',
     },
   },
+  'prefer-explicit-null-ordering': {
+    type: 'suggestion',
+    description:
+      'When `ORDER BY` specifies an explicit direction, require an explicit `NULLS FIRST` / `NULLS LAST` so null ordering is not implicit',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferExplicitNullOrdering:
+        "`ORDER BY ... ASC|DESC` without `NULLS FIRST` / `NULLS LAST` relies on PostgreSQL's implicit ordering (NULLS LAST for ASC, NULLS FIRST for DESC), which trips up cross-database readers. Add an explicit `NULLS FIRST` / `NULLS LAST`.",
+    },
+  },
   'prefer-not-equals-operator': {
     type: 'layout',
     description: 'Enforce a single style for the not-equal operator (`<>` or `!=`)',

--- a/status.json
+++ b/status.json
@@ -5943,19 +5943,19 @@
       },
       {
         "name": "prefer-explicit-null-ordering",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-explicit-null-ordering."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-explicit-null-ordering; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-in-list-over-or",


### PR DESCRIPTION
Part of #14. Ports `prefer-explicit-null-ordering`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038708&installation_id=136613492&pr_number=346&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F346&signature=8d316b3c1c65934cb63799b884b2b8649557073ee38805226bdfe24d6f5366c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->