### PR TITLE
feat(postgresql): port no-money-type

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -31,6 +31,7 @@ mod no_having_without_group_by;
 mod no_identifier_too_long;
 mod no_implicit_join;
 mod no_leading_wildcard_like;
+mod no_money_type;
 mod no_natural_join;
 mod no_not_in_subquery;
 mod no_on_delete_cascade;
@@ -192,6 +193,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-identifier-too-long",
     "no-implicit-join",
     "no-leading-wildcard-like",
+    "no-money-type",
     "no-natural-join",
     "no-not-in-subquery",
     "no-on-delete-cascade",
@@ -370,6 +372,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-leading-wildcard-like",
         run: no_leading_wildcard_like::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-money-type",
+        run: no_money_type::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_money_type.rs
+++ b/crates/postgresql/src/rules/no_money_type.rs
@@ -1,0 +1,40 @@
+//! Port of `no-money-type`: disallow the `money` column type. Its output
+//! format and precision depend on `lc_monetary`, so the same row looks
+//! different on different servers and round-trips badly.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
+/// is the segment at key `"1"` (lower segments are schema qualifiers such as
+/// `pg_catalog`), falling back to key `"0"` for unqualified names like `money`.
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if !type_name.is_object() {
+        return None;
+    }
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    if get_type_name(type_name) == Some("money") {
+        ctx.report(node, "noMoney");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -424,6 +424,17 @@ const ruleMeta = Object.freeze({
         '`LIKE`/`ILIKE` patterns that begin with `%` cannot use a B-tree index and force a sequential scan. If you need substring search, use a `pg_trgm` GIN index, full-text search, or rework the schema so the prefix is indexable.',
     },
   },
+  'no-money-type': {
+    type: 'problem',
+    description: 'Disallow the `money` column type',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noMoney:
+        'Avoid `money`. Its output format and precision depend on `lc_monetary`, so the same row looks different on different servers and round-trips badly. Store amounts as `numeric` and keep the currency in a separate column.',
+    },
+  },
   'no-natural-join': {
     type: 'problem',
     description: 'Disallow `NATURAL JOIN`',

--- a/status.json
+++ b/status.json
@@ -5431,19 +5431,19 @@
       },
       {
         "name": "no-money-type",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-money-type."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-money-type; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-natural-join",


### PR DESCRIPTION
Part of #14. Ports `no-money-type`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047081&installation_id=136613492&pr_number=367&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F367&signature=42d8cf0f8b8de00c4ca85cd93fe6970e7836dbbacc4fe52057562834892234df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->