### PR TITLE
feat(postgresql): port consistent-fk-not-valid

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -7,6 +7,7 @@ mod consistent_as_for_column_alias;
 mod consistent_between_over_and;
 mod consistent_create_or_replace;
 mod consistent_explicit_inner_join;
+mod consistent_fk_not_valid;
 mod consistent_identity_over_serial;
 mod consistent_reindex_concurrently;
 mod no_add_check_constraint_without_not_valid;
@@ -171,6 +172,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-between-over-and",
     "consistent-create-or-replace",
     "consistent-explicit-inner-join",
+    "consistent-fk-not-valid",
     "consistent-identity-over-serial",
     "consistent-reindex-concurrently",
     "no-add-check-constraint-without-not-valid",
@@ -257,6 +259,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "consistent-explicit-inner-join",
         run: consistent_explicit_inner_join::run,
         uses_parse_error: true,
+    },
+    RuleDef {
+        name: "consistent-fk-not-valid",
+        run: consistent_fk_not_valid::run,
+        uses_parse_error: false,
     },
     RuleDef {
         name: "consistent-identity-over-serial",

--- a/crates/postgresql/src/rules/consistent_fk_not_valid.rs
+++ b/crates/postgresql/src/rules/consistent_fk_not_valid.rs
@@ -1,0 +1,37 @@
+//! Port of `consistent-fk-not-valid`
+use crate::RuleContext;
+use crate::ast::{field, is_type, str_field};
+use serde_json::Value;
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "AlterTableCmd") {
+        return;
+    }
+    if str_field(node, "subtype") != Some("AT_AddConstraint") {
+        return;
+    }
+    let Some(def) = field(node, "def") else {
+        return;
+    };
+    if !is_type(def, "Constraint") {
+        return;
+    }
+    if str_field(def, "contype") != Some("CONSTR_FOREIGN") {
+        return;
+    }
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+    let skip_validation = def
+        .get("skip_validation")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if style == "always" && !skip_validation {
+        ctx.report(node, "preferFkNotValid");
+    } else if style == "never" && skip_validation {
+        ctx.report(node, "unexpectedFkNotValid");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -100,6 +100,28 @@ const ruleMeta = Object.freeze({
       unexpectedInnerJoin: 'Omit the redundant `INNER`; use bare `JOIN` for inner joins.',
     },
   },
+  'consistent-fk-not-valid': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `NOT VALID` for `ADD CONSTRAINT ... FOREIGN KEY` (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferFkNotValid:
+        'Adding a foreign key without `NOT VALID` validates every existing row under an `ACCESS EXCLUSIVE` lock that blocks writers. Use `ADD CONSTRAINT ... FOREIGN KEY (...) REFERENCES ... NOT VALID`, then `ALTER TABLE ... VALIDATE CONSTRAINT` in a separate migration (`VALIDATE` only takes a `SHARE UPDATE EXCLUSIVE` lock).',
+      unexpectedFkNotValid:
+        "Avoid `NOT VALID` on foreign keys. The constraint is added in a non-validated state and won't reject existing violations until you remember to run `VALIDATE CONSTRAINT`; some projects prefer to fail loudly at constraint-add time instead.",
+    },
+  },
   'consistent-identity-over-serial': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -4967,19 +4967,19 @@
       },
       {
         "name": "consistent-fk-not-valid",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-fk-not-valid."
+        "notes": "Rust port validated against upstream test fixtures."
       },
       {
         "name": "consistent-identity-over-serial",


### PR DESCRIPTION
Part of #14. Ports `consistent-fk-not-valid`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784049987&installation_id=136613492&pr_number=378&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F378&signature=25509395f19411d038efd5b2faf4ed41cf18e1e6e0149a2885491d42847ce037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->