### PR TITLE
perf(postgresql): share the token stream via RuleContext

### DIFF
--- a/crates/postgresql/src/lib.rs
+++ b/crates/postgresql/src/lib.rs
@@ -99,6 +99,7 @@ pub fn scan_postgresql(source_text: &str, options: &ScanOptions) -> SmallVec<[Di
         options: &options.options,
         error: parsed.error.as_ref(),
         statements: &parsed.statements,
+        tokens: &parsed.tokens,
         diagnostics: SmallVec::new(),
         rule_name: "",
     };
@@ -138,6 +139,10 @@ pub struct RuleContext<'a> {
     /// program-exit behaviour (e.g. `require-index-on-fk-column`) walk this
     /// slice directly instead of relying on the visitor dispatch.
     pub statements: &'a [Value],
+    /// The token stream produced by the single tokenization of the source file.
+    /// Rules that need to walk the token stream (e.g. `prefer-keyword-case`)
+    /// use this shared slice instead of calling `tokenize(ctx.source)` again.
+    pub tokens: &'a [crate::tokenize::Token],
     diagnostics: SmallVec<[Diagnostic; 8]>,
     rule_name: &'static str,
 }

--- a/crates/postgresql/src/rules/consistent_as_for_column_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_column_alias.rs
@@ -16,7 +16,7 @@
 use serde_json::Value;
 
 use crate::ast::{array_field, field, is_type};
-use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::tokenize::{Token, TokenKind};
 use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -48,8 +48,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         return;
     };
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     for target in target_list {
         visit_target(target, style, tokens, ctx);

--- a/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
+++ b/crates/postgresql/src/rules/consistent_as_for_table_alias.rs
@@ -12,7 +12,7 @@
 use serde_json::Value;
 
 use crate::ast::is_type;
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -49,8 +49,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         .and_then(Value::as_str)
         .unwrap_or("always");
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     let Some((next_index, next)) = tokens
         .iter()

--- a/crates/postgresql/src/rules/consistent_create_or_replace.rs
+++ b/crates/postgresql/src/rules/consistent_create_or_replace.rs
@@ -17,7 +17,7 @@
 use serde_json::Value;
 
 use crate::ast::is_type;
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -36,8 +36,7 @@ fn node_range_start(node: &Value) -> u32 {
 /// `node.range[0]` forward. Returns `None` if no such token is found.
 fn find_create_loc(node: &Value, ctx: &RuleContext) -> Option<DiagnosticLoc> {
     let start_off = node_range_start(node);
-    let tokenized = tokenize(ctx.source);
-    let tok = tokenized.tokens.iter().find(|t| {
+    let tok = ctx.tokens.iter().find(|t| {
         t.start >= start_off
             && t.kind == TokenKind::Keyword
             && t.value.eq_ignore_ascii_case("CREATE")

--- a/crates/postgresql/src/rules/consistent_explicit_inner_join.rs
+++ b/crates/postgresql/src/rules/consistent_explicit_inner_join.rs
@@ -8,7 +8,7 @@
 
 use serde_json::Value;
 
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -37,8 +37,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         .and_then(Value::as_str)
         .unwrap_or("always");
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     for i in 0..tokens.len() {
         let token = &tokens[i];

--- a/crates/postgresql/src/rules/consistent_explicit_outer_join.rs
+++ b/crates/postgresql/src/rules/consistent_explicit_outer_join.rs
@@ -1,5 +1,5 @@
 //! Port of `consistent-explicit-outer-join`
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 use serde_json::Value;
@@ -19,8 +19,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         .and_then(|o| o.get("style"))
         .and_then(Value::as_str)
         .unwrap_or("always");
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     for i in 0..tokens.len() {
         let token = &tokens[i];

--- a/crates/postgresql/src/rules/no_identifier_too_long.rs
+++ b/crates/postgresql/src/rules/no_identifier_too_long.rs
@@ -6,7 +6,7 @@
 use core::fmt::Write as _;
 use serde_json::Value;
 
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, FastHashSet, SmallVec};
 
@@ -41,8 +41,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         .map(|v| v as usize)
         .unwrap_or(DEFAULT_MAX);
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     // Deduplicate by start offset (upstream uses `seen.has(range[0])`).
     let mut seen: FastHashSet<u32> = FastHashSet::default();

--- a/crates/postgresql/src/rules/no_unnecessary_quoted_identifier.rs
+++ b/crates/postgresql/src/rules/no_unnecessary_quoted_identifier.rs
@@ -11,7 +11,6 @@
 
 use serde_json::Value;
 
-use crate::tokenize::{Tokenized, tokenize};
 use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -59,8 +58,8 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         return;
     }
 
-    let Tokenized { tokens, .. } = tokenize(ctx.source);
-    for token in &tokens {
+    let tokens = ctx.tokens;
+    for token in tokens {
         // The parser emits `"..."` as a String-typed token; distinguish it from
         // a `'...'` literal by the opening quote.
         if !token.value.starts_with('"') {

--- a/crates/postgresql/src/rules/prefer_cast_operator.rs
+++ b/crates/postgresql/src/rules/prefer_cast_operator.rs
@@ -7,7 +7,7 @@
 
 use serde_json::Value;
 
-use crate::tokenize::{Token, TokenKind, tokenize};
+use crate::tokenize::{Token, TokenKind};
 use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -100,8 +100,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         .unwrap_or("operator");
     let target_operator = form != "function";
 
-    let tokenized = tokenize(source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     // Collect all TypeCast nodes across all statements.
     let mut type_casts: SmallVec<[&Value; 16]> = SmallVec::new();

--- a/crates/postgresql/src/rules/prefer_current_timestamp_over_now.rs
+++ b/crates/postgresql/src/rules/prefer_current_timestamp_over_now.rs
@@ -8,7 +8,7 @@
 
 use serde_json::Value;
 
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -18,8 +18,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         return;
     }
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     for (i, token) in tokens.iter().enumerate() {
         // `now()` — three-token sequence: Identifier "now", "(", ")".

--- a/crates/postgresql/src/rules/prefer_keyword_case.rs
+++ b/crates/postgresql/src/rules/prefer_keyword_case.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use oxlint_plugins_carton::{CompactString, FastHashSet, SmallVec};
 
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticDatum, DiagnosticFix, DiagnosticLoc, RuleContext};
 
 // Node types whose `range[0]` is a general identifier (only the first token
@@ -200,8 +200,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     // `transformType = null` in upstream when types_mode == "skip".
     let apply_types = types_mode != "skip";
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     // Phase 1: collect AST position exemptions.
     let mut positions = Positions::new();

--- a/crates/postgresql/src/rules/prefer_not_equals_operator.rs
+++ b/crates/postgresql/src/rules/prefer_not_equals_operator.rs
@@ -8,7 +8,7 @@
 
 use serde_json::Value;
 
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -32,8 +32,8 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         "preferBang"
     };
 
-    let Tokenized { tokens, .. } = tokenize(ctx.source);
-    for token in &tokens {
+    let tokens = ctx.tokens;
+    for token in tokens {
         if token.kind != TokenKind::Operator {
             continue;
         }
@@ -54,5 +54,3 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         ctx.report_loc(loc, message_id, SmallVec::new(), Some(fix));
     }
 }
-
-use crate::tokenize::Tokenized;

--- a/crates/postgresql/src/rules/require_if_exists.rs
+++ b/crates/postgresql/src/rules/require_if_exists.rs
@@ -13,7 +13,7 @@
 
 use serde_json::Value;
 
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::SmallVec;
 
@@ -64,8 +64,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
     // Constraining the search to the node range avoids false attribution to
     // `ALTER TABLE … DROP COLUMN` / `ALTER TABLE … DROP CONSTRAINT` when
     // those precede a standalone `DROP` statement.
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     let drop_idx = match tokens.iter().position(|tok| {
         tok.kind == TokenKind::Keyword

--- a/crates/postgresql/src/rules/require_on_delete_action.rs
+++ b/crates/postgresql/src/rules/require_on_delete_action.rs
@@ -4,7 +4,7 @@
 use serde_json::Value;
 
 use crate::ast::{is_type, str_field};
-use crate::tokenize::{TokenKind, tokenize};
+use crate::tokenize::TokenKind;
 use crate::{DiagnosticDatum, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -118,8 +118,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         _ => return,
     };
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     // Find the first token at or after the constraint start.
     let Some(start_idx) = tokens.iter().position(|t| t.start >= constraint_start) else {

--- a/crates/postgresql/src/rules/require_trailing_semicolon.rs
+++ b/crates/postgresql/src/rules/require_trailing_semicolon.rs
@@ -4,7 +4,6 @@
 
 use serde_json::Value;
 
-use crate::tokenize::tokenize;
 use crate::{DiagnosticFix, DiagnosticLoc, RuleContext};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
@@ -14,8 +13,7 @@ pub fn run(node: &Value, _ancestors: &[&Value], ctx: &mut RuleContext) {
         return;
     }
 
-    let tokenized = tokenize(ctx.source);
-    let tokens = &tokenized.tokens;
+    let tokens = ctx.tokens;
 
     let last = match tokens.last() {
         Some(t) => t,


### PR DESCRIPTION
Several rules called `tokenize(ctx.source)` on each matched AST node, re-tokenizing the entire source file once per matching node (O(n·|source|) per rule). This PR exposes the already-computed token stream on `RuleContext` and wires every rule to consume it instead.

## Changes

**`crates/postgresql/src/lib.rs`** — Add `pub tokens: &'a [crate::tokenize::Token]` to `RuleContext` and initialize it from `parsed.tokens` in `scan_postgresql` (the `Parsed` struct already holds `tokens`).

**14 rule files** — Remove the per-call `tokenize(ctx.source)` (and its `Tokenized` / `tokenize` imports) and use `ctx.tokens` instead:

| Rule file | Old trigger |
|---|---|
| `consistent_as_for_column_alias` | per `SelectStmt` node |
| `consistent_as_for_table_alias` | per `RangeVar` node |
| `consistent_create_or_replace` | per CREATE node |
| `consistent_explicit_inner_join` | once via null trigger |
| `consistent_explicit_outer_join` | once via null trigger |
| `no_identifier_too_long` | once via null trigger |
| `no_unnecessary_quoted_identifier` | once via null trigger |
| `prefer_cast_operator` | once via null trigger |
| `prefer_current_timestamp_over_now` | once via null trigger |
| `prefer_keyword_case` | once via null trigger |
| `prefer_not_equals_operator` | once via null trigger |
| `require_if_exists` | per DROP node |
| `require_on_delete_action` | per Constraint node |
| `require_trailing_semicolon` | once via null trigger |

After this commit: `grep -rn 'tokenize(' crates/postgresql/src/rules/` returns nothing.

## Validation

No behavior change. Full 89-rule parity preserved (`FAILURES:0`); `clippy -D warnings` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784067664&installation_id=136613492&pr_number=413&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F413&signature=660dfac1487fb899d8c7f3d232e820d61aeafb4e9ba8171bc3602b432f55711b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->