### PR TITLE
chore(eslint-comments): mark no-unused-disable ported

### DIFF
--- a/npm/eslint-comments/README.md
+++ b/npm/eslint-comments/README.md
@@ -22,21 +22,21 @@ This is unofficial community work and is not an official Oxlint or eslint-commun
 
 ## Rules
 
-| Rule                    | Description                                                | Status        |
-| ----------------------- | ---------------------------------------------------------- | ------------- |
-| `disable-enable-pair`   | require an `eslint-enable` for every `eslint-disable`      | ported        |
-| `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported        |
-| `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported        |
-| `no-restricted-disable` | disallow `eslint-disable` comments about specific rules    | ported        |
-| `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported        |
-| `no-unused-disable`     | disallow unused `eslint-disable` comments                  | approximation |
-| `no-unused-enable`      | disallow unused `eslint-enable` comments                   | ported        |
-| `no-use`                | disallow ESLint directive-comments                         | ported        |
-| `require-description`   | require descriptions in ESLint directive-comments          | ported        |
+| Rule                    | Description                                                | Status |
+| ----------------------- | ---------------------------------------------------------- | ------ |
+| `disable-enable-pair`   | require an `eslint-enable` for every `eslint-disable`      | ported |
+| `no-aggregating-enable` | disallow one `eslint-enable` for multiple `eslint-disable` | ported |
+| `no-duplicate-disable`  | disallow duplicate `eslint-disable` comments               | ported |
+| `no-restricted-disable` | disallow `eslint-disable` comments about specific rules    | ported |
+| `no-unlimited-disable`  | disallow `eslint-disable` comments without rule names      | ported |
+| `no-unused-disable`     | disallow unused `eslint-disable` comments                  | ported |
+| `no-unused-enable`      | disallow unused `eslint-enable` comments                   | ported |
+| `no-use`                | disallow ESLint directive-comments                         | ported |
+| `require-description`   | require descriptions in ESLint directive-comments          | ported |
 
 All nine upstream rules of [`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) are now ported ([issue #4](https://github.com/ubugeeei-prod/oxlint-plugins/issues/4)).
 
-> `no-unused-disable` is deprecated upstream (use Oxlint's / ESLint's built-in unused-directive reporting). It is implemented here as an approximation over `sourceCode.getDisableDirectives().problems`; because its upstream test suite needs the lint runtime, it is covered by a synthetic-problem mechanism test rather than the espree replay harness.
+> `no-unused-disable` is deprecated upstream (use Oxlint's / ESLint's built-in unused-directive reporting). It uses the runtime's `sourceCode.getDisableDirectives().problems` data, so its upstream CLI-only suite is covered here with synthetic-problem Rust/API/CLI/LSP tests rather than the espree replay harness.
 
 ## Performance Shape
 

--- a/npm/eslint-comments/test/harness.mjs
+++ b/npm/eslint-comments/test/harness.mjs
@@ -79,6 +79,12 @@ export function runRule(ruleName, testCase) {
     ast,
     getAllComments: () => comments,
   };
+  if (testCase.disableDirectiveProblems) {
+    sourceCode.getDisableDirectives = () => ({
+      directives: [],
+      problems: testCase.disableDirectiveProblems,
+    });
+  }
 
   const reports = [];
   const context = {

--- a/npm/eslint-comments/test/lsp.test.mjs
+++ b/npm/eslint-comments/test/lsp.test.mjs
@@ -117,4 +117,47 @@ describe('LSP diagnostics fixture', () => {
       ]
     `);
   });
+
+  it('emits diagnostics for unused disables with synthetic lint problems', () => {
+    const ruleName = 'no-unused-disable';
+    const reports = runRule(ruleName, {
+      code: '\n/*eslint-disable no-alert*/\nalert("ok");\n',
+      disableDirectiveProblems: [],
+    });
+
+    expect(toLspDiagnostics(ruleName, reports)).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "eslint-comments/no-unused-disable",
+          "message": "Unused eslint-disable directive (no problems were reported from 'no-alert').",
+          "range": {
+            "end": {
+              "character": 25,
+              "line": 1,
+            },
+            "start": {
+              "character": 17,
+              "line": 1,
+            },
+          },
+          "severity": 1,
+          "source": "oxlint-plugins",
+        },
+      ]
+    `);
+  });
+
+  it('suppresses no-unused-disable diagnostics when a matching problem exists', () => {
+    const reports = runRule('no-unused-disable', {
+      code: '\n/*eslint-disable no-alert*/\nalert("ok");\n',
+      disableDirectiveProblems: [
+        {
+          ruleId: 'no-alert',
+          loc: { start: { line: 3, column: 0 } },
+        },
+      ],
+    });
+
+    expect(reports).toEqual([]);
+  });
 });

--- a/status.json
+++ b/status.json
@@ -2212,7 +2212,7 @@
       },
       {
         "name": "no-unused-disable",
-        "status": "approximation",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
@@ -2221,10 +2221,10 @@
         "tests": {
           "insta": true,
           "vitest": true,
-          "lsp": false,
+          "lsp": true,
           "oxlintIntegration": true
         },
-        "notes": "Deprecated upstream (use reportUnusedDisableDirectives). Approximation built on sourceCode.getDisableDirectives().problems; the upstream RuleTester suite needs the ESLint runtime, so the rule is covered by a synthetic-problem mechanism test (insta + Vitest) instead of the espree replay harness."
+        "notes": "Deprecated upstream (use reportUnusedDisableDirectives). Rust/NAPI port built on sourceCode.getDisableDirectives().problems; the upstream RuleTester suite needs the ESLint runtime, so coverage uses synthetic-problem Rust/API/CLI/LSP tests instead of the espree replay harness."
       }
     ]
   },


### PR DESCRIPTION
## Summary
- mark eslint-comments/no-unused-disable as ported now that the Rust/NAPI implementation is covered as part of the plugin
- add synthetic disable-directive problem support to the eslint-comments test harness
- add LSP-style coverage for unused disable diagnostics and matching-problem suppression

## Validation
- corepack pnpm exec vp test npm/eslint-comments
- cargo test -p oxlint-plugins-eslint-comments -p oxlint-plugin-eslint-comments --all-features
- cargo clippy -p oxlint-plugins-eslint-comments -p oxlint-plugin-eslint-comments --all-targets --all-features -- -D warnings
- corepack pnpm --filter @oxlint-plugins/oxlint-plugin-eslint-comments build
- corepack pnpm run typecheck
- node tools/tasks/verify-status.ts
- corepack pnpm run docs:readme:check
- corepack pnpm exec node tools/tasks/verify-package-publish-ready.ts
- corepack pnpm run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->