### PR TITLE
feat(postgresql): port consistent-jsonb-over-json

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -8,6 +8,7 @@ mod consistent_between_over_and;
 mod consistent_create_or_replace;
 mod consistent_explicit_inner_join;
 mod consistent_identity_over_serial;
+mod consistent_jsonb_over_json;
 mod consistent_reindex_concurrently;
 mod no_add_check_constraint_without_not_valid;
 mod no_add_column_not_null_without_default;
@@ -172,6 +173,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-create-or-replace",
     "consistent-explicit-inner-join",
     "consistent-identity-over-serial",
+    "consistent-jsonb-over-json",
     "consistent-reindex-concurrently",
     "no-add-check-constraint-without-not-valid",
     "no-add-column-not-null-without-default",
@@ -261,6 +263,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "consistent-identity-over-serial",
         run: consistent_identity_over_serial::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-jsonb-over-json",
+        run: consistent_jsonb_over_json::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/consistent_jsonb_over_json.rs
+++ b/crates/postgresql/src/rules/consistent_jsonb_over_json.rs
@@ -1,0 +1,41 @@
+//! Port of `consistent-jsonb-over-json`
+use crate::RuleContext;
+use crate::ast::is_type;
+use serde_json::Value;
+
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    let Some(t) = get_type_name(type_name) else {
+        return;
+    };
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+    if style == "always" && t == "json" {
+        ctx.report(node, "preferJsonb");
+    } else if style == "never" && t == "jsonb" {
+        ctx.report(node, "unexpectedJsonb");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -122,6 +122,28 @@ const ruleMeta = Object.freeze({
         'Use a serial pseudo-type (e.g. `bigserial`) instead of `GENERATED ... AS IDENTITY`. Useful for projects that need to keep compatibility with tooling that does not understand identity columns.',
     },
   },
+  'consistent-jsonb-over-json': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `jsonb` vs `json` column types (either always require `jsonb`, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferJsonb:
+        'Use `jsonb` instead of `json`. `jsonb` stores the parsed representation, supports indexing, and is what almost every application actually wants.',
+      unexpectedJsonb:
+        "Use `json` instead of `jsonb`. Useful when the project intentionally relies on `json`'s preservation of key order, whitespace, and duplicate keys.",
+    },
+  },
   'consistent-reindex-concurrently': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -4999,19 +4999,19 @@
       },
       {
         "name": "consistent-jsonb-over-json",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-jsonb-over-json."
+        "notes": "Rust port validated against upstream test fixtures."
       },
       {
         "name": "consistent-reindex-concurrently",


### PR DESCRIPTION
Part of #14. Ports `consistent-jsonb-over-json`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050116&installation_id=136613492&pr_number=380&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F380&signature=3cf13347542051bd6a314a207fc59ae3d3b96acd15391d4fcfcc7d2bbc06a80c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->