### PR TITLE
test: guard against advertising option schemas without forwarding options

### DIFF
--- a/test/option-schema-parity.test.mjs
+++ b/test/option-schema-parity.test.mjs
@@ -1,0 +1,84 @@
+// Regression guard: a plugin that advertises a rule options schema must
+// actually read the user's `context.options` in its adapter.
+//
+// Background: several ports declared a permissive `{ additionalProperties: true }`
+// schema (so ESLint/Oxlint accept user options) but never forwarded those
+// options to the Rust core, so the configuration silently did nothing. This is
+// the worst kind of gap — the config validates, then is ignored. testing-library
+// fixed this for `consistent-data-testid` (#343); this test stops it recurring.
+//
+// The check is intentionally static (reads tracked source only — no native
+// build required): if `index.js` declares an options-accepting schema shape
+// (`additionalProperties: true` or `properties: { ... }`), it must also
+// reference `context.options`.
+//
+// KNOWN_OPTION_GAPS lists ports whose Rust cores do not yet implement options
+// at all; they are being given real option support in follow-up PRs and are
+// exempted until then. Remove an entry once its adapter forwards options.
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const npmDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'npm');
+
+// Ports whose cores ignore options entirely; tracked for real implementation.
+// perfectionist: configurable sort engine not implemented.
+// angular-eslint: per-rule options (selectors/prefixes/suffixes) not implemented.
+const KNOWN_OPTION_GAPS = new Set(['perfectionist', 'angular-eslint']);
+
+// Note: `playwright` passes this static check because it reads `context.options`
+// as a presence gate, but its core drops the option *values*; that deeper gap is
+// tracked separately and cannot be detected statically.
+
+function read(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function declaresOptionSchema(indexJs) {
+  return /additionalProperties:\s*true/.test(indexJs) || /\bproperties:\s*\{/.test(indexJs);
+}
+
+const plugins = readdirSync(npmDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && existsSync(join(npmDir, entry.name, 'index.js')))
+  .map((entry) => entry.name);
+
+describe('option schema parity', () => {
+  it('finds plugin packages to check', () => {
+    expect(plugins.length).toBeGreaterThan(10);
+  });
+
+  for (const plugin of plugins) {
+    it(`${plugin}: declaring an options schema implies reading context.options`, () => {
+      const indexJs = read(join(npmDir, plugin, 'index.js'));
+      if (!declaresOptionSchema(indexJs)) {
+        return; // No options advertised — nothing to forward.
+      }
+
+      const readsContextOptions = /context\.options/.test(indexJs);
+      if (KNOWN_OPTION_GAPS.has(plugin)) {
+        // Sanity: keep the allowlist honest. If a gap plugin starts reading
+        // context.options it should be removed from KNOWN_OPTION_GAPS.
+        expect(
+          readsContextOptions,
+          `${plugin} now reads context.options — remove it from KNOWN_OPTION_GAPS`,
+        ).toBe(false);
+        return;
+      }
+
+      expect(
+        readsContextOptions,
+        `${plugin} advertises a rule options schema but never reads context.options, ` +
+          `so user options are silently ignored. Forward context.options to the scanner ` +
+          `(see npm/testing-library for the pattern), or add ${plugin} to KNOWN_OPTION_GAPS ` +
+          `if its core cannot honor options yet.`,
+      ).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Adds a static, repo-wide regression guard so the "advertises a rule options schema but silently ignores user options" class of bug (fixed for testing-library `consistent-data-testid` in #343) cannot recur.

**Invariant:** if a plugin's `index.js` declares an options-accepting schema shape (`additionalProperties: true` or `properties: { ... }`), it must also read `context.options`.

- Pure static check over tracked source — no native build required (runs in ~4ms).
- `KNOWN_OPTION_GAPS` exempts `perfectionist` and `angular-eslint`, whose Rust cores don't implement options yet (real implementations coming as follow-up PRs). The allowlist self-checks that exempted plugins still *don't* read `context.options`, so stale entries fail loudly.
- `playwright` passes the static check (it reads `context.options` as a presence gate) but its core drops the option *values* — documented in a comment as a deeper gap that static analysis can't detect; covered by its core-implementation PR.

## Test
`vitest run test/option-schema-parity.test.mjs` — 25 passed (one assertion per plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784039018&installation_id=136613492&pr_number=348&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F348&signature=40638068b7df45687f61d2e3c2d1fe91e1889d1a15c9ecba540c91430e28c111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->