### PR TITLE
feat(postgresql): port prefer-add-constraint-not-valid

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -60,6 +60,7 @@ mod no_update_without_from_binding;
 mod no_vacuum_full;
 mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
+mod prefer_add_constraint_not_valid;
 mod prefer_bigint_id;
 mod prefer_coalesce_over_case;
 mod prefer_current_timestamp_over_now;
@@ -232,6 +233,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-vacuum-full",
     "no-volatile-default-on-add-column",
     "no-with-recursive-without-limit",
+    "prefer-add-constraint-not-valid",
     "prefer-bigint-id",
     "prefer-coalesce-over-case",
     "prefer-current-timestamp-over-now",
@@ -537,6 +539,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-with-recursive-without-limit",
         run: no_with_recursive_without_limit::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-add-constraint-not-valid",
+        run: prefer_add_constraint_not_valid::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/prefer_add_constraint_not_valid.rs
+++ b/crates/postgresql/src/rules/prefer_add_constraint_not_valid.rs
@@ -1,0 +1,42 @@
+//! Port of `prefer-add-constraint-not-valid`: prefer
+//! `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID` followed by a separate
+//! `VALIDATE CONSTRAINT`. FOREIGN KEY and CHECK constraints scan existing rows
+//! to validate; adding them with `NOT VALID` skips that scan under
+//! `ACCESS EXCLUSIVE`.
+
+use serde_json::Value;
+
+use crate::RuleContext;
+use crate::ast::is_type;
+
+/// Upstream `VALIDATING_CONTYPES`: the constraint kinds whose validating scan
+/// benefits from `NOT VALID`.
+fn is_validating_contype(contype: &str) -> bool {
+    matches!(contype, "CONSTR_FOREIGN" | "CONSTR_CHECK")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if node.get("subtype").and_then(Value::as_str) != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = node.get("def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    // `!contype || !VALIDATING_CONTYPES.has(contype)`: a missing/empty or
+    // non-validating contype is not flagged.
+    match def.get("contype").and_then(Value::as_str) {
+        Some(c) if is_validating_contype(c) => {}
+        _ => return,
+    }
+    // `skip_validation === true` means the user already wrote `NOT VALID`.
+    if def.get("skip_validation") == Some(&Value::Bool(true)) {
+        return;
+    }
+    ctx.report(node, "notValid");
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -805,6 +805,18 @@ const ruleMeta = Object.freeze({
         'Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.',
     },
   },
+  'prefer-add-constraint-not-valid': {
+    type: 'suggestion',
+    description:
+      'Prefer `ADD CONSTRAINT ... NOT VALID` followed by a separate `VALIDATE CONSTRAINT` to avoid an `ACCESS EXCLUSIVE` lock on the full table while it is being scanned',
+    recommended: false,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      notValid:
+        'Add this constraint with `NOT VALID` and run `VALIDATE CONSTRAINT` separately, so the validating scan does not hold `ACCESS EXCLUSIVE` on the table.',
+    },
+  },
   'prefer-bigint-id': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5847,19 +5847,19 @@
       },
       {
         "name": "prefer-add-constraint-not-valid",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-add-constraint-not-valid."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-add-constraint-not-valid; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-bigint-id",


### PR DESCRIPTION
Part of #14. Ports `prefer-add-constraint-not-valid`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047458&installation_id=136613492&pr_number=372&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F372&signature=9819e116b4e968a5fd11bb116ac0f948c434f7398e0c3858f1f48d571ab840fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->