### PR TITLE
feat(postgresql): port consistent-explicit-outer-join

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -10,6 +10,7 @@ mod consistent_create_index_concurrently;
 mod consistent_create_or_replace;
 mod consistent_drop_index_concurrently;
 mod consistent_explicit_inner_join;
+mod consistent_explicit_outer_join;
 mod consistent_fk_not_valid;
 mod consistent_identity_over_serial;
 mod consistent_jsonb_over_json;
@@ -186,6 +187,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-create-or-replace",
     "consistent-drop-index-concurrently",
     "consistent-explicit-inner-join",
+    "consistent-explicit-outer-join",
     "consistent-fk-not-valid",
     "consistent-identity-over-serial",
     "consistent-jsonb-over-json",
@@ -295,6 +297,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "consistent-explicit-inner-join",
         run: consistent_explicit_inner_join::run,
+        uses_parse_error: true,
+    },
+    RuleDef {
+        name: "consistent-explicit-outer-join",
+        run: consistent_explicit_outer_join::run,
         uses_parse_error: true,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/consistent_explicit_outer_join.rs
+++ b/crates/postgresql/src/rules/consistent_explicit_outer_join.rs
@@ -1,0 +1,96 @@
+//! Port of `consistent-explicit-outer-join`
+use crate::tokenize::{TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+fn is_side_keyword(value: &str) -> bool {
+    let up = value.to_ascii_uppercase();
+    matches!(up.as_str(), "LEFT" | "RIGHT" | "FULL")
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !node.is_null() {
+        return;
+    }
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+    let tokenized = tokenize(ctx.source);
+    let tokens = &tokenized.tokens;
+
+    for i in 0..tokens.len() {
+        let token = &tokens[i];
+        if token.kind != TokenKind::Keyword {
+            continue;
+        }
+        if !is_side_keyword(&token.value) {
+            continue;
+        }
+
+        let Some(next) = tokens.get(i + 1) else {
+            continue;
+        };
+        if next.kind != TokenKind::Keyword {
+            continue;
+        }
+
+        if style == "always" {
+            // Look for SIDE JOIN (next token is JOIN)
+            if !next.value.eq_ignore_ascii_case("JOIN") {
+                continue;
+            }
+            let side = token.value.to_ascii_uppercase();
+            let loc = DiagnosticLoc {
+                start_line: token.start_pos.line,
+                start_column: token.start_pos.column,
+                end_line: next.end_pos.line,
+                end_column: next.end_pos.column,
+            };
+            let fix = DiagnosticFix {
+                start: next.start,
+                end: next.start,
+                replacement: CompactString::from("OUTER "),
+            };
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("side"),
+                value: CompactString::from(side),
+            });
+            ctx.report_loc(loc, "preferOuterJoin", data, Some(fix));
+        } else {
+            // style == "never": look for SIDE OUTER JOIN
+            if !next.value.eq_ignore_ascii_case("OUTER") {
+                continue;
+            }
+            let Some(after) = tokens.get(i + 2) else {
+                continue;
+            };
+            if !after.value.eq_ignore_ascii_case("JOIN") {
+                continue;
+            }
+            let side = token.value.to_ascii_uppercase();
+            let loc = DiagnosticLoc {
+                start_line: token.start_pos.line,
+                start_column: token.start_pos.column,
+                end_line: after.end_pos.line,
+                end_column: after.end_pos.column,
+            };
+            // Fix: remove "OUTER " from next.start to after.start
+            let fix = DiagnosticFix {
+                start: next.start,
+                end: after.start,
+                replacement: CompactString::from(""),
+            };
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("side"),
+                value: CompactString::from(side),
+            });
+            ctx.report_loc(loc, "unexpectedOuterJoin", data, Some(fix));
+        }
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -164,6 +164,27 @@ const ruleMeta = Object.freeze({
       unexpectedInnerJoin: 'Omit the redundant `INNER`; use bare `JOIN` for inner joins.',
     },
   },
+  'consistent-explicit-outer-join': {
+    type: 'suggestion',
+    description:
+      'Enforce a consistent stance on the explicit `OUTER` keyword in outer joins (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOuterJoin: 'Write `{{side}} OUTER JOIN` explicitly instead of `{{side}} JOIN`.',
+      unexpectedOuterJoin:
+        'Omit the redundant `OUTER`; use `{{side}} JOIN` instead of `{{side}} OUTER JOIN`.',
+    },
+  },
   'consistent-fk-not-valid': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -4951,19 +4951,19 @@
       },
       {
         "name": "consistent-explicit-outer-join",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-explicit-outer-join."
+        "notes": "Rust port validated against upstream test fixtures."
       },
       {
         "name": "consistent-fk-not-valid",


### PR DESCRIPTION
Part of #14. Ports `consistent-explicit-outer-join`.

Token-based rule that enforces consistent use of the `OUTER` keyword in outer join expressions (LEFT/RIGHT/FULL JOIN).

- `style: "always"` (default): requires `LEFT OUTER JOIN`, `RIGHT OUTER JOIN`, `FULL OUTER JOIN`
- `style: "never"`: forbids the `OUTER` keyword

Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050709&installation_id=136613492&pr_number=383&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F383&signature=8ffd994f32538903fffc60854c985a94df8b331c8bf1fbb7e88071658fee3f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->