### PR TITLE
fix(sonarjs): cookies should not flag single-argument .cookie() reads (S2255 FP)

### DIFF
--- a/crates/sonarjs/src/rules/cookies.rs
+++ b/crates/sonarjs/src/rules/cookies.rs
@@ -22,8 +22,10 @@
 //!
 //! (b) A `CallExpression` whose callee (after `get_inner_expression`) is a
 //!     static member expression whose property name is exactly `cookie` and
-//!     which has at least one argument — the ExpressJS `res.cookie(name, value)`
-//!     write. The call span is reported.
+//!     which has at least two arguments (a name *and* a value) — the ExpressJS
+//!     `res.cookie(name, value)` write. The call span is reported. Requiring two
+//!     arguments avoids flagging a single-argument cookie *read* such as the
+//!     legacy jQuery cookie plugin `$.cookie('session')`.
 //!
 //! (c) A `CallExpression` whose callee is a static member expression whose
 //!     property name is exactly `setHeader` and whose first argument is a string
@@ -34,8 +36,10 @@
 //!
 //! Cookie *reads* are out of scope: a bare `document.cookie` reference that is
 //! not the target of an assignment, and `req.cookies` reads, are not writes. A
-//! `.cookie()` call with zero arguments is not a write (it does not set a value),
-//! and a `setHeader` call with any other header name is unrelated.
+//! `.cookie()` call with fewer than two arguments is not a write (it does not set
+//! a value) — this includes the single-argument read form `$.cookie('session')`
+//! used by the legacy jQuery cookie plugin — and a `setHeader` call with any
+//! other header name is unrelated.
 //!
 //! ## Flagged
 //! ```js
@@ -49,6 +53,7 @@
 //! const c = document.cookie;          // read, not a write
 //! const all = req.cookies;            // read, not a write
 //! res.cookie();                       // zero-argument call, not a write
+//! const v = $.cookie('session');      // single-argument read, not a write
 //! res.setHeader('Content-Type', 'x'); // different header name
 //! ```
 
@@ -83,9 +88,10 @@ impl Scanner<'_> {
             return;
         };
         match member.property.name.as_str() {
-            // (b) `.cookie(name, value)` with at least one argument.
+            // (b) `.cookie(name, value)` with at least two arguments (name and
+            // value). A single-argument call is a read (e.g. `$.cookie('session')`).
             "cookie" => {
-                if !it.arguments.is_empty() {
+                if it.arguments.len() >= 2 {
                     self.report(RULE_NAME, "cookies", it.span);
                 }
             }

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -11350,6 +11350,12 @@ fn cookies_does_not_report_zero_arg_cookie() {
 }
 
 #[test]
+fn cookies_does_not_report_single_arg_cookie_read() {
+    let diagnostics = scan("cookies", "const v = $.cookie('session');");
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
 fn cookies_does_not_report_other_header() {
     let diagnostics = scan("cookies", "res.setHeader('Content-Type', 'text/html');");
     assert!(diagnostics.is_empty());


### PR DESCRIPTION
Require >=2 args for the .cookie() write shape so reads like $.cookie('session') are not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204427&installation_id=136613492&pr_number=560&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F560&signature=cc50251850f560d8d6cf96f0bbe1bcb26163b80f1a1ff6b505120a82f8c00825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->