### PR TITLE
feat(postgresql): port require-fk-include-columns

### DIFF
--- a/crates/postgresql/Cargo.toml
+++ b/crates/postgresql/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 oxlint-plugins-carton.workspace = true
 pg_query.workspace = true
 phf.workspace = true
+regex.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -73,6 +73,7 @@ mod prefer_exists_over_in_subquery;
 mod prefer_explicit_null_ordering;
 mod prefer_in_list_over_or;
 mod prefer_not_equals_operator;
+mod require_fk_include_columns;
 mod require_if_exists;
 mod require_limit;
 mod require_named_constraint;
@@ -251,6 +252,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "prefer-explicit-null-ordering",
     "prefer-in-list-over-or",
     "prefer-not-equals-operator",
+    "require-fk-include-columns",
     "require-if-exists",
     "require-limit",
     "require-named-constraint",
@@ -615,6 +617,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "prefer-not-equals-operator",
         run: prefer_not_equals_operator::run,
         uses_parse_error: true,
+    },
+    RuleDef {
+        name: "require-fk-include-columns",
+        run: require_fk_include_columns::run,
+        uses_parse_error: false,
     },
     RuleDef {
         name: "require-if-exists",

--- a/crates/postgresql/src/rules/require_fk_include_columns.rs
+++ b/crates/postgresql/src/rules/require_fk_include_columns.rs
@@ -1,0 +1,236 @@
+//! Port of `require-fk-include-columns`: every foreign-key constraint must
+//! include a configurable set of columns (e.g. a tenant key) so that child
+//! rows cannot reference a parent in a different tenant.
+
+use regex::Regex;
+use serde_json::Value;
+
+use crate::ast::{array_field, is_type, str_field};
+use crate::{DiagnosticDatum, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// Extract the string value from a libpg_query String node.
+fn get_sval(n: &Value) -> Option<&str> {
+    if let Some(s) = n.as_str() {
+        return Some(s);
+    }
+    if let Some(sval) = n.get("sval") {
+        if let Some(s) = sval.as_str() {
+            return Some(s);
+        }
+        if let Some(s) = sval.get("sval").and_then(Value::as_str) {
+            return Some(s);
+        }
+    }
+    None
+}
+
+/// Collect the FK referencing column names from a `fk_attrs` array.
+fn collect_fk_attrs(attrs: &[Value]) -> SmallVec<[&str; 4]> {
+    attrs.iter().filter_map(get_sval).collect()
+}
+
+struct FkCandidate<'a> {
+    report_node: &'a Value,
+    fk_columns: SmallVec<[&'a str; 4]>,
+    table_name: &'a str,
+    ref_table: &'a str,
+}
+
+/// Check a candidate FK and report any missing required columns.
+fn check<'a>(
+    candidate: FkCandidate<'a>,
+    required_columns: &[&str],
+    exclude_table_pattern: Option<&str>,
+    exclude_ref_table_pattern: Option<&str>,
+    ctx: &mut RuleContext,
+) {
+    // Skip if the table matches the exclusion pattern.
+    if let Some(pat) = exclude_table_pattern
+        && Regex::new(pat).is_ok_and(|re| re.is_match(candidate.table_name))
+    {
+        return;
+    }
+    // Skip if the referenced table matches the exclusion pattern.
+    if let Some(pat) = exclude_ref_table_pattern
+        && Regex::new(pat).is_ok_and(|re| re.is_match(candidate.ref_table))
+    {
+        return;
+    }
+
+    let table_cs = CompactString::from(candidate.table_name);
+    let ref_cs = CompactString::from(candidate.ref_table);
+
+    for &required in required_columns {
+        if !candidate.fk_columns.contains(&required) {
+            let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+            data.push(DiagnosticDatum {
+                key: CompactString::from("table"),
+                value: table_cs.clone(),
+            });
+            data.push(DiagnosticDatum {
+                key: CompactString::from("refTable"),
+                value: ref_cs.clone(),
+            });
+            data.push(DiagnosticDatum {
+                key: CompactString::from("missing"),
+                value: CompactString::from(required),
+            });
+            ctx.report_data(candidate.report_node, "missingFkColumn", data);
+        }
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Copy option references before any ctx mutation.
+    let options = ctx.options;
+
+    let opts = match options.get(0) {
+        Some(o) => o,
+        None => return,
+    };
+
+    let required_columns: SmallVec<[&str; 4]> = opts
+        .get("columns")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    if required_columns.is_empty() {
+        return;
+    }
+
+    let exclude_table_pattern = opts.get("excludeTablePattern").and_then(Value::as_str);
+    let exclude_ref_table_pattern = opts
+        .get("excludeReferencedTablePattern")
+        .and_then(Value::as_str);
+
+    if is_type(node, "CreateStmt") {
+        let table_name = node
+            .get("relation")
+            .and_then(|r| r.get("relname"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+
+        let elts = match array_field(node, "tableElts") {
+            Some(e) => e,
+            None => return,
+        };
+
+        for elt in elts {
+            if is_type(elt, "ColumnDef") {
+                let col_name = match elt.get("colname").and_then(Value::as_str) {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let constraints = match array_field(elt, "constraints") {
+                    Some(c) => c,
+                    None => continue,
+                };
+                for constraint in constraints {
+                    if !is_type(constraint, "Constraint") {
+                        continue;
+                    }
+                    if str_field(constraint, "contype") != Some("CONSTR_FOREIGN") {
+                        continue;
+                    }
+                    let ref_table = constraint
+                        .get("pktable")
+                        .and_then(|t| t.get("relname"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    // For an inline column FK the referencing columns list is
+                    // just [colname] — there is no fk_attrs in this case.
+                    let mut fk_cols: SmallVec<[&str; 4]> = SmallVec::new();
+                    fk_cols.push(col_name);
+                    check(
+                        FkCandidate {
+                            report_node: constraint,
+                            fk_columns: fk_cols,
+                            table_name,
+                            ref_table,
+                        },
+                        &required_columns,
+                        exclude_table_pattern,
+                        exclude_ref_table_pattern,
+                        ctx,
+                    );
+                }
+            } else if is_type(elt, "Constraint") {
+                if str_field(elt, "contype") != Some("CONSTR_FOREIGN") {
+                    continue;
+                }
+                let ref_table = elt
+                    .get("pktable")
+                    .and_then(|t| t.get("relname"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let fk_cols = array_field(elt, "fk_attrs")
+                    .map(collect_fk_attrs)
+                    .unwrap_or_default();
+                check(
+                    FkCandidate {
+                        report_node: elt,
+                        fk_columns: fk_cols,
+                        table_name,
+                        ref_table,
+                    },
+                    &required_columns,
+                    exclude_table_pattern,
+                    exclude_ref_table_pattern,
+                    ctx,
+                );
+            }
+        }
+        return;
+    }
+
+    if is_type(node, "AlterTableStmt") {
+        let table_name = node
+            .get("relation")
+            .and_then(|r| r.get("relname"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+
+        let cmds = match array_field(node, "cmds") {
+            Some(c) => c,
+            None => return,
+        };
+
+        for cmd in cmds {
+            if !is_type(cmd, "AlterTableCmd") {
+                continue;
+            }
+            if str_field(cmd, "subtype") != Some("AT_AddConstraint") {
+                continue;
+            }
+            let def = match cmd.get("def") {
+                Some(d) if is_type(d, "Constraint") => d,
+                _ => continue,
+            };
+            if str_field(def, "contype") != Some("CONSTR_FOREIGN") {
+                continue;
+            }
+            let ref_table = def
+                .get("pktable")
+                .and_then(|t| t.get("relname"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let fk_cols = array_field(def, "fk_attrs")
+                .map(collect_fk_attrs)
+                .unwrap_or_default();
+            check(
+                FkCandidate {
+                    report_node: cmd,
+                    fk_columns: fk_cols,
+                    table_name,
+                    ref_table,
+                },
+                &required_columns,
+                exclude_table_pattern,
+                exclude_ref_table_pattern,
+                ctx,
+            );
+        }
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1005,6 +1005,32 @@ const ruleMeta = Object.freeze({
       preferBang: 'Use `!=` instead of `<>`.',
     },
   },
+  'require-fk-include-columns': {
+    type: 'suggestion',
+    description:
+      'Require that every foreign-key constraint includes a configurable set of columns (e.g. a tenant key) so that child rows cannot reference a parent in a different tenant',
+    recommended: false,
+    fixable: undefined,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          columns: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          excludeTablePattern: { type: 'string' },
+          excludeReferencedTablePattern: { type: 'string' },
+        },
+        required: ['columns'],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingFkColumn:
+        'Foreign-key constraint on `{{table}}` references `{{refTable}}` but does not include `{{missing}}`. In a multi-tenant database every FK should carry the tenant key so a child row cannot point at a parent in a different tenant.',
+    },
+  },
   'require-if-exists': {
     type: 'suggestion',
     description:

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1006,9 +1006,9 @@ const ruleMeta = Object.freeze({
     },
   },
   'require-fk-include-columns': {
-    type: 'suggestion',
+    type: 'problem',
     description:
-      'Require that every foreign-key constraint includes a configurable set of columns (e.g. a tenant key) so that child rows cannot reference a parent in a different tenant',
+      'Require every foreign-key constraint to include a configured set of columns (e.g. `tenant_id` in a multi-tenant database)',
     recommended: false,
     fixable: undefined,
     schema: [
@@ -1018,6 +1018,8 @@ const ruleMeta = Object.freeze({
           columns: {
             type: 'array',
             items: { type: 'string' },
+            uniqueItems: true,
+            minItems: 1,
           },
           excludeTablePattern: { type: 'string' },
           excludeReferencedTablePattern: { type: 'string' },

--- a/status.json
+++ b/status.json
@@ -6007,19 +6007,19 @@
       },
       {
         "name": "require-fk-include-columns",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule require-fk-include-columns."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/require-fk-include-columns; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "require-if-exists",


### PR DESCRIPTION
Part of #14. Ports \`require-fk-include-columns\`. Validated against upstream fixtures; clippy -D warnings clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784056605&installation_id=136613492&pr_number=394&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F394&signature=fdd4c8d9f37226c5fdd7a0b8c7b140ba61f5291b0fb69f516b7bef4b1b6087bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->