### PR TITLE
feat(postgresql): port snake-case-column-name

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -66,6 +66,7 @@ mod require_schema_qualified_table;
 mod require_trailing_semicolon;
 mod require_where_in_delete;
 mod require_where_in_update;
+mod snake_case_column_name;
 mod snake_case_table_name;
 
 /// Every upstream rule name (89), in inventory order. Used by the JS adapter to
@@ -227,6 +228,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "require-trailing-semicolon",
     "require-where-in-delete",
     "require-where-in-update",
+    "snake-case-column-name",
     "snake-case-table-name",
 ];
 
@@ -545,6 +547,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-where-in-update",
         run: require_where_in_update::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "snake-case-column-name",
+        run: snake_case_column_name::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/snake_case_column_name.rs
+++ b/crates/postgresql/src/rules/snake_case_column_name.rs
@@ -1,0 +1,48 @@
+//! Port of `snake-case-column-name`: require column names to be snake_case.
+//! PostgreSQL preserves the case of quoted identifiers, so a mixed-case quoted
+//! name forces every consumer to quote-match it.
+
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Mirrors upstream's `/^[a-z][a-z0-9_]*$/`.
+fn is_snake_case(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    // Upstream: `const name = node.colname; if (typeof name !== "string") return`.
+    let Some(name) = node.get("colname").and_then(Value::as_str) else {
+        return;
+    };
+    // `allow` option set membership (default `[]`).
+    let allowed = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("allow"))
+        .and_then(Value::as_array)
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(name)));
+    if allowed {
+        return;
+    }
+    if is_snake_case(name) {
+        return;
+    }
+    let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+    data.push(DiagnosticDatum {
+        key: CompactString::from("name"),
+        value: CompactString::from(name),
+    });
+    ctx.report_data(node, "notSnakeCase", data);
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -856,6 +856,29 @@ const ruleMeta = Object.freeze({
         'UPDATE without WHERE rewrites every row in the table. Add a WHERE clause to scope the change.',
     },
   },
+  'snake-case-column-name': {
+    type: 'suggestion',
+    description: 'Require column names to be snake_case',
+    recommended: true,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      notSnakeCase:
+        'Column name `{{name}}` is not snake_case. PostgreSQL preserves the case of quoted identifiers; using a mixed-case quoted name forces every consumer to quote-match it.',
+    },
+  },
   'snake-case-table-name': {
     type: 'suggestion',
     description: 'Require table names to be snake_case',

--- a/status.json
+++ b/status.json
@@ -6199,19 +6199,19 @@
       },
       {
         "name": "snake-case-column-name",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule snake-case-column-name."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/snake-case-column-name; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "snake-case-table-name",


### PR DESCRIPTION
Part of #14. Ports `snake-case-column-name`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047303&installation_id=136613492&pr_number=370&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F370&signature=65502b07d539c87a72a133e44f754fc739af4c5c1780a30587112ae76ac80dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->