### PR TITLE
fix(postgresql): review-audit corrections

### DIFF
--- a/crates/postgresql/src/ast.rs
+++ b/crates/postgresql/src/ast.rs
@@ -29,7 +29,24 @@ pub fn array_field<'a>(node: &'a Value, key: &str) -> Option<&'a [Value]> {
 }
 
 /// Borrow a field expected to be a string.
-#[allow(dead_code, reason = "shared accessor used by rules added in later PRs")]
 pub fn str_field<'a>(node: &'a Value, key: &str) -> Option<&'a str> {
     node.get(key).and_then(Value::as_str)
+}
+
+/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type
+/// name lives at key `"1"` of the typeName map (lower segments are schema
+/// qualifiers such as `pg_catalog`), falling back to key `"0"` for
+/// unqualified names like `money`, `time`, `bpchar`, etc.
+pub fn get_type_name(type_name: &Value) -> Option<&str> {
+    if let Some(v1) = type_name
+        .get("1")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
+    {
+        return Some(v1);
+    }
+    type_name
+        .get("0")
+        .and_then(|v| v.get("sval"))
+        .and_then(Value::as_str)
 }

--- a/crates/postgresql/src/ffi.rs
+++ b/crates/postgresql/src/ffi.rs
@@ -60,9 +60,10 @@ pub fn parse_to_json(sql: &str) -> Result<String, String> {
             if result.parse_tree.is_null() {
                 Err("libpg_query returned no parse tree".to_string())
             } else {
-                Ok(CStr::from_ptr(result.parse_tree)
-                    .to_string_lossy()
-                    .into_owned())
+                CStr::from_ptr(result.parse_tree)
+                    .to_str()
+                    .map(str::to_owned)
+                    .map_err(|_| "libpg_query returned non-UTF-8 parse tree".to_string())
             }
         } else {
             // `error` is non-null here, but its `message` field is itself a

--- a/crates/postgresql/src/rules/align_values.rs
+++ b/crates/postgresql/src/rules/align_values.rs
@@ -167,7 +167,12 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     }
     for row in &rows {
         for (i, &(s, e)) in row.item_ranges.iter().enumerate() {
-            let w = (e - s) as usize;
+            let w = ctx
+                .source
+                .slice(s, e)
+                .chars()
+                .map(char::len_utf16)
+                .sum::<usize>();
             if w > widths[i] {
                 widths[i] = w;
             }
@@ -190,7 +195,12 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
                 // Non-last column: `"text," padEnd(widths[i] + 1 + gap)`.
                 // widths[i] + 1 accounts for the comma; + gap is the spacing.
                 let pad_to = widths[i] + 1 + gap;
-                let item_len = (e - s) as usize; // UTF-16 units
+                let item_len = ctx
+                    .source
+                    .slice(s, e)
+                    .chars()
+                    .map(char::len_utf16)
+                    .sum::<usize>();
                 let with_comma = item_len + 1; // item + ','
                 expected.push_str(item_text.as_str());
                 expected.push(',');

--- a/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
@@ -12,20 +12,9 @@
 use serde_json::Value;
 
 use crate::ast::is_type;
-use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::tokenize::{TokenKind, tokenize};
 use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
-
-/// Strips surrounding double quotes from a token value so it can be compared
-/// with `alias.aliasname` (which holds the unquoted identifier from the parser).
-fn token_identifier_text(token: &Token) -> &str {
-    let v = &token.value;
-    if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
-        &v[1..v.len() - 1]
-    } else {
-        v.as_str()
-    }
-}
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "RangeVar") {
@@ -74,9 +63,12 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     let has_as = next.kind == TokenKind::Keyword && next.value.eq_ignore_ascii_case("AS");
 
     if style == "always" && !has_as {
-        // Confirm the token is actually the alias identifier (not a keyword
-        // like WHERE/JOIN that follows an un-aliased table reference).
-        if token_identifier_text(next) != alias_name {
+        // Upstream compares the raw token value (not unquoted) to the alias
+        // name. For a quoted alias like `FROM t "foo"`, aliasname is `foo`
+        // but the raw token value is `"foo"`, so they differ and the rule
+        // correctly skips it (no AS needed for quoted aliases that already
+        // differ from their raw token). Mirror upstream exactly.
+        if next.value != alias_name {
             return;
         }
         let loc = DiagnosticLoc {
@@ -102,7 +94,9 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
             return;
         };
         // Confirm the token after AS is actually the alias identifier.
-        if token_identifier_text(after) != alias_name {
+        // Compare the raw token value (not unquoted) to alias_name, matching
+        // upstream's `if (next.value !== alias.aliasname) return;`.
+        if after.value != alias_name {
             return;
         }
         let loc = DiagnosticLoc {

--- a/crates/postgresql/src/rules/consistent_identity_over_serial.rs
+++ b/crates/postgresql/src/rules/consistent_identity_over_serial.rs
@@ -9,31 +9,11 @@
 
 use serde_json::Value;
 
-use crate::ast::is_type;
+use crate::ast::{get_type_name, is_type};
 use crate::{DiagnosticDatum, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 const SERIAL_TYPES: [&str; 3] = ["smallserial", "serial", "bigserial"];
-
-/// Extract the unqualified PostgreSQL type name from a `ColumnDef.typeName`
-/// value (mirrors upstream `getTypeName`). The parser stores qualified names
-/// in numeric-string keys `"0"`, `"1"`, …; the type name is at key `"1"` when
-/// schema-qualified, or `"0"` otherwise.
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    // Try `typeName["1"].sval` first (schema-qualified: pg_catalog.int8, etc.)
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    // Fall back to `typeName["0"].sval`.
-    type_name
-        .get("0")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-}
 
 /// Returns true when the ColumnDef has any `CONSTR_IDENTITY` constraint
 /// (mirrors upstream `hasIdentity`).

--- a/crates/postgresql/src/rules/consistent_jsonb_over_json.rs
+++ b/crates/postgresql/src/rules/consistent_jsonb_over_json.rs
@@ -1,21 +1,7 @@
 //! Port of `consistent-jsonb-over-json`
 use crate::RuleContext;
-use crate::ast::is_type;
+use crate::ast::{get_type_name, is_type};
 use serde_json::Value;
-
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-}
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "ColumnDef") {

--- a/crates/postgresql/src/rules/consistent_text_over_varchar.rs
+++ b/crates/postgresql/src/rules/consistent_text_over_varchar.rs
@@ -1,21 +1,7 @@
 //! Port of `consistent-text-over-varchar`
 use crate::RuleContext;
-use crate::ast::is_type;
+use crate::ast::{get_type_name, is_type};
 use serde_json::Value;
-
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-}
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "ColumnDef") {

--- a/crates/postgresql/src/rules/consistent_timestamptz.rs
+++ b/crates/postgresql/src/rules/consistent_timestamptz.rs
@@ -1,21 +1,7 @@
 //! Port of `consistent-timestamptz`
 use crate::RuleContext;
-use crate::ast::is_type;
+use crate::ast::{get_type_name, is_type};
 use serde_json::Value;
-
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|v| v.get("sval"))
-        .and_then(Value::as_str)
-}
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "ColumnDef") {

--- a/crates/postgresql/src/rules/no_char_type.rs
+++ b/crates/postgresql/src/rules/no_char_type.rs
@@ -5,27 +5,7 @@
 use serde_json::Value;
 
 use crate::RuleContext;
-use crate::ast::is_type;
-
-/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
-/// is the segment at key `"1"` (lower segments are schema qualifiers such as
-/// `pg_catalog`), falling back to key `"0"` for unqualified names.
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if !type_name.is_object() {
-        return None;
-    }
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-}
+use crate::ast::{get_type_name, is_type};
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "ColumnDef") {

--- a/crates/postgresql/src/rules/no_money_type.rs
+++ b/crates/postgresql/src/rules/no_money_type.rs
@@ -5,27 +5,7 @@
 use serde_json::Value;
 
 use crate::RuleContext;
-use crate::ast::is_type;
-
-/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
-/// is the segment at key `"1"` (lower segments are schema qualifiers such as
-/// `pg_catalog`), falling back to key `"0"` for unqualified names like `money`.
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if !type_name.is_object() {
-        return None;
-    }
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-}
+use crate::ast::{get_type_name, is_type};
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "ColumnDef") {

--- a/crates/postgresql/src/rules/no_numeric_without_precision.rs
+++ b/crates/postgresql/src/rules/no_numeric_without_precision.rs
@@ -5,27 +5,7 @@
 use serde_json::Value;
 
 use crate::RuleContext;
-use crate::ast::is_type;
-
-/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
-/// is the segment at key `"1"` (lower segments are schema qualifiers such as
-/// `pg_catalog`), falling back to key `"0"` for unqualified names.
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if !type_name.is_object() {
-        return None;
-    }
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-}
+use crate::ast::{get_type_name, is_type};
 
 /// Mirrors upstream `hasTypmods`: true when `typeName.typmods` is a non-empty
 /// array (i.e. a precision/scale was declared).

--- a/crates/postgresql/src/rules/no_time_type.rs
+++ b/crates/postgresql/src/rules/no_time_type.rs
@@ -5,27 +5,7 @@
 use serde_json::Value;
 
 use crate::RuleContext;
-use crate::ast::is_type;
-
-/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
-/// is the segment at key `"1"` (lower segments are schema qualifiers such as
-/// `pg_catalog`), falling back to key `"0"` for unqualified names.
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if !type_name.is_object() {
-        return None;
-    }
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-}
+use crate::ast::{get_type_name, is_type};
 
 pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     if !is_type(node, "ColumnDef") {

--- a/crates/postgresql/src/rules/prefer_bigint_id.rs
+++ b/crates/postgresql/src/rules/prefer_bigint_id.rs
@@ -6,32 +6,12 @@
 use serde_json::Value;
 
 use crate::RuleContext;
-use crate::ast::is_type;
+use crate::ast::{get_type_name, is_type};
 
 /// Upstream `SMALL_INT_TYPES`: canonical small-integer type names plus the
 /// pseudo-types PostgreSQL keeps before a SERIAL is rewritten.
 fn is_small_int_type(name: &str) -> bool {
     matches!(name, "int2" | "int4" | "smallserial" | "serial")
-}
-
-/// Mirrors upstream `getTypeName` (`src/utils/ast.ts`): the canonical type name
-/// is the segment at key `"1"` (lower segments are schema qualifiers such as
-/// `pg_catalog`), falling back to key `"0"` for unqualified names.
-fn get_type_name(type_name: &Value) -> Option<&str> {
-    if !type_name.is_object() {
-        return None;
-    }
-    if let Some(v1) = type_name
-        .get("1")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
-    {
-        return Some(v1);
-    }
-    type_name
-        .get("0")
-        .and_then(|s| s.get("sval"))
-        .and_then(Value::as_str)
 }
 
 /// Mirrors upstream `isPrimaryKey`: a column-level `CONSTR_PRIMARY` constraint.

--- a/crates/postgresql/src/rules/require_fk_include_columns.rs
+++ b/crates/postgresql/src/rules/require_fk_include_columns.rs
@@ -33,7 +33,9 @@ fn collect_fk_attrs(attrs: &[Value]) -> SmallVec<[&str; 4]> {
 struct FkCandidate<'a> {
     report_node: &'a Value,
     fk_columns: SmallVec<[&'a str; 4]>,
-    table_name: &'a str,
+    /// `None` when `relation.relname` is absent; mirrors upstream `tableName`
+    /// (which is `undefined` / falsy when absent) for the short-circuit guard.
+    table_name: Option<&'a str>,
     ref_table: &'a str,
 }
 
@@ -45,9 +47,11 @@ fn check<'a>(
     exclude_ref_table_pattern: Option<&str>,
     ctx: &mut RuleContext,
 ) {
-    // Skip if the table matches the exclusion pattern.
-    if let Some(pat) = exclude_table_pattern
-        && Regex::new(pat).is_ok_and(|re| re.is_match(candidate.table_name))
+    // Mirror upstream `tableName && excludeTablePattern.test(tableName)`:
+    // only run the regex when table_name is present (non-None / non-empty).
+    if let (Some(pat), Some(name)) = (exclude_table_pattern, candidate.table_name)
+        && !name.is_empty()
+        && Regex::new(pat).is_ok_and(|re| re.is_match(name))
     {
         return;
     }
@@ -58,7 +62,9 @@ fn check<'a>(
         return;
     }
 
-    let table_cs = CompactString::from(candidate.table_name);
+    // When table name is absent, display "(unknown)" in the message, matching
+    // upstream's `tableName || "(unknown)"` fallback.
+    let table_cs = CompactString::from(candidate.table_name.unwrap_or("(unknown)"));
     let ref_cs = CompactString::from(candidate.ref_table);
 
     for &required in required_columns {
@@ -109,8 +115,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         let table_name = node
             .get("relation")
             .and_then(|r| r.get("relname"))
-            .and_then(Value::as_str)
-            .unwrap_or("");
+            .and_then(Value::as_str);
 
         let elts = match array_field(node, "tableElts") {
             Some(e) => e,
@@ -189,8 +194,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         let table_name = node
             .get("relation")
             .and_then(|r| r.get("relname"))
-            .and_then(Value::as_str)
-            .unwrap_or("");
+            .and_then(Value::as_str);
 
         let cmds = match array_field(node, "cmds") {
             Some(c) => c,

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -204,7 +204,7 @@ const ruleMeta = Object.freeze({
     },
   },
   'consistent-explicit-outer-join': {
-    type: 'suggestion',
+    type: 'layout',
     description:
       'Enforce a consistent stance on the explicit `OUTER` keyword in outer joins (either always require it, or always forbid it)',
     recommended: false,
@@ -225,10 +225,10 @@ const ruleMeta = Object.freeze({
     },
   },
   'consistent-fk-not-valid': {
-    type: 'suggestion',
+    type: 'problem',
     description:
       'Enforce a consistent stance on `NOT VALID` for `ADD CONSTRAINT ... FOREIGN KEY` (either always require it, or always forbid it)',
-    recommended: false,
+    recommended: true,
     fixable: undefined,
     schema: [
       {
@@ -272,7 +272,7 @@ const ruleMeta = Object.freeze({
     type: 'suggestion',
     description:
       'Enforce a consistent stance on `jsonb` vs `json` column types (either always require `jsonb`, or always forbid it)',
-    recommended: false,
+    recommended: true,
     fixable: undefined,
     schema: [
       {
@@ -316,7 +316,7 @@ const ruleMeta = Object.freeze({
     type: 'suggestion',
     description:
       'Enforce a consistent stance on `text` vs `varchar(n)` column types (either always require `text`, or always require a bounded type)',
-    recommended: false,
+    recommended: true,
     fixable: undefined,
     schema: [
       {
@@ -338,7 +338,7 @@ const ruleMeta = Object.freeze({
     type: 'suggestion',
     description:
       'Enforce a consistent stance on `timestamptz` vs `timestamp` column types (either always require `timestamptz`, or always forbid it)',
-    recommended: false,
+    recommended: true,
     fixable: undefined,
     schema: [
       {
@@ -756,7 +756,7 @@ const ruleMeta = Object.freeze({
     type: 'problem',
     description:
       'Require `SECURITY DEFINER` functions to also `SET search_path = ...` to prevent search-path injection attacks',
-    recommended: true,
+    recommended: false,
     fixable: undefined,
     schema: [],
     messages: {


### PR DESCRIPTION
Review-audit fixes for the eslint-plugin-postgresql Oxlint port.

## Changes

**(a) index.js `recommended`/`type` metadata — 6 rules corrected to match upstream:**
- `consistent-fk-not-valid`: `type` → `'problem'`, `recommended` → `true`
- `consistent-jsonb-over-json`: `recommended` → `true`
- `consistent-text-over-varchar`: `recommended` → `true`
- `consistent-timestamptz`: `recommended` → `true`
- `no-security-definer-without-search-path`: `recommended` → `false`
- `consistent-explicit-outer-join`: `type` → `'layout'`

**(b) `consistent-as-for-table-alias` — no longer over-reports quoted aliases:** Compare raw token `.value` (not unquoted) against `alias.aliasname`, matching upstream `if (next.value !== alias.aliasname) return`. Quoted aliases like `FROM t "foo"` correctly skip reporting. Remove the now-dead `token_identifier_text` helper.

**(c) Consolidate `get_type_name` into `crates/postgresql/src/ast.rs`:** Delete 9 private copies in rule files; all rules now import `crate::ast::get_type_name`. Behavior is identical.

**(d) Remove stale `#[allow(dead_code)]` on `str_field`** in `ast.rs` — it is now widely used.

**(e) `ffi.rs` — fail-fast on non-UTF-8 parse tree:** Use `CStr::to_str().map_err(...)` instead of `to_string_lossy()`. The error path still calls `pg_query_free_parse_result`. Error-message extraction left as `to_string_lossy` (diagnostic text).

**(f) `align-values` — UTF-16 widths:** Measure per-column max width and per-item padding width using `chars().map(char::len_utf16).sum()`, matching upstream JS `.length` semantics for non-ASCII VALUES items.

**(g) `require-fk-include-columns` — empty table name:** Change `table_name` to `Option<&str>`; mirror upstream `tableName &&` short-circuit so `excludeTablePattern` is not tested against an absent/empty name; use `"(unknown)"` as message-data fallback when `relname` is absent.

## Validation

Full 89-rule parity preserved (`FAILURES:0`); `clippy -D warnings` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784067163&installation_id=136613492&pr_number=412&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F412&signature=ac729a14a42135059fe0fe73521e8fd5a953051c368058f1d5936e6e4bb1422a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->