### PR TITLE
feat(postgresql): port SQL token rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-postgresql"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-postgresql",
+]
+
+[[package]]
 name = "oxlint-plugin-react-refresh"
 version = "0.0.0"
 dependencies = [
@@ -918,6 +928,14 @@ dependencies = [
  "oxc_span",
  "oxlint-plugins-_carton",
  "regex",
+]
+
+[[package]]
+name = "oxlint-plugins-postgresql"
+version = "0.0.0"
+dependencies = [
+ "oxc_span",
+ "oxlint-plugins-_carton",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/cypress",
   "crates/eslint_comments",
   "crates/mocha",
+  "crates/postgresql",
   "crates/react_refresh",
   "crates/security",
   "crates/simple_import_sort",
@@ -13,6 +14,7 @@ members = [
   "npm/eslint-comments",
   "npm/mocha",
   "npm/no-forbidden-identifiers",
+  "npm/postgresql",
   "npm/react-refresh",
   "npm/security",
   "npm/simple-import-sort",
@@ -47,6 +49,7 @@ oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_ca
 oxlint-plugins-cypress = { path = "crates/cypress", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }
 oxlint-plugins-mocha = { path = "crates/mocha", version = "0.0.0" }
+oxlint-plugins-postgresql = { path = "crates/postgresql", version = "0.0.0" }
 oxlint-plugins-react-refresh = { path = "crates/react_refresh", version = "0.0.0" }
 oxlint-plugins-security = { path = "crates/security", version = "0.0.0" }
 oxlint-plugins-simple-import-sort = { path = "crates/simple_import_sort", version = "0.0.0" }

--- a/crates/postgresql/Cargo.toml
+++ b/crates/postgresql/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oxlint-plugins-postgresql"
+description = "Rust core for the postgresql oxlint JavaScript plugin."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/crates/postgresql/src/lib.rs
+++ b/crates/postgresql/src/lib.rs
@@ -1,0 +1,912 @@
+#![doc = "Rust implementation of eslint-plugin-postgresql rule logic."]
+
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub const RULE_NAMES: [&str; 31] = [
+    "consistent-identity-over-serial",
+    "consistent-jsonb-over-json",
+    "consistent-text-over-varchar",
+    "consistent-timestamptz",
+    "no-char-type",
+    "no-cluster",
+    "no-create-role",
+    "no-cross-join",
+    "no-drop-database",
+    "no-drop-schema-cascade",
+    "no-drop-table-cascade",
+    "no-equality-with-null",
+    "no-grant-all",
+    "no-grant-to-public",
+    "no-money-type",
+    "no-natural-join",
+    "no-not-in-subquery",
+    "no-select-into",
+    "no-select-star",
+    "no-set-search-path",
+    "no-temporary-table",
+    "no-time-type",
+    "no-truncate-cascade",
+    "no-unlogged-table",
+    "no-vacuum-full",
+    "prefer-cast-operator",
+    "prefer-current-timestamp-over-now",
+    "prefer-not-equals-operator",
+    "require-trailing-semicolon",
+    "require-where-in-delete",
+    "require-where-in-update",
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Style {
+    Always,
+    Never,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NotEqualsOperator {
+    Angle,
+    Bang,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CastForm {
+    Operator,
+    Function,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ScanOptions {
+    pub identity_style: Style,
+    pub jsonb_style: Style,
+    pub text_style: Style,
+    pub timestamptz_style: Style,
+    pub not_equals_operator: NotEqualsOperator,
+    pub cast_form: CastForm,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            identity_style: Style::Always,
+            jsonb_style: Style::Always,
+            text_style: Style::Always,
+            timestamptz_style: Style::Always,
+            not_equals_operator: NotEqualsOperator::Angle,
+            cast_form: CastForm::Operator,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub op: Option<CompactString>,
+    pub type_name: Option<CompactString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: DiagnosticData,
+    pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TokenKind {
+    Word,
+    Number,
+    Symbol,
+    String,
+    QuotedIdentifier,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Token {
+    kind: TokenKind,
+    text: CompactString,
+    span: Span,
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source_text: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position_for_offset(source_text, span.start);
+        let (end_line, end_column) = self.position_for_offset(source_text, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self.line_starts.partition_point(|start| *start <= offset);
+        let line_index = line_index.saturating_sub(1);
+        let line_start = self.line_starts[line_index];
+        let column = source_text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line_index + 1) as u32, column as u32)
+    }
+}
+
+pub fn implemented_postgresql_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+pub fn scan_postgresql(
+    source_text: &str,
+    _filename: &str,
+    options: &ScanOptions,
+) -> SmallVec<[Diagnostic; 32]> {
+    let tokens = lex_sql(source_text);
+    if tokens.is_empty() {
+        return SmallVec::new();
+    }
+
+    let line_index = LineIndex::new(source_text);
+    let mut scanner = Scanner {
+        source_text,
+        line_index,
+        diagnostics: SmallVec::new(),
+        tokens,
+        options,
+    };
+    scanner.scan();
+    scanner.diagnostics.sort_by(|left, right| {
+        (
+            left.loc.start_line,
+            left.loc.start_column,
+            left.rule_name,
+            left.message_id,
+        )
+            .cmp(&(
+                right.loc.start_line,
+                right.loc.start_column,
+                right.rule_name,
+                right.message_id,
+            ))
+    });
+    scanner.diagnostics
+}
+
+struct Scanner<'a> {
+    source_text: &'a str,
+    line_index: LineIndex,
+    diagnostics: SmallVec<[Diagnostic; 32]>,
+    tokens: SmallVec<[Token; 256]>,
+    options: &'a ScanOptions,
+}
+
+impl Scanner<'_> {
+    fn scan(&mut self) {
+        self.scan_trailing_semicolon();
+        self.scan_token_patterns();
+        self.scan_statements();
+    }
+
+    fn scan_trailing_semicolon(&mut self) {
+        let Some(last) = self.tokens.last() else {
+            return;
+        };
+        if !last.is_symbol(";") {
+            self.report("require-trailing-semicolon", "missingSemicolon", last.span);
+        }
+    }
+
+    fn scan_token_patterns(&mut self) {
+        let len = self.tokens.len();
+        for index in 0..len {
+            self.scan_select_star(index);
+            self.scan_types(index);
+            self.scan_binary_operator(index);
+            self.scan_current_time_functions(index);
+            self.scan_cast_operator(index);
+        }
+    }
+
+    fn scan_statements(&mut self) {
+        let mut start = 0;
+        while start < self.tokens.len() {
+            while start < self.tokens.len() && self.tokens[start].is_symbol(";") {
+                start += 1;
+            }
+            if start >= self.tokens.len() {
+                break;
+            }
+            let mut end = start;
+            while end < self.tokens.len() && !self.tokens[end].is_symbol(";") {
+                end += 1;
+            }
+            self.scan_statement(start, end);
+            start = end.saturating_add(1);
+        }
+    }
+
+    fn scan_statement(&mut self, start: usize, end: usize) {
+        if start >= end {
+            return;
+        }
+        self.scan_statement_head(start, end);
+        self.scan_statement_contains(start, end);
+    }
+
+    fn scan_statement_head(&mut self, start: usize, end: usize) {
+        if self.is_word(start, "DROP") && self.is_word(start + 1, "DATABASE") {
+            self.report_statement("no-drop-database", "noDropDatabase", start, end);
+        }
+        if self.is_word(start, "VACUUM") && self.is_word(start + 1, "FULL") {
+            self.report_statement("no-vacuum-full", "noVacuumFull", start, end);
+        }
+        if self.is_word(start, "CLUSTER") {
+            self.report_statement("no-cluster", "noCluster", start, end);
+        }
+        if self.is_word(start, "CREATE")
+            && (self.is_word(start + 1, "ROLE") || self.is_word(start + 1, "USER"))
+        {
+            self.report_statement("no-create-role", "noCreateRole", start, end);
+        }
+        if self.is_word(start, "UPDATE") && !self.statement_contains_word(start, end, "WHERE") {
+            self.report_statement("require-where-in-update", "missingWhere", start, end);
+        }
+        if self.is_word(start, "DELETE") && !self.statement_contains_word(start, end, "WHERE") {
+            self.report_statement("require-where-in-delete", "missingWhere", start, end);
+        }
+    }
+
+    fn scan_statement_contains(&mut self, start: usize, end: usize) {
+        for index in start..end {
+            if self.is_word(index, "DROP")
+                && self.is_word(index + 1, "SCHEMA")
+                && self.statement_contains_word(index + 2, end, "CASCADE")
+            {
+                self.report_statement("no-drop-schema-cascade", "noDropSchemaCascade", index, end);
+            }
+            if self.is_word(index, "DROP")
+                && self.is_word(index + 1, "TABLE")
+                && self.statement_contains_word(index + 2, end, "CASCADE")
+            {
+                self.report_statement("no-drop-table-cascade", "noCascade", index, end);
+            }
+            if self.is_word(index, "TRUNCATE")
+                && self.statement_contains_word(index + 1, end, "CASCADE")
+            {
+                self.report_statement("no-truncate-cascade", "noCascade", index, end);
+            }
+            if self.is_word(index, "GRANT") && self.is_word(index + 1, "ALL") {
+                self.report_statement("no-grant-all", "noGrantAll", index, end);
+            }
+            if self.is_word(index, "GRANT")
+                && self.statement_contains_sequence(index + 1, end, &["TO", "PUBLIC"])
+            {
+                self.report_statement("no-grant-to-public", "noPublic", index, end);
+            }
+            if self.is_word(index, "SET")
+                && (self.is_word(index + 1, "search_path")
+                    || ((self.is_word(index + 1, "LOCAL") || self.is_word(index + 1, "SESSION"))
+                        && self.is_word(index + 2, "search_path")))
+            {
+                self.report_statement("no-set-search-path", "noSetSearchPath", index, end);
+            }
+            if self.is_word(index, "CREATE")
+                && (self.is_word(index + 1, "TEMP") || self.is_word(index + 1, "TEMPORARY"))
+                && self.is_word(index + 2, "TABLE")
+            {
+                self.report(
+                    "no-temporary-table",
+                    "noTemporaryTable",
+                    self.tokens[index + 1].span,
+                );
+            }
+            if self.is_word(index, "CREATE")
+                && self.is_word(index + 1, "UNLOGGED")
+                && self.is_word(index + 2, "TABLE")
+            {
+                self.report(
+                    "no-unlogged-table",
+                    "noUnloggedTable",
+                    self.tokens[index + 1].span,
+                );
+            }
+            if self.is_word(index, "SELECT") {
+                self.scan_select_into(index, end);
+            }
+        }
+    }
+
+    fn scan_select_star(&mut self, select_index: usize) {
+        if !self.is_word(select_index, "SELECT") {
+            return;
+        }
+        let mut depth = 0_u32;
+        let mut index = select_index + 1;
+        while index < self.tokens.len() {
+            let token = &self.tokens[index];
+            if token.is_symbol(";") {
+                return;
+            }
+            if depth == 0 && token.is_word("FROM") {
+                return;
+            }
+            if token.is_symbol("(") {
+                depth += 1;
+            } else if token.is_symbol(")") {
+                depth = depth.saturating_sub(1);
+            } else if depth == 0 && token.is_symbol("*") {
+                self.report("no-select-star", "noSelectStar", token.span);
+            }
+            index += 1;
+        }
+    }
+
+    fn scan_select_into(&mut self, select_index: usize, end: usize) {
+        let mut depth = 0_u32;
+        for index in select_index + 1..end {
+            let token = &self.tokens[index];
+            if token.is_symbol("(") {
+                depth += 1;
+            } else if token.is_symbol(")") {
+                depth = depth.saturating_sub(1);
+            } else if depth == 0 && token.is_word("FROM") {
+                return;
+            } else if depth == 0 && token.is_word("INTO") {
+                self.report_statement("no-select-into", "noSelectInto", select_index, end);
+                return;
+            }
+        }
+    }
+
+    fn scan_types(&mut self, index: usize) {
+        if self.is_word(index, "char") || self.is_word(index, "bpchar") {
+            self.report("no-char-type", "noChar", self.tokens[index].span);
+        }
+        if self.is_word(index, "money") {
+            self.report("no-money-type", "noMoney", self.tokens[index].span);
+        }
+        if self.is_word(index, "time") && !self.previous_is(index, "CURRENT") {
+            self.report_type_span("no-time-type", "noTimeType", index);
+        }
+        if self.is_word(index, "timetz") {
+            self.report("no-time-type", "noTimeType", self.tokens[index].span);
+        }
+        if self.options.jsonb_style == Style::Always && self.is_word(index, "json") {
+            self.report(
+                "consistent-jsonb-over-json",
+                "preferJsonb",
+                self.tokens[index].span,
+            );
+        } else if self.options.jsonb_style == Style::Never && self.is_word(index, "jsonb") {
+            self.report(
+                "consistent-jsonb-over-json",
+                "unexpectedJsonb",
+                self.tokens[index].span,
+            );
+        }
+        if self.options.text_style == Style::Always
+            && self.is_word(index, "varchar")
+            && self
+                .token(index + 1)
+                .is_some_and(|token| token.is_symbol("("))
+        {
+            self.report(
+                "consistent-text-over-varchar",
+                "preferText",
+                self.tokens[index].span,
+            );
+        } else if self.options.text_style == Style::Never && self.is_word(index, "text") {
+            self.report(
+                "consistent-text-over-varchar",
+                "unexpectedText",
+                self.tokens[index].span,
+            );
+        }
+        if self.options.timestamptz_style == Style::Always
+            && self.is_word(index, "timestamp")
+            && !self.timestamp_has_time_zone(index)
+            && !self.previous_is(index, "CURRENT")
+        {
+            self.report(
+                "consistent-timestamptz",
+                "preferTimestamptz",
+                self.tokens[index].span,
+            );
+        } else if self.options.timestamptz_style == Style::Never
+            && (self.is_word(index, "timestamptz") || self.timestamp_has_time_zone(index))
+        {
+            self.report(
+                "consistent-timestamptz",
+                "unexpectedTimestamptz",
+                self.tokens[index].span,
+            );
+        }
+        if self.options.identity_style == Style::Always
+            && (self.is_word(index, "serial")
+                || self.is_word(index, "bigserial")
+                || self.is_word(index, "smallserial"))
+        {
+            self.report_with_data(
+                "consistent-identity-over-serial",
+                "preferIdentity",
+                self.tokens[index].span,
+                DiagnosticData {
+                    type_name: Some(self.tokens[index].text.to_ascii_lowercase()),
+                    ..DiagnosticData::default()
+                },
+            );
+        } else if self.options.identity_style == Style::Never
+            && self.is_word(index, "GENERATED")
+            && self.statement_contains_sequence(index + 1, self.tokens.len(), &["AS", "IDENTITY"])
+        {
+            self.report(
+                "consistent-identity-over-serial",
+                "unexpectedIdentity",
+                self.tokens[index].span,
+            );
+        }
+    }
+
+    fn scan_binary_operator(&mut self, index: usize) {
+        if self.tokens[index].is_symbol("!=") || self.tokens[index].is_symbol("<>") {
+            let op = self.tokens[index].text.clone();
+            if self
+                .token(index + 1)
+                .is_some_and(|token| token.is_word("NULL"))
+                || index > 0 && self.tokens[index - 1].is_word("NULL")
+            {
+                self.report_with_data(
+                    "no-equality-with-null",
+                    "useIsNull",
+                    self.tokens[index].span,
+                    DiagnosticData {
+                        op: Some(op.clone()),
+                        ..DiagnosticData::default()
+                    },
+                );
+            }
+            let wrong = match self.options.not_equals_operator {
+                NotEqualsOperator::Angle => "!=",
+                NotEqualsOperator::Bang => "<>",
+            };
+            if self.tokens[index].is_symbol(wrong) {
+                let message_id = match self.options.not_equals_operator {
+                    NotEqualsOperator::Angle => "preferAngle",
+                    NotEqualsOperator::Bang => "preferBang",
+                };
+                self.report(
+                    "prefer-not-equals-operator",
+                    message_id,
+                    self.tokens[index].span,
+                );
+            }
+        } else if self.tokens[index].is_symbol("=")
+            && (self
+                .token(index + 1)
+                .is_some_and(|token| token.is_word("NULL"))
+                || index > 0 && self.tokens[index - 1].is_word("NULL"))
+        {
+            self.report_with_data(
+                "no-equality-with-null",
+                "useIsNull",
+                self.tokens[index].span,
+                DiagnosticData {
+                    op: Some("=".into()),
+                    ..DiagnosticData::default()
+                },
+            );
+        }
+        if self.is_word(index, "CROSS") && self.is_word(index + 1, "JOIN") {
+            self.report_span("no-cross-join", "noCrossJoin", index, index + 1);
+        }
+        if self.is_word(index, "NATURAL") && self.is_word(index + 1, "JOIN") {
+            self.report_span("no-natural-join", "noNaturalJoin", index, index + 1);
+        }
+        if self.is_word(index, "NOT")
+            && self.is_word(index + 1, "IN")
+            && self
+                .token(index + 2)
+                .is_some_and(|token| token.is_symbol("("))
+            && self.is_word(index + 3, "SELECT")
+        {
+            self.report_span("no-not-in-subquery", "noNotInSubquery", index, index + 3);
+        }
+    }
+
+    fn scan_current_time_functions(&mut self, index: usize) {
+        if self.is_word(index, "now")
+            && self
+                .token(index + 1)
+                .is_some_and(|token| token.is_symbol("("))
+            && self
+                .token(index + 2)
+                .is_some_and(|token| token.is_symbol(")"))
+        {
+            self.report_span(
+                "prefer-current-timestamp-over-now",
+                "preferCurrentTimestamp",
+                index,
+                index + 2,
+            );
+        }
+        if self.is_word(index, "localtimestamp") {
+            self.report(
+                "prefer-current-timestamp-over-now",
+                "preferCurrentTimestampOverLocal",
+                self.tokens[index].span,
+            );
+        }
+        if self.is_word(index, "localtime") {
+            self.report(
+                "prefer-current-timestamp-over-now",
+                "preferCurrentTimeOverLocal",
+                self.tokens[index].span,
+            );
+        }
+    }
+
+    fn scan_cast_operator(&mut self, index: usize) {
+        if self.options.cast_form == CastForm::Operator && self.is_word(index, "CAST") {
+            self.report(
+                "prefer-cast-operator",
+                "preferOperator",
+                self.tokens[index].span,
+            );
+        } else if self.options.cast_form == CastForm::Function && self.tokens[index].is_symbol("::")
+        {
+            self.report(
+                "prefer-cast-operator",
+                "preferFunction",
+                self.tokens[index].span,
+            );
+        }
+    }
+
+    fn report_type_span(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        index: usize,
+    ) {
+        let end = if self.is_word(index + 1, "WITH")
+            && self.is_word(index + 2, "TIME")
+            && self.is_word(index + 3, "ZONE")
+        {
+            index + 3
+        } else {
+            index
+        };
+        self.report_span(rule_name, message_id, index, end);
+    }
+
+    fn timestamp_has_time_zone(&self, index: usize) -> bool {
+        self.is_word(index, "timestamp")
+            && self.is_word(index + 1, "WITH")
+            && self.is_word(index + 2, "TIME")
+            && self.is_word(index + 3, "ZONE")
+    }
+
+    fn previous_is(&self, index: usize, word: &str) -> bool {
+        index > 0 && self.tokens[index - 1].is_word(word)
+    }
+
+    fn statement_contains_word(&self, start: usize, end: usize, word: &str) -> bool {
+        (start..end.min(self.tokens.len())).any(|index| self.is_word(index, word))
+    }
+
+    fn statement_contains_sequence(&self, start: usize, end: usize, words: &[&str]) -> bool {
+        if words.is_empty() {
+            return true;
+        }
+        let mut matched = 0;
+        for index in start..end.min(self.tokens.len()) {
+            if self.is_word(index, words[matched]) {
+                matched += 1;
+                if matched == words.len() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn report_statement(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        start: usize,
+        end: usize,
+    ) {
+        if start >= self.tokens.len() {
+            return;
+        }
+        let end = end
+            .saturating_sub(1)
+            .min(self.tokens.len().saturating_sub(1));
+        self.report_span(rule_name, message_id, start, end);
+    }
+
+    fn report_span(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        start: usize,
+        end: usize,
+    ) {
+        if let (Some(start_token), Some(end_token)) = (self.token(start), self.token(end)) {
+            self.report(
+                rule_name,
+                message_id,
+                Span::new(start_token.span.start, end_token.span.end),
+            );
+        }
+    }
+
+    fn report(&mut self, rule_name: &'static str, message_id: &'static str, span: Span) {
+        self.report_with_data(rule_name, message_id, span, DiagnosticData::default());
+    }
+
+    fn report_with_data(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        span: Span,
+        data: DiagnosticData,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+
+    fn is_word(&self, index: usize, word: &str) -> bool {
+        self.token(index).is_some_and(|token| token.is_word(word))
+    }
+
+    fn token(&self, index: usize) -> Option<&Token> {
+        self.tokens.get(index)
+    }
+}
+
+impl Token {
+    fn is_word(&self, word: &str) -> bool {
+        self.kind == TokenKind::Word && self.text.eq_ignore_ascii_case(word)
+    }
+
+    fn is_symbol(&self, symbol: &str) -> bool {
+        self.kind == TokenKind::Symbol && self.text == symbol
+    }
+}
+
+fn lex_sql(source_text: &str) -> SmallVec<[Token; 256]> {
+    let bytes = source_text.as_bytes();
+    let mut tokens = SmallVec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if byte.is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+        if byte == b'-' && bytes.get(index + 1) == Some(&b'-') {
+            index = skip_line_comment(bytes, index + 2);
+            continue;
+        }
+        if byte == b'/' && bytes.get(index + 1) == Some(&b'*') {
+            index = skip_block_comment(bytes, index + 2);
+            continue;
+        }
+        if byte == b'\'' {
+            let end = skip_single_quoted(bytes, index + 1);
+            push_token(&mut tokens, TokenKind::String, source_text, index, end);
+            index = end;
+            continue;
+        }
+        if byte == b'"' {
+            let end = skip_double_quoted(bytes, index + 1);
+            push_token(
+                &mut tokens,
+                TokenKind::QuotedIdentifier,
+                source_text,
+                index,
+                end,
+            );
+            index = end;
+            continue;
+        }
+        if byte == b'$'
+            && let Some(end) = skip_dollar_quoted(bytes, index)
+        {
+            push_token(&mut tokens, TokenKind::String, source_text, index, end);
+            index = end;
+            continue;
+        }
+        if is_word_start(byte) {
+            let start = index;
+            index += 1;
+            while index < bytes.len() && is_word_continue(bytes[index]) {
+                index += 1;
+            }
+            push_token(&mut tokens, TokenKind::Word, source_text, start, index);
+            continue;
+        }
+        if byte.is_ascii_digit() {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_digit() || matches!(bytes[index], b'.' | b'_'))
+            {
+                index += 1;
+            }
+            push_token(&mut tokens, TokenKind::Number, source_text, start, index);
+            continue;
+        }
+        let start = index;
+        if matches!(
+            bytes.get(index..index + 2),
+            Some([b':', b':'] | [b'!', b'='] | [b'<', b'>'])
+        ) {
+            index += 2;
+        } else {
+            index += 1;
+        }
+        push_token(&mut tokens, TokenKind::Symbol, source_text, start, index);
+    }
+    tokens
+}
+
+fn push_token(
+    tokens: &mut SmallVec<[Token; 256]>,
+    kind: TokenKind,
+    source_text: &str,
+    start: usize,
+    end: usize,
+) {
+    tokens.push(Token {
+        kind,
+        text: CompactString::from(source_text.get(start..end).map_or("", |text| text)),
+        span: Span::new(start as u32, end as u32),
+    });
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() && bytes[index] != b'\n' {
+        index += 1;
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'*' && bytes[index + 1] == b'/' {
+            return index + 2;
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn skip_single_quoted(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        if bytes[index] == b'\'' {
+            if bytes.get(index + 1) == Some(&b'\'') {
+                index += 2;
+            } else {
+                return index + 1;
+            }
+        } else {
+            index += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn skip_double_quoted(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        if bytes[index] == b'"' {
+            if bytes.get(index + 1) == Some(&b'"') {
+                index += 2;
+            } else {
+                return index + 1;
+            }
+        } else {
+            index += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn skip_dollar_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut tag_end = start + 1;
+    while tag_end < bytes.len() && is_word_continue(bytes[tag_end]) {
+        tag_end += 1;
+    }
+    if bytes.get(tag_end) != Some(&b'$') {
+        return None;
+    }
+    let tag = &bytes[start..=tag_end];
+    let mut index = tag_end + 1;
+    while index + tag.len() <= bytes.len() {
+        if &bytes[index..index + tag.len()] == tag {
+            return Some(index + tag.len());
+        }
+        index += 1;
+    }
+    Some(bytes.len())
+}
+
+fn is_word_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_word_continue(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ScanOptions, scan_postgresql};
+
+    fn ids(source_text: &str) -> oxlint_plugins_carton::SmallVec<[&'static str; 32]> {
+        scan_postgresql(source_text, "fixture.sql", &ScanOptions::default())
+            .into_iter()
+            .map(|diagnostic| diagnostic.message_id)
+            .collect()
+    }
+
+    #[test]
+    fn scans_core_sql_rules() {
+        let diagnostics =
+            ids("DROP DATABASE archive;\nSELECT * FROM users;\nUPDATE users SET active = false;\n");
+        assert!(diagnostics.contains(&"noDropDatabase"));
+        assert!(diagnostics.contains(&"noSelectStar"));
+        assert!(diagnostics.contains(&"missingWhere"));
+    }
+
+    #[test]
+    fn skips_comments_and_strings() {
+        let diagnostics = ids("-- DROP DATABASE nope\nSELECT 'DROP DATABASE nope';\n");
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn detects_style_and_type_rules() {
+        let diagnostics = ids(
+            "CREATE TABLE t (id serial, payload json, name varchar(255), at timestamp, price money);\nSELECT now() != NULL;\n",
+        );
+        assert!(diagnostics.contains(&"preferIdentity"));
+        assert!(diagnostics.contains(&"preferJsonb"));
+        assert!(diagnostics.contains(&"preferText"));
+        assert!(diagnostics.contains(&"preferTimestamptz"));
+        assert!(diagnostics.contains(&"noMoney"));
+        assert!(diagnostics.contains(&"useIsNull"));
+        assert!(diagnostics.contains(&"preferAngle"));
+        assert!(diagnostics.contains(&"preferCurrentTimestamp"));
+    }
+}

--- a/npm/postgresql/Cargo.toml
+++ b/npm/postgresql/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "oxlint-plugin-postgresql"
+description = "Rust-backed oxlint plugin port of eslint-plugin-postgresql."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_postgresql"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-postgresql.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/npm/postgresql/LICENSE
+++ b/npm/postgresql/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yuichiro Yamashita
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/postgresql/README.md
+++ b/npm/postgresql/README.md
@@ -1,0 +1,57 @@
+# @oxlint-plugins/oxlint-plugin-postgresql
+
+Rust-backed Oxlint plugin port of `eslint-plugin-postgresql` v0.22.1.
+
+The current port scans SQL source text in Rust through NAPI. Oxlint does not
+parse `.sql` files as a first-class language target yet, so the package exposes
+the native scanner API and an ESLint/Oxlint-compatible rule adapter for
+environments that provide SQL source text to ESLint.
+
+## Rules
+
+Implemented rules:
+
+- `postgresql/consistent-identity-over-serial`
+- `postgresql/consistent-jsonb-over-json`
+- `postgresql/consistent-text-over-varchar`
+- `postgresql/consistent-timestamptz`
+- `postgresql/no-char-type`
+- `postgresql/no-cluster`
+- `postgresql/no-create-role`
+- `postgresql/no-cross-join`
+- `postgresql/no-drop-database`
+- `postgresql/no-drop-schema-cascade`
+- `postgresql/no-drop-table-cascade`
+- `postgresql/no-equality-with-null`
+- `postgresql/no-grant-all`
+- `postgresql/no-grant-to-public`
+- `postgresql/no-money-type`
+- `postgresql/no-natural-join`
+- `postgresql/no-not-in-subquery`
+- `postgresql/no-select-into`
+- `postgresql/no-select-star`
+- `postgresql/no-set-search-path`
+- `postgresql/no-temporary-table`
+- `postgresql/no-time-type`
+- `postgresql/no-truncate-cascade`
+- `postgresql/no-unlogged-table`
+- `postgresql/no-vacuum-full`
+- `postgresql/prefer-cast-operator`
+- `postgresql/prefer-current-timestamp-over-now`
+- `postgresql/prefer-not-equals-operator`
+- `postgresql/require-trailing-semicolon`
+- `postgresql/require-where-in-delete`
+- `postgresql/require-where-in-update`
+
+## API
+
+```js
+const { scanPostgresql } = require('@oxlint-plugins/oxlint-plugin-postgresql/api');
+
+const diagnostics = scanPostgresql('SELECT * FROM users;', 'query.sql');
+```
+
+## Attribution
+
+Rule behavior, diagnostic message strings, and fixture ideas are derived from
+`eslint-plugin-postgresql` (v0.22.1, MIT). See `LICENSE`.

--- a/npm/postgresql/api.d.ts
+++ b/npm/postgresql/api.d.ts
@@ -1,0 +1,34 @@
+export type PostgresqlScanOptions = {
+  identityStyle?: 'always' | 'never';
+  jsonbStyle?: 'always' | 'never';
+  textStyle?: 'always' | 'never';
+  timestamptzStyle?: 'always' | 'never';
+  notEqualsOperator?: '<>' | '!=';
+  castForm?: 'operator' | 'function';
+};
+
+export type PostgresqlDiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type PostgresqlDiagnosticData = {
+  op?: string | null;
+  typeName?: string | null;
+};
+
+export type PostgresqlDiagnostic = {
+  ruleName: string;
+  messageId: string;
+  data: PostgresqlDiagnosticData;
+  loc: PostgresqlDiagnosticLoc;
+};
+
+export function implementedPostgresqlRuleNames(): string[];
+export function scanPostgresql(
+  sourceText: string,
+  filename?: string,
+  options?: PostgresqlScanOptions,
+): PostgresqlDiagnostic[];

--- a/npm/postgresql/api.js
+++ b/npm/postgresql/api.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanPostgresql(sourceText, filename = 'schema.sql', options) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanPostgresql(sourceText, filename, normalizeOptions(options));
+}
+
+function normalizeOptions(options) {
+  if (options == null) {
+    return undefined;
+  }
+  if (typeof options !== 'object') {
+    throw new TypeError('options must be an object when provided.');
+  }
+  return options;
+}
+
+module.exports = {
+  implementedPostgresqlRuleNames: native.implementedPostgresqlRuleNames,
+  scanPostgresql,
+};
+module.exports.default = module.exports;

--- a/npm/postgresql/build.rs
+++ b/npm/postgresql/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/postgresql/index.js
+++ b/npm/postgresql/index.js
@@ -1,0 +1,357 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-postgresql (MIT).
+// SQL tokenization and implemented rule checks run in Rust through NAPI.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedPostgresqlRuleNames, scanPostgresql } = require('./api.js');
+
+const PLUGIN_NAME = 'postgresql';
+const DOCS_BASE = 'https://github.com/baseballyama/eslint-plugin-postgresql/blob/main/docs/rules';
+const diagnosticsCache = new WeakMap();
+
+const messages = {
+  'consistent-identity-over-serial': {
+    preferIdentity:
+      'Use `GENERATED ALWAYS AS IDENTITY` (SQL standard) instead of `{{typeName}}`. The serial pseudo-types create a separately-owned sequence that breaks under pg_dump round-trips and does not honor column privileges.',
+    unexpectedIdentity:
+      'Use a serial pseudo-type (e.g. `bigserial`) instead of `GENERATED ... AS IDENTITY`. Useful for projects that need to keep compatibility with tooling that does not understand identity columns.',
+  },
+  'consistent-jsonb-over-json': {
+    preferJsonb:
+      'Use `jsonb` instead of `json`. `jsonb` stores the parsed representation, supports indexing, and is what almost every application actually wants.',
+    unexpectedJsonb:
+      "Use `json` instead of `jsonb`. Useful when the project intentionally relies on `json`'s preservation of key order, whitespace, and duplicate keys.",
+  },
+  'consistent-text-over-varchar': {
+    preferText:
+      'Use `text` instead of `varchar(n)`. PostgreSQL stores both the same way; the length cap is enforced by a constraint that you cannot relax without a full table rewrite. Move the limit into a CHECK constraint.',
+    unexpectedText:
+      "Use `varchar(n)` (or another bounded string type) instead of `text`. Useful for projects that intentionally cap every string column's length at the type level.",
+  },
+  'consistent-timestamptz': {
+    preferTimestamptz:
+      'Use `timestamptz` (or `TIMESTAMP WITH TIME ZONE`) instead of `timestamp`. `timestamp` is timezone-naive: it stores the wall-clock value you handed in and assumes every reader and writer share the same convention, so two clients on different `TimeZone` settings will disagree on which instant the row represents.',
+    unexpectedTimestamptz:
+      "Use `timestamp` instead of `timestamptz` (or `TIMESTAMP WITH TIME ZONE`). When the project treats every timestamp as UTC at the application layer, `timestamp` avoids the implicit conversions `timestamptz` performs against each session's `TimeZone` setting.",
+  },
+  'no-char-type': {
+    noChar:
+      'Avoid `char(n)`. PostgreSQL pads stored values to `n` with trailing spaces and trims on read, which surprises every comparison and round-trip. Use `text` instead.',
+  },
+  'no-cluster': {
+    noCluster:
+      '`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` - and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.',
+  },
+  'no-create-role': {
+    noCreateRole:
+      '`CREATE ROLE` / `CREATE USER` belongs in an operator-managed bootstrap (Terraform, Pulumi, a runbook), not in application migrations. Migration files run with whichever role the deploy uses and are not the right place to manage permissions.',
+  },
+  'no-cross-join': {
+    noCrossJoin:
+      'Avoid `CROSS JOIN`. Cartesian products are almost always a mistake; use an explicit `JOIN ... ON` with a join condition, or `JOIN ... ON true` if you really do want one.',
+  },
+  'no-drop-database': {
+    noDropDatabase:
+      '`DROP DATABASE` is catastrophic and irreversible. Database creation/deletion belongs in an explicit operator workflow, not in versioned SQL applied automatically by a migration tool.',
+  },
+  'no-drop-schema-cascade': {
+    noDropSchemaCascade:
+      "`DROP SCHEMA ... CASCADE` removes every table, view, function, and sequence in the schema with no preview. List the objects you actually want to drop instead, or drop the schema only when it's already empty.",
+  },
+  'no-drop-table-cascade': {
+    noCascade:
+      'Avoid `DROP TABLE ... CASCADE`. CASCADE silently removes dependent objects (views, foreign keys, sequences); list them explicitly so reviewers can see the blast radius.',
+  },
+  'no-equality-with-null': {
+    useIsNull:
+      '`{{op}} NULL` always evaluates to NULL (treated as false). Use `IS NULL` / `IS NOT NULL` instead.',
+  },
+  'no-grant-all': {
+    noGrantAll:
+      '`GRANT ALL` (or `GRANT ALL PRIVILEGES`) is opaque - list the privileges you actually need (e.g. `SELECT, INSERT, UPDATE`) so the grant is auditable and adding a new PostgreSQL privilege in a future release does not silently extend it.',
+  },
+  'no-grant-to-public': {
+    noPublic:
+      'Avoid `GRANT ... TO PUBLIC`. The PUBLIC role covers every current and future role in the database, including ones added later for unrelated services. Name the role(s) you actually want to grant to.',
+  },
+  'no-money-type': {
+    noMoney:
+      'Avoid `money`. Its output format and precision depend on `lc_monetary`, so the same row looks different on different servers and round-trips badly. Store amounts as `numeric` and keep the currency in a separate column.',
+  },
+  'no-natural-join': {
+    noNaturalJoin:
+      'Avoid `NATURAL JOIN`. The join columns are implicit - any future column with a matching name on both sides silently changes the result. Use `JOIN ... USING (...)` or `JOIN ... ON ...` and name the columns.',
+  },
+  'no-not-in-subquery': {
+    noNotInSubquery:
+      '`NOT IN (subquery)` returns no rows if the subquery yields any NULL - almost certainly not what you want. Use `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` instead; it handles NULL correctly.',
+  },
+  'no-select-into': {
+    noSelectInto:
+      "`SELECT ... INTO target FROM ...` creates a new table whose semantics differ from a regular `SELECT` and conflict with PL/pgSQL's `SELECT INTO variable`. Use `CREATE TABLE target AS SELECT ...` so the intent is explicit.",
+  },
+  'no-select-star': {
+    noSelectStar:
+      'Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.',
+  },
+  'no-set-search-path': {
+    noSetSearchPath:
+      '`SET search_path` makes name resolution depend on session state and is a known foot-gun for security-definer functions and CREATE statements. Qualify identifiers with their schema (`audit.events`, `public.users`) instead.',
+  },
+  'no-temporary-table': {
+    noTemporaryTable:
+      '`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.',
+  },
+  'no-time-type': {
+    noTimeType:
+      '`TIME` and `TIME WITH TIME ZONE` rarely model anything correctly: `time` has no date so cannot disambiguate around DST, and `timetz` stores an offset that is meaningless without a date. Use `timestamptz` for points in time, `interval` for durations, or store an opaque `text` if all you need is a display value.',
+  },
+  'no-truncate-cascade': {
+    noCascade:
+      '`TRUNCATE ... CASCADE` also truncates every table that has a foreign key referencing this one. List the dependent tables explicitly so reviewers can see what gets emptied.',
+  },
+  'no-unlogged-table': {
+    noUnloggedTable:
+      '`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file.',
+  },
+  'no-vacuum-full': {
+    noVacuumFull:
+      '`VACUUM FULL` takes `ACCESS EXCLUSIVE` and rewrites the whole table; the table is unavailable for the duration. For shrinking a bloated table on a live database, use `pg_repack` or `pg_squeeze`. A plain `VACUUM` (no `FULL`) is fine.',
+  },
+  'prefer-cast-operator': {
+    preferOperator: 'Use `<expr>::type` operator form instead of `CAST(...)`.',
+    preferFunction: 'Use `CAST(<expr> AS type)` instead of the `::` operator.',
+  },
+  'prefer-current-timestamp-over-now': {
+    preferCurrentTimestamp: 'Use the SQL-standard `CURRENT_TIMESTAMP` instead of `now()`.',
+    preferCurrentTimestampOverLocal:
+      'Use `CURRENT_TIMESTAMP` instead of `LOCALTIMESTAMP`. `LOCALTIMESTAMP` returns a timezone-naive `timestamp`; `CURRENT_TIMESTAMP` returns `timestamptz`, which is what most apps actually want.',
+    preferCurrentTimeOverLocal:
+      'Use `CURRENT_TIME` instead of `LOCALTIME`. `LOCALTIME` returns a timezone-naive `time`; `CURRENT_TIME` returns `timetz`.',
+  },
+  'prefer-not-equals-operator': {
+    preferAngle: 'Use `<>` instead of `!=`.',
+    preferBang: 'Use `!=` instead of `<>`.',
+  },
+  'require-trailing-semicolon': {
+    missingSemicolon: 'Missing trailing `;` at the end of the file.',
+  },
+  'require-where-in-delete': {
+    missingWhere:
+      'DELETE without WHERE removes every row in the table. Add a WHERE clause, or use TRUNCATE if you really mean to empty the table.',
+  },
+  'require-where-in-update': {
+    missingWhere:
+      'UPDATE without WHERE rewrites every row in the table. Add a WHERE clause to scope the change.',
+  },
+};
+
+const descriptions = Object.freeze(
+  Object.fromEntries(
+    Object.keys(messages).map((ruleName) => [
+      ruleName,
+      `port of eslint-plugin-postgresql/${ruleName}`,
+    ]),
+  ),
+);
+
+const implementedRuleNames = Object.freeze(implementedPostgresqlRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [ruleName, createPostgresqlRule(ruleName)]),
+  ),
+);
+
+const recommendedRules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'warn']),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  configs: {
+    recommended: {
+      name: `${PLUGIN_NAME}/recommended`,
+      files: ['**/*.sql'],
+      plugins: [PLUGIN_NAME],
+      rules: recommendedRules,
+    },
+    all: {
+      name: `${PLUGIN_NAME}/all`,
+      files: ['**/*.sql'],
+      plugins: [PLUGIN_NAME],
+      rules: Object.fromEntries(
+        implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
+      ),
+    },
+  },
+});
+
+plugin.implementedPostgresqlRuleNames = implementedRuleNames;
+plugin.scanPostgresql = scanPostgresql;
+
+function createPostgresqlRule(ruleName) {
+  return {
+    meta: {
+      type: ruleName.startsWith('prefer-') ? 'layout' : 'suggestion',
+      docs: {
+        description: descriptions[ruleName],
+        recommended: true,
+        url: `${DOCS_BASE}/${ruleName}.md`,
+      },
+      messages: messages[ruleName],
+      schema: optionSchemaFor(ruleName),
+    },
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForContext(context, ruleName)) {
+            if (diagnostic.ruleName !== ruleName) {
+              continue;
+            }
+            context.report({
+              messageId: diagnostic.messageId,
+              data: compactData(diagnostic.data),
+              loc: {
+                start: {
+                  line: diagnostic.loc.startLine,
+                  column: diagnostic.loc.startColumn,
+                },
+                end: {
+                  line: diagnostic.loc.endLine,
+                  column: diagnostic.loc.endColumn,
+                },
+              },
+            });
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForContext(context, ruleName) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'schema.sql';
+  const options = nativeOptionsForRule(ruleName, context.options?.[0]);
+  const cacheKey = JSON.stringify(options);
+  const cached = diagnosticsCache.get(sourceCode);
+
+  if (
+    cached &&
+    cached.sourceText === sourceText &&
+    cached.filename === filename &&
+    cached.cacheKey === cacheKey
+  ) {
+    return cached.diagnostics;
+  }
+
+  const diagnostics = scanPostgresql(sourceText, filename, options);
+  diagnosticsCache.set(sourceCode, { sourceText, filename, cacheKey, diagnostics });
+  return diagnostics;
+}
+
+function nativeOptionsForRule(ruleName, raw) {
+  const options = raw && typeof raw === 'object' ? raw : {};
+  switch (ruleName) {
+    case 'consistent-identity-over-serial':
+      return { identityStyle: styleOption(options.style) };
+    case 'consistent-jsonb-over-json':
+      return { jsonbStyle: styleOption(options.style) };
+    case 'consistent-text-over-varchar':
+      return { textStyle: styleOption(options.style) };
+    case 'consistent-timestamptz':
+      return { timestamptzStyle: styleOption(options.style) };
+    case 'prefer-not-equals-operator':
+      return {
+        notEqualsOperator: options.operator === '!=' ? '!=' : '<>',
+      };
+    case 'prefer-cast-operator':
+      return {
+        castForm: options.form === 'function' ? 'function' : 'operator',
+      };
+    default:
+      return {};
+  }
+}
+
+function styleOption(value) {
+  return value === 'never' ? 'never' : 'always';
+}
+
+function optionSchemaFor(ruleName) {
+  if (
+    [
+      'consistent-identity-over-serial',
+      'consistent-jsonb-over-json',
+      'consistent-text-over-varchar',
+      'consistent-timestamptz',
+    ].includes(ruleName)
+  ) {
+    return [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['always', 'never'] },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'prefer-not-equals-operator') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          operator: { enum: ['<>', '!='] },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  if (ruleName === 'prefer-cast-operator') {
+    return [
+      {
+        type: 'object',
+        properties: {
+          form: { enum: ['operator', 'function'] },
+        },
+        additionalProperties: false,
+      },
+    ];
+  }
+  return [];
+}
+
+function sourceTextForContext(context) {
+  const sourceCode = context.sourceCode || {};
+  if (typeof sourceCode.getText === 'function') {
+    return sourceCode.getText();
+  }
+  if (typeof sourceCode.text === 'string') {
+    return sourceCode.text;
+  }
+  return '';
+}
+
+function compactData(data) {
+  const out = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    if (value != null) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.implementedPostgresqlRuleNames = implementedRuleNames;
+module.exports.scanPostgresql = scanPostgresql;

--- a/npm/postgresql/package.json
+++ b/npm/postgresql/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-postgresql",
+  "version": "0.0.0",
+  "description": "Rust-backed oxlint plugin port of eslint-plugin-postgresql.",
+  "keywords": [
+    "eslint-plugin",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "postgresql",
+    "rust",
+    "sql"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/postgresql"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_postgresql",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/postgresql/src/lib.rs
+++ b/npm/postgresql/src/lib.rs
@@ -1,0 +1,119 @@
+//! NAPI boundary for the postgresql oxlint plugin.
+
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticLoc, PostgresqlOptions,
+    implemented_postgresql_rule_names, scan_postgresql,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI and proc macros require String/Vec/Option; values are converted before calling core helpers."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_postgresql as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct PostgresqlOptions {
+        pub identity_style: Option<String>,
+        pub jsonb_style: Option<String>,
+        pub text_style: Option<String>,
+        pub timestamptz_style: Option<String>,
+        pub not_equals_operator: Option<String>,
+        pub cast_form: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct DiagnosticData {
+        pub op: Option<String>,
+        pub type_name: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub data: DiagnosticData,
+        pub loc: DiagnosticLoc,
+    }
+
+    #[napi]
+    pub fn implemented_postgresql_rule_names() -> Vec<String> {
+        core::implemented_postgresql_rule_names()
+            .iter()
+            .map(|rule| (*rule).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_postgresql(
+        source_text: String,
+        filename: String,
+        options: Option<PostgresqlOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::ScanOptions {
+            identity_style: style_or_default(options.identity_style),
+            jsonb_style: style_or_default(options.jsonb_style),
+            text_style: style_or_default(options.text_style),
+            timestamptz_style: style_or_default(options.timestamptz_style),
+            not_equals_operator: not_equals_operator_or_default(options.not_equals_operator),
+            cast_form: cast_form_or_default(options.cast_form),
+        };
+
+        core::scan_postgresql(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                data: DiagnosticData {
+                    op: diagnostic.data.op.map(|value| value.as_str().to_owned()),
+                    type_name: diagnostic
+                        .data
+                        .type_name
+                        .map(|value| value.as_str().to_owned()),
+                },
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+            })
+            .collect()
+    }
+
+    fn style_or_default(value: Option<String>) -> core::Style {
+        match value.as_deref() {
+            Some("never") => core::Style::Never,
+            _ => core::Style::Always,
+        }
+    }
+
+    fn not_equals_operator_or_default(value: Option<String>) -> core::NotEqualsOperator {
+        match value.as_deref() {
+            Some("!=") => core::NotEqualsOperator::Bang,
+            _ => core::NotEqualsOperator::Angle,
+        }
+    }
+
+    fn cast_form_or_default(value: Option<String>) -> core::CastForm {
+        match value.as_deref() {
+            Some("function") => core::CastForm::Function,
+            _ => core::CastForm::Operator,
+        }
+    }
+}

--- a/npm/postgresql/test/api.test.mjs
+++ b/npm/postgresql/test/api.test.mjs
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { implementedPostgresqlRuleNames, scanPostgresql } from '../api.js';
+
+describe('postgresql native api', () => {
+  it('exposes the implemented rule set', () => {
+    expect(implementedPostgresqlRuleNames()).toEqual([
+      'consistent-identity-over-serial',
+      'consistent-jsonb-over-json',
+      'consistent-text-over-varchar',
+      'consistent-timestamptz',
+      'no-char-type',
+      'no-cluster',
+      'no-create-role',
+      'no-cross-join',
+      'no-drop-database',
+      'no-drop-schema-cascade',
+      'no-drop-table-cascade',
+      'no-equality-with-null',
+      'no-grant-all',
+      'no-grant-to-public',
+      'no-money-type',
+      'no-natural-join',
+      'no-not-in-subquery',
+      'no-select-into',
+      'no-select-star',
+      'no-set-search-path',
+      'no-temporary-table',
+      'no-time-type',
+      'no-truncate-cascade',
+      'no-unlogged-table',
+      'no-vacuum-full',
+      'prefer-cast-operator',
+      'prefer-current-timestamp-over-now',
+      'prefer-not-equals-operator',
+      'require-trailing-semicolon',
+      'require-where-in-delete',
+      'require-where-in-update',
+    ]);
+  });
+
+  it('runs high-risk SQL rules in native code', () => {
+    const diagnostics = scanPostgresql(
+      [
+        'DROP DATABASE archive_2023;',
+        'SELECT * FROM users;',
+        'UPDATE users SET active = false;',
+        'DELETE FROM sessions;',
+        'VACUUM FULL users;',
+        'GRANT ALL ON t TO u;',
+      ].join('\n'),
+      'migration.sql',
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.messageId)).toEqual([
+      'noDropDatabase',
+      'noSelectStar',
+      'missingWhere',
+      'missingWhere',
+      'noVacuumFull',
+      'noGrantAll',
+    ]);
+  });
+
+  it('keeps comments and strings out of the token stream', () => {
+    expect(
+      scanPostgresql(
+        [
+          '-- DROP DATABASE archive;',
+          "SELECT 'VACUUM FULL users';",
+          'SELECT count(*) FROM users;',
+        ].join('\n'),
+        'safe.sql',
+      ),
+    ).toEqual([]);
+  });
+
+  it('supports upstream style options', () => {
+    expect(
+      scanPostgresql('CREATE TABLE t (payload jsonb, name text);', 'schema.sql', {
+        jsonbStyle: 'never',
+        textStyle: 'never',
+      }).map((diagnostic) => diagnostic.messageId),
+    ).toEqual(['unexpectedJsonb', 'unexpectedText']);
+
+    expect(
+      scanPostgresql('SELECT a <> b, c::int;', 'query.sql', {
+        notEqualsOperator: '!=',
+        castForm: 'function',
+      }).map((diagnostic) => diagnostic.messageId),
+    ).toEqual(['preferBang', 'preferFunction']);
+  });
+
+  it('returns LSP-shaped source locations and message data', () => {
+    const [diagnostic] = scanPostgresql('SELECT id FROM users WHERE name != NULL;', 'query.sql');
+
+    expect(diagnostic).toMatchObject({
+      ruleName: 'no-equality-with-null',
+      messageId: 'useIsNull',
+      data: { op: '!=' },
+      loc: {
+        startLine: 1,
+        startColumn: 32,
+        endLine: 1,
+        endColumn: 34,
+      },
+    });
+  });
+});

--- a/npm/postgresql/test/plugin.test.mjs
+++ b/npm/postgresql/test/plugin.test.mjs
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+function runRule(ruleName, code, options) {
+  const reports = [];
+  const context = {
+    filename: 'fixture.sql',
+    options: options === undefined ? [] : [options],
+    sourceCode: {
+      getText: () => code,
+    },
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  };
+
+  plugin.rules[ruleName].createOnce(context).Program();
+  return reports;
+}
+
+describe('postgresql plugin shape', () => {
+  it('exposes implemented rules and configs', () => {
+    expect(plugin.meta?.name).toBe('postgresql');
+    expect(Object.keys(plugin.rules)).toContain('no-drop-database');
+    expect(Object.keys(plugin.rules)).toContain('require-where-in-update');
+    expect(plugin.configs.recommended.files).toEqual(['**/*.sql']);
+    expect(plugin.configs.recommended.rules['postgresql/no-drop-database']).toBe('warn');
+    expect(plugin.configs.all.rules['postgresql/no-drop-database']).toBe('error');
+  });
+});
+
+describe('postgresql rule adapter', () => {
+  it('reports a single rule from the shared native scan', () => {
+    expect(runRule('no-drop-database', 'DROP DATABASE archive;')).toMatchObject([
+      {
+        messageId: 'noDropDatabase',
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 21 },
+        },
+      },
+    ]);
+  });
+
+  it('passes rule options to native code', () => {
+    expect(
+      runRule('consistent-text-over-varchar', 'CREATE TABLE t (name text);', {
+        style: 'never',
+      }),
+    ).toMatchObject([{ messageId: 'unexpectedText' }]);
+
+    expect(
+      runRule('prefer-not-equals-operator', 'SELECT a <> b;', {
+        operator: '!=',
+      }),
+    ).toMatchObject([{ messageId: 'preferBang' }]);
+  });
+
+  it('renders upstream-style message data', () => {
+    expect(
+      runRule('no-equality-with-null', 'SELECT id FROM users WHERE name = NULL;'),
+    ).toMatchObject([
+      {
+        messageId: 'useIsNull',
+        data: { op: '=' },
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,12 @@ importers:
         specifier: 'catalog:'
         version: 1.68.0
 
+  npm/postgresql:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/react-refresh:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -414,6 +414,519 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-postgresql",
+    "directory": "npm/postgresql",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-postgresql",
+      "version": "0.22.1",
+      "repository": "https://github.com/baseballyama/eslint-plugin-postgresql",
+      "license": "MIT"
+    },
+    "status": "in-progress",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "consistent-identity-over-serial",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port; default and never-style option covered in native/plugin tests."
+      },
+      {
+        "name": "consistent-jsonb-over-json",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port; default and never-style option covered in native/plugin tests."
+      },
+      {
+        "name": "consistent-text-over-varchar",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port; varchar(n), text, and never-style option covered in native/plugin tests."
+      },
+      {
+        "name": "consistent-timestamptz",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port; timestamp and timestamptz defaults covered in native tests."
+      },
+      {
+        "name": "no-char-type",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for char(n)/bpchar tokens."
+      },
+      {
+        "name": "no-cluster",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for CLUSTER statements."
+      },
+      {
+        "name": "no-create-role",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for CREATE ROLE/USER statements."
+      },
+      {
+        "name": "no-cross-join",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for CROSS JOIN."
+      },
+      {
+        "name": "no-drop-database",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for DROP DATABASE; upstream fixture shape covered in native/plugin tests."
+      },
+      {
+        "name": "no-drop-schema-cascade",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for DROP SCHEMA ... CASCADE."
+      },
+      {
+        "name": "no-drop-table-cascade",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for DROP TABLE ... CASCADE."
+      },
+      {
+        "name": "no-equality-with-null",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for =/!=/<> NULL with diagnostic data."
+      },
+      {
+        "name": "no-grant-all",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for GRANT ALL."
+      },
+      {
+        "name": "no-grant-to-public",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for GRANT ... TO PUBLIC."
+      },
+      {
+        "name": "no-money-type",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for money column type."
+      },
+      {
+        "name": "no-natural-join",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for NATURAL JOIN."
+      },
+      {
+        "name": "no-not-in-subquery",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for NOT IN (SELECT ...)."
+      },
+      {
+        "name": "no-select-into",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for SELECT ... INTO before FROM."
+      },
+      {
+        "name": "no-select-star",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for SELECT * and qualified table.* while allowing count(*)."
+      },
+      {
+        "name": "no-set-search-path",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for SET search_path statements."
+      },
+      {
+        "name": "no-temporary-table",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for CREATE TEMP/TEMPORARY TABLE."
+      },
+      {
+        "name": "no-time-type",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for time/timetz column types."
+      },
+      {
+        "name": "no-truncate-cascade",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for TRUNCATE ... CASCADE."
+      },
+      {
+        "name": "no-unlogged-table",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for CREATE UNLOGGED TABLE."
+      },
+      {
+        "name": "no-vacuum-full",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for VACUUM FULL; upstream fixture shape covered in native tests."
+      },
+      {
+        "name": "prefer-cast-operator",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for CAST(...) vs :: style, including form option."
+      },
+      {
+        "name": "prefer-current-timestamp-over-now",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for now(), localtimestamp, and localtime."
+      },
+      {
+        "name": "prefer-not-equals-operator",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for <>/!= style, including operator option."
+      },
+      {
+        "name": "require-trailing-semicolon",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for the file-level trailing semicolon check."
+      },
+      {
+        "name": "require-where-in-delete",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for DELETE statements without WHERE."
+      },
+      {
+        "name": "require-where-in-update",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": true,
+          "oxlintIntegration": false
+        },
+        "notes": "Token-based Rust SQL scanner port for UPDATE statements without WHERE."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-react-refresh",
     "directory": "npm/react-refresh",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -41,6 +41,10 @@ const nativePackages = [
     binding: 'npm/react-refresh/native.js',
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-postgresql',
+    binding: 'npm/postgresql/native.js',
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-mocha',
     binding: 'npm/mocha/native.js',
   },

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -30,6 +30,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-postgresql',
+    dir: 'npm/postgresql',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-security',
     dir: 'npm/security',
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],


### PR DESCRIPTION
## Summary
- add a Rust SQL tokenizer and native scanner for eslint-plugin-postgresql
- expose @oxlint-plugins/oxlint-plugin-postgresql through NAPI and a JS rule adapter
- port 31 SQL text rules covering dangerous DDL/DML, joins, NULL comparisons, type recommendations, and style options

## Verification
- corepack pnpm run verify

## Notes
- Oxlint does not parse .sql files as a first-class language target yet, so this package marks oxlintIntegration=false in status and covers the scanner/API/rule adapter through Rust and Vitest tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->