### PR TITLE
feat(postgresql): port prefer-coalesce-over-case

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -43,6 +43,7 @@ mod no_update_without_from_binding;
 mod no_vacuum_full;
 mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
+mod prefer_coalesce_over_case;
 mod prefer_current_timestamp_over_now;
 mod prefer_exists_over_in_subquery;
 mod prefer_not_equals_operator;
@@ -192,6 +193,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-vacuum-full",
     "no-volatile-default-on-add-column",
     "no-with-recursive-without-limit",
+    "prefer-coalesce-over-case",
     "prefer-current-timestamp-over-now",
     "prefer-exists-over-in-subquery",
     "prefer-not-equals-operator",
@@ -406,6 +408,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-with-recursive-without-limit",
         run: no_with_recursive_without_limit::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-coalesce-over-case",
+        run: prefer_coalesce_over_case::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/prefer_coalesce_over_case.rs
+++ b/crates/postgresql/src/rules/prefer_coalesce_over_case.rs
@@ -1,0 +1,93 @@
+//! Port of `prefer-coalesce-over-case`: prefer `COALESCE(x, y)` over
+//! `CASE WHEN x IS NULL THEN y ELSE x END` (and its IS NOT NULL mirror).
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::{array_field, field, is_type, str_field};
+
+fn is_noise_key(k: &str) -> bool {
+    matches!(k, "parent" | "loc" | "range")
+}
+
+fn same_node(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Null, Value::Null) => true,
+        (Value::Bool(x), Value::Bool(y)) => x == y,
+        (Value::Number(x), Value::Number(y)) => x == y,
+        (Value::String(x), Value::String(y)) => x == y,
+        (Value::Array(xs), Value::Array(ys)) => {
+            xs.len() == ys.len() && xs.iter().zip(ys.iter()).all(|(x, y)| same_node(x, y))
+        }
+        (Value::Object(ao), Value::Object(bo)) => {
+            let a_count = ao.keys().filter(|k| !is_noise_key(k)).count();
+            let b_count = bo.keys().filter(|k| !is_noise_key(k)).count();
+            if a_count != b_count {
+                return false;
+            }
+            ao.iter()
+                .filter(|(k, _)| !is_noise_key(k))
+                .all(|(k, av)| match bo.get(k) {
+                    Some(bv) => same_node(av, bv),
+                    None => false,
+                })
+        }
+        _ => false,
+    }
+}
+
+fn is_null_test(node: &Value, kind: &str) -> bool {
+    is_type(node, "NullTest") && str_field(node, "nulltesttype") == Some(kind)
+}
+
+fn is_coalesce_shape(node: &Value) -> bool {
+    // Only the searched `CASE WHEN ... END` form (no `CASE expr WHEN ...`).
+    if field(node, "arg").is_some() {
+        return false;
+    }
+    let Some(args) = array_field(node, "args") else {
+        return false;
+    };
+    if args.len() != 1 {
+        return false;
+    }
+    let branch = &args[0];
+    let Some(expr) = field(branch, "expr") else {
+        return false;
+    };
+    let Some(defresult) = field(node, "defresult") else {
+        return false;
+    };
+    if defresult.is_null() {
+        return false;
+    }
+
+    // CASE WHEN x IS NULL THEN y ELSE x END  →  COALESCE(x, y)
+    if is_null_test(expr, "IS_NULL")
+        && let Some(expr_arg) = field(expr, "arg")
+        && same_node(expr_arg, defresult)
+        && field(branch, "result").is_none_or(|r| !same_node(expr_arg, r))
+    {
+        return true;
+    }
+    // CASE WHEN x IS NOT NULL THEN x ELSE y END  →  COALESCE(x, y)
+    if is_null_test(expr, "IS_NOT_NULL")
+        && let Some(expr_arg) = field(expr, "arg")
+        && let Some(branch_result) = field(branch, "result")
+        && same_node(expr_arg, branch_result)
+        && !same_node(expr_arg, defresult)
+    {
+        return true;
+    }
+    false
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CaseExpr") {
+        return;
+    }
+    if !is_coalesce_shape(node) {
+        return;
+    }
+    ctx.report(node, "preferCoalesceOverCase");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -511,6 +511,18 @@ const ruleMeta = Object.freeze({
         'Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.',
     },
   },
+  'prefer-coalesce-over-case': {
+    type: 'suggestion',
+    description:
+      'Prefer `COALESCE(x, y)` over `CASE WHEN x IS NULL THEN y ELSE x END` (and its IS NOT NULL mirror)',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferCoalesceOverCase:
+        '`CASE WHEN ... IS NULL THEN ... ELSE ... END` is a verbose `COALESCE`. Use `COALESCE(x, fallback)` instead.',
+    },
+  },
   'prefer-current-timestamp-over-now': {
     type: 'layout',
     description:

--- a/status.json
+++ b/status.json
@@ -5895,19 +5895,19 @@
       },
       {
         "name": "prefer-coalesce-over-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-coalesce-over-case."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-coalesce-over-case; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-current-timestamp-over-now",


### PR DESCRIPTION
Part of #14. Ports `prefer-coalesce-over-case`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038955&installation_id=136613492&pr_number=347&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F347&signature=9260ee2ffe9ce2a64e61b8f004a8d14108f4f624fcb526fdc692e6446456ec16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->