### PR TITLE
feat(postgresql): port consistent-as-for-table-alias

### DIFF
--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -4,6 +4,7 @@
 use crate::RuleDef;
 
 mod consistent_as_for_column_alias;
+mod consistent_as_for_table_alias;
 mod consistent_between_over_and;
 mod consistent_create_or_replace;
 mod consistent_explicit_inner_join;
@@ -168,6 +169,7 @@ pub const RULE_NAMES: [&str; 89] = [
 /// Rules implemented in Rust so far (a growing subset of [`RULE_NAMES`]).
 pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "consistent-as-for-column-alias",
+    "consistent-as-for-table-alias",
     "consistent-between-over-and",
     "consistent-create-or-replace",
     "consistent-explicit-inner-join",
@@ -241,6 +243,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "consistent-as-for-column-alias",
         run: consistent_as_for_column_alias::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "consistent-as-for-table-alias",
+        run: consistent_as_for_table_alias::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
@@ -1,0 +1,128 @@
+//! Port of `consistent-as-for-table-alias`: enforce a consistent stance on
+//! the `AS` keyword before table aliases in `FROM` clauses (either always
+//! require it, or always forbid it).
+//!
+//! Operates on `RangeVar` AST nodes. The alias sub-node carries only
+//! `aliasname` (no range), so we locate the alias token by walking forward
+//! from `node.range[1]` (the table reference's end position).
+//!
+//! Default style `"always"` requires AS (flags bare aliases).
+//! Style `"never"` forbids AS (flags explicit AS keywords).
+
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Strips surrounding double quotes from a token value so it can be compared
+/// with `alias.aliasname` (which holds the unquoted identifier from the parser).
+fn token_identifier_text(token: &Token) -> &str {
+    let v = &token.value;
+    if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
+        &v[1..v.len() - 1]
+    } else {
+        v.as_str()
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "RangeVar") {
+        return;
+    }
+
+    let Some(alias_name) = node
+        .get("alias")
+        .and_then(|a| a.get("aliasname"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+
+    // `node.range[1]` is the byte offset past the last character of the table
+    // reference (relation name + optional schema). Walking forward from here
+    // finds either `AS` or the alias identifier directly.
+    let Some(range_end) = node
+        .get("range")
+        .and_then(Value::as_array)
+        .and_then(|r| r.get(1))
+        .and_then(Value::as_u64)
+        .map(|v| v as u32)
+    else {
+        return;
+    };
+
+    let style = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("always");
+
+    let tokenized = tokenize(ctx.source);
+    let tokens = &tokenized.tokens;
+
+    let Some((next_index, next)) = tokens
+        .iter()
+        .enumerate()
+        .find(|(_, t)| t.start >= range_end)
+    else {
+        return;
+    };
+
+    let has_as = next.kind == TokenKind::Keyword && next.value.eq_ignore_ascii_case("AS");
+
+    if style == "always" && !has_as {
+        // Confirm the token is actually the alias identifier (not a keyword
+        // like WHERE/JOIN that follows an un-aliased table reference).
+        if token_identifier_text(next) != alias_name {
+            return;
+        }
+        let loc = DiagnosticLoc {
+            start_line: next.start_pos.line,
+            start_column: next.start_pos.column,
+            end_line: next.end_pos.line,
+            end_column: next.end_pos.column,
+        };
+        // Fix: insert "AS " before the alias token.
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: next.start,
+            replacement: CompactString::from("AS "),
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("alias"),
+            value: CompactString::from(alias_name),
+        });
+        ctx.report_loc(loc, "preferAs", data, Some(fix));
+    } else if style == "never" && has_as {
+        let Some(after) = tokens.get(next_index + 1) else {
+            return;
+        };
+        // Confirm the token after AS is actually the alias identifier.
+        if token_identifier_text(after) != alias_name {
+            return;
+        }
+        let loc = DiagnosticLoc {
+            start_line: next.start_pos.line,
+            start_column: next.start_pos.column,
+            end_line: next.end_pos.line,
+            end_column: next.end_pos.column,
+        };
+        // Fix: remove from AS.start to after.start (removes "AS " including
+        // the whitespace between AS and the alias identifier).
+        let fix = DiagnosticFix {
+            start: next.start,
+            end: after.start,
+            replacement: CompactString::from(""),
+        };
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("alias"),
+            value: CompactString::from(alias_name),
+        });
+        ctx.report_loc(loc, "unexpectedAs", data, Some(fix));
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -37,6 +37,26 @@ const ruleMeta = Object.freeze({
       unexpectedAs: 'Omit `AS` before the column alias `{{alias}}`.',
     },
   },
+  'consistent-as-for-table-alias': {
+    type: 'layout',
+    description:
+      'Enforce a consistent stance on the `AS` keyword before table aliases in `FROM` clauses (either always require it, or always forbid it)',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferAs: 'Use `AS` before the table alias `{{alias}}`.',
+      unexpectedAs: 'Omit `AS` before the table alias `{{alias}}`.',
+    },
+  },
   'consistent-between-over-and': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -4855,19 +4855,19 @@
       },
       {
         "name": "consistent-as-for-table-alias",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule consistent-as-for-table-alias."
+        "notes": "Token-based rule visiting RangeVar AST nodes; uses node.range[1] to locate the alias token."
       },
       {
         "name": "consistent-between-over-and",


### PR DESCRIPTION
Part of #14. Ports `consistent-as-for-table-alias`.

Visits `RangeVar` AST nodes, uses `node.range[1]` (byte offset past the table name) to locate the alias token via the tokenizer, and enforces consistent use of `AS` before table aliases in `FROM` clauses.

- `style: "always"` (default): requires `FROM users AS u` (flags bare aliases like `FROM users u`)
- `style: "never"`: forbids the `AS` keyword (flags `FROM users AS u`)

Includes autofix in both directions. All 4 upstream fixtures pass; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050990&installation_id=136613492&pr_number=384&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F384&signature=710fa6203d7a67c9fd0e6ece87767c38d6c2cd8db34d4d3add778a20abdc700d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->