### PR TITLE
feat(postgresql): port no-unnecessary-quoted-identifier

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -46,6 +46,7 @@ mod no_set_search_path;
 mod no_temporary_table;
 mod no_truncate_cascade;
 mod no_unlogged_table;
+mod no_unnecessary_quoted_identifier;
 mod no_update_primary_key;
 mod no_update_without_from_binding;
 mod no_vacuum_full;
@@ -207,6 +208,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-temporary-table",
     "no-truncate-cascade",
     "no-unlogged-table",
+    "no-unnecessary-quoted-identifier",
     "no-update-primary-key",
     "no-update-without-from-binding",
     "no-vacuum-full",
@@ -446,6 +448,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "no-unlogged-table",
         run: no_unlogged_table::run,
         uses_parse_error: false,
+    },
+    RuleDef {
+        name: "no-unnecessary-quoted-identifier",
+        run: no_unnecessary_quoted_identifier::run,
+        uses_parse_error: true,
     },
     RuleDef {
         name: "no-update-primary-key",

--- a/crates/postgresql/src/rules/no_unnecessary_quoted_identifier.rs
+++ b/crates/postgresql/src/rules/no_unnecessary_quoted_identifier.rs
@@ -1,0 +1,104 @@
+//! Port of `no-unnecessary-quoted-identifier`: disallow unnecessary
+//! double-quoting of identifiers (e.g. `"users"` when `users` means the same
+//! thing). Autofixes by stripping the quotes — but only when the inner text is
+//! already exclusively lowercase, so unquoting cannot silently rename the
+//! object (PostgreSQL case-folds unquoted identifiers to lowercase).
+//!
+//! Operates on the token stream (not the AST), mirroring upstream's
+//! `Program` handler that walks `context.sourceCode.ast.tokens`. Invoked once
+//! with `node = Value::Null` (the `uses_parse_error` trigger) and returns early
+//! for every real AST node.
+
+use serde_json::Value;
+
+use crate::tokenize::{Tokenized, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Keywords that require double-quoting when used as an identifier in any
+/// context (RESERVED / COL_NAME / TYPE_FUNC_NAME from PostgreSQL 17 kwlist.h).
+/// Mirrors upstream `PG_KEYWORDS_REQUIRING_QUOTES` (`src/utils/pg-keywords.ts`).
+static PG_KEYWORDS_REQUIRING_QUOTES: phf::Set<&'static str> = phf::phf_set! {
+    "all", "analyse", "analyze", "and", "any", "array", "as", "asc",
+    "asymmetric", "authorization", "between", "bigint", "binary", "bit", "boolean", "both",
+    "case", "cast", "char", "character", "check", "coalesce", "collate", "collation",
+    "column", "concurrently", "constraint", "create", "cross", "current_catalog", "current_date", "current_role",
+    "current_schema", "current_time", "current_timestamp", "current_user", "dec", "decimal", "default", "deferrable",
+    "desc", "distinct", "do", "else", "end", "except", "exists", "extract",
+    "false", "fetch", "float", "for", "foreign", "freeze", "from", "full",
+    "grant", "greatest", "group", "grouping", "having", "ilike", "in", "initially",
+    "inner", "inout", "int", "integer", "intersect", "interval", "into", "is",
+    "isnull", "join", "json", "json_array", "json_arrayagg", "json_exists", "json_object", "json_objectagg",
+    "json_query", "json_scalar", "json_serialize", "json_table", "json_value", "lateral", "leading", "least",
+    "left", "like", "limit", "localtime", "localtimestamp", "merge_action", "national", "natural",
+    "nchar", "none", "normalize", "not", "notnull", "null", "nullif", "numeric",
+    "offset", "on", "only", "or", "order", "out", "outer", "overlaps",
+    "overlay", "placing", "position", "precision", "primary", "real", "references", "returning",
+    "right", "row", "select", "session_user", "setof", "similar", "smallint", "some",
+    "substring", "symmetric", "system_user", "table", "tablesample", "then", "time", "timestamp",
+    "to", "trailing", "treat", "trim", "true", "union", "unique", "user",
+    "using", "values", "varchar", "variadic", "verbose", "when", "where", "window",
+    "with", "xmlattributes", "xmlconcat", "xmlelement", "xmlexists", "xmlforest", "xmlnamespaces", "xmlparse",
+    "xmlpi", "xmlroot", "xmlserialize", "xmltable",
+};
+
+/// Mirrors upstream's `/^[a-z_][a-z0-9_$]*$/`: the inner text is already an
+/// unambiguously-lowercase identifier (so unquoting is lossless).
+fn is_safe_unquoted(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '$')
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Only execute on the one-time program-level trigger (Value::Null).
+    if !node.is_null() {
+        return;
+    }
+
+    let Tokenized { tokens, .. } = tokenize(ctx.source);
+    for token in &tokens {
+        // The parser emits `"..."` as a String-typed token; distinguish it from
+        // a `'...'` literal by the opening quote.
+        if !token.value.starts_with('"') {
+            continue;
+        }
+        if token.value.len() < 2 || !token.value.ends_with('"') {
+            continue;
+        }
+        // Strip the surrounding `"` (both ASCII single-byte).
+        let raw = &token.value[1..token.value.len() - 1];
+        // Doubled quotes inside a quoted identifier are an embedded `"`; such a
+        // value cannot be unquoted.
+        if raw.contains("\"\"") {
+            continue;
+        }
+        if !is_safe_unquoted(raw) {
+            continue;
+        }
+        if PG_KEYWORDS_REQUIRING_QUOTES.contains(raw) {
+            continue;
+        }
+
+        let loc = DiagnosticLoc {
+            start_line: token.start_pos.line,
+            start_column: token.start_pos.column,
+            end_line: token.end_pos.line,
+            end_column: token.end_pos.column,
+        };
+        let fix = DiagnosticFix {
+            start: token.start,
+            end: token.end,
+            replacement: CompactString::from(raw),
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("inner"),
+            value: CompactString::from(raw),
+        });
+        ctx.report_loc(loc, "unnecessaryQuoting", data, Some(fix));
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -591,6 +591,18 @@ const ruleMeta = Object.freeze({
         '`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file.',
     },
   },
+  'no-unnecessary-quoted-identifier': {
+    type: 'layout',
+    description:
+      'Disallow unnecessary double-quoting of identifiers (e.g. `"users"` when `users` would mean the same thing)',
+    recommended: false,
+    fixable: 'code',
+    schema: [],
+    messages: {
+      unnecessaryQuoting:
+        'The identifier `"{{inner}}"` does not need quoting; `{{inner}}` means the same thing.',
+    },
+  },
   'no-update-primary-key': {
     type: 'problem',
     description: 'Disallow `UPDATE ... SET <pk> = ...` for columns the rule treats as primary keys',

--- a/status.json
+++ b/status.json
@@ -5735,19 +5735,19 @@
       },
       {
         "name": "no-unnecessary-quoted-identifier",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule no-unnecessary-quoted-identifier."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/no-unnecessary-quoted-identifier; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "no-update-primary-key",


### PR DESCRIPTION
Part of #14. Ports `no-unnecessary-quoted-identifier` (fixable). Validated against upstream fixtures incl. autofix output; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047564&installation_id=136613492&pr_number=373&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F373&signature=4df223af8bf980db8c5654d928e0ed35eada037d6bb9c5047d036eb2d535e778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->