### PR TITLE
port(postgresql): consistent-as-for-column-alias

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -3,6 +3,7 @@
 
 use crate::RuleDef;
 
+mod consistent_as_for_column_alias;
 mod consistent_between_over_and;
 mod consistent_create_or_replace;
 mod consistent_explicit_inner_join;
@@ -163,6 +164,7 @@ pub const RULE_NAMES: [&str; 89] = [
 
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
+    "consistent-as-for-column-alias",
     "consistent-between-over-and",
     "consistent-create-or-replace",
     "consistent-explicit-inner-join",
@@ -230,6 +232,11 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
 
 /// Dispatch table consulted by [`crate::scan_postgresql`].
 pub(crate) const REGISTRY: &[RuleDef] = &[
+    RuleDef {
+        name: "consistent-as-for-column-alias",
+        run: consistent_as_for_column_alias::run,
+        uses_parse_error: false,
+    },
     RuleDef {
         name: "consistent-between-over-and",
         run: consistent_between_over_and::run,

--- a/crates/postgresql/src/rules/consistent_as_for_column_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_column_alias.rs
@@ -1,0 +1,139 @@
+//! Port of `consistent-as-for-column-alias`: enforce a consistent stance on
+//! the `AS` keyword before column aliases in `SELECT` (either always require
+//! it, or always forbid it).
+//!
+//! Operates on `SelectStmt.targetList` only — `InsertStmt` and `UpdateStmt`
+//! use `ResTarget` nodes where inserting `AS` would be a syntax error.
+//!
+//! Default style `"always"` requires AS (flags bare aliases).
+//! Style `"never"` forbids AS (flags explicit AS keywords).
+//!
+//! The `always` mode includes a defense against parser ranges that stop in
+//! the middle of a complex value expression (TypeCast, dotted ColumnRef,
+//! CASE, function calls). Only reports when the token immediately after
+//! `target.val.range[1]` is the alias identifier itself.
+
+use serde_json::Value;
+
+use crate::ast::{array_field, field, is_type};
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Mirrors upstream `tokenIdentifierText`: strips surrounding double quotes
+/// from the token value so it can be compared with `target.name` (which holds
+/// the unquoted identifier as reported by libpg_query).
+fn token_identifier_text(token: &Token) -> &str {
+    let v = &token.value;
+    if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
+        &v[1..v.len() - 1]
+    } else {
+        v.as_str()
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "SelectStmt") {
+        return;
+    }
+
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+
+    let Some(target_list) = array_field(node, "targetList") else {
+        return;
+    };
+
+    let tokenized = tokenize(ctx.source);
+    let tokens = &tokenized.tokens;
+
+    for target in target_list {
+        visit_target(target, style, tokens, ctx);
+    }
+}
+
+fn visit_target(target: &Value, style: &str, tokens: &[Token], ctx: &mut RuleContext) {
+    if !is_type(target, "ResTarget") {
+        return;
+    }
+    let Some(alias_name) = target.get("name").and_then(Value::as_str) else {
+        return;
+    };
+
+    // `target.val.range[1]` — the direct (not full-source) range end of the
+    // value expression. Using the direct range is intentional: for complex
+    // expressions (FuncCall, TypeCast, dotted ColumnRef) the parser reports
+    // only the first token's position, so `val.range[1]` lands inside the
+    // expression.  The following token is then part of the expression, not
+    // the alias, and the defense check below catches it.
+    let Some(val) = field(target, "val") else {
+        return;
+    };
+    let Some(val_range) = val.get("range").and_then(Value::as_array) else {
+        return;
+    };
+    let Some(val_end) = val_range.get(1).and_then(Value::as_u64).map(|v| v as u32) else {
+        return;
+    };
+
+    // Find the first token at or after val_end.
+    let Some((next_index, next)) = tokens.iter().enumerate().find(|(_, t)| t.start >= val_end)
+    else {
+        return;
+    };
+
+    let has_as = next.kind == TokenKind::Keyword && next.value.eq_ignore_ascii_case("AS");
+
+    if style == "always" && !has_as {
+        // Defense: confirm the next token is actually the alias identifier
+        // (not a token in the middle of a complex expression).
+        if token_identifier_text(next) != alias_name {
+            return;
+        }
+        let loc = DiagnosticLoc {
+            start_line: next.start_pos.line,
+            start_column: next.start_pos.column,
+            end_line: next.end_pos.line,
+            end_column: next.end_pos.column,
+        };
+        // Fix: insert "AS " before the alias token.
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: next.start,
+            replacement: CompactString::from("AS "),
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("alias"),
+            value: CompactString::from(alias_name),
+        });
+        ctx.report_loc(loc, "preferAs", data, Some(fix));
+    } else if style == "never" && has_as {
+        let Some(after) = tokens.get(next_index + 1) else {
+            return;
+        };
+        let loc = DiagnosticLoc {
+            start_line: next.start_pos.line,
+            start_column: next.start_pos.column,
+            end_line: next.end_pos.line,
+            end_column: next.end_pos.column,
+        };
+        // Fix: remove from AS.start to after.start (removes "AS " including
+        // the whitespace between AS and the alias identifier).
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: after.start,
+            replacement: CompactString::from(""),
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("alias"),
+            value: CompactString::from(alias_name),
+        });
+        ctx.report_loc(loc, "unexpectedAs", data, Some(fix));
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -17,6 +17,26 @@ const diagnosticsCache = new WeakMap();
 // Per-rule ESLint `meta` (description, messages, fixable, schema), keyed by rule
 // name. Entries are added as each upstream rule is ported.
 const ruleMeta = Object.freeze({
+  'consistent-as-for-column-alias': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the `AS` keyword before column aliases in `SELECT` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferAs: 'Use `AS` before the column alias `{{alias}}`.',
+      unexpectedAs: 'Omit `AS` before the column alias `{{alias}}`.',
+    },
+  },
   'consistent-between-over-and': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -4839,19 +4839,19 @@
       },
       {
         "name": "consistent-as-for-column-alias",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-as-for-column-alias."
+        "notes": "AST+token port visiting SelectStmt.targetList only. Defense check (token at val.range[1] must match alias name) guards against mid-expression parser ranges for FuncCall, TypeCast, dotted ColumnRef, CASE. Autofix inserts/removes AS in both directions."
       },
       {
         "name": "consistent-as-for-table-alias",


### PR DESCRIPTION
## Summary

- AST + token-stream port of `consistent-as-for-column-alias` from `eslint-plugin-postgresql`
- `always` mode (default): flags bare column aliases (without AS) in SELECT, inserts `AS ` before the alias token
- `never` mode: flags explicit `AS` keywords before aliases in SELECT, removes `AS ` (including trailing space)
- Reports at `next.loc` (alias identifier for `preferAs`; AS keyword for `unexpectedAs`) — matching upstream faithfully
- Only visits `SelectStmt.targetList`; INSERT/UPDATE ResTarget nodes are excluded (AS is a syntax error there)
- Defense check: in `always` mode, the token at `target.val.range[1]` must equal the alias name before reporting — guards against mid-expression parser ranges for FuncCall, TypeCast, dotted ColumnRef, CASE

## Validation

```
cargo clippy -p oxlint-plugins-postgresql --all-targets -- -D warnings  ✓
pnpm --filter @oxlint-plugins/oxlint-plugin-postgresql build:debug       ✓
node fixture test (6 cases: 3 valid, 3 invalid)                          ALL MATCH
```

## Test plan

- [x] `compound-expression-with-as` valid — TypeCast/dotted ColumnRef/CASE with AS all pass `always`
- [x] `explicit-as` valid — SELECT with AS, bare columns, `*`, INSERT, UPDATE all pass
- [x] `never-no-as` valid — bare alias passes `never`
- [x] `bare-alias` invalid — two `preferAs` errors, output inserts AS before each alias
- [x] `compound-expression-without-as` invalid — only `id user_id` flagged (not `COUNT(*) total` due to defense check)
- [x] `never-with-as` invalid — `unexpectedAs` at col 11–13, output removes AS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784043330&installation_id=136613492&pr_number=362&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F362&signature=4e86bbfb443a97796154abf1d413a36f40af0de8f3f6927df188a009e9e4907b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->