### PR TITLE
feat(postgresql): port no-numeric-without-precision

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -33,6 +33,7 @@ mod no_implicit_join;
 mod no_leading_wildcard_like;
 mod no_natural_join;
 mod no_not_in_subquery;
+mod no_numeric_without_precision;
 mod no_on_delete_cascade;
 mod no_order_by_ordinal;
 mod no_rename_column;
@@ -194,6 +195,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-leading-wildcard-like",
     "no-natural-join",
     "no-not-in-subquery",
+    "no-numeric-without-precision",
     "no-on-delete-cascade",
     "no-order-by-ordinal",
     "no-rename-column",
@@ -380,6 +382,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-not-in-subquery",
         run: no_not_in_subquery::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-numeric-without-precision",
+        run: no_numeric_without_precision::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_numeric_without_precision.rs
+++ b/crates/postgresql/src/rules/no_numeric_without_precision.rs
@@ -1,0 +1,53 @@
+//! Port of `no-numeric-without-precision`: require an explicit precision (and
+//! scale) on `NUMERIC` / `DECIMAL` columns. A bare `numeric` accepts unbounded
+//! magnitude and encodes nothing about the column's domain.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
+/// is the segment at key `"1"` (lower segments are schema qualifiers such as
+/// `pg_catalog`), falling back to key `"0"` for unqualified names.
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if !type_name.is_object() {
+        return None;
+    }
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+}
+
+/// Mirrors upstream `hasTypmods`: true when `typeName.typmods` is a non-empty
+/// array (i.e. a precision/scale was declared).
+fn has_typmods(type_name: &Value) -> bool {
+    type_name
+        .get("typmods")
+        .and_then(Value::as_array)
+        .is_some_and(|mods| !mods.is_empty())
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    if get_type_name(type_name) != Some("numeric") {
+        return;
+    }
+    if has_typmods(type_name) {
+        return;
+    }
+    ctx.report(node, "noNumericWithoutPrecision");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -447,6 +447,17 @@ const ruleMeta = Object.freeze({
         '`NOT IN (subquery)` returns no rows if the subquery yields any NULL — almost certainly not what you want. Use `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` instead; it handles NULL correctly.',
     },
   },
+  'no-numeric-without-precision': {
+    type: 'suggestion',
+    description: 'Require an explicit precision (and scale) on `NUMERIC` / `DECIMAL` columns',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNumericWithoutPrecision:
+        "`NUMERIC` / `DECIMAL` without precision accepts unbounded magnitude and rejects nothing — it's a missed opportunity to encode the column's domain. Declare `NUMERIC(precision, scale)`.",
+    },
+  },
   'no-on-delete-cascade': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5479,19 +5479,19 @@
       },
       {
         "name": "no-numeric-without-precision",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-numeric-without-precision."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-numeric-without-precision; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-on-delete-cascade",


### PR DESCRIPTION
Part of #14. Ports `no-numeric-without-precision`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047153&installation_id=136613492&pr_number=368&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F368&signature=f9fda39d5f1cf2f81fa17f7a0d9e6e79805759fdae6c5d706eb43d59f1fb06ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->