### PR TITLE
port(postgresql): consistent-explicit-inner-join

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -4,6 +4,7 @@
 use crate::RuleDef;
 
 mod consistent_create_or_replace;
+mod consistent_explicit_inner_join;
 mod consistent_identity_over_serial;
 mod consistent_reindex_concurrently;
 mod no_add_check_constraint_without_not_valid;
@@ -162,6 +163,7 @@ pub const RULE_NAMES: [&str; 89] = [
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-create-or-replace",
+    "consistent-explicit-inner-join",
     "consistent-identity-over-serial",
     "consistent-reindex-concurrently",
     "no-add-check-constraint-without-not-valid",
@@ -230,6 +232,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "consistent-create-or-replace",
         run: consistent_create_or_replace::run,
         uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-explicit-inner-join",
+        run: consistent_explicit_inner_join::run,
+        uses_parse_error: true,
     },
     RuleDef {
         name: "consistent-identity-over-serial",

--- a/crates/postgresql/src/rules/consistent_explicit_inner_join.rs
+++ b/crates/postgresql/src/rules/consistent_explicit_inner_join.rs
@@ -1,0 +1,97 @@
+//! Port of `consistent-explicit-inner-join`: enforce a consistent stance on
+//! the explicit `INNER` keyword in `INNER JOIN`.
+//!
+//! Default style `"always"` requires the `INNER` keyword (flag bare `JOIN`).
+//! Style `"never"` forbids the `INNER` keyword (flag `INNER JOIN` sequences).
+//!
+//! Operates on the token stream. Reports fixes via character-range replacement.
+
+use serde_json::Value;
+
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Keywords that, when appearing immediately before `JOIN`, already declare the
+/// join's kind — a bare `JOIN` (none of these preceding it) is the case that
+/// `always` mode rewrites to `INNER JOIN`.
+fn is_join_kind_keyword(value: &str) -> bool {
+    let up = value.to_ascii_uppercase();
+    matches!(
+        up.as_str(),
+        "INNER" | "OUTER" | "LEFT" | "RIGHT" | "FULL" | "CROSS" | "NATURAL"
+    )
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // This rule operates on the token stream, not on the AST.
+    // It is triggered once via uses_parse_error (node == null).
+    if !node.is_null() {
+        return;
+    }
+
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+
+    let tokenized = tokenize(ctx.source);
+    let tokens = &tokenized.tokens;
+
+    for i in 0..tokens.len() {
+        let token = &tokens[i];
+        if token.kind != TokenKind::Keyword {
+            continue;
+        }
+        if !token.value.eq_ignore_ascii_case("JOIN") {
+            continue;
+        }
+
+        let prev = if i > 0 { tokens.get(i - 1) } else { None };
+        let prev_is_kind = prev
+            .map(|p| p.kind == TokenKind::Keyword && is_join_kind_keyword(&p.value))
+            .unwrap_or(false);
+
+        if style == "always" {
+            if prev_is_kind {
+                continue;
+            }
+            // Bare JOIN without a preceding kind keyword → report and fix.
+            let loc = DiagnosticLoc {
+                start_line: token.start_pos.line,
+                start_column: token.start_pos.column,
+                end_line: token.end_pos.line,
+                end_column: token.end_pos.column,
+            };
+            // Fix: insert "INNER " before the JOIN token.
+            let fix = DiagnosticFix {
+                start: token.start,
+                end: token.start,
+                replacement: CompactString::from("INNER "),
+            };
+            ctx.report_loc(loc, "preferInnerJoin", SmallVec::new(), Some(fix));
+        } else {
+            // style == "never": flag `INNER JOIN`.
+            let Some(prev) = prev else { continue };
+            if prev.kind != TokenKind::Keyword || !prev.value.eq_ignore_ascii_case("INNER") {
+                continue;
+            }
+            // Report from the start of INNER to the end of JOIN.
+            let loc = DiagnosticLoc {
+                start_line: prev.start_pos.line,
+                start_column: prev.start_pos.column,
+                end_line: token.end_pos.line,
+                end_column: token.end_pos.column,
+            };
+            // Fix: remove from INNER.start to JOIN.start (removes "INNER ").
+            let fix = DiagnosticFix {
+                start: prev.start,
+                end: token.start,
+                replacement: CompactString::from(""),
+            };
+            ctx.report_loc(loc, "unexpectedInnerJoin", SmallVec::new(), Some(fix));
+        }
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -39,6 +39,26 @@ const ruleMeta = Object.freeze({
         'Avoid `CREATE OR REPLACE {{kind}}`; drop and re-create the object explicitly so unintended overwrites are surfaced.',
     },
   },
+  'consistent-explicit-inner-join': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the explicit `INNER` keyword in `INNER JOIN` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferInnerJoin: 'Write `INNER JOIN` explicitly instead of bare `JOIN`.',
+      unexpectedInnerJoin: 'Omit the redundant `INNER`; use bare `JOIN` for inner joins.',
+    },
+  },
   'consistent-identity-over-serial': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -4935,19 +4935,19 @@
       },
       {
         "name": "consistent-explicit-inner-join",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-explicit-inner-join."
+        "notes": "Token-stream port: always mode inserts INNER before bare JOIN, never mode removes INNER from INNER JOIN. Autofix in both directions."
       },
       {
         "name": "consistent-explicit-outer-join",


### PR DESCRIPTION
## Summary

- Token-stream port of `consistent-explicit-inner-join` from `eslint-plugin-postgresql`
- `always` mode (default): flags bare `JOIN` without a preceding kind keyword, inserts `INNER ` before it (autofix)
- `never` mode: flags `INNER JOIN`, removes `INNER ` prefix (autofix)
- Reports at `token.loc` (the JOIN token for `always`; INNER-to-JOIN span for `never`) — matching upstream faithfully
- `uses_parse_error: true` (token-based rule, fires on the single null-node pass)

## Validation

```
cargo clippy -p oxlint-plugins-postgresql --all-targets -- -D warnings  ✓
pnpm --filter @oxlint-plugins/oxlint-plugin-postgresql build:debug       ✓
node fixture test (4 cases: 2 valid, 2 invalid)                          ALL MATCH
```

## Test plan

- [x] `explicit-inner` valid case (INNER JOIN / CROSS JOIN / NATURAL JOIN / LEFT JOIN — all pass `always`)
- [x] `never-bare-join` valid case (bare JOIN passes `never`)
- [x] `bare-join` invalid — `preferInnerJoin` at col 26–30, output inserts INNER
- [x] `never-inner-join` invalid — `unexpectedInnerJoin` at col 20–30, output removes INNER

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784042423&installation_id=136613492&pr_number=360&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F360&signature=f9af2adc245423b82f9c692134c198ae6df3752789c5d91e4ac489f626c9cfe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->