### PR TITLE
fix(sonarjs): regular-expr should not flag String.split delimiters (S4784 FP)

### DIFF
--- a/crates/sonarjs/src/rules/regular_expr.rs
+++ b/crates/sonarjs/src/rules/regular_expr.rs
@@ -30,8 +30,8 @@
 //! ### Three flagged shapes (hardcoded patterns only)
 //! - a regex literal: `/(a+)+b/`
 //! - `new RegExp("(a+)+b")` — constructor with a string-literal pattern
-//! - `str.search("(a+)+b")`, `str.match("(a+)+b")`, `str.split("(a+)+b")` — a
-//!   `.search`/`.match`/`.split` call with a string-literal first argument
+//! - `str.search("(a+)+b")`, `str.match("(a+)+b")` — a `.search`/`.match` call
+//!   with a string-literal first argument
 //!
 //! Dynamic values (variables, template literals, computed expressions) are
 //! never analyzed: only literals can be tallied statically, and reporting
@@ -48,6 +48,8 @@
 //! - `/*/` — fewer than 3 characters
 //! - `new RegExp(pattern)` — dynamic argument, skipped
 //! - `str.replace("(a+)+b", "")` — `.replace` is not one of the targeted methods
+//! - `markdown.split("***")` — `String.split(string)` treats its argument as a
+//!   literal delimiter, not a regex, so it is never coerced to a pattern
 //!
 //! [`slow-regex`]: crate::rules::slow_regex
 
@@ -100,14 +102,14 @@ impl Scanner<'_> {
         }
     }
 
-    /// Flags `str.search/match/split("<sensitive>")` with a hardcoded
+    /// Flags `str.search/match("<sensitive>")` with a hardcoded
     /// string-literal first argument.
     pub(crate) fn check_regular_expr_call(&mut self, it: &CallExpression<'_>) {
         let Expression::StaticMemberExpression(member) = it.callee.get_inner_expression() else {
             return;
         };
         let property = member.property.name.as_str();
-        if !matches!(property, "search" | "match" | "split") {
+        if !matches!(property, "search" | "match") {
             return;
         }
         if first_string_arg(&it.arguments).is_some_and(pattern_is_sensitive) {

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -11573,6 +11573,14 @@ fn regular_expr_does_not_report_dynamic_arg() {
 }
 
 #[test]
+fn regular_expr_does_not_report_split_string() {
+    // `String.split(string)` uses a literal delimiter, not a regex, so a
+    // sensitive-looking string argument must NOT be flagged.
+    let diagnostics = scan("regular-expr", "markdown.split(\"***\");");
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
 fn no_os_command_from_path_reports_bare_command() {
     let diagnostics = scan("no-os-command-from-path", "cp.spawn('file.exe');");
     assert_eq!(diagnostics.len(), 1);

--- a/npm/sonarjs/index.js
+++ b/npm/sonarjs/index.js
@@ -1387,7 +1387,7 @@ const ruleDescriptions = Object.freeze({
   encryption:
     'Flag data-encryption calls (the security hotspot S4787): the Node crypto createCipher/createCipheriv/createDecipher/createDecipheriv/publicEncrypt/privateDecrypt/privateEncrypt/publicDecrypt functions, and crypto.subtle.encrypt/decrypt. Generic encrypt/decrypt are gated on a .subtle receiver to keep this zero-false-positive',
   'regular-expr':
-    'Flag a hardcoded regular expression with at least 3 characters and at least 2 of the characters *, +, or { (the documented heuristic of the security hotspot S4784): a regex literal, new RegExp("..."), or a .search/.match/.split("...") string argument. Deprecated upstream in favor of slow-regex (S5852)',
+    'Flag a hardcoded regular expression with at least 3 characters and at least 2 of the characters *, +, or { (the documented heuristic of the security hotspot S4784): a regex literal, new RegExp("..."), or a .search/.match("...") string argument. Deprecated upstream in favor of slow-regex (S5852)',
   'no-os-command-from-path':
     'Flag a child_process spawn/spawnSync/execFile/execFileSync call whose first argument is a bare command name string literal (no path separator), which resolves via PATH (the security hotspot S4036). exec/execSync are excluded to avoid colliding with RegExp.exec, keeping this zero-false-positive',
   'publicly-writable-directories':


### PR DESCRIPTION
String.split(string) uses a literal delimiter, not a regex; dropped split, kept match/search which coerce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204435&installation_id=136613492&pr_number=559&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F559&signature=8e406a3ee27e62b8ebc0e889cb9c827cc599dff1d50218946f811f8426b827fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->