### PR TITLE
feat(postgresql): port consistent-text-over-varchar

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -9,6 +9,7 @@ mod consistent_create_or_replace;
 mod consistent_explicit_inner_join;
 mod consistent_identity_over_serial;
 mod consistent_reindex_concurrently;
+mod consistent_text_over_varchar;
 mod no_add_check_constraint_without_not_valid;
 mod no_add_column_not_null_without_default;
 mod no_add_unique_constraint_directly;
@@ -173,6 +174,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-explicit-inner-join",
     "consistent-identity-over-serial",
     "consistent-reindex-concurrently",
+    "consistent-text-over-varchar",
     "no-add-check-constraint-without-not-valid",
     "no-add-column-not-null-without-default",
     "no-add-unique-constraint-directly",
@@ -266,6 +268,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "consistent-reindex-concurrently",
         run: consistent_reindex_concurrently::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-text-over-varchar",
+        run: consistent_text_over_varchar::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/consistent_text_over_varchar.rs
+++ b/crates/postgresql/src/rules/consistent_text_over_varchar.rs
@@ -1,0 +1,45 @@
+//! Port of `consistent-text-over-varchar`
+use crate::RuleContext;
+use crate::ast::is_type;
+use serde_json::Value;
+
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    let Some(t) = get_type_name(type_name) else {
+        return;
+    };
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+    if style == "always" && t == "varchar" {
+        // Only flag varchar(n) (with typmods), not plain varchar
+        let has_typmods = type_name.get("typmods").and_then(Value::as_array).is_some();
+        if has_typmods {
+            ctx.report(node, "preferText");
+        }
+    } else if style == "never" && t == "text" {
+        ctx.report(node, "unexpectedText");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -144,6 +144,28 @@ const ruleMeta = Object.freeze({
         'Avoid `REINDEX CONCURRENTLY`. Concurrent reindex cannot run inside a transaction; use plain `REINDEX` when the migration tool wraps each step in BEGIN/COMMIT.',
     },
   },
+  'consistent-text-over-varchar': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `text` vs `varchar(n)` column types (either always require `text`, or always require a bounded type)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferText:
+        'Use `text` instead of `varchar(n)`. PostgreSQL stores both the same way; the length cap is enforced by a constraint that you cannot relax without a full table rewrite. Move the limit into a CHECK constraint.',
+      unexpectedText:
+        "Use `varchar(n)` (or another bounded string type) instead of `text`. Useful for projects that intentionally cap every string column's length at the type level.",
+    },
+  },
   'no-add-check-constraint-without-not-valid': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5031,19 +5031,19 @@
       },
       {
         "name": "consistent-text-over-varchar",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-text-over-varchar."
+        "notes": "Rust port validated against upstream test fixtures."
       },
       {
         "name": "consistent-timestamptz",


### PR DESCRIPTION
Part of #14. Ports `consistent-text-over-varchar`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050232&installation_id=136613492&pr_number=381&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F381&signature=a268655d87136bd3b44907f4f111a88792d7c933abf91c5e41752b56b072caba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->