### PR TITLE
feat(postgresql): port consistent-identity-over-serial

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,6 +3,7 @@
 
 use crate::RuleDef;
 
+mod consistent_identity_over_serial;
 mod consistent_reindex_concurrently;
 mod no_add_check_constraint_without_not_valid;
 mod no_add_column_not_null_without_default;
@@ -159,6 +160,7 @@ pub const RULE_NAMES: [&str; 89] = [
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "consistent-identity-over-serial",
     "consistent-reindex-concurrently",
     "no-add-check-constraint-without-not-valid",
     "no-add-column-not-null-without-default",
@@ -222,6 +224,11 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "consistent-identity-over-serial",
+        run: consistent_identity_over_serial::run,
+        uses_parse_error: false,
+    },
     RuleDef {
         name: "consistent-reindex-concurrently",
         run: consistent_reindex_concurrently::run,

--- a/crates/postgresql/src/rules/consistent_identity_over_serial.rs
+++ b/crates/postgresql/src/rules/consistent_identity_over_serial.rs
@@ -1,0 +1,83 @@
+//! Port of `consistent-identity-over-serial`: enforce a consistent stance on
+//! `GENERATED ... AS IDENTITY` vs `SERIAL` / `BIGSERIAL` / `SMALLSERIAL`.
+//!
+//! Default style `"always"` flags any column typed as a serial pseudo-type and
+//! requires the SQL-standard identity column form. Style `"never"` flags any
+//! column with a `CONSTR_IDENTITY` constraint and requires a serial type.
+//!
+//! Reports on the `ColumnDef` node (the column definition itself).
+
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+const SERIAL_TYPES: [&str; 3] = ["smallserial", "serial", "bigserial"];
+
+/// Extract the unqualified PostgreSQL type name from a `ColumnDef.typeName`
+/// value (mirrors upstream `getTypeName`). The parser stores qualified names
+/// in numeric-string keys `"0"`, `"1"`, …; the type name is at key `"1"` when
+/// schema-qualified, or `"0"` otherwise.
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    // Try `typeName["1"].sval` first (schema-qualified: pg_catalog.int8, etc.)
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    // Fall back to `typeName["0"].sval`.
+    type_name
+        .get("0")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+}
+
+/// Returns true when the ColumnDef has any `CONSTR_IDENTITY` constraint
+/// (mirrors upstream `hasIdentity`).
+fn has_identity(node: &Value) -> bool {
+    let constraints = match node.get("constraints").and_then(Value::as_array) {
+        Some(c) => c,
+        None => return false,
+    };
+    constraints.iter().any(|c| {
+        is_type(c, "Constraint")
+            && c.get("contype").and_then(Value::as_str) == Some("CONSTR_IDENTITY")
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+
+    if style == "always" {
+        let type_name = match node.get("typeName") {
+            Some(t) => t,
+            None => return,
+        };
+        let t = match get_type_name(type_name) {
+            Some(n) => n,
+            None => return,
+        };
+        if SERIAL_TYPES.contains(&t) {
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("type"),
+                value: CompactString::from(t),
+            });
+            ctx.report_data(node, "preferIdentity", data);
+        }
+    } else if style == "never" && has_identity(node) {
+        ctx.report(node, "unexpectedIdentity");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,28 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'consistent-identity-over-serial': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `GENERATED ... AS IDENTITY` vs `SERIAL` / `BIGSERIAL` / `SMALLSERIAL`',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferIdentity:
+        'Use `GENERATED ALWAYS AS IDENTITY` (SQL standard) instead of `{{type}}`. The serial pseudo-types create a separately-owned sequence that breaks under pg_dump round-trips and does not honor column privileges.',
+      unexpectedIdentity:
+        'Use a serial pseudo-type (e.g. `bigserial`) instead of `GENERATED ... AS IDENTITY`. Useful for projects that need to keep compatibility with tooling that does not understand identity columns.',
+    },
+  },
   'consistent-reindex-concurrently': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -4983,19 +4983,19 @@
       },
       {
         "name": "consistent-identity-over-serial",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-identity-over-serial."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-identity-over-serial; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-jsonb-over-json",


### PR DESCRIPTION
## Summary
- Ports `consistent-identity-over-serial` from eslint-plugin-postgresql to Rust/NAPI
- Style `always` (default): flags serial pseudo-types (`serial`, `bigserial`, `smallserial`), requires `GENERATED ... AS IDENTITY`
- Style `never`: flags identity columns (`CONSTR_IDENTITY`), requires a serial type
- Reports on the `ColumnDef` AST node; no autofix (upstream has none)

## Test plan
- [x] `cargo clippy` clean
- [x] `pnpm build:debug` passes
- [x] Upstream fixture harness prints `ALL MATCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784041565&installation_id=136613492&pr_number=356&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F356&signature=42a2f4933ab64ceb8df38f1352c30f9586ec6bafe883e8de87400e76ad6dd102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->