### PR TITLE
feat(postgresql): port no-time-type

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -44,6 +44,7 @@ mod no_select_star;
 mod no_set_not_null;
 mod no_set_search_path;
 mod no_temporary_table;
+mod no_time_type;
 mod no_truncate_cascade;
 mod no_unlogged_table;
 mod no_update_primary_key;
@@ -205,6 +206,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-set-not-null",
     "no-set-search-path",
     "no-temporary-table",
+    "no-time-type",
     "no-truncate-cascade",
     "no-unlogged-table",
     "no-update-primary-key",
@@ -435,6 +437,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-temporary-table",
         run: no_temporary_table::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-time-type",
+        run: no_time_type::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/no_time_type.rs
+++ b/crates/postgresql/src/rules/no_time_type.rs
@@ -1,0 +1,44 @@
+//! Port of `no-time-type`: disallow `TIME` / `TIME WITH TIME ZONE` (`timetz`)
+//! columns. `time` has no date so cannot disambiguate around DST, and `timetz`
+//! stores an offset that is meaningless without a date.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
+/// is the segment at key `"1"` (lower segments are schema qualifiers such as
+/// `pg_catalog`), falling back to key `"0"` for unqualified names.
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if !type_name.is_object() {
+        return None;
+    }
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    // Upstream's `TIME_TYPES` set; `getTypeName` must return a string.
+    let Some(t) = get_type_name(type_name) else {
+        return;
+    };
+    if t == "time" || t == "timetz" {
+        ctx.report(node, "noTimeType");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -567,6 +567,18 @@ const ruleMeta = Object.freeze({
         '`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.',
     },
   },
+  'no-time-type': {
+    type: 'suggestion',
+    description:
+      'Disallow `TIME` / `TIME WITH TIME ZONE` columns; they rarely model a real-world value correctly',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noTimeType:
+        '`TIME` and `TIME WITH TIME ZONE` rarely model anything correctly: `time` has no date so cannot disambiguate around DST, and `timetz` stores an offset that is meaningless without a date. Use `timestamptz` for points in time, `interval` for durations, or store an opaque `text` if all you need is a display value.',
+    },
+  },
   'no-truncate-cascade': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5687,19 +5687,19 @@
       },
       {
         "name": "no-time-type",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-time-type."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-time-type; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-truncate-cascade",


### PR DESCRIPTION
Part of #14. Ports `no-time-type`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047225&installation_id=136613492&pr_number=369&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F369&signature=e1c259d5b5dc3ce120e6c7257217a2f79e622740c34a3be2e631cd52ff84feb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->