### PR TITLE
feat(postgresql): port require-table-columns

### DIFF
--- a/crates/postgresql/Cargo.toml
+++ b/crates/postgresql/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 oxlint-plugins-carton.workspace = true
 pg_query.workspace = true
 phf.workspace = true
+regex.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -79,6 +79,7 @@ mod require_named_constraint;
 mod require_on_delete_action;
 mod require_primary_key;
 mod require_schema_qualified_table;
+mod require_table_columns;
 mod require_trailing_semicolon;
 mod require_where_in_delete;
 mod require_where_in_update;
@@ -257,6 +258,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "require-on-delete-action",
     "require-primary-key",
     "require-schema-qualified-table",
+    "require-table-columns",
     "require-trailing-semicolon",
     "require-where-in-delete",
     "require-where-in-update",
@@ -644,6 +646,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "require-schema-qualified-table",
         run: require_schema_qualified_table::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-table-columns",
+        run: require_table_columns::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/require_table_columns.rs
+++ b/crates/postgresql/src/rules/require_table_columns.rs
@@ -1,0 +1,112 @@
+//! Port of `require-table-columns`: every `CREATE TABLE` must contain a
+//! required set of columns, with per-table-name pattern overrides and an
+//! optional exclusion pattern.
+
+use regex::Regex;
+use serde_json::Value;
+
+use crate::ast::{array_field, is_type};
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "CreateStmt") {
+        return;
+    }
+
+    // Copy the options reference before any ctx mutation to avoid borrow conflict.
+    let options = ctx.options;
+
+    let opts = match options.get(0) {
+        Some(o) => o,
+        None => return,
+    };
+
+    let base_columns: SmallVec<[&str; 8]> = opts
+        .get("columns")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    if base_columns.is_empty() {
+        return;
+    }
+
+    let table_name = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    // Check exclude pattern — skip this table entirely if it matches.
+    if let Some(exclude) = opts.get("exclude").and_then(Value::as_str)
+        && Regex::new(exclude).is_ok_and(|re| re.is_match(table_name))
+    {
+        return;
+    }
+
+    // Find the first matching override (first-match-wins).
+    let (required_columns, rationale): (SmallVec<[&str; 8]>, CompactString) =
+        if let Some(overrides) = opts.get("overrides").and_then(Value::as_array) {
+            let mut found: Option<(SmallVec<[&str; 8]>, CompactString)> = None;
+            for ov in overrides {
+                let pattern = match ov.get("pattern").and_then(Value::as_str) {
+                    Some(p) => p,
+                    None => continue,
+                };
+                if Regex::new(pattern).is_ok_and(|re| re.is_match(table_name)) {
+                    let cols: SmallVec<[&str; 8]> = ov
+                        .get("columns")
+                        .and_then(Value::as_array)
+                        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+                        .unwrap_or_default();
+                    let mut r = CompactString::new("");
+                    r.push_str("Required by the override for pattern `");
+                    r.push_str(pattern);
+                    r.push_str("`.");
+                    found = Some((cols, r));
+                    break;
+                }
+            }
+            found.unwrap_or_else(|| {
+                (
+                    base_columns.clone(),
+                    CompactString::from("Required by the default column list."),
+                )
+            })
+        } else {
+            (
+                base_columns,
+                CompactString::from("Required by the default column list."),
+            )
+        };
+
+    // Collect the column names that are actually present in the table definition.
+    let present: SmallVec<[&str; 8]> = array_field(node, "tableElts")
+        .unwrap_or(&[])
+        .iter()
+        .filter(|elt| is_type(elt, "ColumnDef"))
+        .filter_map(|elt| elt.get("colname").and_then(Value::as_str))
+        .collect();
+
+    // Report each required column that is absent.
+    let table_cs = CompactString::from(table_name);
+    for col in &required_columns {
+        if !present.contains(col) {
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("table"),
+                value: table_cs.clone(),
+            });
+            data.push(DiagnosticDatum {
+                key: CompactString::from("missing"),
+                value: CompactString::from(*col),
+            });
+            data.push(DiagnosticDatum {
+                key: CompactString::from("rationale"),
+                value: rationale.clone(),
+            });
+            ctx.report_data(node, "missingColumn", data);
+        }
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1088,6 +1088,46 @@ const ruleMeta = Object.freeze({
         '`CREATE TABLE` should specify a schema (e.g. `audit.events`). Without one, the target depends on `search_path` and may land in an unintended schema. The rule is off by default in `recommended` because many projects intentionally use the `public` schema.',
     },
   },
+  'require-table-columns': {
+    type: 'suggestion',
+    description:
+      'Require that every `CREATE TABLE` contains a configurable set of columns, with per-table-name pattern overrides and an optional exclusion pattern',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          columns: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          overrides: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                pattern: { type: 'string' },
+                columns: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+              },
+              required: ['pattern', 'columns'],
+              additionalProperties: false,
+            },
+          },
+          exclude: { type: 'string' },
+        },
+        required: ['columns'],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingColumn:
+        '`CREATE TABLE {{table}}` is missing required column `{{missing}}`. {{rationale}}',
+    },
+  },
   'require-trailing-semicolon': {
     type: 'layout',
     description: 'Require a trailing `;` at the end of the SQL file',

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1089,9 +1089,9 @@ const ruleMeta = Object.freeze({
     },
   },
   'require-table-columns': {
-    type: 'suggestion',
+    type: 'problem',
     description:
-      'Require that every `CREATE TABLE` contains a configurable set of columns, with per-table-name pattern overrides and an optional exclusion pattern',
+      'Require every `CREATE TABLE` to include a configured set of columns (e.g. multi-tenant / audit columns like `tenant_id`, `created_at`, `updated_by`)',
     recommended: false,
     fixable: undefined,
     schema: [
@@ -1101,6 +1101,8 @@ const ruleMeta = Object.freeze({
           columns: {
             type: 'array',
             items: { type: 'string' },
+            uniqueItems: true,
+            minItems: 1,
           },
           overrides: {
             type: 'array',
@@ -1111,6 +1113,7 @@ const ruleMeta = Object.freeze({
                 columns: {
                   type: 'array',
                   items: { type: 'string' },
+                  uniqueItems: true,
                 },
               },
               required: ['pattern', 'columns'],

--- a/status.json
+++ b/status.json
@@ -6135,19 +6135,19 @@
       },
       {
         "name": "require-table-columns",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-table-columns."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-table-columns; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-trailing-semicolon",


### PR DESCRIPTION
Part of #14. Ports \`require-table-columns\`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784055915&installation_id=136613492&pr_number=392&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F392&signature=1ee1eaa4e817c7f15e1ce97c3e82bd3d06649d6c7c2f68cfffb2261872215e80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->