### PR TITLE
feat(postgresql): port require-index-on-fk-column

### DIFF
--- a/crates/postgresql/src/lib.rs
+++ b/crates/postgresql/src/lib.rs
@@ -93,6 +93,7 @@ pub fn scan_postgresql(source_text: &str, options: &ScanOptions) -> SmallVec<[Di
         source: &parsed.source,
         options: &options.options,
         error: parsed.error.as_ref(),
+        statements: &parsed.statements,
         diagnostics: SmallVec::new(),
         rule_name: "",
     };
@@ -128,6 +129,10 @@ pub struct RuleContext<'a> {
     pub source: &'a Source,
     pub options: &'a Value,
     pub error: Option<&'a ParseError>,
+    /// All top-level statement nodes for the parsed SQL file.  Rules that need
+    /// program-exit behaviour (e.g. `require-index-on-fk-column`) walk this
+    /// slice directly instead of relying on the visitor dispatch.
+    pub statements: &'a [Value],
     diagnostics: SmallVec<[Diagnostic; 8]>,
     rule_name: &'static str,
 }
@@ -224,7 +229,7 @@ fn is_recursible(key: &str, value: &Value) -> bool {
     !matches!(key, "parent" | "type" | "range" | "loc") && (value.is_object() || value.is_array())
 }
 
-fn loc_of(node: &Value) -> Option<DiagnosticLoc> {
+pub(crate) fn loc_of(node: &Value) -> Option<DiagnosticLoc> {
     let loc = node.get("loc")?;
     let start = loc.get("start")?;
     let end = loc.get("end")?;

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -74,6 +74,7 @@ mod prefer_explicit_null_ordering;
 mod prefer_in_list_over_or;
 mod prefer_not_equals_operator;
 mod require_if_exists;
+mod require_index_on_fk_column;
 mod require_limit;
 mod require_named_constraint;
 mod require_on_delete_action;
@@ -252,6 +253,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "prefer-in-list-over-or",
     "prefer-not-equals-operator",
     "require-if-exists",
+    "require-index-on-fk-column",
     "require-limit",
     "require-named-constraint",
     "require-on-delete-action",
@@ -620,6 +622,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "require-if-exists",
         run: require_if_exists::run,
         uses_parse_error: false,
+    },
+    RuleDef {
+        name: "require-index-on-fk-column",
+        run: require_index_on_fk_column::run,
+        uses_parse_error: true,
     },
     RuleDef {
         name: "require-limit",

--- a/crates/postgresql/src/rules/require_index_on_fk_column.rs
+++ b/crates/postgresql/src/rules/require_index_on_fk_column.rs
@@ -1,0 +1,256 @@
+//! Port of `require-index-on-fk-column`: every foreign-key column must have a
+//! covering index so that `DELETE` / `UPDATE` of the parent row does not
+//! sequentially scan the child table to enforce the constraint.
+//!
+//! The rule operates on the full statement list (program-exit) so it can
+//! correlate `CREATE INDEX` / `ALTER TABLE ADD PK` statements that appear
+//! after the `CREATE TABLE` that introduces the FK.
+
+use serde_json::Value;
+
+use crate::ast::{array_field, is_type, str_field};
+use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext, loc_of};
+use oxlint_plugins_carton::{CompactString, FastHashMap, FastHashSet, SmallVec};
+
+/// A pending FK that still needs a covering index.
+struct FkInfo {
+    leading_col: CompactString,
+    report_loc: DiagnosticLoc,
+}
+
+/// Per-table state accumulated while walking all statements.
+struct TableState {
+    fks: SmallVec<[FkInfo; 4]>,
+    indexed_leading_cols: FastHashSet<CompactString>,
+}
+
+impl TableState {
+    fn new() -> Self {
+        Self {
+            fks: SmallVec::new(),
+            indexed_leading_cols: FastHashSet::default(),
+        }
+    }
+}
+
+/// Extract the string value from a libpg_query String node.
+/// Handles `"sval"`, `{"sval": "..."}`, and `{"sval": {"sval": "..."}}`.
+fn get_sval(n: &Value) -> Option<&str> {
+    if let Some(s) = n.as_str() {
+        return Some(s);
+    }
+    if let Some(sval) = n.get("sval") {
+        if let Some(s) = sval.as_str() {
+            return Some(s);
+        }
+        if let Some(s) = sval.get("sval").and_then(Value::as_str) {
+            return Some(s);
+        }
+    }
+    None
+}
+
+/// Collect FK and index information from a `CreateStmt`.
+fn collect_create_stmt(node: &Value, tables: &mut FastHashMap<CompactString, TableState>) {
+    let table_name = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if table_name.is_empty() {
+        return;
+    }
+    let state = tables
+        .entry(CompactString::from(table_name))
+        .or_insert_with(TableState::new);
+
+    let elts = match array_field(node, "tableElts") {
+        Some(e) => e,
+        None => return,
+    };
+
+    for elt in elts {
+        if is_type(elt, "ColumnDef") {
+            let col_name = match elt.get("colname").and_then(Value::as_str) {
+                Some(n) => n,
+                None => continue,
+            };
+            let constraints = match array_field(elt, "constraints") {
+                Some(c) => c,
+                None => continue,
+            };
+            for constraint in constraints {
+                if !is_type(constraint, "Constraint") {
+                    continue;
+                }
+                match str_field(constraint, "contype") {
+                    Some("CONSTR_FOREIGN") => {
+                        if let Some(loc) = loc_of(constraint) {
+                            state.fks.push(FkInfo {
+                                leading_col: CompactString::from(col_name),
+                                report_loc: loc,
+                            });
+                        }
+                    }
+                    Some("CONSTR_PRIMARY") | Some("CONSTR_UNIQUE") => {
+                        state
+                            .indexed_leading_cols
+                            .insert(CompactString::from(col_name));
+                    }
+                    _ => {}
+                }
+            }
+        } else if is_type(elt, "Constraint") {
+            match str_field(elt, "contype") {
+                Some("CONSTR_FOREIGN") => {
+                    let first_attr = array_field(elt, "fk_attrs")
+                        .and_then(|a| a.first())
+                        .and_then(get_sval);
+                    if let (Some(col), Some(loc)) = (first_attr, loc_of(elt)) {
+                        state.fks.push(FkInfo {
+                            leading_col: CompactString::from(col),
+                            report_loc: loc,
+                        });
+                    }
+                }
+                Some("CONSTR_PRIMARY") | Some("CONSTR_UNIQUE") => {
+                    let first_key = array_field(elt, "keys")
+                        .and_then(|k| k.first())
+                        .and_then(get_sval);
+                    if let Some(col) = first_key {
+                        state.indexed_leading_cols.insert(CompactString::from(col));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Collect index information from an `IndexStmt`.
+fn collect_index_stmt(node: &Value, tables: &mut FastHashMap<CompactString, TableState>) {
+    let table_name = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if table_name.is_empty() {
+        return;
+    }
+    let first_col = array_field(node, "indexParams")
+        .and_then(|p| p.first())
+        .and_then(|e| e.get("name"))
+        .and_then(Value::as_str);
+    if let Some(col) = first_col {
+        tables
+            .entry(CompactString::from(table_name))
+            .or_insert_with(TableState::new)
+            .indexed_leading_cols
+            .insert(CompactString::from(col));
+    }
+}
+
+/// Collect FK / index information from an `AlterTableStmt`.
+fn collect_alter_table_stmt(node: &Value, tables: &mut FastHashMap<CompactString, TableState>) {
+    let table_name = node
+        .get("relation")
+        .and_then(|r| r.get("relname"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if table_name.is_empty() {
+        return;
+    }
+    let cmds = match array_field(node, "cmds") {
+        Some(c) => c,
+        None => return,
+    };
+    let state = tables
+        .entry(CompactString::from(table_name))
+        .or_insert_with(TableState::new);
+
+    for cmd in cmds {
+        if !is_type(cmd, "AlterTableCmd") {
+            continue;
+        }
+        if str_field(cmd, "subtype") != Some("AT_AddConstraint") {
+            continue;
+        }
+        let def = match cmd.get("def") {
+            Some(d) if is_type(d, "Constraint") => d,
+            _ => continue,
+        };
+        match str_field(def, "contype") {
+            Some("CONSTR_FOREIGN") => {
+                let first_attr = array_field(def, "fk_attrs")
+                    .and_then(|a| a.first())
+                    .and_then(get_sval);
+                if let (Some(col), Some(loc)) = (first_attr, loc_of(cmd)) {
+                    state.fks.push(FkInfo {
+                        leading_col: CompactString::from(col),
+                        report_loc: loc,
+                    });
+                }
+            }
+            Some("CONSTR_PRIMARY") | Some("CONSTR_UNIQUE") => {
+                let first_key = array_field(def, "keys")
+                    .and_then(|k| k.first())
+                    .and_then(get_sval);
+                if let Some(col) = first_key {
+                    state.indexed_leading_cols.insert(CompactString::from(col));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Only execute on the one-time program-level trigger (Value::Null).
+    if !node.is_null() {
+        return;
+    }
+
+    let stmts = ctx.statements;
+
+    // First pass: collect all FK info and indexed columns across all statements.
+    let mut tables: FastHashMap<CompactString, TableState> = FastHashMap::default();
+    for stmt in stmts {
+        match stmt.get("type").and_then(Value::as_str) {
+            Some("CreateStmt") => collect_create_stmt(stmt, &mut tables),
+            Some("IndexStmt") => collect_index_stmt(stmt, &mut tables),
+            Some("AlterTableStmt") => collect_alter_table_stmt(stmt, &mut tables),
+            _ => {}
+        }
+    }
+
+    // Second pass: for each FK whose leading column has no covering index, report.
+    // Collect into a SmallVec first to avoid holding a borrow on `tables` while
+    // calling ctx.report_loc.
+    let mut to_report: SmallVec<[(DiagnosticLoc, CompactString); 4]> = SmallVec::new();
+    for state in tables.values() {
+        for fk in &state.fks {
+            if !state.indexed_leading_cols.contains(&fk.leading_col) {
+                to_report.push((fk.report_loc, fk.leading_col.clone()));
+            }
+        }
+    }
+
+    // Sort by loc so diagnostics come out in source order.
+    to_report.sort_by_key(|(loc, _)| {
+        (
+            loc.start_line,
+            loc.start_column,
+            loc.end_line,
+            loc.end_column,
+        )
+    });
+
+    for (loc, col) in to_report {
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("col"),
+            value: col,
+        });
+        ctx.report_loc(loc, "missingIndex", data, None);
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1018,10 +1018,10 @@ const ruleMeta = Object.freeze({
     },
   },
   'require-index-on-fk-column': {
-    type: 'suggestion',
+    type: 'problem',
     description:
-      'Require a covering index on every foreign-key leading column so that parent-row deletes and updates do not trigger a sequential scan of the child table',
-    recommended: true,
+      'Require an index on every foreign-key column; without it a `DELETE` or `UPDATE` on the referenced table sequentially scans the referencing table to enforce the constraint',
+    recommended: false,
     fixable: undefined,
     schema: [],
     messages: {

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1017,6 +1017,18 @@ const ruleMeta = Object.freeze({
         'Add `IF EXISTS` to this `DROP` so re-running the migration on a database that already lost the object does not abort.',
     },
   },
+  'require-index-on-fk-column': {
+    type: 'suggestion',
+    description:
+      'Require a covering index on every foreign-key leading column so that parent-row deletes and updates do not trigger a sequential scan of the child table',
+    recommended: true,
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingIndex:
+        'Foreign-key column `{{col}}` has no covering index in this file. Without one, a DELETE / UPDATE of the parent row sequentially scans this table to enforce the FK.',
+    },
+  },
   'require-limit': {
     type: 'suggestion',
     description: 'Require LIMIT clause in SELECT statements',

--- a/status.json
+++ b/status.json
@@ -6039,19 +6039,19 @@
       },
       {
         "name": "require-index-on-fk-column",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-index-on-fk-column."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-index-on-fk-column; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-limit",


### PR DESCRIPTION
Part of #14. Ports \`require-index-on-fk-column\`. Validated against upstream fixtures; clippy -D warnings clean. Adds \`pub statements\` to RuleContext and makes \`loc_of\` pub(crate) for program-exit rules.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784056342&installation_id=136613492&pr_number=393&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F393&signature=f259d60c94e33a0c215bb368be21332ee46ba130ecce3ddd5bd34a5b9ec8fe5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->