### PR TITLE
feat(postgresql): port prefer-in-list-over-or

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -49,6 +49,7 @@ mod prefer_coalesce_over_case;
 mod prefer_current_timestamp_over_now;
 mod prefer_exists_over_in_subquery;
 mod prefer_explicit_null_ordering;
+mod prefer_in_list_over_or;
 mod prefer_not_equals_operator;
 mod require_if_exists;
 mod require_limit;
@@ -203,6 +204,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "prefer-current-timestamp-over-now",
     "prefer-exists-over-in-subquery",
     "prefer-explicit-null-ordering",
+    "prefer-in-list-over-or",
     "prefer-not-equals-operator",
     "require-if-exists",
     "require-limit",
@@ -446,6 +448,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "prefer-explicit-null-ordering",
         run: prefer_explicit_null_ordering::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-in-list-over-or",
+        run: prefer_in_list_over_or::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/prefer_in_list_over_or.rs
+++ b/crates/postgresql/src/rules/prefer_in_list_over_or.rs
@@ -1,0 +1,161 @@
+//! Port of `prefer-in-list-over-or`: prefer `x IN (a, b, c)` over a chain
+//! of `x = a OR x = b OR x = c`. Produces an autofix.
+
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type, str_field};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+fn get_full_source_range(node: &Value) -> Option<(u32, u32)> {
+    let mut min = u32::MAX;
+    let mut max = 0u32;
+    let mut found = false;
+    walk_range(node, &mut min, &mut max, &mut found);
+    if found { Some((min, max)) } else { None }
+}
+
+fn walk_range(node: &Value, min: &mut u32, max: &mut u32, found: &mut bool) {
+    match node {
+        Value::Object(map) => {
+            if let Some(range) = map.get("range").and_then(Value::as_array)
+                && range.len() == 2
+            {
+                let s = range[0].as_u64().unwrap_or(0) as u32;
+                let e = range[1].as_u64().unwrap_or(0) as u32;
+                if s != 0 {
+                    *found = true;
+                    if s < *min {
+                        *min = s;
+                    }
+                    if e > *max {
+                        *max = e;
+                    }
+                }
+            }
+            for (k, v) in map {
+                if matches!(k.as_str(), "parent" | "range" | "loc") {
+                    continue;
+                }
+                walk_range(v, min, max, found);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                walk_range(item, min, max, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_equality(node: &Value) -> bool {
+    if !is_type(node, "A_Expr") {
+        return false;
+    }
+    if str_field(node, "kind") != Some("AEXPR_OP") {
+        return false;
+    }
+    let Some(name) = array_field(node, "name") else {
+        return false;
+    };
+    if name.len() != 1 {
+        return false;
+    }
+    name[0].get("sval").and_then(Value::as_str) == Some("=")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "BoolExpr") {
+        return;
+    }
+    if str_field(node, "boolop") != Some("OR_EXPR") {
+        return;
+    }
+    let Some(args) = array_field(node, "args") else {
+        return;
+    };
+    if args.len() < 2 {
+        return;
+    }
+
+    let mut lhs_text: Option<CompactString> = None;
+    let mut chain_start = u32::MAX;
+    let mut chain_end = 0u32;
+    let mut rhs_ranges: SmallVec<[(u32, u32); 8]> = SmallVec::new();
+
+    for arg in args {
+        if !is_equality(arg) {
+            return;
+        }
+        let Some(lexpr) = field(arg, "lexpr") else {
+            return;
+        };
+        let Some(rexpr) = field(arg, "rexpr") else {
+            return;
+        };
+        let Some(lhs_r) = get_full_source_range(lexpr) else {
+            return;
+        };
+        let Some(rhs_r) = get_full_source_range(rexpr) else {
+            return;
+        };
+        let lhs_src = ctx.source.slice(lhs_r.0, lhs_r.1);
+        if let Some(ref existing) = lhs_text {
+            if existing.as_str() != lhs_src.as_str() {
+                return;
+            }
+        } else {
+            lhs_text = Some(CompactString::from(lhs_src.as_str()));
+        }
+        rhs_ranges.push(rhs_r);
+        if lhs_r.0 < chain_start {
+            chain_start = lhs_r.0;
+        }
+        if rhs_r.1 > chain_end {
+            chain_end = rhs_r.1;
+        }
+    }
+
+    let Some(lhs_text) = lhs_text else {
+        return;
+    };
+    if chain_end == 0 {
+        return;
+    }
+
+    // Build replacement: `{lhs} IN ({rhs1}, {rhs2}, ...)`
+    let mut replacement = CompactString::from(lhs_text.as_str());
+    replacement.push_str(" IN (");
+    for (i, &(s, e)) in rhs_ranges.iter().enumerate() {
+        if i > 0 {
+            replacement.push_str(", ");
+        }
+        let rhs_src = ctx.source.slice(s, e);
+        replacement.push_str(rhs_src.as_str());
+    }
+    replacement.push(')');
+
+    let start_pos = ctx.source.position(chain_start);
+    let end_pos = ctx.source.position(chain_end);
+    let loc = DiagnosticLoc {
+        start_line: start_pos.line,
+        start_column: start_pos.column,
+        end_line: end_pos.line,
+        end_column: end_pos.column,
+    };
+
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("lhs"),
+        value: lhs_text,
+    });
+
+    let fix = DiagnosticFix {
+        start: chain_start,
+        end: chain_end,
+        replacement,
+    };
+
+    ctx.report_loc(loc, "preferIn", data, Some(fix));
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -585,6 +585,16 @@ const ruleMeta = Object.freeze({
         "`ORDER BY ... ASC|DESC` without `NULLS FIRST` / `NULLS LAST` relies on PostgreSQL's implicit ordering (NULLS LAST for ASC, NULLS FIRST for DESC), which trips up cross-database readers. Add an explicit `NULLS FIRST` / `NULLS LAST`.",
     },
   },
+  'prefer-in-list-over-or': {
+    type: 'suggestion',
+    description: 'Prefer `x IN (a, b, c)` over a chain of `x = a OR x = b OR x = c`',
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferIn: 'Combine these `=` checks on `{{lhs}}` into a single `IN (...)` clause.',
+    },
+  },
   'prefer-not-equals-operator': {
     type: 'layout',
     description: 'Enforce a single style for the not-equal operator (`<>` or `!=`)',

--- a/status.json
+++ b/status.json
@@ -5959,19 +5959,19 @@
       },
       {
         "name": "prefer-in-list-over-or",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-in-list-over-or."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-in-list-over-or; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-keyword-case",


### PR DESCRIPTION
Part of #14. Ports `prefer-in-list-over-or`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784039260&installation_id=136613492&pr_number=350&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F350&signature=c79e1b755e8cce8e3a2a5af2502696c8a36820d5d64cf74f597a4cd9a7fe7a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->