### PR TITLE
feat(postgresql): port prefer-bigint-id

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -51,6 +51,7 @@ mod no_update_without_from_binding;
 mod no_vacuum_full;
 mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
+mod prefer_bigint_id;
 mod prefer_coalesce_over_case;
 mod prefer_current_timestamp_over_now;
 mod prefer_exists_over_in_subquery;
@@ -212,6 +213,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-vacuum-full",
     "no-volatile-default-on-add-column",
     "no-with-recursive-without-limit",
+    "prefer-bigint-id",
     "prefer-coalesce-over-case",
     "prefer-current-timestamp-over-now",
     "prefer-exists-over-in-subquery",
@@ -470,6 +472,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-with-recursive-without-limit",
         run: no_with_recursive_without_limit::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-bigint-id",
+        run: prefer_bigint_id::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/prefer_bigint_id.rs
+++ b/crates/postgresql/src/rules/prefer_bigint_id.rs
@@ -1,0 +1,96 @@
+//! Port of `prefer-bigint-id`: primary-key `id` columns should be `bigint`.
+//! `int` / `smallint` (and the `serial` / `smallserial` pseudo-types) overflow
+//! on growing tables and widening them later forces a table rewrite under
+//! `ACCESS EXCLUSIVE`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Upstream `SMALL_INT_TYPES`: canonical small-integer type names plus the
+/// pseudo-types PostgreSQL keeps before a SERIAL is rewritten.
+fn is_small_int_type(name: &str) -> bool {
+    matches!(name, "int2" | "int4" | "smallserial" | "serial")
+}
+
+/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
+/// is the segment at key `"1"` (lower segments are schema qualifiers such as
+/// `pg_catalog`), falling back to key `"0"` for unqualified names.
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if !type_name.is_object() {
+        return None;
+    }
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|s| s.get("sval"))
+        .and_then(Value::as_str)
+}
+
+/// Mirrors upstream `isPrimaryKey`: a column-level `CONSTR_PRIMARY` constraint.
+fn is_primary_key(col: &Value) -> bool {
+    col.get("constraints")
+        .and_then(Value::as_array)
+        .is_some_and(|cs| {
+            cs.iter().any(|c| {
+                is_type(c, "Constraint")
+                    && c.get("contype").and_then(Value::as_str) == Some("CONSTR_PRIMARY")
+            })
+        })
+}
+
+/// Mirrors upstream `isTablePrimaryKeyOn`: a table-level `CONSTR_PRIMARY`
+/// constraint whose `keys` include `colname`.
+fn is_table_primary_key_on(elts: &[Value], colname: &str) -> bool {
+    elts.iter().any(|elt| {
+        if !is_type(elt, "Constraint") {
+            return false;
+        }
+        if elt.get("contype").and_then(Value::as_str) != Some("CONSTR_PRIMARY") {
+            return false;
+        }
+        elt.get("keys")
+            .and_then(Value::as_array)
+            .is_some_and(|keys| {
+                keys.iter()
+                    .any(|k| k.get("sval").and_then(Value::as_str) == Some(colname))
+            })
+    })
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+    let Some(elts) = node.get("tableElts").and_then(Value::as_array) else {
+        return;
+    };
+    for elt in elts {
+        if !is_type(elt, "ColumnDef") {
+            continue;
+        }
+        if elt.get("colname").and_then(Value::as_str) != Some("id") {
+            continue;
+        }
+        let Some(type_name) = elt.get("typeName") else {
+            continue;
+        };
+        let Some(t) = get_type_name(type_name) else {
+            continue;
+        };
+        if !is_small_int_type(t) {
+            continue;
+        }
+        if !is_primary_key(elt) && !is_table_primary_key_on(elts, "id") {
+            continue;
+        }
+        ctx.report(elt, "preferBigintId");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -662,6 +662,18 @@ const ruleMeta = Object.freeze({
         'Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.',
     },
   },
+  'prefer-bigint-id': {
+    type: 'suggestion',
+    description:
+      'Prefer `bigint` for primary-key `id` columns; `int` / `smallint` primary keys risk silent overflow on growing tables',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferBigintId:
+        'Primary-key `id` columns should be `bigint`. `int` overflows at 2.1 billion rows and the migration to widen it later requires a table rewrite under `ACCESS EXCLUSIVE`. Declare the column as `bigint GENERATED ALWAYS AS IDENTITY` from the start.',
+    },
+  },
   'prefer-coalesce-over-case': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5863,19 +5863,19 @@
       },
       {
         "name": "prefer-bigint-id",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-bigint-id."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-bigint-id; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-cast-operator",


### PR DESCRIPTION
Part of #14. Ports `prefer-bigint-id`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047386&installation_id=136613492&pr_number=371&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F371&signature=e17fb0850999cd760e65337a918c66a1dec6c9d55aa932d8a734c6880b302658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->