### PR TITLE
perf(sonarjs): parse each regex literal once, O(1) has_rule, guard hot-path records

### DIFF
--- a/crates/sonarjs/src/rules/anchor_precedence.rs
+++ b/crates/sonarjs/src/rules/anchor_precedence.rs
@@ -110,13 +110,14 @@ fn check_top_level_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span;
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_anchor_precedence(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            check_top_level_disjunction(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_anchor_precedence_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        check_top_level_disjunction(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "anchorPrecedence", span);
         }
     }

--- a/crates/sonarjs/src/rules/concise_regex.rs
+++ b/crates/sonarjs/src/rules/concise_regex.rs
@@ -125,13 +125,14 @@ fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>)
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_concise_regex(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disjunction(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_concise_regex_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disjunction(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "conciseRegex", span);
         }
     }

--- a/crates/sonarjs/src/rules/duplicates_in_character_class.rs
+++ b/crates/sonarjs/src/rules/duplicates_in_character_class.rs
@@ -64,13 +64,14 @@ fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>)
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_duplicates_in_character_class(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disjunction(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_duplicates_in_character_class_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disjunction(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "duplicateCharacter", span);
         }
     }

--- a/crates/sonarjs/src/rules/empty_string_repetition.rs
+++ b/crates/sonarjs/src/rules/empty_string_repetition.rs
@@ -116,13 +116,14 @@ fn collect_in_disj<'a>(disj: &Disjunction<'a>, out: &mut SmallVec<[Span; 8]>) {
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_empty_string_repetition(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disj(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_empty_string_repetition_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disj(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "emptyStringRepetition", span);
         }
     }

--- a/crates/sonarjs/src/rules/no_control_regex.rs
+++ b/crates/sonarjs/src/rules/no_control_regex.rs
@@ -109,17 +109,18 @@ fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>)
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_no_control_regex(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            for alt in pattern.body.body.iter() {
-                for term in alt.body.iter() {
-                    collect_in_term(term, &mut out);
-                }
+    pub(crate) fn check_no_control_regex_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        for alt in pattern.body.body.iter() {
+            for term in alt.body.iter() {
+                collect_in_term(term, &mut out);
             }
-            out
-        });
-        for span in spans {
+        }
+        for span in out {
             self.report(RULE_NAME, "controlCharacter", span);
         }
     }

--- a/crates/sonarjs/src/rules/no_duplicate_string.rs
+++ b/crates/sonarjs/src/rules/no_duplicate_string.rs
@@ -31,6 +31,9 @@ fn qualifies(value: &str) -> bool {
 
 impl<'a> Scanner<'a> {
     pub(crate) fn record_string_literal(&mut self, lit: &StringLiteral<'a>) {
+        if !self.options.has_rule(RULE_NAME) {
+            return;
+        }
         self.string_literals.push((lit.value.as_str(), lit.span));
     }
 

--- a/crates/sonarjs/src/rules/no_empty_after_reluctant.rs
+++ b/crates/sonarjs/src/rules/no_empty_after_reluctant.rs
@@ -137,13 +137,14 @@ fn collect_in_disj<'a>(disj: &Disjunction<'a>, out: &mut SmallVec<[Span; 8]>) {
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_no_empty_after_reluctant(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disj(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_no_empty_after_reluctant_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disj(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "emptyAfterReluctant", span);
         }
     }

--- a/crates/sonarjs/src/rules/no_empty_alternatives.rs
+++ b/crates/sonarjs/src/rules/no_empty_alternatives.rs
@@ -69,13 +69,14 @@ fn collect_empty_alternatives<'a>(disj: &Disjunction<'a>, out: &mut SmallVec<[Sp
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_no_empty_alternatives(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_empty_alternatives(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_no_empty_alternatives_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_empty_alternatives(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "emptyAlternative", span);
         }
     }

--- a/crates/sonarjs/src/rules/no_empty_group.rs
+++ b/crates/sonarjs/src/rules/no_empty_group.rs
@@ -85,13 +85,14 @@ fn collect_empty_groups<'a>(disj: &Disjunction<'a>, out: &mut SmallVec<[Span; 8]
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_no_empty_group(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_empty_groups(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_no_empty_group_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_empty_groups(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "emptyGroup", span);
         }
     }

--- a/crates/sonarjs/src/rules/no_hardcoded_ip.rs
+++ b/crates/sonarjs/src/rules/no_hardcoded_ip.rs
@@ -129,6 +129,9 @@ fn contains_flagged_ipv6(s: &str) -> bool {
 
 impl Scanner<'_> {
     pub(crate) fn check_no_hardcoded_ip(&mut self, it: &StringLiteral<'_>) {
+        if !self.options.has_rule(RULE_NAME) {
+            return;
+        }
         let value = it.value.as_str();
         if contains_flagged_ipv4(value) || contains_flagged_ipv6(value) {
             self.report(RULE_NAME, "hardcodedIp", it.span);

--- a/crates/sonarjs/src/rules/no_misleading_character_class.rs
+++ b/crates/sonarjs/src/rules/no_misleading_character_class.rs
@@ -109,18 +109,19 @@ fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>)
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_no_misleading_character_class(&mut self, lit: &RegExpLiteral<'_>) {
+    pub(crate) fn check_no_misleading_character_class_with_pattern(
+        &mut self,
+        lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
         // With the `u`/`v` flag the engine treats an astral code point as a
         // single unit, so the class is not misleading.
         if lit.regex.flags.intersects(RegExpFlags::U | RegExpFlags::V) {
             return;
         }
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disjunction(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disjunction(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "misleadingCharacterClass", span);
         }
     }

--- a/crates/sonarjs/src/rules/no_regex_spaces.rs
+++ b/crates/sonarjs/src/rules/no_regex_spaces.rs
@@ -105,15 +105,16 @@ fn scan_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>) {
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_no_regex_spaces(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            for alt in pattern.body.body.iter() {
-                scan_alternative(&alt.body, &mut out);
-            }
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_no_regex_spaces_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        for alt in pattern.body.body.iter() {
+            scan_alternative(&alt.body, &mut out);
+        }
+        for span in out {
             self.report(RULE_NAME, "multipleSpaces", span);
         }
     }

--- a/crates/sonarjs/src/rules/single_char_in_character_classes.rs
+++ b/crates/sonarjs/src/rules/single_char_in_character_classes.rs
@@ -63,13 +63,14 @@ fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>)
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_single_char_in_character_classes(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disjunction(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_single_char_in_character_classes_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disjunction(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "singleCharInCharacterClass", span);
         }
     }

--- a/crates/sonarjs/src/rules/single_character_alternation.rs
+++ b/crates/sonarjs/src/rules/single_character_alternation.rs
@@ -97,13 +97,14 @@ fn collect_single_char_alternations<'a>(disj: &Disjunction<'a>, out: &mut SmallV
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_single_character_alternation(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_single_char_alternations(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_single_character_alternation_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_single_char_alternations(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "singleCharAlternation", span);
         }
     }

--- a/crates/sonarjs/src/rules/slow_regex.rs
+++ b/crates/sonarjs/src/rules/slow_regex.rs
@@ -104,13 +104,14 @@ fn collect_in_disjunction(disj: &Disjunction<'_>, out: &mut SmallVec<[Span; 8]>)
 }
 
 impl Scanner<'_> {
-    pub(crate) fn check_slow_regex(&mut self, lit: &RegExpLiteral<'_>) {
-        let spans = crate::regex_ast::with_parsed_regex_literal(lit, self.source_text, |pattern| {
-            let mut out: SmallVec<[Span; 8]> = SmallVec::new();
-            collect_in_disjunction(&pattern.body, &mut out);
-            out
-        });
-        for span in spans {
+    pub(crate) fn check_slow_regex_with_pattern(
+        &mut self,
+        _lit: &RegExpLiteral<'_>,
+        pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    ) {
+        let mut out: SmallVec<[Span; 8]> = SmallVec::new();
+        collect_in_disjunction(&pattern.body, &mut out);
+        for span in out {
             self.report(RULE_NAME, "slowRegex", span);
         }
     }

--- a/crates/sonarjs/src/scanner.rs
+++ b/crates/sonarjs/src/scanner.rs
@@ -604,22 +604,34 @@ impl<'a> Visit<'a> for Scanner<'a> {
     }
 
     fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
+        // Non-parsing checks: these read `lit.regex.pattern.text`/flags directly
+        // and never parse the regex AST, so they are called as before.
         self.check_no_empty_character_class(it);
-        self.check_no_empty_group(it);
-        self.check_no_empty_alternatives(it);
-        self.check_no_empty_after_reluctant(it);
-        self.check_no_regex_spaces(it);
-        self.check_no_control_regex(it);
-        self.check_single_char_in_character_classes(it);
-        self.check_duplicates_in_character_class(it);
-        self.check_concise_regex(it);
-        self.check_anchor_precedence(it);
-        self.check_single_character_alternation(it);
-        self.check_empty_string_repetition(it);
         self.check_unicode_aware_regex(it);
-        self.check_no_misleading_character_class(it);
-        self.check_slow_regex(it);
         self.check_regular_expr_literal(it);
+
+        // Parsing checks: parse the literal exactly ONCE and share the resulting
+        // `&Pattern` with every check that needs the regex AST. On a parse error
+        // `with_parsed_regex_literal` runs nothing (closure returns `()`),
+        // preserving the previous "report nothing on parse error" behavior for
+        // each of these checks.
+        let source_text = self.source_text; // &'a str is Copy; avoids a borrow conflict.
+        crate::regex_ast::with_parsed_regex_literal(it, source_text, |pattern| {
+            self.check_no_empty_group_with_pattern(it, pattern);
+            self.check_no_empty_alternatives_with_pattern(it, pattern);
+            self.check_no_empty_after_reluctant_with_pattern(it, pattern);
+            self.check_no_regex_spaces_with_pattern(it, pattern);
+            self.check_no_control_regex_with_pattern(it, pattern);
+            self.check_single_char_in_character_classes_with_pattern(it, pattern);
+            self.check_duplicates_in_character_class_with_pattern(it, pattern);
+            self.check_concise_regex_with_pattern(it, pattern);
+            self.check_anchor_precedence_with_pattern(it, pattern);
+            self.check_single_character_alternation_with_pattern(it, pattern);
+            self.check_empty_string_repetition_with_pattern(it, pattern);
+            self.check_no_misleading_character_class_with_pattern(it, pattern);
+            self.check_slow_regex_with_pattern(it, pattern);
+        });
+
         walk::walk_reg_exp_literal(self, it);
     }
 

--- a/crates/sonarjs/src/tests.rs
+++ b/crates/sonarjs/src/tests.rs
@@ -1,13 +1,14 @@
 //! Rust unit tests for the sonarjs core. All test inputs are independently
 //! authored (clean-room); no upstream SonarJS fixtures or expectations are used.
 
-use oxlint_plugins_carton::{CompactString, SmallVec};
+use oxlint_plugins_carton::{CompactString, FastHashSet, SmallVec};
 
 use crate::{Diagnostic, SonarjsOptions, scan_sonarjs};
 
 fn scan(rule_name: &str, source: &str) -> SmallVec<[Diagnostic; 32]> {
     let options = SonarjsOptions {
         rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+        rule_name_set: [CompactString::from(rule_name)].into_iter().collect(),
         ..SonarjsOptions::default()
     };
     scan_sonarjs(source, "sample.ts", &options)
@@ -16,6 +17,7 @@ fn scan(rule_name: &str, source: &str) -> SmallVec<[Diagnostic; 32]> {
 fn scan_with_file(rule_name: &str, source: &str, filename: &str) -> SmallVec<[Diagnostic; 32]> {
     let options = SonarjsOptions {
         rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+        rule_name_set: [CompactString::from(rule_name)].into_iter().collect(),
         ..SonarjsOptions::default()
     };
     scan_sonarjs(source, filename, &options)
@@ -124,6 +126,7 @@ fn reports_two_diagnostics_for_doubly_nested_conditional() {
 fn disabled_rule_reports_nothing() {
     let options = SonarjsOptions {
         rule_names: SmallVec::new(),
+        rule_name_set: FastHashSet::default(),
         ..SonarjsOptions::default()
     };
     let diagnostics = scan_sonarjs("const x = `outer ${`inner`}`;", "sample.ts", &options);
@@ -2426,6 +2429,7 @@ fn function_name_respects_custom_format() {
 fn options_for(rule_name: &str) -> SonarjsOptions {
     SonarjsOptions {
         rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+        rule_name_set: [CompactString::from(rule_name)].into_iter().collect(),
         ..SonarjsOptions::default()
     }
 }
@@ -6096,6 +6100,7 @@ fn no_extra_arguments_does_not_report_spread_argument() {
 fn scan_jsx(rule_name: &str, source: &str) -> SmallVec<[Diagnostic; 32]> {
     let options = SonarjsOptions {
         rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+        rule_name_set: [CompactString::from(rule_name)].into_iter().collect(),
         ..SonarjsOptions::default()
     };
     scan_sonarjs(source, "sample.tsx", &options)

--- a/crates/sonarjs/src/types.rs
+++ b/crates/sonarjs/src/types.rs
@@ -1,7 +1,7 @@
 //! Public-facing diagnostic and option types for the sonarjs port.
 
 use oxc_span::Span;
-use oxlint_plugins_carton::{CompactString, SmallVec};
+use oxlint_plugins_carton::{CompactString, FastHashSet, SmallVec};
 
 use crate::RULE_NAMES;
 
@@ -45,6 +45,10 @@ pub struct Diagnostic {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SonarjsOptions {
     pub rule_names: SmallVec<[CompactString; 32]>,
+    /// O(1) membership set mirroring [`Self::rule_names`]. Built once at
+    /// construction so the per-node `has_rule` guard avoids a linear scan.
+    /// Keep in sync with `rule_names`; use [`Self::rule_name_set`] to derive it.
+    pub rule_name_set: FastHashSet<CompactString>,
     /// Threshold for `max-lines` (S104); the SonarJS default is 1000.
     pub max_lines_threshold: u32,
     /// Threshold for `max-lines-per-function` (S138); the SonarJS default is 200.
@@ -77,11 +81,13 @@ pub struct SonarjsOptions {
 
 impl Default for SonarjsOptions {
     fn default() -> Self {
+        let rule_names: SmallVec<[CompactString; 32]> = RULE_NAMES
+            .iter()
+            .map(|rule_name| CompactString::from(*rule_name))
+            .collect();
         Self {
-            rule_names: RULE_NAMES
-                .iter()
-                .map(|rule_name| CompactString::from(*rule_name))
-                .collect(),
+            rule_name_set: SonarjsOptions::build_rule_name_set(&rule_names),
+            rule_names,
             max_lines_threshold: 1000,
             max_lines_per_function_threshold: 200,
             max_switch_cases_threshold: 30,
@@ -98,8 +104,15 @@ impl Default for SonarjsOptions {
 }
 
 impl SonarjsOptions {
+    /// Builds the O(1) membership set from a list of rule names. Construction
+    /// sites must populate [`Self::rule_name_set`] with this so it stays in sync
+    /// with [`Self::rule_names`].
+    pub fn build_rule_name_set(rule_names: &[CompactString]) -> FastHashSet<CompactString> {
+        rule_names.iter().cloned().collect()
+    }
+
     pub(crate) fn has_rule(&self, rule_name: &str) -> bool {
-        self.rule_names.iter().any(|name| name == rule_name)
+        self.rule_name_set.contains(rule_name)
     }
 }
 

--- a/npm/sonarjs/src/lib.rs
+++ b/npm/sonarjs/src/lib.rs
@@ -82,8 +82,10 @@ mod napi_abi {
     ) -> Vec<Diagnostic> {
         let options = options.unwrap_or_default();
         let default_options = core::SonarjsOptions::default();
+        let rule_names = compact_rule_names(options.rule_names);
         let core_options = core::SonarjsOptions {
-            rule_names: compact_rule_names(options.rule_names),
+            rule_name_set: core::SonarjsOptions::build_rule_name_set(&rule_names),
+            rule_names,
             max_lines_threshold: options
                 .max_lines_threshold
                 .unwrap_or(default_options.max_lines_threshold),


### PR DESCRIPTION
Performance hardening (pure refactor, no rule behavior change — all 1495 tests pass unchanged):
- visit_reg_exp_literal now parses each regex literal ONCE and shares the &Pattern across the 13 regex rules (was up to 13× parse per literal).
- has_rule is now O(1) (FastHashSet) instead of an O(rules) linear scan; set built at every SonarjsOptions construction site.
- Guarded two unconditional per-string-literal hot paths (no-hardcoded-ip scan, no-duplicate-string record) behind has_rule so disabled rules do no work.

Addresses performance findings from the multi-dimension review. RULE_NAMES unchanged at 221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784208250&installation_id=136613492&pr_number=561&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F561&signature=78e18287c1db8d98f29c82cb8ad0bb92520306312afe368ea7747079ede47a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->