### PR TITLE
port(postgresql): plpgsql-keyword-case

### DIFF
--- a/crates/postgresql/src/embedded_code.rs
+++ b/crates/postgresql/src/embedded_code.rs
@@ -23,7 +23,13 @@ pub fn attach_embedded_code(program: &mut Value, tokens: &[Token], source: &Sour
     let Some(body) = program.get_mut("body").and_then(Value::as_array_mut) else {
         return;
     };
-    for node in body.iter_mut() {
+    attach_embedded_code_to_stmts(body, tokens, source);
+}
+
+/// Attach `embeddedCode` to every `CreateFunctionStmt` in a statement slice.
+/// Used by `scan_postgresql` so rule-scanning also has access to PL/pgSQL bodies.
+pub fn attach_embedded_code_to_stmts(stmts: &mut [Value], tokens: &[Token], source: &Source) {
+    for node in stmts.iter_mut() {
         // Only CreateFunctionStmt carries a function body. `CREATE PROCEDURE`
         // surfaces under the same node in libpg_query (with `is_procedure: true`).
         if node.get("type").and_then(Value::as_str) != Some("CreateFunctionStmt") {

--- a/crates/postgresql/src/lib.rs
+++ b/crates/postgresql/src/lib.rs
@@ -22,6 +22,7 @@ mod tokenize;
 use oxlint_plugins_carton::{CompactString, SmallVec};
 use serde_json::Value;
 
+use crate::embedded_code::attach_embedded_code_to_stmts;
 use crate::parse::{ParseError, parse};
 use crate::text::Source;
 
@@ -88,7 +89,11 @@ pub fn implemented_postgresql_rule_names() -> &'static [&'static str] {
 
 /// Lint `source_text` (raw SQL) with the rules enabled in `options`.
 pub fn scan_postgresql(source_text: &str, options: &ScanOptions) -> SmallVec<[Diagnostic; 8]> {
-    let parsed = parse(source_text);
+    let mut parsed = parse(source_text);
+    // Attach EmbeddedCode nodes to CreateFunctionStmt so that rules like
+    // `plpgsql-keyword-case` can visit them, mirroring the attachment that
+    // `parse_for_eslint` performs for the ESLint adapter.
+    attach_embedded_code_to_stmts(&mut parsed.statements, &parsed.tokens, &parsed.source);
     let mut ctx = RuleContext {
         source: &parsed.source,
         options: &options.options,

--- a/crates/postgresql/src/rules.rs
+++ b/crates/postgresql/src/rules.rs
@@ -65,6 +65,7 @@ mod no_update_without_from_binding;
 mod no_vacuum_full;
 mod no_volatile_default_on_add_column;
 mod no_with_recursive_without_limit;
+mod plpgsql_keyword_case;
 mod prefer_add_constraint_not_valid;
 mod prefer_bigint_id;
 mod prefer_cast_operator;
@@ -247,6 +248,7 @@ pub const IMPLEMENTED_RULE_NAMES: &[&str] = &[
     "no-vacuum-full",
     "no-volatile-default-on-add-column",
     "no-with-recursive-without-limit",
+    "plpgsql-keyword-case",
     "prefer-add-constraint-not-valid",
     "prefer-bigint-id",
     "prefer-cast-operator",
@@ -582,6 +584,11 @@ pub(crate) const REGISTRY: &[RuleDef] = &[
     RuleDef {
         name: "no-with-recursive-without-limit",
         run: no_with_recursive_without_limit::run,
+        uses_parse_error: false,
+    },
+    RuleDef {
+        name: "plpgsql-keyword-case",
+        run: plpgsql_keyword_case::run,
         uses_parse_error: false,
     },
     RuleDef {

--- a/crates/postgresql/src/rules/plpgsql_keyword_case.rs
+++ b/crates/postgresql/src/rules/plpgsql_keyword_case.rs
@@ -1,0 +1,403 @@
+//! Port of `plpgsql-keyword-case`: enforce a consistent case (upper or lower)
+//! for SQL and PL/pgSQL reserved keywords inside PL/pgSQL function bodies.
+//!
+//! Visits `EmbeddedCode` nodes where `language == "plpgsql"`, collects skip
+//! ranges (string literals, comments), locates `GET [STACKED] DIAGNOSTICS`
+//! spans, then walks every identifier-shaped word and reports those that are
+//! in `PLPGSQL_RESERVED_KEYWORDS` with the wrong case. Each wrong-case keyword
+//! gets its own separate `DiagnosticFix`.
+//!
+//! Default style: `"upper"`.
+//!
+//! Faithfully ported from upstream `src/rules/plpgsql-keyword-case.ts`.
+
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::ast::is_type;
+use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
+
+/// Reserved keywords in PL/pgSQL: the union of PostgreSQL's `RESERVED_KEYWORD`
+/// set and the PL/pgSQL reserved kwlist. Case-folding rules must only touch
+/// these because unreserved / COL_NAME / TYPE_FUNC_NAME keywords (`role`,
+/// `date`, `value`, …) can legitimately be column/variable names.
+///
+/// Mirrors upstream `PLPGSQL_RESERVED_KEYWORDS` from `src/utils/pg-keywords.ts`.
+static PLPGSQL_RESERVED_KEYWORDS: phf::Set<&'static str> = phf::phf_set! {
+    "all", "analyse", "analyze", "and", "any", "array", "as", "asc",
+    "asymmetric", "begin", "both", "by", "case", "cast", "check", "collate",
+    "column", "constraint", "create", "current_catalog", "current_date",
+    "current_role", "current_time", "current_timestamp", "current_user",
+    "declare", "default", "deferrable", "desc", "distinct", "do", "else",
+    "end", "except", "execute", "false", "fetch", "for", "foreach", "foreign",
+    "from", "grant", "group", "having", "if", "in", "initially", "intersect",
+    "into", "lateral", "leading", "limit", "localtime", "localtimestamp",
+    "loop", "not", "null", "offset", "on", "only", "or", "order", "placing",
+    "primary", "references", "returning", "select", "session_user", "some",
+    "strict", "symmetric", "system_user", "table", "then", "to", "trailing",
+    "true", "union", "unique", "user", "using", "variadic", "when", "where",
+    "while", "window", "with",
+};
+
+/// Identifiers that PostgreSQL only treats as keywords inside
+/// `GET [STACKED] DIAGNOSTICS … = <name>`. Everywhere else they are ordinary
+/// identifiers (variable names, `information_schema` column names, etc.), so
+/// they must not be case-folded unless they appear inside a GET DIAGNOSTICS
+/// statement.
+///
+/// Mirrors upstream `DIAGNOSTIC_ITEM_NAMES`.
+static DIAGNOSTIC_ITEM_NAMES: phf::Set<&'static str> = phf::phf_set! {
+    "row_count", "pg_context", "returned_sqlstate", "column_name",
+    "constraint_name", "pg_datatype_name", "message_text", "table_name",
+    "schema_name", "pg_exception_detail", "pg_exception_hint",
+    "pg_exception_context",
+};
+
+// ----- UTF-16 unit helpers --------------------------------------------------
+
+/// True when the UTF-16 unit is an identifier-start character (`[a-zA-Z_]`).
+#[inline]
+fn is_ident_start(u: u16) -> bool {
+    // A-Z: 0x41-0x5A, a-z: 0x61-0x7A, _: 0x5F
+    matches!(u, 0x41..=0x5A | 0x61..=0x7A | 0x5F)
+}
+
+/// True when the UTF-16 unit can continue an identifier (`[a-zA-Z0-9_]`).
+#[inline]
+fn is_ident_cont(u: u16) -> bool {
+    is_ident_start(u) || matches!(u, 0x30..=0x39) // 0-9: 0x30-0x39
+}
+
+/// True when `offset` falls inside any of the `[start, end)` ranges.
+fn is_in_range(offset: usize, ranges: &[(usize, usize)]) -> bool {
+    ranges.iter().any(|&(s, e)| offset >= s && offset < e)
+}
+
+// ----- Skip-range collection ------------------------------------------------
+
+/// Collect spans of string literals (`'…'`), line comments (`--…`), and block
+/// comments (`/*…*/`) inside `units`. Positions are UTF-16 unit indices into
+/// `units`. Ported 1:1 from upstream `collectSkipRanges`.
+fn collect_skip_ranges(units: &[u16]) -> SmallVec<[(usize, usize); 16]> {
+    let mut skip: SmallVec<[(usize, usize); 16]> = SmallVec::new();
+    let n = units.len();
+    let mut i = 0usize;
+    while i < n {
+        let c = units[i];
+        if c == 0x27 {
+            // Single-quote: scan to closing quote, treating '' as an escape.
+            let start = i;
+            i += 1;
+            while i < n {
+                if units[i] == 0x27 {
+                    if i + 1 < n && units[i + 1] == 0x27 {
+                        // Escaped quote ''
+                        i += 2;
+                        continue;
+                    }
+                    i += 1; // consume closing quote
+                    break;
+                }
+                i += 1;
+            }
+            skip.push((start, i));
+        } else if c == 0x2D && i + 1 < n && units[i + 1] == 0x2D {
+            // Line comment: scan to newline (exclusive).
+            let start = i;
+            while i < n && units[i] != 0x0A {
+                i += 1;
+            }
+            skip.push((start, i));
+        } else if c == 0x2F && i + 1 < n && units[i + 1] == 0x2A {
+            // Block comment: scan to closing */.
+            let start = i;
+            i += 2;
+            while i + 1 < n && !(units[i] == 0x2A && units[i + 1] == 0x2F) {
+                i += 1;
+            }
+            i += 2; // skip past */
+            skip.push((start, n.min(i)));
+        } else {
+            i += 1;
+        }
+    }
+    skip
+}
+
+// ----- GET DIAGNOSTICS range detection -------------------------------------
+
+/// Find every `GET [STACKED] DIAGNOSTICS … ;` span in `units` (not in skip),
+/// returning `[start_of_GET, position_of_semicolon)` ranges. Item names inside
+/// these spans may be case-folded. Ported 1:1 from upstream
+/// `findGetDiagnosticsRanges`.
+fn find_get_diagnostics_ranges(
+    units: &[u16],
+    skip: &[(usize, usize)],
+) -> SmallVec<[(usize, usize); 4]> {
+    let mut ranges: SmallVec<[(usize, usize); 4]> = SmallVec::new();
+    let n = units.len();
+    let mut i = 0usize;
+
+    while i < n {
+        // Skip non-identifier-start characters.
+        if !is_ident_start(units[i]) {
+            i += 1;
+            continue;
+        }
+
+        // Scan the complete word.
+        let word_start = i;
+        while i < n && is_ident_cont(units[i]) {
+            i += 1;
+        }
+        let word_end = i;
+
+        // Must be exactly "get" (case-insensitive).
+        if word_end - word_start != 3 {
+            continue;
+        }
+        if !word_eq_ci(&units[word_start..word_end], b"get") {
+            continue;
+        }
+        if is_in_range(word_start, skip) {
+            continue;
+        }
+
+        // Require whitespace after "get".
+        let mut j = word_end;
+        if j >= n || !is_ws(units[j]) {
+            continue;
+        }
+        while j < n && is_ws(units[j]) {
+            j += 1;
+        }
+
+        // Scan the next word: "stacked" or "diagnostics".
+        let next_start = j;
+        while j < n && is_ident_cont(units[j]) {
+            j += 1;
+        }
+        let next_end = j;
+        let next_len = next_end - next_start;
+
+        if next_len == 7 && word_eq_ci(&units[next_start..next_end], b"stacked") {
+            // Optional "stacked": require whitespace then "diagnostics".
+            if j >= n || !is_ws(units[j]) {
+                continue;
+            }
+            while j < n && is_ws(units[j]) {
+                j += 1;
+            }
+            let diag_start = j;
+            while j < n && is_ident_cont(units[j]) {
+                j += 1;
+            }
+            if j - diag_start != 11 || !word_eq_ci(&units[diag_start..j], b"diagnostics") {
+                continue;
+            }
+        } else if next_len == 11 && word_eq_ci(&units[next_start..next_end], b"diagnostics") {
+            // Direct "get diagnostics".
+        } else {
+            continue;
+        }
+
+        // Scan forward to find the terminating ';' (not in skip).
+        while j < n {
+            if units[j] == 0x3B && !is_in_range(j, skip) {
+                break;
+            }
+            j += 1;
+        }
+        ranges.push((word_start, j));
+    }
+
+    ranges
+}
+
+/// Case-insensitive ASCII comparison: `units` (all < 0x80) vs `word` (ASCII).
+fn word_eq_ci(units: &[u16], word: &[u8]) -> bool {
+    if units.len() != word.len() {
+        return false;
+    }
+    units
+        .iter()
+        .zip(word.iter())
+        .all(|(&u, &b)| (u as u8).eq_ignore_ascii_case(&b))
+}
+
+/// True when `u` is ASCII whitespace (space, tab, LF, CR).
+#[inline]
+fn is_ws(u: u16) -> bool {
+    matches!(u, 0x20 | 0x09 | 0x0A | 0x0D)
+}
+
+// ----- Field-access detection ----------------------------------------------
+
+/// True when the word at `start` is the right-hand side of a dotted access
+/// (`NEW.role`, `t . column`). Walks backward over inline whitespace and checks
+/// for a single `.` (not `..`). Ported 1:1 from upstream `isFieldAccessTarget`.
+fn is_field_access_target(units: &[u16], start: usize) -> bool {
+    if start == 0 {
+        return false;
+    }
+    let mut i = start - 1;
+    // Skip spaces and tabs going backward.
+    loop {
+        if units[i] != 0x20 && units[i] != 0x09 {
+            break;
+        }
+        if i == 0 {
+            return false;
+        }
+        i -= 1;
+    }
+    // Require a single dot (not `..`).
+    if units[i] != 0x2E {
+        return false;
+    }
+    if i > 0 && units[i - 1] == 0x2E {
+        return false;
+    }
+    true
+}
+
+// ----- Rule entry point ----------------------------------------------------
+
+pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
+    if !is_type(node, "EmbeddedCode") {
+        return;
+    }
+
+    // Only PL/pgSQL bodies (language is already lower-cased by the parser).
+    let language = node.get("language").and_then(Value::as_str).unwrap_or("");
+    if language != "plpgsql" {
+        return;
+    }
+
+    let source_str = node.get("source").and_then(Value::as_str).unwrap_or("");
+    let Some(range_arr) = node.get("range").and_then(Value::as_array) else {
+        return;
+    };
+    let Some(abs_body_start) = range_arr.first().and_then(Value::as_u64).map(|v| v as u32) else {
+        return;
+    };
+
+    let target = ctx
+        .options
+        .get(0)
+        .and_then(|o| o.get("case"))
+        .and_then(Value::as_str)
+        .unwrap_or("upper");
+    let is_upper = target == "upper";
+    let message_id: &'static str = if is_upper {
+        "expectedUpper"
+    } else {
+        "expectedLower"
+    };
+
+    // Encode the body as UTF-16 units so all offsets match ESLint's convention.
+    // SmallVec<[u16; 128]> avoids heap allocation for small bodies (≤128 chars).
+    let body_units: SmallVec<[u16; 128]> = source_str.encode_utf16().collect();
+    let body_len = body_units.len();
+
+    let skip = collect_skip_ranges(&body_units);
+    let diag_ranges = find_get_diagnostics_ranges(&body_units, &skip);
+
+    let mut i = 0usize;
+    while i < body_len {
+        if !is_ident_start(body_units[i]) {
+            i += 1;
+            continue;
+        }
+
+        // Scan the complete word.
+        let word_start = i;
+        while i < body_len && is_ident_cont(body_units[i]) {
+            i += 1;
+        }
+        let word_end = i;
+
+        // Skip words inside string literals or comments.
+        if is_in_range(word_start, &skip) {
+            continue;
+        }
+
+        // Skip right-hand sides of dotted field accesses (`NEW.role`, etc.).
+        if is_field_access_target(&body_units, word_start) {
+            continue;
+        }
+
+        // Build the lowercase form for keyword lookup (all units are ASCII).
+        let lower_cs: CompactString = body_units[word_start..word_end]
+            .iter()
+            .map(|&u| char::from((u as u8).to_ascii_lowercase()))
+            .collect();
+
+        // Only reserved keywords are eligible for case-folding.
+        if !PLPGSQL_RESERVED_KEYWORDS.contains(lower_cs.as_str()) {
+            continue;
+        }
+
+        // Diagnostic item names must only be folded when they appear inside a
+        // GET DIAGNOSTICS statement; otherwise they are regular identifiers.
+        if DIAGNOSTIC_ITEM_NAMES.contains(lower_cs.as_str())
+            && !is_in_range(word_start, &diag_ranges)
+        {
+            continue;
+        }
+
+        // Build the expected (transformed) form.
+        let expected_cs: CompactString = if is_upper {
+            body_units[word_start..word_end]
+                .iter()
+                .map(|&u| char::from((u as u8).to_ascii_uppercase()))
+                .collect()
+        } else {
+            lower_cs.clone()
+        };
+
+        // Build the original word for the message data and comparison.
+        let word_cs: CompactString = body_units[word_start..word_end]
+            .iter()
+            .map(|&u| char::from(u as u8))
+            .collect();
+
+        // Already the correct case — nothing to report.
+        if word_cs == expected_cs {
+            continue;
+        }
+
+        let abs_start = abs_body_start + word_start as u32;
+        let abs_end = abs_body_start + word_end as u32;
+
+        let start_pos = ctx.source.position(abs_start);
+        let end_pos = ctx.source.position(abs_end);
+
+        let loc = DiagnosticLoc {
+            start_line: start_pos.line,
+            start_column: start_pos.column,
+            end_line: end_pos.line,
+            end_column: end_pos.column,
+        };
+
+        let fix_replacement = expected_cs.clone();
+
+        let mut data: SmallVec<[DiagnosticDatum; 2]> = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("actual"),
+            value: word_cs,
+        });
+        data.push(DiagnosticDatum {
+            key: CompactString::from("expected"),
+            value: expected_cs,
+        });
+
+        let fix = DiagnosticFix {
+            start: abs_start,
+            end: abs_end,
+            replacement: fix_replacement,
+        };
+
+        ctx.report_loc(loc, message_id, data, Some(fix));
+    }
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -902,6 +902,26 @@ const ruleMeta = Object.freeze({
         'Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.',
     },
   },
+  'plpgsql-keyword-case': {
+    type: 'layout',
+    description:
+      'Enforce a consistent case (upper or lower) for SQL and PL/pgSQL keywords inside PL/pgSQL function bodies',
+    recommended: false,
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          case: { enum: ['upper', 'lower'] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      expectedUpper: "PL/pgSQL keyword '{{actual}}' should be uppercase: '{{expected}}'.",
+      expectedLower: "PL/pgSQL keyword '{{actual}}' should be lowercase: '{{expected}}'.",
+    },
+  },
   'prefer-add-constraint-not-valid': {
     type: 'suggestion',
     description:

--- a/status.json
+++ b/status.json
@@ -5831,19 +5831,19 @@
       },
       {
         "name": "plpgsql-keyword-case",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": true,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
           "oxlintIntegration": false
         },
-        "notes": "Pending port of upstream rule plpgsql-keyword-case."
+        "notes": "Ported. Visits EmbeddedCode nodes for plpgsql language; each mismatched keyword gets its own DiagnosticFix."
       },
       {
         "name": "prefer-add-constraint-not-valid",


### PR DESCRIPTION
## Summary

- Faithful port of `eslint-plugin-postgresql` `plpgsql-keyword-case` rule
- Visits `EmbeddedCode` nodes where `language == "plpgsql"`, collects skip ranges for string literals and comments, detects `GET [STACKED] DIAGNOSTICS` spans, then reports each reserved keyword with the wrong case using a separate `DiagnosticFix`
- Also attaches `EmbeddedCode` nodes in `scan_postgresql` (previously only done in `parse_for_eslint`) — this is the infrastructure fix that makes PL/pgSQL body scanning available to all rules going forward

## Test plan

- [ ] All 8 upstream fixture tests pass (`valid` × 5, `invalid` × 3)
- [ ] `cargo clippy -p oxlint-plugins-postgresql -- -D warnings` clean
- [ ] `pnpm --filter @oxlint-plugins/oxlint-plugin-postgresql build:debug` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784063357&installation_id=136613492&pr_number=405&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F405&signature=8fccde3fdc429a3a8ef5e676142119843a28fdc3731d96154e2fa55cca5b5f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->