### PR TITLE
fix(angular-eslint,playwright,perfectionist): stop advertising unhonored option schemas

### DIFF
--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -69,12 +69,10 @@ function createAngularEslintRule(ruleName) {
       messages: {
         unexpected: 'Unexpected Angular pattern.',
       },
-      schema: [
-        {
-          type: 'object',
-          additionalProperties: true,
-        },
-      ],
+      // These rules do not yet honor upstream options (the core is a heuristic
+      // scanner). Declare no schema so configured options are surfaced as an
+      // error rather than silently ignored. Tracked for real implementation.
+      schema: [],
     },
     createOnce(context) {
       return {

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -64,9 +64,13 @@ function createLegacyConfig(options) {
   };
 }
 
-function recommendedRules(options) {
+function recommendedRules() {
+  // The core sorts with fixed defaults and does not honor option values yet, so
+  // configs enable rules at `error` without an (ignored) options payload — which
+  // would also violate the now-empty per-rule schema. The `recommended-*`
+  // variants therefore behave identically until the sort engine lands.
   return Object.fromEntries(
-    recommendedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, ['error', options]]),
+    recommendedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
   );
 }
 
@@ -84,12 +88,10 @@ function createPerfectionistRule(ruleName) {
       messages: {
         unexpected: 'Expected sorted order.',
       },
-      schema: [
-        {
-          type: 'object',
-          additionalProperties: true,
-        },
-      ],
+      // The core sorts with fixed defaults and does not honor upstream options
+      // yet, so declare no schema rather than silently ignore configured
+      // options. Tracked for implementation of the configurable sort engine.
+      schema: [],
     },
     createOnce(context) {
       return {

--- a/npm/playwright/index.js
+++ b/npm/playwright/index.js
@@ -146,12 +146,11 @@ function createPlaywrightRule(ruleName) {
       messages: {
         unexpected: 'Unexpected Playwright pattern.',
       },
-      schema: [
-        {
-          type: 'object',
-          additionalProperties: true,
-        },
-      ],
+      // The core does not honor upstream option values (it has no options
+      // struct). Declare no schema so configured options surface as an error
+      // rather than being silently dropped. The `no-restricted-*` rules need
+      // real options support to function; tracked for implementation.
+      schema: [],
     },
     createOnce(context) {
       return {

--- a/test/option-schema-parity.test.mjs
+++ b/test/option-schema-parity.test.mjs
@@ -24,14 +24,12 @@ import { describe, expect, it } from 'vitest';
 
 const npmDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'npm');
 
-// Ports whose cores ignore options entirely; tracked for real implementation.
-// perfectionist: configurable sort engine not implemented.
-// angular-eslint: per-rule options (selectors/prefixes/suffixes) not implemented.
-const KNOWN_OPTION_GAPS = new Set(['perfectionist', 'angular-eslint']);
-
-// Note: `playwright` passes this static check because it reads `context.options`
-// as a presence gate, but its core drops the option *values*; that deeper gap is
-// tracked separately and cannot be detected statically.
+// Ports whose cores ignore options entirely. perfectionist, angular-eslint and
+// playwright now declare `schema: []` (options are surfaced as an error rather
+// than silently ignored) until their cores implement options, so they no longer
+// advertise an options schema and are skipped by the check below. Add a plugin
+// here only if it must advertise an options schema before its core can honor it.
+const KNOWN_OPTION_GAPS = new Set();
 
 function read(path) {
   try {


### PR DESCRIPTION
## Summary
These three plugin cores are heuristic scanners that **do not honor upstream options**, yet every rule advertised a permissive `{ additionalProperties: true }` schema — so user options validated and were then silently ignored (the worst UX). Per the discussion, this switches them to **honest "unsupported"** rather than faking support:

- **angular-eslint** — `schema: []` for all rules (core is one whole-file regex per rule).
- **playwright** — `schema: []` for all rules (no options struct; only gated on option *presence*, never honored values).
- **perfectionist** — `schema: []` for all rules, and drop the ignored options payload from the `recommended-{alphabetical,natural,line-length,custom}` configs so they validate against the empty schema. The per-type variants behave identically until the sort engine lands.

Configured options now surface as an error instead of being dropped.

## Guard
Empties `KNOWN_OPTION_GAPS` in the option-schema parity guard (#348): these plugins no longer advertise an options schema, so the guard skips them — no exemption needed.

## Why honesty instead of implementation
Investigation showed these cores are demonstration-grade stubs (single crafted fixture, shallow regexes, no parity tests). Faithfully honoring options means re-porting the rules properly — a large, separate effort per plugin, tracked as follow-up. (Note: I was blocked from filing GitHub issues by a permission policy; happy to file them if you enable it, or you can.)

## Test
`vitest run test/option-schema-parity.test.mjs npm/perfectionist npm/angular-eslint npm/playwright` — **170 passed** (7 files). `vp lint`/`vp fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784041335&installation_id=136613492&pr_number=354&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F354&signature=d63843c9852c29853077fe022b6ff37a43a601144ebb497d096616df483879b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->