### PR TITLE
feat(postgresql): port consistent-create-or-replace

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,6 +3,7 @@
 
 use crate::RuleDef;
 
+mod consistent_create_or_replace;
 mod consistent_identity_over_serial;
 mod consistent_reindex_concurrently;
 mod no_add_check_constraint_without_not_valid;
@@ -160,6 +161,7 @@ pub const RULE_NAMES: [&str; 89] = [
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "consistent-create-or-replace",
     "consistent-identity-over-serial",
     "consistent-reindex-concurrently",
     "no-add-check-constraint-without-not-valid",
@@ -224,6 +226,11 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "consistent-create-or-replace",
+        run: consistent_create_or_replace::run,
+        uses_parse_error: false,
+    },
     RuleDef {
         name: "consistent-identity-over-serial",
         run: consistent_identity_over_serial::run,

--- a/crates/postgresql/src/rules/consistent_create_or_replace.rs
+++ b/crates/postgresql/src/rules/consistent_create_or_replace.rs
@@ -1,0 +1,100 @@
+//! Port of `consistent-create-or-replace`: enforce a consistent stance on
+//! `CREATE OR REPLACE` for `FUNCTION` / `PROCEDURE` / `VIEW`.
+//!
+//! Default style `"always"` requires `CREATE OR REPLACE`.
+//! Style `"never"` forbids `OR REPLACE`.
+//!
+//! Reports at the `CREATE` keyword token's location. Upstream resolves the
+//! CREATE keyword via a per-file cursor over the token stream (because the
+//! PostgreSQL parser's `stmt_location` for statements after the first points
+//! to the preceding newline, not the C of CREATE). We replicate that faithfully:
+//! for each visited node we scan forward from `node.range[0]` in the token
+//! stream to find the first `CREATE` keyword at or after that offset.
+//!
+//! No autofix (upstream deliberately omits one: adding/removing `OR REPLACE`
+//! changes runtime semantics).
+
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Return the UTF-16 start offset stored in `node.range[0]`, or 0 if absent.
+fn node_range_start(node: &Value) -> u32 {
+    node.get("range")
+        .and_then(|r| r.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(Value::as_u64)
+        .map(|n| n as u32)
+        .unwrap_or(0)
+}
+
+/// Locate the `DiagnosticLoc` of the `CREATE` keyword that begins the
+/// statement containing `node`, by scanning the token stream from
+/// `node.range[0]` forward. Returns `None` if no such token is found.
+fn find_create_loc(node: &Value, ctx: &RuleContext) -> Option<DiagnosticLoc> {
+    let start_off = node_range_start(node);
+    let tokenized = tokenize(ctx.source);
+    let tok = tokenized.tokens.iter().find(|t| {
+        t.start >= start_off
+            && t.kind == TokenKind::Keyword
+            && t.value.eq_ignore_ascii_case("CREATE")
+    })?;
+    Some(DiagnosticLoc {
+        start_line: tok.start_pos.line,
+        start_column: tok.start_pos.column,
+        end_line: tok.end_pos.line,
+        end_column: tok.end_pos.column,
+    })
+}
+
+fn visit(node: &Value, has_or_replace: bool, kind: &str, style: &str, ctx: &mut RuleContext) {
+    let Some(loc) = find_create_loc(node, ctx) else {
+        return;
+    };
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("kind"),
+        value: CompactString::from(kind),
+    });
+    if style == "always" && !has_or_replace {
+        ctx.report_loc(loc, "preferOrReplace", data, None);
+    } else if style == "never" && has_or_replace {
+        ctx.report_loc(loc, "unexpectedOrReplace", data, None);
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+
+    if is_type(node, "CreateFunctionStmt") {
+        let has_or_replace = node
+            .get("replace")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        // `is_procedure === true` means it's a PROCEDURE, not a FUNCTION.
+        let kind = if node
+            .get("is_procedure")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "PROCEDURE"
+        } else {
+            "FUNCTION"
+        };
+        visit(node, has_or_replace, kind, style, ctx);
+    } else if is_type(node, "ViewStmt") {
+        let has_or_replace = node
+            .get("replace")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        visit(node, has_or_replace, "VIEW", style, ctx);
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,28 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'consistent-create-or-replace': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `CREATE OR REPLACE` for `FUNCTION` / `PROCEDURE` / `VIEW` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOrReplace:
+        'Use `CREATE OR REPLACE {{kind}}` so re-running this migration does not abort with `relation already exists`.',
+      unexpectedOrReplace:
+        'Avoid `CREATE OR REPLACE {{kind}}`; drop and re-create the object explicitly so unintended overwrites are surfaced.',
+    },
+  },
   'consistent-identity-over-serial': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -4903,19 +4903,19 @@
       },
       {
         "name": "consistent-create-or-replace",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-create-or-replace."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/consistent-create-or-replace; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "consistent-drop-index-concurrently",


### PR DESCRIPTION
## Summary
- Ports `consistent-create-or-replace` from eslint-plugin-postgresql to Rust/NAPI
- Style `always` (default): requires `CREATE OR REPLACE` for FUNCTION/PROCEDURE/VIEW
- Style `never`: forbids `OR REPLACE`
- Reports at the `CREATE` keyword token's location (found via forward token scan from `node.range[0]` to handle libpg_query's `stmt_location` quirk where subsequent-statement positions include the preceding newline)
- No autofix (upstream omits one; adding/removing `OR REPLACE` changes runtime semantics)

## Test plan
- [x] `cargo clippy` clean
- [x] `pnpm build:debug` passes
- [x] Upstream fixture harness prints `ALL MATCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784042068&installation_id=136613492&pr_number=357&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F357&signature=b8463b68a05f6e5a2b4eca37b2e9471dca442a6fab9dd476d498323ac9504ee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->