### PR TITLE
fix(sonarjs): argument-type should not flag logical && / 

### DIFF
--- a/crates/sonarjs/src/rules/argument_type.rs
+++ b/crates/sonarjs/src/rules/argument_type.rs
@@ -20,9 +20,13 @@
 //! An argument counts as boolean-producing when, after stripping parentheses,
 //! it is one of:
 //! - a `BinaryExpression` with a comparison operator
-//!   (`<`, `>`, `<=`, `>=`, `==`, `===`, `!=`, `!==`);
-//! - a `LogicalExpression` (`&&` or `||`); or
+//!   (`<`, `>`, `<=`, `>=`, `==`, `===`, `!=`, `!==`); or
 //! - a `UnaryExpression` with the logical-not operator (`!`).
+//!
+//! A `LogicalExpression` (`&&` / `||`) is *not* boolean-producing: in
+//! JavaScript these operators evaluate to one of their operands, not a boolean,
+//! so `Math.floor(width || 100)` is a valid numeric-fallback idiom and must not
+//! be flagged.
 //!
 //! Numbers, identifiers, and any other expression are never flagged: a number
 //! is the correct type, and an identifier's type is unknown without type
@@ -32,7 +36,7 @@
 //! ## Flagged
 //! ```js
 //! Math.abs(x < 0.0042);   // comparison -> boolean
-//! Math.floor(a && b);     // logical    -> boolean
+//! Math.floor(a < b);      // comparison -> boolean
 //! Math.sqrt(!ready);      // logical-not -> boolean
 //! ```
 //!
@@ -41,6 +45,8 @@
 //! Math.abs(x);            // identifier (unknown type)
 //! Math.abs(x) < 0.0042;   // comparison is outside the call
 //! Math.floor(1.5);        // numeric argument (correct type)
+//! Math.floor(width || 100); // `||` returns an operand (a number), not a boolean
+//! Math.abs(a && b);       // `&&` returns an operand (a number), not a boolean
 //! Math.max(a < b, c);     // max is excluded (multi-argument)
 //! Math.atan2(a, b);       // atan2 is excluded (two arguments)
 //! foo.abs(x < 1);         // object is not the `Math` identifier
@@ -109,7 +115,6 @@ fn is_boolean_producing(expr: &Expression<'_>) -> bool {
                 | BinaryOperator::Inequality
                 | BinaryOperator::StrictInequality
         ),
-        Expression::LogicalExpression(_) => true,
         Expression::UnaryExpression(unary) => unary.operator == UnaryOperator::LogicalNot,
         _ => false,
     }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -11142,10 +11142,17 @@ fn argument_type_reports_math_abs_comparison() {
 }
 
 #[test]
-fn argument_type_reports_math_floor_logical() {
-    let diagnostics = scan("argument-type", "Math.floor(a && b);");
-    assert_eq!(diagnostics.len(), 1);
-    assert_eq!(diagnostics[0].message_id, "argumentType");
+fn argument_type_does_not_report_logical_or() {
+    // `||` evaluates to one of its operands (a number here), not a boolean.
+    let diagnostics = scan("argument-type", "Math.floor(width || 100);");
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn argument_type_does_not_report_logical_and() {
+    // `&&` evaluates to one of its operands (a number here), not a boolean.
+    let diagnostics = scan("argument-type", "Math.abs(a && b);");
+    assert!(diagnostics.is_empty());
 }
 
 #[test]

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -1369,7 +1369,7 @@ const ruleDescriptions = Object.freeze({
   'os-command':
     'Flag a child_process spawn/spawnSync/execFile/execFileSync call passed an options object with shell:true (the shell-interpreter form of S4721), which risks OS command injection; exec/execSync are intentionally excluded to avoid colliding with RegExp.exec, keeping this zero-false-positive',
   'argument-type':
-    'Flag a single-argument Math.* numeric call (abs, floor, sqrt, ...) whose argument is a boolean-producing expression — a comparison, a logical &&/||, or a logical-not — which is the documented type-mismatch bug of S3782 (e.g. Math.abs(x < 0.0042)); requiring a boolean-producing argument to a numeric Math method keeps this zero-false-positive',
+    'Flag a single-argument Math.* numeric call (abs, floor, sqrt, ...) whose argument is a boolean-producing expression — a comparison or a logical-not — which is the documented type-mismatch bug of S3782 (e.g. Math.abs(x < 0.0042)); logical &&/|| arguments are not flagged because they evaluate to an operand (often a number), so requiring a boolean-producing argument keeps this zero-false-positive',
   'aws-s3-bucket-insecure-http':
     'Flag an AWS CDK S3 bucket property enforceSSL:false (the explicit insecure-HTTP form of S6249), which authorizes cleartext HTTP access. The distinctive enforceSSL key keeps this zero-false-positive; omission is intentionally not flagged',
   'aws-s3-bucket-server-encryption':


### PR DESCRIPTION
| arguments (S3782 FP)|argument-type no longer flags Math.x(a||b)/Math.x(a&&b) — logical operators return an operand, not a boolean. Keeps comparison and logical-not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204406&installation_id=136613492&pr_number=557&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F557&signature=ebc85902fc0dda318b6e8e9af3110755143ab76e9bf33702836f5c1f059e386d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->