### PR TITLE
port(postgresql): implement prefer-cast-operator rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "oxlint-plugins-_carton",
  "pg_query",
  "phf",
+ "regex",
  "serde_json",
 ]
 

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -67,6 +67,7 @@ mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
 mod prefer_add_constraint_not_valid;
 mod prefer_bigint_id;
+mod prefer_cast_operator;
 mod prefer_coalesce_over_case;
 mod prefer_current_timestamp_over_now;
 mod prefer_exists_over_in_subquery;
@@ -248,6 +249,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-with-recursive-without-limit",
     "prefer-add-constraint-not-valid",
     "prefer-bigint-id",
+    "prefer-cast-operator",
     "prefer-coalesce-over-case",
     "prefer-current-timestamp-over-now",
     "prefer-exists-over-in-subquery",
@@ -591,6 +593,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
         name: "prefer-bigint-id",
         run: prefer_bigint_id::run,
         uses_parse_error: false,
+    },
+    RuleDef {
+        name: "prefer-cast-operator",
+        run: prefer_cast_operator::run,
+        uses_parse_error: true,
     },
     RuleDef {
         name: "prefer-coalesce-over-case",

--- a/crates/postgresql/src/rules/prefer_cast_operator.rs
+++ b/crates/postgresql/src/rules/prefer_cast_operator.rs
@@ -1,0 +1,266 @@
+//! Port of `prefer-cast-operator`: enforce a consistent style for PostgreSQL
+//! type casts — either the `::` operator form or the `CAST(... AS ...)`
+//! function form.  Produces autofixes in both directions.
+//!
+//! The rule tokenizes the source once in the program-exit trigger (null node)
+//! and then walks the full statement tree to find TypeCast nodes.
+
+use serde_json::Value;
+
+use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+/// A fully resolved cast fix ready to emit.
+struct TypeCastDiag {
+    loc: DiagnosticLoc,
+    message_id: &'static str,
+    fix_start: u32,
+    fix_end: u32,
+    replacement: CompactString,
+}
+
+/// Return the exclusive end offset of the type expression that begins at
+/// `tokens[start_idx]`.  The type may be:
+///   - a bare keyword / identifier (e.g. `integer`, `text`)
+///   - a schema-qualified name (e.g. `public.my_type`)
+///   - a name with typmod parens (e.g. `varchar(255)`, `numeric(10, 2)`)
+fn find_type_end(tokens: &[Token], start_idx: usize) -> u32 {
+    let first = &tokens[start_idx];
+    if !first.is_identifier_like() {
+        return first.end;
+    }
+    let mut type_end = first.end;
+    let mut i = start_idx + 1;
+    // Optional dot-identifier chain (e.g. `public.my_type`).
+    while i + 1 < tokens.len() && tokens[i].value == "." && tokens[i + 1].is_identifier_like() {
+        type_end = tokens[i + 1].end;
+        i += 2;
+    }
+    // Optional typmod paren group (e.g. `(255)` in `varchar(255)`).
+    if i < tokens.len() && tokens[i].value == "(" {
+        let mut depth: i32 = 1;
+        i += 1;
+        while i < tokens.len() && depth > 0 {
+            if tokens[i].value == "(" {
+                depth += 1;
+            } else if tokens[i].value == ")" {
+                depth -= 1;
+                if depth == 0 {
+                    type_end = tokens[i].end;
+                }
+            }
+            i += 1;
+        }
+    }
+    type_end
+}
+
+/// Recursively collect every `TypeCast` node in the JSON tree.
+fn collect_type_casts<'a>(node: &'a Value, out: &mut SmallVec<[&'a Value; 16]>) {
+    if node
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|t| t == "TypeCast")
+    {
+        out.push(node);
+    }
+    match node {
+        Value::Object(map) => {
+            for (key, val) in map {
+                if !matches!(key.as_str(), "parent" | "type" | "range" | "loc") {
+                    collect_type_casts(val, out);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_type_casts(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    // Only execute on the one-time program-level trigger (Value::Null).
+    if !node.is_null() {
+        return;
+    }
+
+    // Copy long-lived references out of ctx so we can call ctx.report_loc later.
+    let stmts = ctx.statements;
+    let options = ctx.options;
+    let source = ctx.source;
+
+    let form = options
+        .get(0)
+        .and_then(|o| o.get("form"))
+        .and_then(Value::as_str)
+        .unwrap_or("operator");
+    let target_operator = form != "function";
+
+    let tokenized = tokenize(source);
+    let tokens = &tokenized.tokens;
+
+    // Collect all TypeCast nodes across all statements.
+    let mut type_casts: SmallVec<[&Value; 16]> = SmallVec::new();
+    for stmt in stmts {
+        collect_type_casts(stmt, &mut type_casts);
+    }
+
+    // Process each TypeCast and accumulate diagnostics.
+    let mut diags: SmallVec<[TypeCastDiag; 8]> = SmallVec::new();
+
+    for tc_node in &type_casts {
+        let tc_range_start = match tc_node.get("range").and_then(Value::as_array) {
+            Some(r) if !r.is_empty() => r[0].as_u64().unwrap_or(0) as u32,
+            _ => continue,
+        };
+        let arg = match tc_node.get("arg") {
+            Some(a) => a,
+            None => continue,
+        };
+        let arg_range = match arg.get("range").and_then(Value::as_array) {
+            Some(r) if r.len() >= 2 => (
+                r[0].as_u64().unwrap_or(0) as u32,
+                r[1].as_u64().unwrap_or(0) as u32,
+            ),
+            _ => continue,
+        };
+        let (arg_start, arg_end) = arg_range;
+
+        let Some(head_idx) = tokens.iter().position(|t| t.start == tc_range_start) else {
+            continue;
+        };
+        let head = &tokens[head_idx];
+
+        let is_function =
+            head.kind == TokenKind::Keyword && head.value.eq_ignore_ascii_case("CAST");
+        let is_operator = head.kind == TokenKind::Operator && head.value == "::";
+
+        if !is_function && !is_operator {
+            continue;
+        }
+        // Skip if already in the target form.
+        if target_operator && is_operator {
+            continue;
+        }
+        if !target_operator && is_function {
+            continue;
+        }
+
+        if is_function {
+            // CAST(arg AS type) → arg::type
+            // Find the opening '(' immediately after the CAST keyword.
+            let Some(open_idx) = tokens[head_idx + 1..]
+                .iter()
+                .position(|t| t.value == "(")
+                .map(|pos| head_idx + 1 + pos)
+            else {
+                continue;
+            };
+
+            // Scan for the `AS` keyword at depth 1 and the closing `)` at depth 0.
+            let mut depth: i32 = 1;
+            let mut as_idx: Option<usize> = None;
+            let mut close_idx: Option<usize> = None;
+            let mut i = open_idx + 1;
+            while i < tokens.len() {
+                if tokens[i].value == "(" {
+                    depth += 1;
+                } else if tokens[i].value == ")" {
+                    depth -= 1;
+                    if depth == 0 {
+                        close_idx = Some(i);
+                        break;
+                    }
+                } else if depth == 1
+                    && tokens[i].kind == TokenKind::Keyword
+                    && tokens[i].value.eq_ignore_ascii_case("AS")
+                {
+                    as_idx = Some(i);
+                }
+                i += 1;
+            }
+            let (Some(as_idx), Some(close_idx)) = (as_idx, close_idx) else {
+                continue;
+            };
+            let type_start_idx = as_idx + 1;
+            if type_start_idx >= tokens.len() {
+                continue;
+            }
+
+            let type_end = find_type_end(tokens, type_start_idx);
+            let arg_src = source.slice(arg_start, arg_end);
+            let type_src = source.slice(tokens[type_start_idx].start, type_end);
+            let mut replacement = CompactString::new("");
+            replacement.push_str(arg_src.as_str());
+            replacement.push_str("::");
+            replacement.push_str(type_src.as_str());
+
+            let fix_start = head.start;
+            let fix_end = tokens[close_idx].end;
+            let start_pos = source.position(fix_start);
+            let end_pos = source.position(fix_end);
+            diags.push(TypeCastDiag {
+                loc: DiagnosticLoc {
+                    start_line: start_pos.line,
+                    start_column: start_pos.column,
+                    end_line: end_pos.line,
+                    end_column: end_pos.column,
+                },
+                message_id: "preferOperator",
+                fix_start,
+                fix_end,
+                replacement,
+            });
+        } else {
+            // arg::type → CAST(arg AS type)
+            let type_start_idx = head_idx + 1;
+            if type_start_idx >= tokens.len() {
+                continue;
+            }
+
+            let type_end = find_type_end(tokens, type_start_idx);
+            let arg_src = source.slice(arg_start, arg_end);
+            let type_src = source.slice(tokens[type_start_idx].start, type_end);
+            let mut replacement = CompactString::new("");
+            replacement.push_str("CAST(");
+            replacement.push_str(arg_src.as_str());
+            replacement.push_str(" AS ");
+            replacement.push_str(type_src.as_str());
+            replacement.push(')');
+
+            let fix_start = arg_start;
+            let fix_end = type_end;
+            let start_pos = source.position(fix_start);
+            let end_pos = source.position(fix_end);
+            diags.push(TypeCastDiag {
+                loc: DiagnosticLoc {
+                    start_line: start_pos.line,
+                    start_column: start_pos.column,
+                    end_line: end_pos.line,
+                    end_column: end_pos.column,
+                },
+                message_id: "preferFunction",
+                fix_start,
+                fix_end,
+                replacement,
+            });
+        }
+    }
+
+    for diag in diags {
+        ctx.report_loc(
+            diag.loc,
+            diag.message_id,
+            SmallVec::new(),
+            Some(DiagnosticFix {
+                start: diag.fix_start,
+                end: diag.fix_end,
+                replacement: diag.replacement,
+            }),
+        );
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -929,7 +929,7 @@ const ruleMeta = Object.freeze({
   'prefer-cast-operator': {
     type: 'layout',
     description:
-      'Enforce a consistent style for PostgreSQL type casts — either the `::` operator form or the `CAST(... AS ...)` function form',
+      'Enforce a single style for type casts (`x::int` operator form vs `CAST(x AS int)` function form)',
     recommended: false,
     fixable: 'code',
     schema: [

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -926,6 +926,26 @@ const ruleMeta = Object.freeze({
         'Primary-key `id` columns should be `bigint`. `int` overflows at 2.1 billion rows and the migration to widen it later requires a table rewrite under `ACCESS EXCLUSIVE`. Declare the column as `bigint GENERATED ALWAYS AS IDENTITY` from the start.',
     },
   },
+  'prefer-cast-operator': {
+    type: 'layout',
+    description:
+      'Enforce a consistent style for PostgreSQL type casts — either the `::` operator form or the `CAST(... AS ...)` function form',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          form: { enum: ['operator', 'function'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOperator: 'Use `<expr>::type` operator form instead of `CAST(...)`.',
+      preferFunction: 'Use `CAST(<expr> AS type)` instead of the `::` operator.',
+    },
+  },
   'prefer-coalesce-over-case': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5879,19 +5879,19 @@
       },
       {
         "name": "prefer-cast-operator",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
-        "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule prefer-cast-operator."
+        "notes": "Rust libpg_query (PostgreSQL 17) port of eslint-plugin-postgresql/prefer-cast-operator; covered by native API and upstream-fixture parity Vitest tests. Oxlint does not route .sql files to jsPlugins."
       },
       {
         "name": "prefer-coalesce-over-case",


### PR DESCRIPTION
## Summary

- Ports `prefer-cast-operator` from `eslint-plugin-postgresql` to the Rust/NAPI Oxlint plugin
- Enforces a consistent PostgreSQL cast style: either the `::` operator form or the `CAST(... AS ...)` function form
- Supports autofixes in both directions (`preferOperator` ↔ `preferFunction`)
- Controlled by `{ form: "operator" }` (default) or `{ form: "function" }` option
- Handles schema-qualified types (`public.my_type`), typmod parens (`varchar(255)`, `numeric(10,2)`)

## Implementation details

- Rule fires on program-exit trigger (`uses_parse_error: true`, `Value::Null` node)
- Tokenizes source once, then recursively walks all AST statements to find `TypeCast` nodes
- `find_type_end` helper correctly advances past base identifier, optional dot-chain, and optional typmod parens
- All diagnostics collected before `ctx.report_loc` calls to avoid borrow checker conflicts

## Test plan

- [x] `cargo clippy -p oxlint-plugins-postgresql` — clean
- [x] NAPI `build:debug` — success
- [x] `node` test harness against `prefer-cast-operator.json` fixtures — ALL MATCH
- [x] `cargo fmt` + `pnpm exec vp fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784057174&installation_id=136613492&pr_number=396&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F396&signature=4010fc6c24fa56f09936f7b45f068381b96e30d9efc79e466da59345909bd13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->