### PR TITLE
feat(port-target): register eslint-plugin-astro

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,3 +98,7 @@
 	path = upstream/eslint-plugin-mocha
 	url = https://github.com/lo1tuma/eslint-plugin-mocha
 	shallow = true
+[submodule "upstream/eslint-plugin-astro"]
+	path = upstream/eslint-plugin-astro
+	url = https://github.com/ota-meshi/eslint-plugin-astro
+	shallow = true

--- a/tools/port-targets.json
+++ b/tools/port-targets.json
@@ -455,6 +455,21 @@
       "rules": { "type": "none" },
       "docsUrlTemplate": null,
       "notes": "Parser dependency of eslint-plugin-postgresql (no lint rules of its own). Required so the postgresql rules can be ported."
+    },
+    {
+      "id": "eslint-plugin-astro",
+      "npm": "eslint-plugin-astro",
+      "repo": "https://github.com/ota-meshi/eslint-plugin-astro",
+      "submodule": "upstream/eslint-plugin-astro",
+      "packageSubdir": ".",
+      "baselineVersion": "1.7.0",
+      "pinnedRef": "v1.7.0",
+      "license": "MIT",
+      "monorepo": false,
+      "expectedRuleCount": 19,
+      "rules": { "type": "glob", "dir": "src/rules", "ext": ".ts", "exclude": ["index.ts"] },
+      "docsUrlTemplate": "https://ota-meshi.github.io/eslint-plugin-astro/rules/{rule}/",
+      "notes": "Lints .astro files via astro-eslint-parser; full parity depends on that parser (cf. eslint-plugin-svelte / eslint-plugin-vue, which are excluded, and @unocss/eslint-plugin)."
     }
   ]
 }

--- a/tools/tasks/sync-status-from-port-targets.ts
+++ b/tools/tasks/sync-status-from-port-targets.ts
@@ -217,6 +217,7 @@ const PACKAGE_MAP: Record<
     typeAware: true,
   },
   'postgresql-eslint-parser': { pkgName: null },
+  'eslint-plugin-astro': { pkgName: null },
 };
 
 const manifest = JSON.parse(


### PR DESCRIPTION
## Summary
Registers **eslint-plugin-astro** (v1.7.0, 19 rules, MIT, by ota-meshi) as a port target, the same way other not-yet-implemented targets are tracked.

- Vendored as a git submodule under `upstream/eslint-plugin-astro` (shallow, pinned to `v1.7.0`).
- Added to `tools/port-targets.json` (rules: `src/rules/*.ts` glob, expected 19).
- Mapped as `pkgName: null` in the status sync (registered, no npm package scaffolded yet — like `typescript-eslint` / `postgresql-eslint-parser`).

## ⚠️ Parser caveat
eslint-plugin-astro lints `.astro` files via **astro-eslint-parser**. That's the same dependency that excludes `eslint-plugin-svelte` / `eslint-plugin-vue` from this repo and constrains `@unocss/eslint-plugin`. Full rule parity will likely be limited until/unless that parser story is solved — captured in the tracking issue.

## Not included
- npm package / Rust crate scaffold and rule implementations (future work, tracked by the port issue).
- `docs/port-targets/` regeneration — requires every submodule checked out; run `pnpm run port:rules` to refresh.

## CI safety
`status:check` only validates existing `status.json` entries (astro isn't added there), and CI doesn't run `port:rules`, so this is a safe registration-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784074511&installation_id=136613492&pr_number=421&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F421&signature=579c373048703f7f17ca0308c4a284e10cbaa25da4818bb74588b8e93c01abf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->