### PR TITLE
feat(postgresql): port consistent-reindex-concurrently

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,6 +3,7 @@
 
 use crate::RuleDef;
 
+mod consistent_reindex_concurrently;
 mod no_add_check_constraint_without_not_valid;
 mod no_add_column_not_null_without_default;
 mod no_add_unique_constraint_directly;
@@ -158,6 +159,7 @@ pub const RULE_NAMES: [&str; 89] = [
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "consistent-reindex-concurrently",
     "no-add-check-constraint-without-not-valid",
     "no-add-column-not-null-without-default",
     "no-add-unique-constraint-directly",
@@ -220,6 +222,11 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "consistent-reindex-concurrently",
+        run: consistent_reindex_concurrently::run,
+        uses_parse_error: false,
+    },
     RuleDef {
         name: "no-add-check-constraint-without-not-valid",
         run: no_add_check_constraint_without_not_valid::run,

--- a/crates/postgresql/src/rules/consistent_reindex_concurrently.rs
+++ b/crates/postgresql/src/rules/consistent_reindex_concurrently.rs
@@ -1,0 +1,45 @@
+//! Port of `consistent-reindex-concurrently`: enforce a consistent stance on
+//! `CONCURRENTLY` for `REINDEX` (either always require it, or always forbid it).
+//!
+//! Default style `"always"` requires `REINDEX ... CONCURRENTLY ...`.
+//! Style `"never"` forbids the `CONCURRENTLY` option.
+//!
+//! Reports on the `ReindexStmt` node itself.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Returns true when the `params` array of a `ReindexStmt` contains a
+/// `DefElem` with `defname === "concurrently"`.
+fn is_concurrent(node: &Value) -> bool {
+    let params = match node.get("params").and_then(Value::as_array) {
+        Some(p) => p,
+        None => return false,
+    };
+    params.iter().any(|p| {
+        is_type(p, "DefElem") && p.get("defname").and_then(Value::as_str) == Some("concurrently")
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ReindexStmt") {
+        return;
+    }
+
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+
+    let concurrent = is_concurrent(node);
+
+    if style == "always" && !concurrent {
+        ctx.report(node, "preferReindexConcurrently");
+    } else if style == "never" && concurrent {
+        ctx.report(node, "unexpectedReindexConcurrently");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,28 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'consistent-reindex-concurrently': {
+    type: 'problem',
+    description:
+      'Enforce a consistent stance on `CONCURRENTLY` for `REINDEX` (either always require it, or always forbid it)',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferReindexConcurrently:
+        '`REINDEX` without `CONCURRENTLY` takes a `SHARE` lock (table) or `ACCESS EXCLUSIVE` (index), blocking writers for the rebuild. Use `REINDEX (TABLE|INDEX) CONCURRENTLY ...` (PG ≥ 12) so writers keep working.',
+      unexpectedReindexConcurrently:
+        'Avoid `REINDEX CONCURRENTLY`. Concurrent reindex cannot run inside a transaction; use plain `REINDEX` when the migration tool wraps each step in BEGIN/COMMIT.',
+    },
+  },
   'no-add-check-constraint-without-not-valid': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5015,19 +5015,19 @@
       },
       {
         "name": "consistent-reindex-concurrently",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-reindex-concurrently."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-reindex-concurrently; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-text-over-varchar",


### PR DESCRIPTION
## Summary
- Ports `consistent-reindex-concurrently` from eslint-plugin-postgresql to Rust/NAPI
- Style option `always` (default): requires `REINDEX ... CONCURRENTLY ...`; style `never`: forbids `CONCURRENTLY`
- Reports on the `ReindexStmt` AST node; no autofix (upstream has none)

## Test plan
- [x] `cargo clippy` clean
- [x] `pnpm build:debug` passes
- [x] Upstream fixture harness prints `ALL MATCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784041416&installation_id=136613492&pr_number=355&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F355&signature=bc7f5bd3b7f74e15d286aa5dc0b945359bf092cad0cd5b9d90593a1b9f7df9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->