### PR TITLE
feat(postgresql): port consistent-timestamptz

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -15,6 +15,7 @@ mod consistent_identity_over_serial;
 mod consistent_jsonb_over_json;
 mod consistent_reindex_concurrently;
 mod consistent_text_over_varchar;
+mod consistent_timestamptz;
 mod no_add_check_constraint_without_not_valid;
 mod no_add_column_not_null_without_default;
 mod no_add_unique_constraint_directly;
@@ -190,6 +191,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-jsonb-over-json",
     "consistent-reindex-concurrently",
     "consistent-text-over-varchar",
+    "consistent-timestamptz",
     "no-add-check-constraint-without-not-valid",
     "no-add-column-not-null-without-default",
     "no-add-unique-constraint-directly",
@@ -318,6 +320,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "consistent-text-over-varchar",
         run: consistent_text_over_varchar::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-timestamptz",
+        run: consistent_timestamptz::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/consistent_timestamptz.rs
+++ b/crates/postgresql/src/rules/consistent_timestamptz.rs
@@ -1,0 +1,41 @@
+//! Port of `consistent-timestamptz`
+use crate::RuleContext;
+use crate::ast::is_type;
+use serde_json::Value;
+
+fn get_type_name(type_name: &Value) -> Option<&str> {
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "ColumnDef") {
+        return;
+    }
+    let Some(type_name) = node.get("typeName") else {
+        return;
+    };
+    let Some(t) = get_type_name(type_name) else {
+        return;
+    };
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+    if style == "always" && t == "timestamp" {
+        ctx.report(node, "preferTimestamptz");
+    } else if style == "never" && t == "timestamptz" {
+        ctx.report(node, "unexpectedTimestamptz");
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -274,6 +274,28 @@ const ruleMeta = Object.freeze({
         "Use `varchar(n)` (or another bounded string type) instead of `text`. Useful for projects that intentionally cap every string column's length at the type level.",
     },
   },
+  'consistent-timestamptz': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on `timestamptz` vs `timestamp` column types (either always require `timestamptz`, or always forbid it)',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferTimestamptz:
+        'Use `timestamptz` (or `TIMESTAMP WITH TIME ZONE`) instead of `timestamp`. `timestamp` is timezone-naive: it stores the wall-clock value you handed in and assumes every reader and writer share the same convention, so two clients on different `TimeZone` settings will disagree on which instant the row represents.',
+      unexpectedTimestamptz:
+        "Use `timestamp` instead of `timestamptz` (or `TIMESTAMP WITH TIME ZONE`). When the project treats every timestamp as UTC at the application layer, `timestamp` avoids the implicit conversions `timestamptz` performs against each session's `TimeZone` setting.",
+    },
+  },
   'no-add-check-constraint-without-not-valid': {
     type: 'problem',
     description:

--- a/status.json
+++ b/status.json
@@ -5047,19 +5047,19 @@
       },
       {
         "name": "consistent-timestamptz",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-timestamptz."
+        "notes": "Rust port validated against upstream test fixtures."
       },
       {
         "name": "no-add-check-constraint-without-not-valid",


### PR DESCRIPTION
Part of #14. Ports `consistent-timestamptz`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050377&installation_id=136613492&pr_number=382&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F382&signature=8cbeac4c6641dded92537e329f203e75b22c6a6ade63386baae418f585179343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->