### PR TITLE
feat(postgresql): port no-char-type

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -13,6 +13,7 @@ mod no_add_check_constraint_without_not_valid;
 mod no_add_column_not_null_without_default;
 mod no_add_unique_constraint_directly;
 mod no_alter_column_type;
+mod no_char_type;
 mod no_cluster;
 mod no_composite_primary_key;
 mod no_create_role;
@@ -174,6 +175,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-add-column-not-null-without-default",
     "no-add-unique-constraint-directly",
     "no-alter-column-type",
+    "no-char-type",
     "no-cluster",
     "no-composite-primary-key",
     "no-create-role",
@@ -280,6 +282,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-alter-column-type",
         run: no_alter_column_type::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-char-type",
+        run: no_char_type::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_char_type.rs
+++ b/crates/postgresql/src/rules/no_char_type.rs
@@ -1,0 +1,40 @@
+//! Port of `no-char-type`: disallow the blank-padded `char(n)` / `bpchar`
+//! column type. PostgreSQL pads stored values to `n` with trailing spaces and
+//! trims on read, surprising every comparison and round-trip.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
+/// is the segment at key `"1"` (lower segments are schema qualifiers such as
+/// `pg_catalog`), falling back to key `"0"` for unqualified names.
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if !type_name.is_object() {
+        return None;
+    }
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    if get_type_name(type_name) == Some("bpchar") {
+        ctx.report(node, "noChar");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -192,6 +192,17 @@ const ruleMeta = Object.freeze({
         '`ALTER COLUMN ... TYPE` can rewrite the entire table under an ACCESS EXCLUSIVE lock. For non-trivial tables, add a new column, dual-write, backfill, and swap — or use `USING` only for known-safe conversions in a separate migration.',
     },
   },
+  'no-char-type': {
+    type: 'suggestion',
+    description: 'Disallow the blank-padded `char(n)` / `bpchar` column type',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noChar:
+        'Avoid `char(n)`. PostgreSQL pads stored values to `n` with trailing spaces and trims on read, which surprises every comparison and round-trip. Use `text` instead.',
+    },
+  },
   'no-cluster': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5127,19 +5127,19 @@
       },
       {
         "name": "no-char-type",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-char-type."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-char-type; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-cluster",


### PR DESCRIPTION
Part of #14. Ports `no-char-type`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047012&installation_id=136613492&pr_number=365&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F365&signature=dc62f0d259a96659b95e98a612df572e0dca4b3acd196a773b432c88fa0dd471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->