### PR TITLE
feat: upstream parity testing harness + first ported plugins

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,57 @@
+name: Parity
+
+# Drift gate for the upstream parity corpora. Separate from CI/verify because it needs the
+# upstream submodules checked out, whereas verify stays hermetic (committed corpora + built
+# port only). Runs only when parity inputs change.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/parity/**'
+      - 'upstream/**'
+      - '.gitmodules'
+      - 'npm/eslint-comments/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/parity/**'
+      - 'upstream/**'
+      - '.gitmodules'
+      - 'npm/eslint-comments/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: parity-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Corpus drift
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      # Only the captured submodules are needed; avoid fetching the large ones.
+      - run: |
+          git submodule update --init --depth 1 \
+            upstream/eslint-plugin-eslint-comments \
+            upstream/eslint-plugin-simple-import-sort
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - run: corepack enable
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '24'
+          cache: true
+
+      - run: vp install --frozen-lockfile
+      - run: pnpm run parity:drift

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pnpm run port:rules                      # regenerate docs/port-targets/*
 - Rust tests use `insta` snapshots.
 - Vitest covers wrapper reports and skip behavior.
 
-See `docs/guides/porting.md`, `docs/guides/testing-strategy.md`, and `docs/guides/trusted-publishing.md`.
+See `docs/guides/porting.md`, `docs/guides/testing-strategy.md`, `docs/guides/parity-testing.md`, and `docs/guides/trusted-publishing.md`.
 
 ## Credits
 

--- a/docs/guides/parity-testing.md
+++ b/docs/guides/parity-testing.md
@@ -1,0 +1,307 @@
+# Upstream Parity Testing
+
+How we guarantee that a Rust+NAPI oxlint port behaves identically to the original
+upstream ESLint plugin it replaces.
+
+This extends `docs/guides/testing-strategy.md`. It does not replace its layers; it adds a
+new mandatory **Layer 0: upstream parity replay** and the tooling that feeds it.
+
+## Thesis
+
+We do not hand-author parity. For every ported rule we:
+
+1. **Capture** the upstream test corpus at runtime (not by static parsing).
+2. **Materialize ground truth** by executing the _real upstream rule_ as an oracle.
+3. **Freeze** that into a versioned JSON corpus committed in-repo.
+4. **Replay** it against the oxlint port through the real oxc parser, using `RuleTester`
+   from `oxlint/plugins-dev`, which asserts the match and fails CI on any divergence.
+
+Genuinely unavoidable differences (parser AST quirks, etc.) live in an explicit, reviewed
+**divergences ledger**; everything else must match or CI is red.
+
+## Architecture
+
+```
+A. CAPTURE  (Node, against the pinned upstream submodule)
+   import upstream test files with patched tester/Linter sink
+   → fully-resolved input cases (code / options / settings / languageOptions)
+                         │
+B. ORACLE   (Node, real ESLint Linter runs the real upstream rule)
+   linter.verify / verifyAndFix → messageId, data, line/column, fixOutput, suggestions
+   → emits a versioned JSON corpus committed under tools/parity/corpora/
+                         │  (frozen corpus, in git)
+C. REPLAY   (in-repo vitest, runs the built oxlint port)
+   RuleTester from oxlint/plugins-dev → real oxc parse + visitor
+   → RuleTester asserts each case; honor the divergences ledger
+```
+
+Capture (A) and Oracle (B) run **in separate Node processes** per plugin to avoid sink
+self-pollution (see "Pitfalls"). Replay (C) is a separate vitest process that depends only
+on the committed corpus + the built port — it never imports upstream or ESLint, so PR CI
+needs no submodule checkout.
+
+### Why dynamic capture, not static extraction
+
+Upstream `valid`/`invalid` arrays are rarely static literals. They use `semver.satisfies`
+version gating with spreads, `require()` of ESLint core rules, `dedent`/`String.raw`
+template builders, `.map()` loops, function-computed `output`, and sidecar snapshot files
+(`regexp` `.eslintsnap`, `functional` `.snap`). The concrete set of cases — and their
+expected output — only exists _after the test file's JS has executed_.
+
+So we capture at the tester boundary, where every value is already resolved:
+
+- **Universal sink:** monkeypatch `Linter.prototype.verify` / `verifyAndFix` before importing
+  any test file. Every tester family ultimately calls `Linter.verify`, so this records every
+  `(code, resolvedConfig)` regardless of how the framework drove it.
+- **Structured layer:** also patch `RuleTester.prototype.run` (and family equivalents) to
+  record the as-authored `{valid, invalid}` grouping, names, and `only`, which the raw
+  `verify` stream lacks.
+- **Hook neutralization:** stub `describe`/`it`/`afterAll` so upstream assertions never fire
+  and the ts-eslint "all cases ran" check never throws — we harvest inputs, not run their
+  asserts.
+
+Static AST extraction would require re-implementing a JS+TS interpreter to be correct:
+strictly more work for strictly less fidelity. It is rejected as a primary strategy.
+
+### Why the oracle layer is mandatory
+
+Expected behavior is frequently missing from the test source itself: `errors: <number>`
+count-only assertions (`simple-import-sort`, `security`, `eslint-comments`), plain-string
+messages with no `messageId`, and snapshot suites with nothing inline. For each captured
+input we run the real upstream rule through ESLint's `Linter` to obtain the authoritative
+`{ messageId, message, data, line, column, endLine, endColumn, fix, suggestions }`. This:
+
+- **fills every gap** — count-only and string-only cases get real messageIds, locations, fixes;
+- **self-validates** — we assert the oracle output is _consistent with_ whatever the upstream
+  test did assert (count matches; any asserted messageId/loc is a subset). If the oracle
+  disagrees with the upstream's own inline assertion (e.g. wrong ESLint version), we **fail
+  the capture build** rather than freezing garbage.
+
+## How the port is compared: use RuleTester's native assertions
+
+The only public test API in `oxlint/plugins-dev` is `RuleTester`. Its `run()` returns `void`
+and **throws on mismatch** — there is no function that lints a string and returns diagnostics.
+That is fine, because the verified `InvalidTestCase` surface already accepts everything we need
+and asserts it internally:
+
+```ts
+interface InvalidTestCase {
+  code: string;
+  options?: unknown[];
+  filename?: string;
+  settings?: object;
+  languageOptions?: LanguageOptions;
+  errors:
+    | number
+    | Array<{
+        messageId?: string;
+        message?: string | RegExp;
+        data?: object;
+        line?: number;
+        column?: number;
+        endLine?: number;
+        endColumn?: number;
+        suggestions?: Array<{ messageId?: string; desc?: string; data?: object; output: string }>;
+      }>;
+  output?: string | null;
+}
+// Config also supports: recursive?: boolean | number  (fix passes; true = 10)
+//                       eslintCompat?: boolean         (1-based column, loc end===start)
+```
+
+So replay is: translate each corpus case into this shape, feed the **oracle-derived expected
+values**, and let RuleTester assert. **Do not build a custom diagnostic differ or a `rangeText`
+scheme** — RuleTester already compares `messageId`, `data`, `line`/`column`/`endLine`/`endColumn`,
+`output`, and `suggestions` for us.
+
+- **Location is verified** through RuleTester's own `line`/`column` checks. Set
+  `eslintCompat: true` so the column base and `loc`-only `end === start` match ESLint.
+- **Autofix is verified** by feeding `output = fixOutput` (post-application full source). Never
+  compare fix `{range,text}` objects — oxc byte offsets vs ESLint UTF-16 offsets are not
+  comparable; compare the _resulting source string_.
+- **Multi-pass fixes**: the oracle uses `verifyAndFix` (multi-pass). Record the pass behavior
+  and set RuleTester `recursive` to match (default is single-pass), or false-failures appear on
+  rules whose fix needs multiple passes (`simple-import-sort`, sort rules).
+- **String-only rules** (`security`, `eslint-comments`, `postgresql`) emit no `messageId`. For
+  these the port **must** reproduce byte-identical `message` text, and `message` becomes the
+  compared key — a hard requirement, not a divergence.
+- **Suggestions** are compared as `{ messageId | desc, data, output }`, where `output` is the
+  source after applying the suggestion. Suggestion fix ranges are never compared.
+
+Where oxc and ESTree genuinely disagree on `line`/`column` (column base aside), the case goes
+into the divergences ledger rather than being silently dropped from comparison.
+
+## Corpus schema
+
+One file per rule: `tools/parity/corpora/<plugin-id>/<rule>.json`, committed, machine-generated.
+Validated in CI against `tools/parity/schema/corpus.v1.json`.
+
+```jsonc
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "…",
+    "eslintVersion": "9.x", // oracle ESLint version (self-validation depends on it)
+    "license": "MIT",
+    // NOTE: no capturedAt / capturedNode — non-deterministic fields break `--check` (see Drift)
+  },
+  "languageDefaults": {
+    "sourceType": "module",
+    "parserOptions": {
+      /* … */
+    },
+  },
+  "cases": [
+    {
+      "kind": "invalid", // or "valid"
+      "code": "/*eslint-disable */",
+      "options": [],
+      "filename": "file.js",
+      "settings": {},
+      "languageOptions": {},
+      "expectedErrors": [
+        {
+          "messageId": "disabled", // null if the rule emits no messageId (string-only)
+          "message": "…", // compared only when messageId is null; else advisory
+          "data": { "…": "…" },
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 20,
+          "suggestions": [
+            { "messageId": "…", "data": {}, "output": "<full source after this suggestion>" },
+          ],
+        },
+      ],
+      "fixOutput": "<full source after verifyAndFix>", // null ⇒ no fix
+      "recursive": false, // mirror the upstream pass behavior for this case
+      "upstreamAssertion": { "style": "count|plain-string|messageId|snapshot|location" },
+    },
+  ],
+}
+```
+
+- `valid` cases have `expectedErrors: []` and `fixOutput: null`.
+- `fixOutput` and suggestion `output` are **post-application full source strings**, never fix
+  ranges.
+- `corpusVersion` bumps on any schema change; the replay runner refuses a mismatched version.
+  Bump deliberately — it forces regenerating every plugin's corpus at once.
+
+## Pipeline
+
+- **Capture+oracle:** `tools/parity/capture/run.mjs <plugin-id>` imports the upstream test files
+  (with the patched sink), resolves cases, runs each through the oracle Linter, runs the
+  self-validation assertions, and emits one corpus file per rule. It **aborts the whole plugin**
+  if any oracle/assertion mismatch — never writes a half-trusted corpus. Per-family intake
+  adapters live in `tools/parity/capture/adapters/`.
+- **Replay:** `tools/parity/replay/<plugin>.parity.test.ts` (generated, one suite per ported
+  rule) loads the committed corpus and drives `RuleTester` from `oxlint/plugins-dev`. Hermetic,
+  fast, part of `pnpm run verify` on every PR.
+
+## License matrix
+
+| Plugin                           | License      | Persist converted corpus?           | Notes                                                                                                                                     |
+| -------------------------------- | ------------ | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| eslint-plugin-eslint-comments    | MIT          | Yes                                 | NOTICE entry + `provenance.license`.                                                                                                      |
+| eslint-plugin-functional         | MIT          | Yes                                 | NOTICE entry.                                                                                                                             |
+| eslint-plugin-regexp             | MIT          | Yes                                 | NOTICE entry.                                                                                                                             |
+| eslint-plugin-simple-import-sort | MIT          | Yes                                 | NOTICE entry.                                                                                                                             |
+| eslint-plugin-storybook          | MIT          | Yes                                 | NOTICE entry.                                                                                                                             |
+| @unocss/eslint-plugin            | MIT          | Yes                                 | NOTICE entry.                                                                                                                             |
+| eslint-markdown                  | MIT          | Yes                                 | Language plugin — see "Out of replay scope".                                                                                              |
+| eslint-plugin-postgresql         | MIT          | Yes                                 | SQL parser — see "Out of replay scope".                                                                                                   |
+| eslint-plugin-security           | Apache-2.0   | Yes                                 | Apache §4: carry LICENSE, retain notices, **state modifications** per modified file ("derived/converted"). Upstream ships no NOTICE file. |
+| eslint-json                      | Apache-2.0   | Yes                                 | Language plugin — see "Out of replay scope".                                                                                              |
+| eslint-plugin-sonarjs (SonarJS)  | **disputed** | **Hold — legal review in progress** | See below.                                                                                                                                |
+
+For every "Yes" row: a single `tools/parity/corpora/NOTICE` enumerates each upstream repo,
+license, copyright holder, pinned SHA, and that fixtures were converted/derived under that
+license; per-corpus `provenance` duplicates the essentials. MIT and Apache both require the
+license text + copyright notice to travel with substantial copies — an SPDX string alone is not
+enough.
+
+### SonarJS — handle separately
+
+`upstream/SonarJS/LICENSE.txt` is the **Sonar Source-Available License (SSAL)**, while its
+`package.json` says `LGPL-3.0-only` — a genuine conflict. SSAL carries a field-of-use clause
+that can reach a product "ported to a different platform or programming language" acting as a
+substitute for SonarQube, **even when free**. That is a restriction on _use_, which clean-room
+does not cure. Per maintainer direction this is **under legal review and provisionally proceeding**.
+Until it clears:
+
+- Keep SonarJS **out of the persisted-corpus path**. Run capture/oracle only in a throwaway,
+  gitignored scratch dir; a CI check fails if any `corpora/eslint-plugin-sonarjs/**` file is ever
+  committed.
+- The committed parity artifact is **hand-authored independent cases** under
+  `tools/parity/handwritten/sonarjs/` (our own code, our own expectations), never upstream text.
+- Fix `tools/port-targets.json` to record the SSAL/LGPL conflict and the hold status.
+
+## Out of replay scope (for now)
+
+`oxlint/plugins-dev` `RuleTester` only parses JS dialects (`lang: "js"|"jsx"|"ts"|"tsx"|"dts"`,
+no custom parser). The language/parser plugins therefore **cannot** run Layer-0 replay:
+
+- **eslint-json** (momoa JSON parser), **eslint-markdown** (mdast/gfm) — already noted as
+  outside oxlint's JS/TS scope in `port-targets.json`.
+- **eslint-plugin-postgresql** (postgresql-eslint-parser, SQL in template literals).
+
+Track these as future language targets. Their corpora can still be _captured_ for the day a
+language-aware harness exists, but they are excluded from the per-PR replay gate until then.
+
+## Known divergences ledger
+
+`tools/parity/divergences.json` (machine-enforced) + `tools/parity/DIVERGENCES.md` (human).
+Every entry is an explicit allowlisted exception naming specific `caseId`s; the replay runner
+converts those cases from "must match" to known-divergent (xfail). **An xfail that starts
+passing also fails CI**, so the ledger cannot rot into permanent green-by-omission. Admissible
+classes only (anything else requires a code fix, not a ledger entry):
+
+1. `parser-ast-quirk` — node `type` names / AST shape differences (oxc vs ESTree/momoa).
+2. `location-coordinate` — a specific `line`/`column` that genuinely cannot match.
+3. `core-rule-dependency` — cases that require an ESLint core rule (e.g.
+   `eslint-comments/no-restricted-disable` wiring `no-undef`), captured as `oracle: "manual"`.
+
+Each entry carries an `expires` date and a `ledgerReviewedSha`; entries are reviewed in every
+porting PR.
+
+## Drift control
+
+- Corpora regenerate when a submodule pin moves. `tools/parity/capture/run.mjs --all --check`
+  regenerates into a scratch dir and `git diff`s — CI fails if a committed corpus would change.
+  **Capture output must be byte-deterministic**: no wall-clock/Node-version fields in the schema,
+  sorted object keys, stable case ordering, and pin the oracle ESLint version per plugin.
+- A per-PR `parity:audit` compares the live submodule's _case-identity set_ against the committed
+  corpus and **fails (not warns)** if a corpus shrank or upstream grew uncovered cases — so a sink
+  that silently stops intercepting after an upstream refactor is caught, not masked.
+- Tie regeneration into the existing `port:rules` / upstream-release-tracking tooling.
+
+## Pitfalls (learned from design review)
+
+- **Sink self-pollution:** `verifyAndFix` calls `verify` internally up to 10×; if capture and
+  oracle share a process with the sink installed, intermediate fix passes get recorded as fake
+  inputs. Run them in separate processes / phases.
+- **Monkeypatch realm:** each submodule may resolve its own `eslint`. Patch the `Linter` the test
+  file actually imports (resolve `eslint` from the test file's location), or the sink silently
+  records nothing.
+- **Side-effecting tests:** some upstream tests spawn the `eslint` CLI (`eslint-comments`
+  `no-unused-disable`) or mock `fs` (`storybook` `no-uninstalled-addons`). Apply per-rule
+  exclusions _before_ import; mark them `oracle: "manual"` and cover via the ledger.
+- **ESM named imports** (`import { it } from "vitest"`) can't be intercepted by assigning
+  `globalThis.it`; the imperative families (`functional`, `unocss`) need a runner-driven adapter,
+  and the universal `Linter.verify` sink is what makes them capturable at all.
+
+## Rollout
+
+| Phase | Target                                                                            | Proves                                                    |
+| ----- | --------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| 0     | `tools/parity/` skeleton + one rule end-to-end                                    | the capture→oracle→replay loop                            |
+| 1     | **eslint-plugin-eslint-comments** (MIT, pure JS, core RuleTester)                 | messageId + fix + options; exclude the CLI-spawn rule     |
+| 2     | eslint-plugin-simple-import-sort                                                  | multi-pass `recursive` fixes + count-only→oracle backfill |
+| 3     | security (Apache) / functional, storybook, unocss, regexp (TS + snapshot testers) | TS transpile + imperative/snapshot adapters               |
+| —     | json, markdown, postgresql                                                        | deferred (language/parser plugins)                        |
+| —     | SonarJS                                                                           | hold for legal review; hand-authored cases only           |
+
+Recommended first prototype: **eslint-plugin-eslint-comments** — small, pure JS, MIT (persistable),
+exercising messageId, fixes, and options in one pass.

--- a/npm/eslint-comments/index.js
+++ b/npm/eslint-comments/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+
+const noUnlimitedDisable = require('./src/no-unlimited-disable.js');
+
+const PLUGIN_NAME = 'eslint-comments';
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules: {
+    'no-unlimited-disable': noUnlimitedDisable,
+  },
+});
+
+module.exports = plugin;
+module.exports.default = plugin;

--- a/npm/eslint-comments/package.json
+++ b/npm/eslint-comments/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-eslint-comments",
+  "version": "0.0.0",
+  "description": "Oxlint port of eslint-plugin-eslint-comments rules.",
+  "keywords": [
+    "eslint-comments",
+    "eslint-plugin",
+    "oxlint",
+    "oxlint-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/eslint-comments"
+  },
+  "files": [
+    "index.js",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "commonjs",
+  "main": "index.js",
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "devDependencies": {
+    "oxlint": "^1.67.0",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/eslint-comments/src/no-unlimited-disable.js
+++ b/npm/eslint-comments/src/no-unlimited-disable.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// Port of eslint-plugin-eslint-comments `no-unlimited-disable`.
+//
+// Behavior is a clean reimplementation of the upstream all-comments path
+// (lib/internal/get-all-directive-comments.js + lib/internal/utils.js), parsing
+// each comment's text directly so the result is parser-independent. Parity with the
+// upstream rule is enforced by the captured corpus under
+// tools/parity/corpora/eslint-plugin-eslint-comments/no-unlimited-disable.json.
+
+const DIRECTIVE_PATTERN =
+  /^(eslint(?:-env|-enable|-disable(?:(?:-next)?-line)?)?|exported|globals?)(?:\s|$)/u;
+const LINE_COMMENT_PATTERN = /^eslint-disable-(next-)?line$/u;
+
+/** Split off a `-- description` trailer, matching upstream `divideDirectiveComment`. */
+function divideDirectiveComment(value) {
+  const divided = value.split(/\s-{2,}\s/u);
+  return { text: divided[0].trim() };
+}
+
+/** Parse a comment's text into `{ kind, value }`, or null if not a directive. */
+function parseDirectiveText(textToParse) {
+  const { text } = divideDirectiveComment(textToParse);
+  const match = DIRECTIVE_PATTERN.exec(text);
+  if (!match) return null;
+  const kind = match[1];
+  const value = text.slice(match.index + kind.length).trim();
+  return { kind, value };
+}
+
+/** Apply the comment-type and single-line constraints, matching upstream `parseDirectiveComment`. */
+function parseDirectiveComment(comment) {
+  const parsed = parseDirectiveText(comment.value);
+  if (!parsed) return null;
+
+  const lineCommentSupported = LINE_COMMENT_PATTERN.test(parsed.kind);
+  if (comment.type === 'Line' && !lineCommentSupported) return null;
+
+  if (parsed.kind === 'eslint-disable-line' && comment.loc.start.line !== comment.loc.end.line) {
+    // An `eslint-disable-line` comment must not span multiple lines.
+    return null;
+  }
+  return parsed;
+}
+
+const DISABLE_KINDS = new Set([
+  'eslint-disable',
+  'eslint-disable-line',
+  'eslint-disable-next-line',
+]);
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow `eslint-disable` comments without rule names',
+      recommended: true,
+      url: 'https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unlimited-disable.html',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      unexpected: "Unexpected unlimited '{{kind}}' comment. Specify some rule names to disable.",
+    },
+  },
+
+  create(context) {
+    return {
+      Program() {
+        for (const comment of context.sourceCode.getAllComments()) {
+          const parsed = parseDirectiveComment(comment);
+          if (!parsed || !DISABLE_KINDS.has(parsed.kind)) continue;
+          if (!parsed.value) {
+            context.report({
+              loc: comment.loc,
+              messageId: 'unexpected',
+              data: { kind: parsed.kind },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/npm/eslint-comments/test/fix-replay.test.mjs
+++ b/npm/eslint-comments/test/fix-replay.test.mjs
@@ -1,0 +1,107 @@
+// Replay capability self-test: prove the parity runner's autofix path through oxlint's
+// RuleTester — `output` (applied-fix string) comparison, multi-pass `recursive` convergence,
+// and that a wrong fix turns the suite red (no false-green on fixes). This is the replay-side
+// counterpart to the captured `simple-import-sort` fix corpus; a full byte-parity port of the
+// sort rule (shared.js is ~900 lines of whitespace/comment-preserving logic) is tracked
+// separately. Uses a small convergent fixer so the capability is proven in isolation.
+
+import { RuleTester } from 'oxlint/plugins-dev';
+import { describe, expect, it } from 'vitest';
+
+import { runRuleParity } from '../../../tools/parity/replay/runner.mjs';
+
+// Collapse a double negation `!!e` -> `e`, but only report the OUTERMOST one so each fix pass
+// removes one pair and re-linting the fixed source reveals the next. `!!!!x` therefore needs
+// two passes to converge to `x` — a genuine multi-pass fixer.
+const collapseDoubleNegation = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+    messages: { double: 'Collapse redundant double negation.' },
+  },
+  create(context) {
+    return {
+      UnaryExpression(node) {
+        if (node.operator !== '!') return;
+        const arg = node.argument;
+        if (!arg || arg.type !== 'UnaryExpression' || arg.operator !== '!') return;
+        const parent = node.parent;
+        if (parent && parent.type === 'UnaryExpression' && parent.operator === '!') return;
+        context.report({
+          node,
+          messageId: 'double',
+          // Remove the two leading `!` (from this node's start to the inner-inner argument).
+          fix: (fixer) => fixer.removeRange([node.range[0], arg.argument.range[0]]),
+        });
+      },
+    };
+  },
+};
+
+function corpusOf(cases) {
+  return { corpusVersion: 1, provenance: { plugin: 'self-test' }, cases };
+}
+
+describe('parity replay: autofix output', () => {
+  it('compares single-pass applied fix against the corpus fixOutput', () => {
+    const corpus = corpusOf([
+      { kind: 'valid', code: '!x', options: [], expectedErrors: [], fixOutput: null },
+      {
+        kind: 'invalid',
+        code: '!!x',
+        options: [],
+        expectedErrors: [{ messageId: 'double', message: 'Collapse redundant double negation.' }],
+        fixOutput: 'x',
+      },
+    ]);
+    const counts = runRuleParity({
+      RuleTester,
+      rule: collapseDoubleNegation,
+      ruleName: 'collapse-double-negation',
+      corpus,
+    });
+    expect(counts.invalid).toBe(1);
+  });
+
+  it('converges a multi-pass fixer when the case sets recursive', () => {
+    const corpus = corpusOf([
+      {
+        kind: 'invalid',
+        code: '!!!!x',
+        options: [],
+        expectedErrors: [{ messageId: 'double', message: 'Collapse redundant double negation.' }],
+        fixOutput: 'x', // only reachable after two passes
+        recursive: true,
+      },
+    ]);
+    expect(() =>
+      runRuleParity({
+        RuleTester,
+        rule: collapseDoubleNegation,
+        ruleName: 'collapse-double-negation',
+        corpus,
+      }),
+    ).not.toThrow();
+  });
+
+  it('goes red when the corpus fixOutput does not match the port (no false-green on fixes)', () => {
+    const corpus = corpusOf([
+      {
+        kind: 'invalid',
+        code: '!!x',
+        options: [],
+        expectedErrors: [{ messageId: 'double', message: 'Collapse redundant double negation.' }],
+        fixOutput: 'WRONG',
+      },
+    ]);
+    expect(() =>
+      runRuleParity({
+        RuleTester,
+        rule: collapseDoubleNegation,
+        ruleName: 'collapse-double-negation',
+        corpus,
+      }),
+    ).toThrow();
+  });
+});

--- a/npm/eslint-comments/test/no-unlimited-disable.parity.test.mjs
+++ b/npm/eslint-comments/test/no-unlimited-disable.parity.test.mjs
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { RuleTester } from 'oxlint/plugins-dev';
+import { describe, expect, it } from 'vitest';
+
+import {
+  loadCorpus,
+  loadLedgerEntry,
+  runRuleParity,
+} from '../../../tools/parity/replay/runner.mjs';
+
+const require = createRequire(import.meta.url);
+const rule = require('../src/no-unlimited-disable.js');
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+const PLUGIN_ID = 'eslint-plugin-eslint-comments';
+const RULE_NAME = 'no-unlimited-disable';
+
+const corpus = loadCorpus(
+  path.join(REPO_ROOT, 'tools', 'parity', 'corpora', PLUGIN_ID, `${RULE_NAME}.json`),
+);
+const ledgerEntry = loadLedgerEntry(
+  path.join(REPO_ROOT, 'tools', 'parity', 'divergences.json'),
+  PLUGIN_ID,
+  RULE_NAME,
+);
+
+describe(`parity: ${PLUGIN_ID}/${RULE_NAME}`, () => {
+  it('reproduces the upstream corpus exactly (minus ledgered divergences)', () => {
+    const counts = runRuleParity({ RuleTester, rule, ruleName: RULE_NAME, corpus, ledgerEntry });
+    // Sanity: the corpus actually exercised both branches.
+    expect(counts.valid).toBeGreaterThan(0);
+    expect(counts.invalid).toBeGreaterThan(0);
+  });
+});

--- a/npm/simple-import-sort/LICENSE
+++ b/npm/simple-import-sort/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018, 2019, 2020, 2022, 2023, 2024 Simon Lydell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/simple-import-sort/index.js
+++ b/npm/simple-import-sort/index.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+
+const imports = require('./src/imports.js');
+const exports_ = require('./src/exports.js');
+
+const PLUGIN_NAME = 'simple-import-sort';
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules: {
+    imports,
+    exports: exports_,
+  },
+});
+
+module.exports = plugin;
+module.exports.default = plugin;

--- a/npm/simple-import-sort/package.json
+++ b/npm/simple-import-sort/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-simple-import-sort",
+  "version": "0.0.0",
+  "description": "Oxlint port of eslint-plugin-simple-import-sort.",
+  "keywords": [
+    "eslint-plugin",
+    "import",
+    "oxlint",
+    "oxlint-plugin",
+    "simple-import-sort",
+    "sort"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/simple-import-sort"
+  },
+  "files": [
+    "index.js",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "commonjs",
+  "main": "index.js",
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "devDependencies": {
+    "oxlint": "^1.67.0",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/simple-import-sort/src/exports.js
+++ b/npm/simple-import-sort/src/exports.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Ported from eslint-plugin-simple-import-sort (MIT, Copyright (c) 2018-2024 Simon Lydell).
+// Faithful adaptation onto the oxlint plugin API. See ./shared.js header and ../LICENSE.
+
+const shared = require('./shared');
+
+module.exports = {
+  meta: {
+    type: 'layout',
+    fixable: 'code',
+    schema: [],
+    docs: {
+      url: 'https://github.com/lydell/eslint-plugin-simple-import-sort#sort-order',
+      description: 'Automatically sort exports.',
+    },
+    messages: {
+      sort: 'Run autofix to sort these exports!',
+    },
+  },
+  create: (context) => {
+    const parents = new Set();
+
+    const addParent = (node) => {
+      if (isExportFrom(node)) {
+        parents.add(node.parent);
+      }
+    };
+
+    return {
+      ExportNamedDeclaration: (node) => {
+        if (node.source == null && node.declaration == null) {
+          maybeReportExportSpecifierSorting(node, context);
+        } else {
+          addParent(node);
+        }
+      },
+
+      ExportAllDeclaration: addParent,
+
+      'Program:exit': () => {
+        const sourceCode = shared.getSourceCode(context);
+        for (const parent of parents) {
+          for (const chunk of shared.extractChunks(parent, (node, lastNode) =>
+            isPartOfChunk(node, lastNode, sourceCode),
+          )) {
+            maybeReportChunkSorting(chunk, context);
+          }
+        }
+        parents.clear();
+      },
+    };
+  },
+};
+
+function maybeReportChunkSorting(chunk, context) {
+  const sourceCode = shared.getSourceCode(context);
+  const items = shared.getImportExportItems(
+    chunk,
+    sourceCode,
+    () => 1, // getStyle
+    getSpecifiers,
+  );
+  const sortedItems = [[shared.sortImportExportItems(items)]];
+  const sorted = shared.printSortedItems(sortedItems, items, sourceCode);
+  const { start } = items[0];
+  const { end } = items[items.length - 1];
+  shared.maybeReportSorting(context, sorted, start, end);
+}
+
+function maybeReportExportSpecifierSorting(node, context) {
+  const sorted = shared.printWithSortedSpecifiers(
+    node,
+    shared.getSourceCode(context),
+    getSpecifiers,
+  );
+  const [start, end] = node.range;
+  shared.maybeReportSorting(context, sorted, start, end);
+}
+
+// `export * from "a"` does not have `.specifiers`.
+function getSpecifiers(exportNode) {
+  return exportNode.specifiers || [];
+}
+
+function isPartOfChunk(node, lastNode, sourceCode) {
+  if (!isExportFrom(node)) {
+    return 'NotPartOfChunk';
+  }
+
+  const hasGroupingComment = sourceCode
+    .getCommentsBefore(node)
+    .some(
+      (comment) =>
+        (lastNode == null || comment.loc.start.line > lastNode.loc.end.line) &&
+        comment.loc.end.line < node.loc.start.line,
+    );
+
+  return hasGroupingComment ? 'PartOfNewChunk' : 'PartOfChunk';
+}
+
+// Full export-from statement.
+// export {a, b} from "A"
+// export * from "A"
+// export * as A from "A"
+function isExportFrom(node) {
+  return (
+    (node.type === 'ExportNamedDeclaration' || node.type === 'ExportAllDeclaration') &&
+    node.source != null
+  );
+}

--- a/npm/simple-import-sort/src/imports.js
+++ b/npm/simple-import-sort/src/imports.js
@@ -1,0 +1,200 @@
+'use strict';
+
+// Ported from eslint-plugin-simple-import-sort (MIT, Copyright (c) 2018-2024 Simon Lydell).
+// Faithful adaptation onto the oxlint plugin API. See ./shared.js header and ../LICENSE.
+
+const shared = require('./shared');
+
+const defaultGroups = [
+  // Side effect imports.
+  ['^\\u0000'],
+  // Node.js builtins prefixed with `node:`.
+  ['^node:'],
+  // Packages.
+  // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
+  ['^@?\\w'],
+  // Absolute imports and other imports such as Vue-style `@/foo`.
+  // Anything not matched in another group.
+  ['^'],
+  // Relative imports.
+  // Anything that starts with a dot.
+  ['^\\.'],
+];
+
+module.exports = {
+  meta: {
+    type: 'layout',
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          groups: {
+            type: 'array',
+            items: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    docs: {
+      url: 'https://github.com/lydell/eslint-plugin-simple-import-sort#sort-order',
+      description: 'Automatically sort imports.',
+    },
+    messages: {
+      sort: 'Run autofix to sort these imports!',
+    },
+  },
+  create: (context) => {
+    const { groups: rawGroups = defaultGroups } = context.options[0] || {};
+
+    const outerGroups = rawGroups.map((groups) => groups.map((item) => RegExp(item, 'u')));
+
+    const parents = new Set();
+
+    return {
+      ImportDeclaration: (node) => {
+        parents.add(node.parent);
+      },
+
+      'Program:exit': () => {
+        for (const parent of parents) {
+          for (const chunk of shared.extractChunks(parent, (node) =>
+            isImport(node) ? 'PartOfChunk' : 'NotPartOfChunk',
+          )) {
+            maybeReportChunkSorting(chunk, context, outerGroups);
+          }
+        }
+        parents.clear();
+      },
+    };
+  },
+};
+
+function maybeReportChunkSorting(chunk, context, outerGroups) {
+  const sourceCode = shared.getSourceCode(context);
+  const items = shared.getImportExportItems(chunk, sourceCode, getStyle, getSpecifiers);
+  const sortedItems = makeSortedItems(items, outerGroups);
+  const sorted = shared.printSortedItems(sortedItems, items, sourceCode);
+  const { start } = items[0];
+  const { end } = items[items.length - 1];
+  shared.maybeReportSorting(context, sorted, start, end);
+}
+
+function makeSortedItems(items, outerGroups) {
+  const itemGroups = outerGroups.map((groups) => groups.map((regex) => ({ regex, items: [] })));
+  const rest = [];
+
+  for (const item of items) {
+    const { originalSource } = item.source;
+    const source =
+      item.style === shared.SideEffectImport
+        ? `\0${originalSource}`
+        : item.source.kind !== 'value'
+          ? `${originalSource}\0`
+          : originalSource;
+    const [matchedGroup] = shared
+      .flatMap(itemGroups, (groups) => groups.map((group) => [group, group.regex.exec(source)]))
+      .reduce(
+        ([group, longestMatch], [nextGroup, nextMatch]) =>
+          nextMatch != null &&
+          (longestMatch == null || nextMatch[0].length > longestMatch[0].length)
+            ? [nextGroup, nextMatch]
+            : [group, longestMatch],
+        [undefined, undefined],
+      );
+    if (matchedGroup == null) {
+      rest.push(item);
+    } else {
+      matchedGroup.items.push(item);
+    }
+  }
+
+  return itemGroups
+    .concat([[{ regex: /^/, items: rest }]])
+    .map((groups) => groups.filter((group) => group.items.length > 0))
+    .filter((groups) => groups.length > 0)
+    .map((groups) => groups.map((group) => shared.sortImportExportItems(group.items)));
+}
+
+// Exclude "ImportDefaultSpecifier" – the "def" in `import def, {a, b}`.
+function getSpecifiers(importNode) {
+  return importNode.specifiers.filter((node) => isImportSpecifier(node));
+}
+
+// Full import statement.
+function isImport(node) {
+  return node.type === 'ImportDeclaration';
+}
+
+// import def, { a, b as c, type d } from "A"
+//               ^  ^^^^^^  ^^^^^^
+function isImportSpecifier(node) {
+  return node.type === 'ImportSpecifier';
+}
+
+// Returns a number representing the import style for deterministic ordering.
+// Order: side-effect (0) < namespace (1) < default (2) < named-only (3)
+//
+// Note: There are two primary use cases to keep in mind for deterministic ordering.
+//
+// The first use case is mixing a namespace import with importing a few things separately:
+//
+//     import * as Mod from "mod"
+//     import Thing, { Other, type Mod } from "mod"
+//
+// It makes sense to have the namespace import first, since that feels like the “main” import.
+//
+// The second use case is type imports.
+//
+// The following is not allowed by TypeScript:
+//
+//     import type Def, {A, B} from "A"
+//
+// "A type-only import can specify a default import or named bindings, but not both."
+// It must be split into two imports:
+//
+//     import type Def from "A"
+//     import type {A, B} from "A"
+//     // Or, depending on what you meant:
+//     import {A, B} from "A"
+//
+// It makes sense to have the default import first, since a default import has to be first
+// in a regular import statement with both a default import and named imports.
+function getStyle(importNode, sourceCode) {
+  if (importNode.specifiers.length === 0) {
+    if (
+      shared.isPunctuator(
+        sourceCode.getFirstToken(importNode, {
+          skip: importNode.importKind === 'type' ? 2 : 1,
+        }),
+        '{',
+      )
+    ) {
+      // `import {} from "A"` or `import type {} from "A"`
+      // This counts as named-only (with 0 named items).
+      return 3;
+    }
+
+    // `import "A"`
+    // Note that `import type "A"` is _not_ a type import:
+    // It is a default import creating a variable called `type`.
+    return shared.SideEffectImport;
+  }
+
+  const [firstSpecifier] = importNode.specifiers;
+
+  return firstSpecifier.type === 'ImportNamespaceSpecifier'
+    ? // `import * as x from "A"`
+      1
+    : firstSpecifier.type === 'ImportDefaultSpecifier'
+      ? // `import x from "A"` or `import x, { y } from "A"`
+        2
+      : // `import { x } from "A"`
+        3;
+}

--- a/npm/simple-import-sort/src/shared.js
+++ b/npm/simple-import-sort/src/shared.js
@@ -1,0 +1,850 @@
+'use strict';
+
+// Ported from eslint-plugin-simple-import-sort (MIT, Copyright (c) 2018-2024 Simon Lydell).
+// Faithful adaptation onto the oxlint plugin API (the oxc sourceCode/token/comment API is
+// ESLint-compatible, so the algorithm is reused as-is). Behavior is parity-tested against the
+// captured upstream corpus under tools/parity/corpora/eslint-plugin-simple-import-sort.
+// Original: https://github.com/lydell/eslint-plugin-simple-import-sort — see ../LICENSE.
+
+// A “chunk” is a sequence of statements of a certain type with only comments
+// and whitespace between.
+function extractChunks(parentNode, isPartOfChunk) {
+  const chunks = [];
+  let chunk = [];
+  let lastNode = undefined;
+
+  for (const node of parentNode.body) {
+    const result = isPartOfChunk(node, lastNode);
+    switch (result) {
+      case 'PartOfChunk':
+        chunk.push(node);
+        break;
+
+      case 'PartOfNewChunk':
+        if (chunk.length > 0) {
+          chunks.push(chunk);
+        }
+        chunk = [node];
+        break;
+
+      case 'NotPartOfChunk':
+        if (chunk.length > 0) {
+          chunks.push(chunk);
+          chunk = [];
+        }
+        break;
+
+      /* v8 ignore start */
+      default:
+        throw new Error(`Unknown chunk result: ${result}`);
+      /* v8 ignore stop */
+    }
+
+    lastNode = node;
+  }
+
+  if (chunk.length > 0) {
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+function maybeReportSorting(context, sorted, start, end) {
+  const sourceCode = getSourceCode(context);
+  const original = sourceCode.getText().slice(start, end);
+  if (original !== sorted) {
+    context.report({
+      messageId: 'sort',
+      loc: {
+        start: sourceCode.getLocFromIndex(start),
+        end: sourceCode.getLocFromIndex(end),
+      },
+      fix: (fixer) => fixer.replaceTextRange([start, end], sorted),
+    });
+  }
+}
+
+function printSortedItems(sortedItems, originalItems, sourceCode) {
+  const newline = guessNewline(sourceCode);
+
+  const sorted = sortedItems
+    .map((groups) =>
+      groups.map((groupItems) => groupItems.map((item) => item.code).join(newline)).join(newline),
+    )
+    .join(newline + newline);
+
+  // Edge case: If the last import/export (after sorting) ends with a line
+  // comment and there’s code (or a multiline block comment) on the same line,
+  // add a newline so we don’t accidentally comment stuff out.
+  const flattened = flatMap(sortedItems, (groups) => [].concat(...groups));
+  const lastSortedItem = flattened[flattened.length - 1];
+  const lastOriginalItem = originalItems[originalItems.length - 1];
+  const nextToken = lastSortedItem.needsNewline
+    ? sourceCode.getTokenAfter(lastOriginalItem.node, {
+        includeComments: true,
+        filter: (token) =>
+          !isLineComment(token) &&
+          !(isBlockComment(token) && token.loc.end.line === lastOriginalItem.node.loc.end.line),
+      })
+    : undefined;
+  const maybeNewline =
+    nextToken != null && nextToken.loc.start.line === lastOriginalItem.node.loc.end.line
+      ? newline
+      : '';
+
+  return sorted + maybeNewline;
+}
+
+// Wrap the import/export nodes in `passedChunk` in objects with more data about
+// the import/export. Most importantly there’s a `code` property that contains
+// the node as a string, with comments (if any). Finding the corresponding
+// comments is the hard part.
+function getImportExportItems(passedChunk, sourceCode, getStyle, getSpecifiers) {
+  const chunk = handleLastSemicolon(passedChunk, sourceCode);
+  return chunk.map((node, nodeIndex) => {
+    const lastLine = nodeIndex === 0 ? node.loc.start.line - 1 : chunk[nodeIndex - 1].loc.end.line;
+
+    // Get all comments before the import/export, except:
+    //
+    // - Comments on another line for the first import/export.
+    // - Comments that belong to the previous import/export (if any) – that is,
+    //   comments that are on the same line as the previous import/export. But
+    //   multiline block comments always belong to this import/export, not the
+    //   previous.
+    const commentsBefore = sourceCode
+      .getCommentsBefore(node)
+      .filter(
+        (comment) =>
+          comment.loc.start.line <= node.loc.start.line &&
+          comment.loc.end.line > lastLine &&
+          (nodeIndex > 0 || comment.loc.start.line > lastLine),
+      );
+
+    // Get all comments after the import/export that are on the same line.
+    // Multiline block comments belong to the _next_ import/export (or the
+    // following code in case of the last import/export).
+    const commentsAfter = sourceCode
+      .getCommentsAfter(node)
+      .filter((comment) => comment.loc.end.line === node.loc.end.line);
+
+    const before = printCommentsBefore(node, commentsBefore, sourceCode);
+    const after = printCommentsAfter(node, commentsAfter, sourceCode);
+
+    // Print the indentation before the import/export or its first comment, if
+    // any, to support indentation in `<script>` tags.
+    const indentation = getIndentation(
+      commentsBefore.length > 0 ? commentsBefore[0] : node,
+      sourceCode,
+    );
+
+    // Print spaces after the import/export or its last comment, if any, to
+    // avoid producing a sort error just because you accidentally added a few
+    // trailing spaces among the imports/exports.
+    const trailingSpaces = getTrailingSpaces(
+      commentsAfter.length > 0 ? commentsAfter[commentsAfter.length - 1] : node,
+      sourceCode,
+    );
+
+    const code =
+      indentation +
+      before +
+      printWithSortedSpecifiers(node, sourceCode, getSpecifiers) +
+      after +
+      trailingSpaces;
+
+    const all = [...commentsBefore, node, ...commentsAfter];
+    const [start] = all[0].range;
+    const [, end] = all[all.length - 1].range;
+
+    const source = getSource(node);
+
+    return {
+      node,
+      code,
+      start: start - indentation.length,
+      end: end + trailingSpaces.length,
+      style: getStyle(node, sourceCode),
+      source,
+      index: nodeIndex,
+      needsNewline:
+        commentsAfter.length > 0 && isLineComment(commentsAfter[commentsAfter.length - 1]),
+    };
+  });
+}
+
+// Parsers think that a semicolon after a statement belongs to that statement.
+// But in a semicolon-free code style it might belong to the next statement:
+//
+//     import x from "x"
+//     ;[].forEach()
+//
+// If the last import/export of a chunk ends with a semicolon, and that
+// semicolon isn’t located on the same line as the `from` string, adjust the
+// node to end at the `from` string instead.
+//
+// In the above example, the import is adjusted to end after `"x"`.
+function handleLastSemicolon(chunk, sourceCode) {
+  const lastIndex = chunk.length - 1;
+  const lastNode = chunk[lastIndex];
+  const [nextToLastToken, lastToken] = sourceCode.getLastTokens(lastNode, {
+    count: 2,
+  });
+  const lastIsSemicolon = isPunctuator(lastToken, ';');
+
+  if (!lastIsSemicolon) {
+    return chunk;
+  }
+
+  const semicolonBelongsToNode =
+    nextToLastToken.loc.end.line === lastToken.loc.start.line ||
+    // If there’s no more code after the last import/export the semicolon has to
+    // belong to the import/export, even if it is not on the same line.
+    sourceCode.getTokenAfter(lastToken) == null;
+
+  if (semicolonBelongsToNode) {
+    return chunk;
+  }
+
+  // Preserve the start position, but use the end position of the `from` string.
+  const newLastNode = {
+    ...lastNode,
+    range: [lastNode.range[0], nextToLastToken.range[1]],
+    loc: {
+      start: lastNode.loc.start,
+      end: nextToLastToken.loc.end,
+    },
+  };
+
+  return chunk.slice(0, lastIndex).concat(newLastNode);
+}
+
+function printWithSortedSpecifiers(node, sourceCode, getSpecifiers) {
+  const allTokens = getAllTokens(node, sourceCode);
+  const openBraceIndex = allTokens.findIndex((token) => isPunctuator(token, '{'));
+  const closeBraceIndex = allTokens.findIndex((token) => isPunctuator(token, '}'));
+
+  const specifiers = getSpecifiers(node);
+
+  if (openBraceIndex === -1 || closeBraceIndex === -1 || specifiers.length <= 1) {
+    return printTokens(allTokens);
+  }
+
+  const specifierTokens = allTokens.slice(openBraceIndex + 1, closeBraceIndex);
+  const itemsResult = getSpecifierItems(specifierTokens, sourceCode);
+
+  const items = itemsResult.items.map((originalItem, index) => ({
+    ...originalItem,
+    node: specifiers[index],
+  }));
+
+  const sortedItems = sortSpecifierItems(items);
+
+  const newline = guessNewline(sourceCode);
+
+  // `allTokens[closeBraceIndex - 1]` wouldn’t work because `allTokens` contains
+  // comments and whitespace.
+  const hasTrailingComma = isPunctuator(sourceCode.getTokenBefore(allTokens[closeBraceIndex]), ',');
+
+  const lastIndex = sortedItems.length - 1;
+  const sorted = flatMap(sortedItems, (item, index) => {
+    const previous = index === 0 ? undefined : sortedItems[index - 1];
+
+    // Add a newline if the item needs one, unless the previous item (if any)
+    // already ends with a newline.
+    const maybeNewline =
+      previous != null &&
+      needsStartingNewline(item.before) &&
+      !(previous.after.length > 0 && isNewline(previous.after[previous.after.length - 1]))
+        ? [{ type: 'Newline', code: newline }]
+        : [];
+
+    if (index < lastIndex || hasTrailingComma) {
+      return [
+        ...maybeNewline,
+        ...item.before,
+        ...item.specifier,
+        { type: 'Comma', code: ',' },
+        ...item.after,
+      ];
+    }
+
+    const nonBlankIndex = item.after.findIndex((token) => !isNewline(token) && !isSpaces(token));
+
+    // Remove whitespace and newlines at the start of `.after` if the item had a
+    // comma before, but now hasn’t to avoid blank lines and excessive
+    // whitespace before `}`.
+    const after = !item.hadComma
+      ? item.after
+      : nonBlankIndex === -1
+        ? []
+        : item.after.slice(nonBlankIndex);
+
+    return [...maybeNewline, ...item.before, ...item.specifier, ...after];
+  });
+
+  const maybeNewline =
+    needsStartingNewline(itemsResult.after) && !isNewline(sorted[sorted.length - 1])
+      ? [{ type: 'Newline', code: newline }]
+      : [];
+
+  return printTokens([
+    ...allTokens.slice(0, openBraceIndex + 1),
+    ...itemsResult.before,
+    ...sorted,
+    ...maybeNewline,
+    ...itemsResult.after,
+    ...allTokens.slice(closeBraceIndex),
+  ]);
+}
+
+// Turns a list of tokens between the `{` and `}` of an import/export specifiers
+// list into an object with the following properties:
+//
+// - before: Array of tokens – whitespace and comments after the `{` that do not
+//   belong to any specifier.
+// - after: Array of tokens – whitespace and comments before the `}` that do not
+//   belong to any specifier.
+// - items: Array of specifier items.
+//
+// Each specifier item looks like this:
+//
+// - before: Array of tokens – whitespace and comments before the specifier.
+// - after: Array of tokens – whitespace and comments after the specifier.
+// - specifier: Array of tokens – identifiers, whitespace and comments of the
+//   specifier.
+// - hadComma: A Boolean representing if the specifier had a comma originally.
+//
+// We have to do carefully preserve all original whitespace this way in order to
+// be compatible with other stylistic ESLint rules.
+function getSpecifierItems(tokens) {
+  const result = {
+    before: [],
+    after: [],
+    items: [],
+  };
+
+  let current = makeEmptyItem();
+
+  for (const token of tokens) {
+    switch (current.state) {
+      case 'before':
+        switch (token.type) {
+          case 'Newline':
+            current.before.push(token);
+
+            // All whitespace and comments before the first newline or
+            // identifier belong to the `{`, not the first specifier.
+            if (result.before.length === 0 && result.items.length === 0) {
+              result.before = current.before;
+              current = makeEmptyItem();
+            }
+            break;
+
+          case 'Spaces':
+          case 'Block':
+          case 'Line':
+            current.before.push(token);
+            break;
+
+          // We’ve reached an identifier.
+          default:
+            // All whitespace and comments before the first newline or
+            // identifier belong to the `{`, not the first specifier.
+            if (result.before.length === 0 && result.items.length === 0) {
+              result.before = current.before;
+              current = makeEmptyItem();
+            }
+
+            current.state = 'specifier';
+            current.specifier.push(token);
+        }
+        break;
+
+      case 'specifier':
+        switch (token.type) {
+          case 'Punctuator':
+            // There can only be comma punctuators, but future-proof by checking.
+            if (isPunctuator(token, ',')) {
+              current.hadComma = true;
+              current.state = 'after';
+              /* v8 ignore start */
+            } else {
+              current.specifier.push(token);
+            }
+            /* v8 ignore stop */
+            break;
+
+          // When consuming the specifier part, we eat every token until a comma
+          // or to the end, basically.
+          default:
+            current.specifier.push(token);
+        }
+        break;
+
+      case 'after':
+        switch (token.type) {
+          // Only whitespace and comments after a specifier that are on the same
+          // belong to the specifier.
+          case 'Newline':
+            current.after.push(token);
+            result.items.push(current);
+            current = makeEmptyItem();
+            break;
+
+          case 'Spaces':
+          case 'Line':
+            current.after.push(token);
+            break;
+
+          case 'Block':
+            // Multiline block comments belong to the next specifier.
+            if (hasNewline(token.code)) {
+              result.items.push(current);
+              current = makeEmptyItem();
+              current.before.push(token);
+            } else {
+              current.after.push(token);
+            }
+            break;
+
+          // We’ve reached another specifier – time to process that one.
+          default:
+            result.items.push(current);
+            current = makeEmptyItem();
+            current.state = 'specifier';
+            current.specifier.push(token);
+        }
+        break;
+
+      /* v8 ignore start */
+      default:
+        throw new Error(`Unknown state: ${current.state}`);
+      /* v8 ignore stop */
+    }
+  }
+
+  // We’ve reached the end of the tokens. Handle what’s currently in `current`.
+  switch (current.state) {
+    // If the last specifier has a trailing comma and some of the remaining
+    // whitespace and comments are on the same line we end up here. If so we
+    // want to put that whitespace and comments in `result.after`.
+    case 'before':
+      result.after = current.before;
+      break;
+
+    // If the last specifier has no trailing comma we end up here. Move all
+    // trailing comments and whitespace from `.specifier` to `.after`, and
+    // comments and whitespace that don’t belong to the specifier to
+    // `result.after`. The last non-comment and non-whitespace token is usually
+    // an identifier, but in this case it’s a keyword:
+    //
+    //    export { z, d as default } from "a"
+    case 'specifier': {
+      const lastIdentifierIndex = findLastIndex(
+        current.specifier,
+        (token2) => isIdentifier(token2) || isKeyword(token2),
+      );
+
+      const specifier = current.specifier.slice(0, lastIdentifierIndex + 1);
+      const after = current.specifier.slice(lastIdentifierIndex + 1);
+
+      // If there’s a newline, put everything up to and including (hence the `+
+      // 1`) that newline in the specifiers’s `.after`.
+      const newlineIndexRaw = after.findIndex((token2) => isNewline(token2));
+      const newlineIndex = newlineIndexRaw === -1 ? -1 : newlineIndexRaw + 1;
+
+      // If there’s a multiline block comment, put everything _before_ that
+      // comment in the specifiers’s `.after`.
+      const multilineBlockCommentIndex = after.findIndex(
+        (token2) => isBlockComment(token2) && hasNewline(token2.code),
+      );
+
+      const sliceIndex =
+        // If both a newline and a multiline block comment exists, choose the
+        // earlier one.
+        newlineIndex >= 0 && multilineBlockCommentIndex >= 0
+          ? Math.min(newlineIndex, multilineBlockCommentIndex)
+          : newlineIndex >= 0
+            ? newlineIndex
+            : multilineBlockCommentIndex >= 0
+              ? multilineBlockCommentIndex
+              : // If there are no newlines, move the last whitespace into `result.after`.
+                endsWithSpaces(after)
+                ? after.length - 1
+                : -1;
+
+      current.specifier = specifier;
+      current.after = sliceIndex === -1 ? after : after.slice(0, sliceIndex);
+      result.items.push(current);
+      result.after = sliceIndex === -1 ? [] : after.slice(sliceIndex);
+
+      break;
+    }
+
+    // If the last specifier has a trailing comma and all remaining whitespace
+    // and comments are on the same line we end up here. If so we want to move
+    // the final whitespace to `result.after`.
+    case 'after':
+      if (endsWithSpaces(current.after)) {
+        const last = current.after.pop();
+        result.after = [last];
+      }
+      result.items.push(current);
+      break;
+
+    /* v8 ignore start */
+    default:
+      throw new Error(`Unknown state: ${current.state}`);
+    /* v8 ignore stop */
+  }
+
+  return result;
+}
+
+function makeEmptyItem() {
+  return {
+    // "before" | "specifier" | "after"
+    state: 'before',
+    before: [],
+    after: [],
+    specifier: [],
+    hadComma: false,
+  };
+}
+
+// If a specifier item starts with a line comment or a singleline block comment
+// it needs a newline before that. Otherwise that comment can end up belonging
+// to the _previous_ specifier after sorting.
+function needsStartingNewline(tokens) {
+  const before = tokens.filter((token) => !isSpaces(token));
+
+  if (before.length === 0) {
+    return false;
+  }
+
+  const firstToken = before[0];
+  return isLineComment(firstToken) || (isBlockComment(firstToken) && !hasNewline(firstToken.code));
+}
+
+function endsWithSpaces(tokens) {
+  const last = tokens.length > 0 ? tokens[tokens.length - 1] : undefined;
+  return last == null ? false : isSpaces(last);
+}
+
+const NEWLINE = /(\r?\n)/;
+
+function hasNewline(string) {
+  return NEWLINE.test(string);
+}
+
+function guessNewline(sourceCode) {
+  const match = NEWLINE.exec(sourceCode.text);
+  return match == null ? '\n' : match[0];
+}
+
+function parseWhitespace(whitespace) {
+  const allItems = whitespace.split(NEWLINE);
+
+  // Remove blank lines. `allItems` contains alternating `spaces` (which can be
+  // the empty string) and `newline` (which is either "\r\n" or "\n"). So in
+  // practice `allItems` grows like this as there are more newlines in
+  // `whitespace`:
+  //
+  //     [spaces]
+  //     [spaces, newline, spaces]
+  //     [spaces, newline, spaces, newline, spaces]
+  //     [spaces, newline, spaces, newline, spaces, newline, spaces]
+  //
+  // If there are 5 or more items we have at least one blank line. If so, keep
+  // the first `spaces`, the first `newline` and the last `spaces`.
+  const items = allItems.length >= 5 ? allItems.slice(0, 2).concat(allItems.slice(-1)) : allItems;
+
+  return (
+    items
+      .map((spacesOrNewline, index) =>
+        index % 2 === 0
+          ? { type: 'Spaces', code: spacesOrNewline }
+          : { type: 'Newline', code: spacesOrNewline },
+      )
+      // Remove empty spaces since it makes debugging easier.
+      .filter((token) => token.code !== '')
+  );
+}
+
+function removeBlankLines(whitespace) {
+  return printTokens(parseWhitespace(whitespace));
+}
+
+// Returns `sourceCode.getTokens(node)` plus whitespace and comments. All tokens
+// have a `code` property with `sourceCode.getText(token)`.
+function getAllTokens(node, sourceCode) {
+  const tokens = sourceCode.getTokens(node);
+  const lastTokenIndex = tokens.length - 1;
+  return flatMap(tokens, (token, tokenIndex) => {
+    const newToken = { ...token, code: sourceCode.getText(token) };
+
+    if (tokenIndex === lastTokenIndex) {
+      return [newToken];
+    }
+
+    const comments = sourceCode.getCommentsAfter(token);
+    const last = comments.length > 0 ? comments[comments.length - 1] : token;
+    const nextToken = tokens[tokenIndex + 1];
+
+    return [
+      newToken,
+      ...flatMap(comments, (comment, commentIndex) => {
+        const previous = commentIndex === 0 ? token : comments[commentIndex - 1];
+        return [
+          ...parseWhitespace(sourceCode.text.slice(previous.range[1], comment.range[0])),
+          { ...comment, code: sourceCode.getText(comment) },
+        ];
+      }),
+      ...parseWhitespace(sourceCode.text.slice(last.range[1], nextToken.range[0])),
+    ];
+  });
+}
+
+// Prints tokens that are enhanced with a `code` property – like those returned
+// by `getAllTokens` and `parseWhitespace`.
+function printTokens(tokens) {
+  return tokens.map((token) => token.code).join('');
+}
+
+// `comments` is a list of comments that occur before `node`. Print those and
+// the whitespace between themselves and between `node`.
+function printCommentsBefore(node, comments, sourceCode) {
+  const lastIndex = comments.length - 1;
+  return comments
+    .map((comment, index) => {
+      const next = index === lastIndex ? node : comments[index + 1];
+      return (
+        sourceCode.getText(comment) +
+        removeBlankLines(sourceCode.text.slice(comment.range[1], next.range[0]))
+      );
+    })
+    .join('');
+}
+
+// `comments` is a list of comments that occur after `node`. Print those and
+// the whitespace between themselves and between `node`.
+function printCommentsAfter(node, comments, sourceCode) {
+  return comments
+    .map((comment, index) => {
+      const previous = index === 0 ? node : comments[index - 1];
+      return (
+        removeBlankLines(sourceCode.text.slice(previous.range[1], comment.range[0])) +
+        sourceCode.getText(comment)
+      );
+    })
+    .join('');
+}
+
+function getIndentation(node, sourceCode) {
+  const tokenBefore = sourceCode.getTokenBefore(node, {
+    includeComments: true,
+  });
+  if (tokenBefore == null) {
+    const text = sourceCode.text.slice(0, node.range[0]);
+    const lines = text.split(NEWLINE);
+    return lines[lines.length - 1];
+  }
+  const text = sourceCode.text.slice(tokenBefore.range[1], node.range[0]);
+  const lines = text.split(NEWLINE);
+  return lines.length > 1 ? lines[lines.length - 1] : '';
+}
+
+function getTrailingSpaces(node, sourceCode) {
+  const tokenAfter = sourceCode.getTokenAfter(node, {
+    includeComments: true,
+  });
+  if (tokenAfter == null) {
+    const text = sourceCode.text.slice(node.range[1]);
+    const lines = text.split(NEWLINE);
+    return lines[0];
+  }
+  const text = sourceCode.text.slice(node.range[1], tokenAfter.range[0]);
+  const lines = text.split(NEWLINE);
+  return lines[0];
+}
+
+const SideEffectImport = 0;
+
+function sortImportExportItems(items) {
+  return items.slice().sort((itemA, itemB) =>
+    // If both items are side effect imports, keep their original order.
+    itemA.style === SideEffectImport && itemB.style === SideEffectImport
+      ? itemA.index - itemB.index
+      : // If one of the items is a side effect import, move it first.
+        itemA.style === SideEffectImport
+        ? -1
+        : itemB.style === SideEffectImport
+          ? 1
+          : // Compare the `from` part.
+            compare(itemA.source.source, itemB.source.source) ||
+            // The `.source` has been slightly tweaked. To stay fully deterministic,
+            // also sort on the original value.
+            compare(itemA.source.originalSource, itemB.source.originalSource) ||
+            // Then put type imports/exports before regular ones.
+            compare(itemA.source.kind, itemB.source.kind) ||
+            // Then sort by style.
+            // imports: namespace < default (maybe with named) < named-only
+            // exports: no styles.
+            itemA.style - itemB.style ||
+            // Keep the original order if the sources are the same. It’s not worth
+            // trying to compare anything else, and you can use `import/no-duplicates`
+            // to get rid of the problem anyway.
+            itemA.index - itemB.index,
+  );
+}
+
+function sortSpecifierItems(items) {
+  return items.slice().sort(
+    (itemA, itemB) =>
+      // Compare by imported or exported name (external interface name).
+      // import { a as b } from "a"
+      //          ^
+      // export { b as a }
+      //               ^
+      compare(
+        (itemA.node.imported || itemA.node.exported).name,
+        (itemB.node.imported || itemB.node.exported).name,
+      ) ||
+      // Then compare by the file-local name.
+      // import { a as b } from "a"
+      //               ^
+      // export { b as a }
+      //          ^
+      compare(itemA.node.local.name, itemB.node.local.name) ||
+      // Then put type specifiers before regular ones.
+      compare(
+        getImportExportKind(itemA.node),
+        getImportExportKind(itemB.node),
+        /* v8 ignore start */
+      ) ||
+      // Keep the original order if the names are the same. It’s not worth
+      // trying to compare anything else, `import {a, a} from "mod"` is a syntax
+      // error anyway (but @babel/eslint-parser kind of supports it).
+      itemA.index - itemB.index,
+    /* v8 ignore stop */
+  );
+}
+
+const collator = new Intl.Collator('en', {
+  sensitivity: 'base',
+  numeric: true,
+});
+
+function compare(a, b) {
+  return collator.compare(a, b) || (a < b ? -1 : a > b ? 1 : 0);
+}
+
+function isIdentifier(node) {
+  return node.type === 'Identifier';
+}
+
+function isKeyword(node) {
+  return node.type === 'Keyword';
+}
+
+function isPunctuator(node, value) {
+  return node.type === 'Punctuator' && node.value === value;
+}
+
+function isBlockComment(node) {
+  return node.type === 'Block';
+}
+
+function isLineComment(node) {
+  return node.type === 'Line';
+}
+
+function isSpaces(node) {
+  return node.type === 'Spaces';
+}
+
+function isNewline(node) {
+  return node.type === 'Newline';
+}
+
+function getSource(node) {
+  const source = node.source.value;
+
+  return {
+    // Sort by directory level rather than by string length.
+    source: source
+      // Treat `.` as `./`, `..` as `../`, `../..` as `../../` etc.
+      .replace(/^[./]*\.$/, '$&/')
+      // Make `../` sort after `../../` but before `../a` etc.
+      // Why a comma? See the next comment.
+      .replace(/^[./]*\/$/, '$&,')
+      // Make `.` and `/` sort before any other punctuation.
+      // The default order is: _ - , x x x . x x x / x x x
+      // We’re changing it to: . / , x x x _ x x x - x x x
+      .replace(/[./_-]/g, (char) => {
+        switch (char) {
+          case '.':
+            return '_';
+          case '/':
+            return '-';
+          case '_':
+            return '.';
+          case '-':
+            return '/';
+          /* v8 ignore start */
+          default:
+            throw new Error(`Unknown source substitution character: ${char}`);
+          /* v8 ignore stop */
+        }
+      }),
+    originalSource: source,
+    kind: getImportExportKind(node),
+  };
+}
+
+function getImportExportKind(node) {
+  // `type` and `typeof` imports, as well as `type` exports (there are no
+  // `typeof` exports).
+  return node.importKind || node.exportKind || 'value';
+}
+
+// Like `Array.prototype.findIndex`, but searches from the end.
+/* v8 ignore start */
+// Ignore coverage because:
+// - There are currently no usages of `findLastIndex` where nothing is found.
+// - vitest reports `return index;` as not covered, despite it actually being hit.
+function findLastIndex(array, fn) {
+  for (let index = array.length - 1; index >= 0; index--) {
+    if (fn(array[index], index, array)) {
+      return index;
+    }
+  }
+  return -1;
+  /* v8 ignore stop */
+}
+
+// Like `Array.prototype.flatMap`, had it been available.
+function flatMap(array, fn) {
+  return [].concat(...array.map(fn));
+}
+
+function getSourceCode(context) {
+  // `.getSourceCode()` is deprecated in favor of `.sourceCode`.
+  // We support both for now.
+  /* v8 ignore next */
+  return context.sourceCode || context.getSourceCode();
+}
+
+module.exports = {
+  extractChunks,
+  flatMap,
+  getImportExportItems,
+  getSourceCode,
+  isPunctuator,
+  maybeReportSorting,
+  printSortedItems,
+  printWithSortedSpecifiers,
+  SideEffectImport,
+  sortImportExportItems,
+};

--- a/npm/simple-import-sort/test/parity.test.mjs
+++ b/npm/simple-import-sort/test/parity.test.mjs
@@ -1,0 +1,42 @@
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { RuleTester } from 'oxlint/plugins-dev';
+import { describe, expect, it } from 'vitest';
+
+import {
+  loadCorpus,
+  loadLedgerEntry,
+  runRuleParity,
+} from '../../../tools/parity/replay/runner.mjs';
+
+const require = createRequire(import.meta.url);
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+const PLUGIN_ID = 'eslint-plugin-simple-import-sort';
+
+const RULES = {
+  imports: require('../src/imports.js'),
+  exports: require('../src/exports.js'),
+};
+
+for (const [ruleName, rule] of Object.entries(RULES)) {
+  const corpus = loadCorpus(
+    path.join(REPO_ROOT, 'tools', 'parity', 'corpora', PLUGIN_ID, `${ruleName}.json`),
+  );
+  const ledgerEntry = loadLedgerEntry(
+    path.join(REPO_ROOT, 'tools', 'parity', 'divergences.json'),
+    PLUGIN_ID,
+    ruleName,
+  );
+
+  describe(`parity: ${PLUGIN_ID}/${ruleName}`, () => {
+    it('reproduces the upstream corpus exactly (minus ledgered divergences)', () => {
+      const counts = runRuleParity({ RuleTester, rule, ruleName, corpus, ledgerEntry });
+      expect(counts.valid).toBeGreaterThan(0);
+      expect(counts.invalid).toBeGreaterThan(0);
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
     "lint:rust": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
     "lint:rust:layout": "node tools/tasks/check-rust-layout.ts",
     "new": "node tools/tasks/new-port-prompt.ts",
+    "parity:capture": "node tools/parity/capture/run.cjs",
+    "parity:capture:esm": "vitest run --config tools/parity/capture/vitest.config.ts",
+    "parity:check": "node tools/parity/capture/run.cjs eslint-plugin-eslint-comments --check",
+    "parity:drift": "node tools/parity/check-drift.mjs",
     "port:releases": "node tools/tasks/check-upstream-releases.ts",
     "port:rules": "node tools/tasks/enumerate-port-rules.ts",
     "profile": "node tools/tasks/profile.ts",
@@ -62,9 +66,17 @@
     "verify": "pnpm run fmt:rust:check && vp fmt --check && pnpm run typecheck && vp lint && pnpm run lint:rust && pnpm run lint:rust:layout && vp build && vp test && pnpm run test:rust && pnpm run bench:check && pnpm run security:audit && pnpm run license && pnpm run status:check && node tools/tasks/verify-package-publish-ready.ts"
   },
   "devDependencies": {
+    "@babel/core": "7.26.0",
+    "@babel/eslint-parser": "7.25.9",
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
+    "@typescript-eslint/parser": "8.18.0",
+    "@typescript-eslint/rule-tester": "8.18.0",
     "@typescript/native-preview": "catalog:",
+    "escape-string-regexp": "4.0.0",
+    "eslint": "9.39.4",
+    "ignore": "7.0.5",
+    "semver": "7.6.3",
     "vite-plus": "catalog:",
     "vitest": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,18 +38,42 @@ importers:
 
   .:
     devDependencies:
+      '@babel/core':
+        specifier: 7.26.0
+        version: 7.26.0
+      '@babel/eslint-parser':
+        specifier: 7.25.9
+        version: 7.25.9(@babel/core@7.26.0)(eslint@9.39.4)
       '@napi-rs/cli':
         specifier: 'catalog:'
         version: 3.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.13.1)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.1
+      '@typescript-eslint/parser':
+        specifier: 8.18.0
+        version: 8.18.0(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/rule-tester':
+        specifier: 8.18.0
+        version: 8.18.0(eslint@9.39.4)(typescript@5.7.3)
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260608.1
+      escape-string-regexp:
+        specifier: 4.0.0
+        version: 4.0.0
+      eslint:
+        specifier: 9.39.4
+        version: 9.39.4
+      ignore:
+        specifier: 7.0.5
+        version: 7.0.5
+      semver:
+        specifier: 7.6.3
+        version: 7.6.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+        version: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
@@ -61,13 +85,39 @@ importers:
         version: 2.64.0
       void:
         specifier: 'catalog:'
-        version: 0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3)
+        version: 0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1(typescript@5.7.3))(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3)
+
+  npm/eslint-comments:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+    devDependencies:
+      oxlint:
+        specifier: ^1.67.0
+        version: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
 
   npm/no-forbidden-identifiers:
     dependencies:
       '@oxlint/plugins':
         specifier: 'catalog:'
         version: 1.68.0
+
+  npm/simple-import-sort:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+    devDependencies:
+      oxlint:
+        specifier: ^1.67.0
+        version: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
 
   npm/type-aware:
     dependencies:
@@ -77,11 +127,89 @@ importers:
 
 packages:
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@ark/schema@0.56.0':
     resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
 
   '@ark/util@0.56.0':
     resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.26.0':
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/eslint-parser@7.25.9':
+    resolution: {integrity: sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0
+      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
 
   '@better-auth/core@1.6.14':
     resolution: {integrity: sha512-12cA7tnR4Wyb3nLpPmeq/Id7QNB+4OhjbzuX7sIhqglgXGjyT5iiNpe2lx/8FF532sHC450Yx1850salCYbkzw==}
@@ -912,11 +1040,69 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@hono/oauth-providers@0.8.5':
     resolution: {integrity: sha512-hgEDH/gUmB/opman9jvT8dLItZsSC9M9yFiaam0b6InK7WQkdzIcaRAkdda47QpixnK9S1Ah2vjDB2U16LkMnA==}
     engines: {node: '>=18.4.0'}
     peerDependencies:
       hono: '>=3.0.0'
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1205,12 +1391,18 @@ packages:
       '@types/node':
         optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -1649,6 +1841,9 @@ packages:
     resolution: {integrity: sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==}
     engines: {node: '>= 10'}
 
+  '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
+    resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
+
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
@@ -1656,6 +1851,18 @@ packages:
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -2137,8 +2344,49 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  '@typescript-eslint/parser@8.18.0':
+    resolution: {integrity: sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/rule-tester@8.18.0':
+    resolution: {integrity: sha512-y3ZqVb6eMssPFJklplsQ+2MKcic7HqRgCkcu7MQryhRmqmhAgn+1hJnpqOipZIBTOWZeCiQ/X/XrbHdqjHFivQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@typescript-eslint/scope-manager@8.18.0':
+    resolution: {integrity: sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.18.0':
+    resolution: {integrity: sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.18.0':
+    resolution: {integrity: sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/utils@8.18.0':
+    resolution: {integrity: sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/visitor-keys@8.18.0':
+    resolution: {integrity: sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
     resolution: {integrity: sha512-ZGs+yhsPWFDkSHydJyF8I3d4witpXiD69auWZtSotNWG3gBR5Ne291m38rvxoLFDRlFHwAQpPT7q3yStp+cQSQ==}
@@ -2362,6 +2610,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2378,8 +2643,16 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -2470,11 +2743,33 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
@@ -2482,6 +2777,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -2498,8 +2797,18 @@ packages:
     peerDependencies:
       typanion: '*'
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
@@ -2511,6 +2820,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2528,6 +2841,9 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -2650,6 +2966,9 @@ packages:
       drizzle-orm: '>=0.36.0'
       zod: ^3.25.0 || ^4.0.0
 
+  electron-to-chromium@1.5.380:
+    resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
+
   emnapi@1.10.0:
     resolution: {integrity: sha512-swoyZjupDvLoe/KC3HZ4SY1JUN+tviT6eOZ3Px28TZAYdBHtRIiMWWrIUUH+2/9CYY4fNTID1YhYZ+kdFHszHg==}
     peerDependencies:
@@ -2693,8 +3012,70 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    engines: {node: '>=10'}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -2703,6 +3084,19 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -2713,6 +3107,9 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2722,8 +3119,27 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2733,11 +3149,31 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
@@ -2750,9 +3186,21 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2760,18 +3208,58 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -2780,6 +3268,10 @@ packages:
   kysely@0.29.2:
     resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
     engines: {node: '>=22.0.0'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2855,8 +3347,26 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -2866,6 +3376,13 @@ packages:
     resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -2896,9 +3413,16 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
 
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
@@ -2906,6 +3430,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   oxfmt@0.52.0:
     resolution: {integrity: sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==}
@@ -2936,6 +3464,26 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -2980,6 +3528,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3018,8 +3570,19 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -3029,8 +3592,16 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -3040,11 +3611,23 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.8.2:
     resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
@@ -3057,6 +3640,14 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3103,9 +3694,17 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -3133,9 +3732,19 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  ts-api-utils@1.4.3:
+    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3151,6 +3760,15 @@ packages:
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -3163,6 +3781,15 @@ packages:
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3283,10 +3910,19 @@ packages:
       zod:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   workerd@1.20260603.1:
     resolution: {integrity: sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==}
@@ -3334,6 +3970,13 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -3345,11 +3988,124 @@ packages:
 
 snapshots:
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@ark/schema@0.56.0':
     dependencies:
       '@ark/util': 0.56.0
 
   '@ark/util@0.56.0': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.26.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.26.0)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/eslint-parser@7.25.9(@babel/core@7.26.0)(eslint@9.39.4)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 9.39.4
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.1
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@better-auth/core@1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260607.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
@@ -3820,9 +4576,71 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
   '@hono/oauth-providers@0.8.5(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0': {}
 
@@ -4039,9 +4857,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.1
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -4365,9 +5193,25 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
+    dependencies:
+      eslint-scope: 5.1.1
+
   '@noble/ciphers@2.2.0': {}
 
   '@noble/hashes@2.2.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -4661,9 +5505,73 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
+
+  '@typescript-eslint/parser@8.18.0(eslint@9.39.4)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.18.0
+      '@typescript-eslint/types': 8.18.0
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.18.0
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/rule-tester@8.18.0(eslint@9.39.4)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.39.4)(typescript@5.7.3)
+      ajv: 6.15.0
+      eslint: 9.39.4
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/scope-manager@8.18.0':
+    dependencies:
+      '@typescript-eslint/types': 8.18.0
+      '@typescript-eslint/visitor-keys': 8.18.0
+
+  '@typescript-eslint/types@8.18.0': {}
+
+  '@typescript-eslint/typescript-estree@8.18.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.18.0
+      '@typescript-eslint/visitor-keys': 8.18.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.9
+      semver: 7.6.3
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.18.0(eslint@9.39.4)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.18.0
+      '@typescript-eslint/types': 8.18.0
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.3)
+      eslint: 9.39.4
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.18.0':
+    dependencies:
+      '@typescript-eslint/types': 8.18.0
+      eslint-visitor-keys: 4.2.1
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
     optional: true
@@ -4737,7 +5645,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)':
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)':
     dependencies:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
@@ -4748,6 +5656,7 @@ snapshots:
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.4
+      typescript: 5.7.3
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.24':
     optional: true
@@ -4767,11 +5676,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))':
+  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)
       es-module-lexer: 1.7.0
       obug: 2.1.2
       pixelmatch: 7.2.0
@@ -4813,6 +5722,23 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.24':
     optional: true
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   argparse@2.0.1: {}
 
   arkregex@0.0.5:
@@ -4829,7 +5755,11 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
+  balanced-match@1.0.2: {}
+
   base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.40: {}
 
   before-after-hook@4.0.0: {}
 
@@ -4890,6 +5820,27 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.380
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -4897,9 +5848,18 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001799: {}
+
   capnweb@0.8.0: {}
 
   chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chardet@2.1.1: {}
 
@@ -4911,13 +5871,27 @@ snapshots:
     dependencies:
       typanion: 3.14.0
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   colorette@2.0.20: {}
+
+  concat-map@0.0.1: {}
 
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
@@ -4928,6 +5902,8 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-extend@0.6.0: {}
+
+  deep-is@0.1.4: {}
 
   defu@6.1.7: {}
 
@@ -4952,15 +5928,17 @@ snapshots:
       kysely: 0.29.2
       pg: 8.21.0
 
-  drizzle-valibot@0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1):
+  drizzle-valibot@0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1(typescript@5.7.3)):
     dependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0)
-      valibot: 1.4.1
+      valibot: 1.4.1(typescript@5.7.3)
 
   drizzle-zod@0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(zod@4.4.3):
     dependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0)
       zod: 4.4.3
+
+  electron-to-chromium@1.5.380: {}
 
   emnapi@1.10.0: {}
 
@@ -5088,13 +6066,106 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@2.1.0: {}
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -5106,22 +6177,60 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  gensync@1.0.0-beta.2: {}
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
 
   hono@4.12.23: {}
 
@@ -5131,25 +6240,65 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore@5.3.2: {}
+
   ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
   jose@6.2.3: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json-with-bigint@3.5.8: {}
 
+  json5@2.2.3: {}
+
   jsonc-parser@3.3.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
 
   kleur@4.1.5: {}
 
   kysely@0.29.2: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5200,9 +6349,26 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
 
   mimic-response@3.1.0: {}
 
@@ -5217,6 +6383,14 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
 
   minimist@1.2.8: {}
 
@@ -5234,9 +6408,13 @@ snapshots:
 
   napi-build-utils@2.0.0: {}
 
+  natural-compare@1.4.0: {}
+
   node-abi@3.92.0:
     dependencies:
-      semver: 7.8.2
+      semver: 7.6.3
+
+  node-releases@2.0.50: {}
 
   obug@2.1.2: {}
 
@@ -5244,7 +6422,16 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -5267,7 +6454,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.52.0
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -5278,7 +6465,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.67.0
       '@oxlint/binding-android-arm64': 1.67.0
@@ -5300,7 +6487,23 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.67.0
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+      vite-plus: 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   path-to-regexp@6.3.0: {}
 
@@ -5343,6 +6546,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   pixelmatch@7.2.0:
@@ -5382,10 +6587,16 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
+  prelude-ls@1.2.1: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
 
   rc@1.2.8:
     dependencies:
@@ -5400,7 +6611,11 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  resolve-from@4.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
+
+  reusify@1.1.0: {}
 
   rolldown@1.0.3:
     dependencies:
@@ -5425,9 +6640,17 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  semver@6.3.1: {}
+
+  semver@7.6.3: {}
 
   semver@7.8.2: {}
 
@@ -5463,6 +6686,12 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -5503,7 +6732,13 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  strip-json-comments@3.1.1: {}
+
   supports-color@10.2.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tar-fs@2.1.4:
     dependencies:
@@ -5533,7 +6768,15 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   totalist@3.0.1: {}
+
+  ts-api-utils@1.4.3(typescript@5.7.3):
+    dependencies:
+      typescript: 5.7.3
 
   tslib@2.8.1:
     optional: true
@@ -5550,6 +6793,12 @@ snapshots:
 
   typanion@3.14.0: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript@5.7.3: {}
+
   undici-types@7.18.2: {}
 
   undici@7.24.8: {}
@@ -5560,18 +6809,30 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
   util-deprecate@1.0.2: {}
 
-  valibot@1.4.1: {}
+  valibot@1.4.1(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
 
-  vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)):
+  vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)):
     dependencies:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
-      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))
+      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)(typescript@5.7.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))
       oxlint-tsgolint: 0.23.0
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
@@ -5654,7 +6915,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  void@0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3):
+  void@0.9.2(arktype@2.2.0)(kysely@0.29.2)(valibot@1.4.1(typescript@5.7.3))(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4)))(workerd@1.20260603.1)(zod@4.4.3):
     dependencies:
       '@cloudflare/sandbox': 0.10.3
       '@cloudflare/vite-plugin': 1.40.0(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(tsx@4.22.4))(workerd@1.20260603.1)(wrangler@4.98.0(@cloudflare/workers-types@4.20260607.1))
@@ -5667,7 +6928,7 @@ snapshots:
       drizzle-arktype: 0.1.3(arktype@2.2.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0)
-      drizzle-valibot: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1)
+      drizzle-valibot: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(valibot@1.4.1(typescript@5.7.3))
       drizzle-zod: 0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260607.1)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(zod@4.4.3)
       es-module-lexer: 2.1.0
       hono: 4.12.23
@@ -5678,7 +6939,7 @@ snapshots:
       wrangler: 4.98.0(@cloudflare/workers-types@4.20260607.1)
     optionalDependencies:
       arktype: 2.2.0
-      valibot: 1.4.1
+      valibot: 1.4.1(typescript@5.7.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -5727,10 +6988,16 @@ snapshots:
       - vue
       - workerd
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
 
   workerd@1.20260603.1:
     optionalDependencies:
@@ -5764,6 +7031,10 @@ snapshots:
   ws@8.21.0: {}
 
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
+
+  yocto-queue@0.1.0: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/status.json
+++ b/status.json
@@ -26,5 +26,77 @@
         "notes": "Scaffold rule used to prove the Rust/NAPI/Oxlint plugin shape."
       }
     ]
+  },
+  {
+    "packageName": "@oxlint-plugins/oxlint-plugin-eslint-comments",
+    "directory": "npm/eslint-comments",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": "eslint-plugin-eslint-comments",
+    "status": "in-progress",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "no-unlimited-disable",
+        "status": "in-progress",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pure-JS port. Parity-replayed against the captured upstream corpus (tools/parity)."
+      }
+    ]
+  },
+  {
+    "packageName": "@oxlint-plugins/oxlint-plugin-simple-import-sort",
+    "directory": "npm/simple-import-sort",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": "eslint-plugin-simple-import-sort",
+    "status": "in-progress",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "imports",
+        "status": "in-progress",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pure-JS faithful port. Byte-exact autofix parity on the captured corpus; 1 directive-suppressed valid case ledgered."
+      },
+      {
+        "name": "exports",
+        "status": "in-progress",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pure-JS faithful port. Byte-exact autofix parity on the captured corpus; 1 directive-suppressed valid case ledgered."
+      }
+    ]
   }
 ]

--- a/tools/license-exceptions.json
+++ b/tools/license-exceptions.json
@@ -28,5 +28,17 @@
     "license": "Apache-2.0 AND LGPL-3.0-or-later",
     "scope": "optional binary dependency of docs image tooling",
     "reason": "Optional sharp binary package pulled by the private documentation toolchain. Not included in published plugin npm packages."
+  },
+  {
+    "package": "@typescript-eslint/parser",
+    "license": "MITClause",
+    "scope": "dev-only parity capture tooling",
+    "reason": "v8.18.0 ships a malformed SPDX string (\"MITClause\") in package.json; the package is actually MIT. Used only to load eslint-plugin tests as a capture oracle (tools/parity); never bundled into a published plugin."
+  },
+  {
+    "package": "caniuse-lite",
+    "license": "CC-BY-4.0",
+    "scope": "dev-only parity capture tooling",
+    "reason": "Pulled transitively by @babel/core -> browserslist, which @babel/eslint-parser needs only to load eslint-plugin-simple-import-sort's tests as a capture oracle (tools/parity). Data package, never bundled into a published plugin."
   }
 ]

--- a/tools/parity/README.md
+++ b/tools/parity/README.md
@@ -1,0 +1,85 @@
+# Parity tooling
+
+Mechanically proves that a ported oxlint rule behaves identically to the upstream ESLint
+rule it replaces. See `docs/guides/parity-testing.md` for the full design.
+
+```
+tools/parity/
+  capture/        Layer A+B: harvest upstream cases + run the upstream rule as an oracle
+    core.cjs      shared primitives (normalize, oracle, self-validate, serialize)
+    run.cjs       CLI for plain require()-loadable CJS upstreams: run.cjs <plugin-id> [--check]
+    plugins.cjs   per-plugin capture config (test glob, exclusions, module stubs)
+    *.capture.mjs vitest-hosted capture for ESM/transform-required upstreams
+    vitest.config.ts  isolated config for the .capture.mjs specs
+  corpora/        committed, machine-generated JSON ground truth (one file per rule)
+    NOTICE        upstream attribution for the converted fixtures
+  replay/
+    runner.mjs    Layer C: drive a ported rule through oxlint/plugins-dev RuleTester
+  divergences.json  known-divergences ledger (relaxes specific, reviewed expectations)
+```
+
+## Two capture paths
+
+- **CJS upstreams** (`eslint-plugin-eslint-comments`): tests load with plain `require()`.
+  `node tools/parity/capture/run.cjs <plugin-id>`.
+- **ESM / transform-required upstreams** (`eslint-plugin-simple-import-sort`, and the TS
+  plugins): tests use `import`, `require.resolve(parser)`, and vitest snapshot helpers that
+  only work under a bundler transform. These run under vitest:
+  `pnpm exec vitest run --config tools/parity/capture/vitest.config.ts`. The sink and oracle
+  are identical (shared `core.cjs`); only the loader differs.
+
+## Capture / regenerate a corpus
+
+Requires `eslint` + the upstream plugin's runtime deps installed at the repo root (so the
+vendored submodule rule can be `require()`d):
+
+```sh
+node tools/parity/capture/run.cjs eslint-plugin-eslint-comments
+```
+
+The harness monkeypatches `RuleTester.prototype.run` to harvest every fully-resolved case,
+runs the real upstream rule through ESLint's `Linter` to materialize ground truth, and
+**self-validates** that the oracle agrees with the upstream test's own assertion before it
+writes anything. It aborts rather than freeze an unverified corpus.
+
+`--check` regenerates into a scratch dir and fails if the committed corpora are stale (CI
+drift gate; run after bumping a submodule pin).
+
+## Replay
+
+Each ported rule gets a vitest suite that loads its corpus and runs it through
+`oxlint/plugins-dev` `RuleTester` (real oxc parser). Example:
+`npm/eslint-comments/test/no-unlimited-disable.parity.test.mjs`.
+
+Comparison asserts the rendered `message` (embeds interpolated data; most discriminating)
+plus `line`/`endLine`/`endColumn`, and `column` unless the ledger suppresses it. `fixOutput`
+is fed as RuleTester `output` so the port's fixer is applied and the resulting source string
+is compared. Cases flagged `outOfScope` (non-JS language / custom parser) are skipped.
+
+## Status
+
+- `eslint-plugin-eslint-comments` — 8 corpora captured (176 cases, all self-validated).
+  `no-unlimited-disable` is ported (pure JS) and replays green through oxlint's RuleTester
+  with a single ledgered start-column divergence. Removing the ledger entry (asserting start
+  column) or breaking the port both correctly turn the suite red — not false-green.
+- `eslint-plugin-simple-import-sort` — **fully ported and replaying green**. `imports` (74) +
+  `exports` (35) corpora captured via the vitest-hosted path; the faithful 1.2k-line port
+  (`imports.js` + `exports.js` + `shared.js`, reused as-is because the oxc sourceCode/token/
+  comment API is ESLint-compatible) reproduces **byte-exact autofix output on every replayable
+  case**. Two valid cases that are valid only because an `eslint-disable*` directive suppresses
+  the report are ledgered (oxlint's RuleTester does not apply inline disable directives).
+- `@typescript-eslint/rule-tester` path (storybook/functional family) — capture mechanism
+  proven by `capture/ts-rule-tester.test.mjs`: intercept its `run()` (after
+  `core.installRuleTesterHooks` sets the `afterAll`/`describe`/`it` hooks it requires even at
+  construction), oracle the real rule through `@typescript-eslint/parser` (TS/JSX), and
+  materialize **suggestions** (messageId + applied output). Capturing the real TS plugins is
+  **deferred**: their rules import heavy upstream runtimes (e.g. storybook rules import
+  `storybook/internal/csf`), which must be installed before the oracle can run the genuine
+  rule — stubbing those deps would corrupt the oracle. Replay of TS corpora uses oxlint
+  `RuleTester` with `lang: 'ts' | 'tsx'`.
+- Autofix replay path — proven by `npm/eslint-comments/test/fix-replay.test.mjs`: oxlint
+  RuleTester compares the port's applied fix against the corpus `fixOutput`, honors per-case
+  `recursive` for convergent multi-pass fixers (`!!!!x` → `x` over two passes), and goes red
+  when the fix output diverges (no false-green on fixes). This path is now also exercised by
+  the real `simple-import-sort` port above, which replays its full captured fix corpus
+  byte-exactly.

--- a/tools/parity/capture/core.cjs
+++ b/tools/parity/capture/core.cjs
@@ -1,0 +1,191 @@
+'use strict';
+
+// Shared capture/oracle primitives, used by both the CJS CLI (run.cjs) and the
+// vitest-hosted capture used for ESM/transform-required upstreams (e.g. simple-import-sort).
+
+const JS_LANGS = new Set(['js', 'jsx', 'ts', 'tsx', 'dts', undefined, null]);
+
+/** Turn a raw RuleTester case into a plain, serializable shape; flag non-replayable cases. */
+function normalizeCase(raw, kind) {
+  if (typeof raw === 'string') {
+    return { kind, code: raw, options: [] };
+  }
+  const out = {
+    kind,
+    code: raw.code,
+    options: Array.isArray(raw.options) ? raw.options : [],
+  };
+  if (raw.filename) out.filename = raw.filename;
+  if (raw.settings) out.settings = raw.settings;
+  if (raw.languageOptions) out.languageOptions = raw.languageOptions;
+  if (raw.parserOptions) out.parserOptions = raw.parserOptions;
+  if (kind === 'invalid') out._errors = raw.errors;
+
+  const langId = typeof raw.language === 'string' ? raw.language.split('/')[0] : raw.language;
+  if (raw.language && !JS_LANGS.has(langId)) {
+    out.outOfScope = { reason: `non-JS language: ${raw.language}` };
+  } else if (raw.parser) {
+    out.outOfScope = { reason: 'custom parser' };
+  } else if (raw.plugins && Object.keys(raw.plugins).length > 0) {
+    out.outOfScope = { reason: 'requires extra eslint plugins/languages' };
+  }
+  return out;
+}
+
+function applyFix(code, fix) {
+  return code.slice(0, fix.range[0]) + fix.text + code.slice(fix.range[1]);
+}
+
+function makeConfig(rule, c, defaultLanguageOptions) {
+  return [
+    {
+      linterOptions: { reportUnusedDisableDirectives: 'off' },
+      languageOptions: c.languageOptions ||
+        defaultLanguageOptions || { ecmaVersion: 'latest', sourceType: 'script' },
+      plugins: { __p: { rules: { __r: rule } } },
+      rules: { '__p/__r': ['error', ...c.options] },
+    },
+  ];
+}
+
+/** Run the real upstream rule and return filtered, materialized diagnostics + applied fix. */
+function runOracle(Linter, rule, c, defaultLanguageOptions) {
+  const linter = new Linter({ configType: 'flat' });
+  const config = makeConfig(rule, c, defaultLanguageOptions);
+  const filename = c.filename || 'file.js';
+  const messages = linter.verify(c.code, config, { filename });
+
+  const fatal = messages.find((m) => m.fatal);
+  if (fatal) throw new Error(`parse error in case: ${fatal.message}`);
+
+  const mine = messages.filter((m) => m.ruleId === '__p/__r');
+  const expectedErrors = mine.map((m) => {
+    const e = {
+      messageId: m.messageId ?? null,
+      message: m.message,
+      line: m.line,
+      column: m.column,
+      endLine: m.endLine ?? null,
+      endColumn: m.endColumn ?? null,
+    };
+    if (Array.isArray(m.suggestions) && m.suggestions.length > 0) {
+      e.suggestions = m.suggestions.map((s) => ({
+        messageId: s.messageId ?? null,
+        desc: s.desc ?? null,
+        output: applyFix(c.code, s.fix),
+      }));
+    }
+    return e;
+  });
+
+  let fixOutput = null;
+  if (c.kind === 'invalid' && rule.meta && rule.meta.fixable) {
+    const fixed = linter.verifyAndFix(c.code, config, { filename });
+    if (fixed.fixed) fixOutput = fixed.output;
+  }
+
+  return { expectedErrors, fixOutput };
+}
+
+function classifyAssertion(errors) {
+  if (typeof errors === 'number') return 'count';
+  if (!Array.isArray(errors)) return 'unknown';
+  if (errors.every((e) => typeof e === 'string')) return 'plain-string';
+  if (errors.some((e) => e && typeof e === 'object' && e.messageId)) return 'messageId';
+  return 'location';
+}
+
+/** The oracle must agree with whatever the upstream test itself asserted, or we abort. */
+function selfValidate(ruleName, idx, c, oracle) {
+  const got = oracle.expectedErrors;
+  if (c.kind === 'valid') {
+    if (got.length !== 0)
+      return `valid case #${idx} of ${ruleName} produced ${got.length} oracle diagnostic(s)`;
+    return null;
+  }
+  const expected = c._errors;
+  if (typeof expected === 'number') {
+    if (got.length !== expected)
+      return `${ruleName} invalid #${idx}: upstream asserts ${expected} error(s), oracle produced ${got.length}`;
+    return null;
+  }
+  if (!Array.isArray(expected)) return `${ruleName} invalid #${idx}: unsupported errors assertion`;
+  if (got.length !== expected.length)
+    return `${ruleName} invalid #${idx}: upstream asserts ${expected.length} error(s), oracle produced ${got.length}`;
+  for (let i = 0; i < expected.length; i++) {
+    const exp = expected[i];
+    const g = got[i];
+    if (typeof exp === 'string') {
+      if (g.message !== exp)
+        return `${ruleName} invalid #${idx} error ${i}: message mismatch\n    upstream: ${exp}\n    oracle:   ${g.message}`;
+      continue;
+    }
+    for (const key of ['messageId', 'message', 'line', 'column', 'endLine', 'endColumn']) {
+      if (exp[key] !== undefined && exp[key] !== g[key])
+        return `${ruleName} invalid #${idx} error ${i}: ${key} mismatch (upstream ${JSON.stringify(exp[key])} vs oracle ${JSON.stringify(g[key])})`;
+    }
+  }
+  return null;
+}
+
+function buildCorpusCase(c, oracle) {
+  if (c.outOfScope) {
+    return { kind: c.kind, code: c.code, outOfScope: c.outOfScope };
+  }
+  if (c.kind === 'valid') {
+    const out = {
+      kind: 'valid',
+      code: c.code,
+      options: c.options,
+      expectedErrors: [],
+      fixOutput: null,
+    };
+    if (c.filename) out.filename = c.filename;
+    if (c.settings) out.settings = c.settings;
+    if (c.languageOptions) out.languageOptions = c.languageOptions;
+    return out;
+  }
+  const out = {
+    kind: 'invalid',
+    code: c.code,
+    options: c.options,
+    expectedErrors: oracle.expectedErrors,
+    fixOutput: oracle.fixOutput,
+    upstreamAssertion: { style: classifyAssertion(c._errors) },
+  };
+  if (c.filename) out.filename = c.filename;
+  if (c.settings) out.settings = c.settings;
+  if (c.languageOptions) out.languageOptions = c.languageOptions;
+  return out;
+}
+
+function stableStringify(obj) {
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+/**
+ * Neutralize a RuleTester's test-runner hooks so it executes synchronously and never
+ * registers nested describe/it/afterAll callbacks. Required for `@typescript-eslint/rule-tester`,
+ * whose constructor *reads* `afterAll` and throws if it is missing. Safe for the core ESLint
+ * RuleTester too. Call before constructing the tester / importing the test file.
+ */
+function installRuleTesterHooks(RuleTester) {
+  RuleTester.afterAll = () => {};
+  RuleTester.describe = (_name, fn) => (fn ? fn() : undefined);
+  RuleTester.it = (_name, fn) => (fn ? fn() : undefined);
+  RuleTester.itOnly = (_name, fn) => (fn ? fn() : undefined);
+}
+
+module.exports = {
+  JS_LANGS,
+  normalizeCase,
+  applyFix,
+  makeConfig,
+  runOracle,
+  classifyAssertion,
+  selfValidate,
+  buildCorpusCase,
+  stableStringify,
+  installRuleTesterHooks,
+  CORPUS_VERSION: 1,
+};

--- a/tools/parity/capture/plugins.cjs
+++ b/tools/parity/capture/plugins.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+// Per-plugin capture configuration.
+//
+// This is the single source of truth for how each upstream port-target's test
+// suite is harvested. Keep it small and declarative; per-family quirks live in
+// adapters, not here.
+//
+// Fields:
+//   submodule    repo-relative path to the vendored upstream submodule
+//   pinnedRef    the submodule tag we capture against (must match port-targets.json)
+//   license      SPDX id of the upstream (gates whether converted fixtures may be persisted)
+//   copyright    upstream copyright holder, recorded in corpus provenance + NOTICE
+//   testGlob     repo-relative glob of rule test files (CJS RuleTester suites)
+//   excludeFiles basenames to skip BEFORE require() — used for tests with unsafe
+//                import-time side effects (CLI spawn, fs mocks). Tracked in the ledger.
+//   stubModules  module ids to replace with an inert stub at import time, for optional
+//                deps that only feed out-of-scope (non-JS) language cases.
+
+/** @type {Record<string, import('./types.js').PluginCaptureConfig>} */
+const PLUGINS = {
+  'eslint-plugin-eslint-comments': {
+    submodule: 'upstream/eslint-plugin-eslint-comments',
+    pinnedRef: 'v4.7.2',
+    license: 'MIT',
+    copyright: 'Toru Nagashima',
+    testGlob: 'upstream/eslint-plugin-eslint-comments/tests/lib/rules/*.js',
+    // no-unused-disable spawns the real eslint CLI via cross-spawn at test time;
+    // capturing it requires a running ESLint binary and is order/fs dependent.
+    // Ported behavior for it is covered by hand-authored cases + ledger DIV-ESC-001.
+    excludeFiles: ['no-unused-disable.js'],
+    // 7 of 9 suites build CSS-language valid cases behind `semver >= 9.6.0`, pulling
+    // in @eslint/css purely for those cases. We stub it: CSS is out of oxlint's JS/TS
+    // scope, and such cases are flagged `outOfScope` and never sent to the oracle.
+    stubModules: ['@eslint/css'],
+  },
+};
+
+module.exports = { PLUGINS };

--- a/tools/parity/capture/run.cjs
+++ b/tools/parity/capture/run.cjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Parity capture + oracle harness (CJS upstreams, plain `require()`-loadable tests).
+ *
+ *   node tools/parity/capture/run.cjs <plugin-id> [--check]
+ *
+ * Layer A (capture): monkeypatch `RuleTester.prototype.run` and import each upstream rule
+ * test file. By the time `run()` is called every dynamic case (semver gates, spreads,
+ * builders) is already resolved, so we harvest the exact `{valid, invalid}` set.
+ *
+ * Layer B (oracle): execute the real upstream rule through ESLint's `Linter` to materialize
+ * authoritative diagnostics, then self-validate against the upstream test's own assertion.
+ *
+ * Output: one deterministic JSON corpus per rule under tools/parity/corpora/<plugin-id>/.
+ * `--check` writes to a scratch dir and diffs against the committed copies (CI drift gate).
+ *
+ * ESM/transform-required upstreams (simple-import-sort, functional, …) cannot be loaded by
+ * plain require(); they are captured under vitest instead — see capture/*.capture.mjs and
+ * the shared primitives in capture/core.cjs.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const Module = require('node:module');
+const { execFileSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const { PLUGINS } = require('./plugins.cjs');
+const {
+  normalizeCase,
+  runOracle,
+  selfValidate,
+  buildCorpusCase,
+  stableStringify,
+  CORPUS_VERSION,
+} = require('./core.cjs');
+
+function fail(msg) {
+  console.error(`\n✖ ${msg}`);
+  process.exit(1);
+}
+
+function installModuleStubs(ids) {
+  const stubbed = new Set(ids);
+  const origLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (stubbed.has(request)) return { default: { meta: { name: `parity-stub:${request}` } } };
+    return origLoad.call(this, request, parent, isMain);
+  };
+}
+
+function captureFile(absTestFile, RuleTester) {
+  const runs = [];
+  const original = RuleTester.prototype.run;
+  RuleTester.prototype.run = function (ruleName, rule, cases) {
+    runs.push({ ruleName, rule, valid: cases.valid || [], invalid: cases.invalid || [] });
+  };
+  try {
+    require(absTestFile);
+  } finally {
+    RuleTester.prototype.run = original;
+  }
+  return runs;
+}
+
+function submoduleSha(submodule) {
+  return execFileSync('git', ['-C', path.join(REPO_ROOT, submodule), 'rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+function listTestFiles(testGlob) {
+  const dir = path.join(REPO_ROOT, path.dirname(testGlob));
+  const ext = path.extname(testGlob);
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(ext))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+function main() {
+  const pluginId = process.argv[2];
+  const check = process.argv.includes('--check');
+  if (!pluginId || !PLUGINS[pluginId]) {
+    fail(
+      `usage: node tools/parity/capture/run.cjs <plugin-id> [--check]\n  known: ${Object.keys(PLUGINS).join(', ')}`,
+    );
+  }
+  const cfg = PLUGINS[pluginId];
+
+  installModuleStubs(cfg.stubModules || []);
+  const { RuleTester, Linter } = require('eslint');
+  const eslintVersion = require('eslint/package.json').version;
+  const sha = submoduleSha(cfg.submodule);
+
+  const outRoot = check
+    ? fs.mkdtempSync(path.join(os.tmpdir(), 'parity-check-'))
+    : path.join(REPO_ROOT, 'tools', 'parity', 'corpora', pluginId);
+  fs.mkdirSync(outRoot, { recursive: true });
+
+  const excluded = new Set(cfg.excludeFiles || []);
+  const files = listTestFiles(cfg.testGlob);
+  const failures = [];
+  const written = [];
+  let totalCases = 0;
+  let outOfScope = 0;
+
+  for (const file of files) {
+    if (excluded.has(path.basename(file))) continue;
+    let runs;
+    try {
+      runs = captureFile(file, RuleTester);
+    } catch (err) {
+      failures.push(`capture import failed for ${path.basename(file)}: ${err.message}`);
+      continue;
+    }
+    for (const run of runs) {
+      const cases = [];
+      for (const [list, kind] of [
+        [run.valid, 'valid'],
+        [run.invalid, 'invalid'],
+      ]) {
+        list.forEach((raw, idx) => {
+          const c = normalizeCase(raw, kind);
+          if (c.outOfScope) {
+            outOfScope++;
+            cases.push(buildCorpusCase(c, null));
+            return;
+          }
+          let oracle;
+          try {
+            oracle = runOracle(Linter, run.rule, c);
+          } catch (err) {
+            failures.push(`${run.ruleName} ${kind} #${idx}: oracle error: ${err.message}`);
+            return;
+          }
+          const problem = selfValidate(run.ruleName, idx, c, oracle);
+          if (problem) failures.push(problem);
+          cases.push(buildCorpusCase(c, oracle));
+          totalCases++;
+        });
+      }
+
+      const corpus = {
+        corpusVersion: CORPUS_VERSION,
+        provenance: {
+          plugin: pluginId,
+          rule: run.ruleName,
+          pinnedRef: cfg.pinnedRef,
+          submoduleSha: sha,
+          eslintVersion,
+          license: cfg.license,
+          copyright: cfg.copyright,
+          note: 'Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE.',
+        },
+        cases,
+      };
+      const outFile = path.join(outRoot, `${run.ruleName}.json`);
+      fs.writeFileSync(outFile, stableStringify(corpus));
+      written.push({ rule: run.ruleName, file: outFile, cases: cases.length });
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n✖ self-validation failed (${failures.length}):`);
+    for (const f of failures) console.error(`  - ${f}`);
+    fail('aborting: refusing to freeze an unverified corpus');
+  }
+
+  if (check) {
+    const committedRoot = path.join(REPO_ROOT, 'tools', 'parity', 'corpora', pluginId);
+    const diffs = [];
+    for (const w of written) {
+      const committed = path.join(committedRoot, `${w.rule}.json`);
+      const fresh = fs.readFileSync(w.file, 'utf8');
+      if (!fs.existsSync(committed)) diffs.push(`missing committed corpus: ${w.rule}`);
+      else if (fs.readFileSync(committed, 'utf8') !== fresh) diffs.push(`corpus drift: ${w.rule}`);
+    }
+    if (diffs.length) {
+      console.error('\n✖ corpus --check drift:');
+      for (const d of diffs) console.error(`  - ${d}`);
+      fail('committed corpora are stale; regenerate with the capture harness');
+    }
+    console.log(`✔ ${pluginId}: ${written.length} corpora match committed (check mode)`);
+    return;
+  }
+
+  console.log(`✔ ${pluginId} captured`);
+  console.log(`  rules:        ${written.length}`);
+  console.log(`  cases:        ${totalCases} (+${outOfScope} out-of-scope, skipped)`);
+  console.log(`  eslint:       ${eslintVersion}`);
+  console.log(`  submodule:    ${cfg.pinnedRef} (${sha.slice(0, 10)})`);
+  console.log(`  written to:   tools/parity/corpora/${pluginId}/`);
+}
+
+main();

--- a/tools/parity/capture/simple-import-sort.capture.mjs
+++ b/tools/parity/capture/simple-import-sort.capture.mjs
@@ -1,0 +1,124 @@
+// Vitest-hosted capture for eslint-plugin-simple-import-sort.
+//
+// Its tests are ESM, use `require.resolve(parser)`, vitest snapshot serializers, and
+// function-valued `output:` callbacks — none of which load under plain `node require()`.
+// Running under vitest lets vite transform the files and provides the real vitest globals
+// the upstream helpers need. We monkeypatch `RuleTester.prototype.run` before importing,
+// harvest the JavaScript-parser run, and materialize ground truth via the shared oracle.
+//
+//   pnpm exec vitest run --config tools/parity/capture/vitest.config.ts
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { Linter, RuleTester } from 'eslint';
+import { expect, test } from 'vitest';
+
+import core from './core.cjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+
+const PLUGIN_ID = 'eslint-plugin-simple-import-sort';
+const PINNED_REF = 'v13.0.0';
+const DEFAULT_LANGUAGE_OPTIONS = { ecmaVersion: 2020, sourceType: 'module' };
+
+// The JavaScript RuleTester run is labelled "JavaScript"; the Flow/TypeScript runs use
+// custom parsers and are out of scope for the oxc replay, so we ignore them here.
+const JS_RUN_LABEL = 'JavaScript';
+
+const TEST_FILES = [
+  { file: 'upstream/eslint-plugin-simple-import-sort/test/imports.test.js', rule: 'imports' },
+  { file: 'upstream/eslint-plugin-simple-import-sort/test/exports.test.js', rule: 'exports' },
+];
+
+// Install the run() sink before any upstream test module evaluates.
+const RUNS = [];
+RuleTester.prototype.run = function (label, rule, cases) {
+  RUNS.push({ label, rule, valid: cases.valid || [], invalid: cases.invalid || [] });
+};
+
+function submoduleSha() {
+  return execFileSync(
+    'git',
+    [
+      '-C',
+      path.join(REPO_ROOT, 'upstream', 'eslint-plugin-simple-import-sort'),
+      'rev-parse',
+      'HEAD',
+    ],
+    { encoding: 'utf8' },
+  ).trim();
+}
+
+const sha = submoduleSha();
+const eslintVersion = (await import('eslint/package.json', { with: { type: 'json' } })).default
+  .version;
+
+test('capture simple-import-sort (imports, exports)', async () => {
+  const outRoot = path.join(REPO_ROOT, 'tools', 'parity', 'corpora', PLUGIN_ID);
+  mkdirSync(outRoot, { recursive: true });
+
+  for (const { file, rule: ruleName } of TEST_FILES) {
+    RUNS.length = 0;
+    await import(pathToFileURL(path.join(REPO_ROOT, file)).href);
+
+    const jsRun = RUNS.find((r) => r.label === JS_RUN_LABEL);
+    expect(jsRun, `no "${JS_RUN_LABEL}" run captured from ${file}`).toBeTruthy();
+
+    const failures = [];
+    const cases = [];
+    let fixCount = 0;
+    let countOnly = 0;
+
+    for (const [list, kind] of [
+      [jsRun.valid, 'valid'],
+      [jsRun.invalid, 'invalid'],
+    ]) {
+      list.forEach((raw, idx) => {
+        const c = core.normalizeCase(raw, kind);
+        if (c.outOfScope) {
+          cases.push(core.buildCorpusCase(c, null));
+          return;
+        }
+        let oracle;
+        try {
+          oracle = core.runOracle(Linter, jsRun.rule, c, DEFAULT_LANGUAGE_OPTIONS);
+        } catch (err) {
+          failures.push(`${ruleName} ${kind} #${idx}: oracle error: ${err.message}`);
+          return;
+        }
+        const problem = core.selfValidate(ruleName, idx, c, oracle);
+        if (problem) failures.push(problem);
+        if (kind === 'invalid' && typeof raw === 'object' && typeof raw.errors === 'number')
+          countOnly++;
+        if (oracle.fixOutput != null) fixCount++;
+        cases.push(core.buildCorpusCase(c, oracle));
+      });
+    }
+
+    expect(failures, failures.join('\n')).toEqual([]);
+    // These two capabilities are exactly what this plugin proves: fixable-rule fix capture
+    // and count-only assertions backfilled by the oracle.
+    expect(fixCount, 'expected at least one captured autofix output').toBeGreaterThan(0);
+    expect(countOnly, 'expected count-only upstream assertions').toBeGreaterThan(0);
+
+    const corpus = {
+      corpusVersion: core.CORPUS_VERSION,
+      provenance: {
+        plugin: PLUGIN_ID,
+        rule: ruleName,
+        pinnedRef: PINNED_REF,
+        submoduleSha: sha,
+        eslintVersion,
+        license: 'MIT',
+        copyright: 'Simon Lydell',
+        note: 'Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE.',
+      },
+      cases,
+    };
+    writeFileSync(path.join(outRoot, `${ruleName}.json`), core.stableStringify(corpus));
+  }
+});

--- a/tools/parity/capture/ts-rule-tester.test.mjs
+++ b/tools/parity/capture/ts-rule-tester.test.mjs
@@ -1,0 +1,107 @@
+// Phase-3 capture capability self-test.
+//
+// Proves the parity capture machinery handles the @typescript-eslint/rule-tester family used
+// by the TS plugins (storybook, functional, …): intercept its `run()`, run the real rule as a
+// TS/JSX oracle through @typescript-eslint/parser, and materialize *suggestions* (messageId +
+// applied output) — exactly the shape storybook rules assert. It uses a self-contained rule so
+// it does not drag in a plugin's heavy ecosystem deps; capturing the real TS plugins (which
+// need their upstream runtime installed) is deferred — see tools/parity/README.md.
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import { describe, expect, it } from 'vitest';
+
+import core from './core.cjs';
+
+// A faithful miniature of storybook's no-redundant-story-name shape: a Property whose key is
+// `name` with a string literal value is reported, with a suggestion that removes the property.
+const rule = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      redundant: 'Redundant name {{name}}.',
+      remove: 'Remove the redundant name.',
+    },
+  },
+  create(context) {
+    return {
+      Property(node) {
+        if (node.key?.name === 'name' && node.value?.type === 'Literal') {
+          context.report({
+            node,
+            messageId: 'redundant',
+            data: { name: String(node.value.value) },
+            suggest: [
+              { messageId: 'remove', fix: (f) => f.removeRange([node.range[0], node.range[1]]) },
+            ],
+          });
+        }
+      },
+    };
+  },
+};
+
+const TS_LANGUAGE_OPTIONS = {
+  parser: tsParser,
+  parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+};
+
+function capture() {
+  core.installRuleTesterHooks(RuleTester);
+  const runs = [];
+  RuleTester.prototype.run = function (name, r, cases) {
+    runs.push({ name, rule: r, valid: cases.valid, invalid: cases.invalid });
+  };
+  const tester = new RuleTester();
+  tester.run('demo', rule, {
+    // TS-only syntax (type annotation) the espree path could not parse.
+    valid: ['const a: Id = { id: 1 }'],
+    invalid: [
+      {
+        code: 'const x: Foo = { name: "Primary" }',
+        errors: [
+          {
+            messageId: 'redundant',
+            suggestions: [{ messageId: 'remove', output: 'const x: Foo = {  }' }],
+          },
+        ],
+      },
+    ],
+  });
+  return runs[0];
+}
+
+describe('parity capture: @typescript-eslint/rule-tester path', () => {
+  const run = capture();
+
+  it('intercepts ts-eslint RuleTester.run and harvests both branches', () => {
+    expect(run).toBeTruthy();
+    expect(run.valid).toHaveLength(1);
+    expect(run.invalid).toHaveLength(1);
+  });
+
+  it('oracles a valid TS case to zero diagnostics', () => {
+    const c = core.normalizeCase(run.valid[0], 'valid');
+    const oracle = core.runOracle(Linter, run.rule, c, TS_LANGUAGE_OPTIONS);
+    expect(oracle.expectedErrors).toEqual([]);
+    expect(core.selfValidate('demo', 0, c, oracle)).toBeNull();
+  });
+
+  it('materializes messageId + suggestion output from the real rule on a TS/JSX case', () => {
+    const c = core.normalizeCase(run.invalid[0], 'invalid');
+    const oracle = core.runOracle(Linter, run.rule, c, TS_LANGUAGE_OPTIONS);
+    expect(oracle.expectedErrors).toHaveLength(1);
+    const [err] = oracle.expectedErrors;
+    expect(err.messageId).toBe('redundant');
+    expect(err.message).toBe('Redundant name Primary.');
+    expect(err.suggestions).toEqual([
+      { messageId: 'remove', desc: 'Remove the redundant name.', output: 'const x: Foo = {  }' },
+    ]);
+    // Self-validation against the upstream-style inline assertion must agree.
+    expect(core.selfValidate('demo', 0, c, oracle)).toBeNull();
+  });
+});

--- a/tools/parity/capture/vitest.config.ts
+++ b/tools/parity/capture/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// Dedicated config for capture specs that must load ESM / transform-required upstream test
+// files (simple-import-sort, functional, …). These run via vite's transform pipeline, which
+// plain `node require()` cannot do. Kept separate from the main suite so capture (which writes
+// corpora and needs the upstream submodules) is an explicit step, not part of `vp test`.
+//
+//   pnpm exec vitest run --config tools/parity/capture/vitest.config.ts
+
+export default defineConfig({
+  test: {
+    include: ['tools/parity/capture/**/*.capture.mjs'],
+    testTimeout: 120_000,
+    pool: 'forks',
+  },
+});

--- a/tools/parity/check-drift.mjs
+++ b/tools/parity/check-drift.mjs
@@ -1,0 +1,36 @@
+// Parity corpus drift gate.
+//
+// Regenerates every committed corpus from the pinned upstream submodules and fails if the
+// working tree changed — i.e. the committed ground truth no longer matches what the pinned
+// upstream rule actually produces. Run this after bumping a submodule pin (regenerate +
+// commit) and in the dedicated CI job that checks out submodules. It is intentionally NOT
+// part of `pnpm run verify`, which stays hermetic (committed corpora + built port only).
+//
+//   pnpm run parity:drift
+
+import { execFileSync } from 'node:child_process';
+
+function run(cmd, args) {
+  console.log(`$ ${cmd} ${args.join(' ')}`);
+  execFileSync(cmd, args, { stdio: 'inherit' });
+}
+
+// CJS upstreams (plain require()).
+run('node', ['tools/parity/capture/run.cjs', 'eslint-plugin-eslint-comments']);
+
+// ESM / transform-required upstreams (loaded under vitest).
+run('pnpm', ['exec', 'vitest', 'run', '--config', 'tools/parity/capture/vitest.config.ts']);
+
+// Any change to committed corpora means drift from the pinned upstream.
+try {
+  run('git', ['diff', '--exit-code', '--', 'tools/parity/corpora']);
+} catch {
+  console.error(
+    '\n✖ parity corpora drift: regenerated corpora differ from the committed copies.\n' +
+      '  Either an upstream submodule pin moved without regenerating, or a corpus was hand-edited.\n' +
+      '  Regenerate with `pnpm run parity:capture <plugin>` / `pnpm run parity:capture:esm` and commit.',
+  );
+  process.exit(1);
+}
+
+console.log('\n✔ parity corpora match the pinned upstream submodules.');

--- a/tools/parity/corpora/NOTICE
+++ b/tools/parity/corpora/NOTICE
@@ -1,0 +1,24 @@
+Parity corpora — upstream attribution
+======================================
+
+The JSON files under tools/parity/corpora/ are test fixtures converted/derived from the
+upstream ESLint plugins' own test suites, by executing the upstream rule as an oracle (see
+docs/guides/parity-testing.md). They remain under their upstream licenses; this repository's
+MIT license does not relicense them. Per-corpus provenance is also embedded in each file.
+
+eslint-plugin-eslint-comments
+  Source:    https://github.com/eslint-community/eslint-plugin-eslint-comments
+  License:   MIT
+  Copyright: Toru Nagashima and eslint-community contributors
+  Pinned:    v4.7.2 (62a2c3a4ee30)
+  Derived:   valid/invalid cases and oracle-materialized diagnostics converted from
+             tests/lib/rules/*.js.
+
+eslint-plugin-simple-import-sort
+  Source:    https://github.com/lydell/eslint-plugin-simple-import-sort
+  License:   MIT
+  Copyright: Simon Lydell
+  Pinned:    v13.0.0 (90078e7fce90)
+  Derived:   JavaScript-parser valid/invalid cases and oracle-materialized diagnostics +
+             applied-fix output converted from test/imports.test.js and test/exports.test.js
+             (Flow and TypeScript parser runs are out of scope and not captured).

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/disable-enable-pair.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/disable-enable-pair.json
@@ -1,0 +1,336 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "disable-enable-pair",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable*/\n/*eslint-enable*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable no-undef,no-unused-vars*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "//eslint-disable-line",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "//eslint-disable-next-line",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-line*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-next-line*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint no-undef: off */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\nfunction foo() {\n    /*eslint-disable*/\n    /*eslint-enable*/\n}\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable no-unused-vars*/\n/*eslint-enable*/\n/*eslint-enable*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\nconsole.log('This code does not even have any special comments')\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable no-unused-vars*/\n/*eslint-enable*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n\n/**\n * @file This test case makes sure comments and blank lines\n * before \"whole-file\" eslint-disable are allowed.\n */\n\n/*eslint-disable*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-unused-vars, no-undef */\nvar foo = 1\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef -- description*/\n/*eslint-enable no-undef*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef,no-unused-vars -- description*/\n/*eslint-enable no-undef,no-unused-vars*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-enable no-undef*/\na {}\n",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingPair",
+          "message": "Requires 'eslint-enable' directive.",
+          "line": 2,
+          "column": 0,
+          "endLine": 2,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-undef'.",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable no-undef*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 2,
+          "column": 27,
+          "endLine": 2,
+          "endColumn": 41
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable no-unused-vars*/\n/*eslint-enable no-unused-vars*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-undef'.",
+          "line": 2,
+          "column": 18,
+          "endLine": 2,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\nconsole.log();\n/*eslint-disable no-unused-vars*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 4,
+          "column": 18,
+          "endLine": 4,
+          "endColumn": 32
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\nconsole.log();\n/*eslint-disable no-unused-vars*/\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n{\n/*eslint-disable no-unused-vars*/\n}\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n{\n/*eslint-disable no-unused-vars -- description */\n}\n",
+      "options": [
+        {
+          "allowWholeFile": true
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "missingRulePair",
+          "message": "Requires 'eslint-enable' directive for 'no-unused-vars'.",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable no-unused-vars */ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/no-aggregating-enable.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/no-aggregating-enable.json
@@ -1,0 +1,140 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "no-aggregating-enable",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "\n            /*eslint-disable no-redeclare*/\n            /*eslint-enable no-redeclare*/\n        ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n            /*eslint-disable no-redeclare*/\n            /*eslint-enable no-shadow*/\n        ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable*/\n        ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable no-redeclare, no-shadow*/\n        ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable no-redeclare*/\n            /*eslint-enable no-shadow*/\n        ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable no-redeclare*/\n            /*eslint-enable no-shadow*/\n            a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable*/\n            ",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "aggregatingEnable",
+          "message": "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment.",
+          "line": 4,
+          "column": 0,
+          "endLine": 4,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-disable no-undef*/\n                /*eslint-enable*/\n            ",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "aggregatingEnable",
+          "message": "This `eslint-enable` comment affects 3 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment.",
+          "line": 5,
+          "column": 0,
+          "endLine": 5,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable no-redeclare, no-shadow*/\n            ",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "aggregatingEnable",
+          "message": "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment.",
+          "line": 4,
+          "column": 0,
+          "endLine": 4,
+          "endColumn": 58
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable -- description*/\n            ",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "aggregatingEnable",
+          "message": "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment.",
+          "line": 4,
+          "column": 0,
+          "endLine": 4,
+          "endColumn": 49
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n                /*eslint-disable no-redeclare*/\n                /*eslint-disable no-shadow*/\n                /*eslint-enable*/\n            a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/no-duplicate-disable.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/no-duplicate-disable.json
@@ -1,0 +1,190 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "no-duplicate-disable",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "\n//eslint-disable-line\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable-line*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-line no-unused-vars\n//eslint-disable-next-line semi\n/*eslint-disable eqeqeq*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-unused-vars*/\n/*eslint-disable-next-line semi*/\n/*eslint-disable eqeqeq*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-unused-vars*/\n/*eslint-disable-next-line semi*/\n/*eslint-disable eqeqeq*/\na {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-line no-undef\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-line no-undef*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\n//eslint-disable-next-line no-undef\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 28,
+          "endLine": 3,
+          "endColumn": 36
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-undef*/\n/*eslint-disable-next-line no-undef*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 28,
+          "endLine": 3,
+          "endColumn": 36
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n//eslint-disable-next-line no-undef\n//eslint-disable-line no-undef\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable-next-line no-undef*/\n/*eslint-disable-line no-undef*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 23,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n// eslint-disable-next-line no-undef -- description\n// eslint-disable-line no-undef -- description\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "duplicateRule",
+          "message": "'no-undef' rule has been disabled already.",
+          "line": 3,
+          "column": 24,
+          "endLine": 3,
+          "endColumn": 32
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/* eslint-disable-next-line no-undef */\n/* eslint-disable-line no-undef */\na {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/no-restricted-disable.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/no-restricted-disable.json
@@ -1,0 +1,619 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "no-restricted-disable",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "//eslint-disable-line",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "//eslint-disable-next-line",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-line*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-next-line*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable eqeqeq*/",
+      "options": [
+        "no-unused-vars"
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-enable eqeqeq*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable eqeqeq*/",
+      "options": [
+        "*",
+        "!eqeqeq"
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable eqeqeq*/ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable eqeqeq*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 18,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-line eqeqeq",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-line eqeqeq*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-line",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-line*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-next-line eqeqeq",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 28,
+          "endLine": 1,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-next-line eqeqeq*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 28,
+          "endLine": 1,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-next-line",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-next-line*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable eqeqeq, no-undef, no-redeclare*/",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 18,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable*/",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling '*,!no-undef,!no-redeclare' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-line eqeqeq, no-undef, no-redeclare",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-line eqeqeq, no-undef, no-redeclare*/",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 23,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-line",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling '*,!no-undef,!no-redeclare' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-line*/",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling '*,!no-undef,!no-redeclare' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-next-line eqeqeq, no-undef, no-redeclare",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 28,
+          "endLine": 1,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-next-line eqeqeq, no-undef, no-redeclare*/",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 28,
+          "endLine": 1,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-next-line",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling '*,!no-undef,!no-redeclare' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-next-line*/",
+      "options": [
+        "*",
+        "!no-undef",
+        "!no-redeclare"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling '*,!no-undef,!no-redeclare' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable semi, no-extra-semi, semi-style, comma-style*/",
+      "options": [
+        "*semi*"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'semi' is not allowed.",
+          "line": 1,
+          "column": 18,
+          "endLine": 1,
+          "endColumn": 22
+        },
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'no-extra-semi' is not allowed.",
+          "line": 1,
+          "column": 24,
+          "endLine": 1,
+          "endColumn": 37
+        },
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'semi-style' is not allowed.",
+          "line": 1,
+          "column": 39,
+          "endLine": 1,
+          "endColumn": 49
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable no-undef, no-redeclare, foo/no-undef, foo/no-redeclare*/",
+      "options": [
+        "foo/*"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'foo/no-undef' is not allowed.",
+          "line": 1,
+          "column": 42,
+          "endLine": 1,
+          "endColumn": 54
+        },
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'foo/no-redeclare' is not allowed.",
+          "line": 1,
+          "column": 56,
+          "endLine": 1,
+          "endColumn": 72
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable -- description*/",
+      "options": [
+        "eqeqeq"
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Disabling 'eqeqeq' is not allowed.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable eqeqeq*/ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/no-unlimited-disable.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/no-unlimited-disable.json
@@ -1,0 +1,332 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "no-unlimited-disable",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "/*eslint-enable*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable eqeqeq*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "//eslint-disable-line eqeqeq",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "//eslint-disable-next-line eqeqeq",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-line eqeqeq*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-next-line eqeqeq*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "var foo;\n//eslint-disable-line eqeqeq",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "var foo;\n/*eslint-disable-line eqeqeq*/",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/*eslint-disable-line eqeqeq*/ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-line*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-line ",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-line */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "//eslint-disable-next-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-next-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable-next-line*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-next-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-next-line ",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-next-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-next-line */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-next-line' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "var foo;\n//eslint-disable-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
+          "line": 2,
+          "column": 0,
+          "endLine": 2,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "var foo;\n/*eslint-disable-line*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
+          "line": 2,
+          "column": 0,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-disable -- description */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unexpected",
+          "message": "Unexpected unlimited 'eslint-disable' comment. Specify some rule names to disable.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable */ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/no-unused-enable.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/no-unused-enable.json
@@ -1,0 +1,126 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "no-unused-enable",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "\n/*eslint no-undef:error*/\n/*eslint-disable*/\nvar a = b\n/*eslint-enable*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint no-undef:error*/\n/*eslint-disable no-undef*/\nvar a = b\n/*eslint-enable no-undef*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint no-undef:error*/\n/*eslint-disable no-undef*/\nvar a = b\n/*eslint-enable*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint no-undef:error, no-unused-vars:error*/\n/*eslint-disable no-undef,no-unused-vars*/\nvar a = b\n/*eslint-enable no-undef*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "\n/*eslint no-undef:error, no-unused-vars:error*/\n/*eslint-disable no-undef,no-unused-vars*/\nvar a = b\n/*eslint-enable*/\n",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-enable*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unused",
+          "message": "ESLint rules are re-enabled but those have not been disabled.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 18
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-enable no-undef*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unusedRule",
+          "message": "'no-undef' rule is re-enabled but it has not been disabled.",
+          "line": 1,
+          "column": 17,
+          "endLine": 1,
+          "endColumn": 25
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "\n/*eslint-disable no-unused-vars*/\n/*eslint-enable no-undef*/\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unusedRule",
+          "message": "'no-undef' rule is re-enabled but it has not been disabled.",
+          "line": 3,
+          "column": 17,
+          "endLine": 3,
+          "endColumn": 25
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*eslint-enable -- description*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "unused",
+          "message": "ESLint rules are re-enabled but those have not been disabled.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 33
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "location"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/no-use.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/no-use.json
@@ -1,0 +1,398 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "no-use",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "// eslint foo",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-enable",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// exported",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// global",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// globals",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* just eslint in a normal comment */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint */",
+      "options": [
+        {
+          "allow": [
+            "eslint"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-enable */",
+      "options": [
+        {
+          "allow": [
+            "eslint-enable"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable */",
+      "options": [
+        {
+          "allow": [
+            "eslint-disable"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-line",
+      "options": [
+        {
+          "allow": [
+            "eslint-disable-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-next-line",
+      "options": [
+        {
+          "allow": [
+            "eslint-disable-next-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable-line */",
+      "options": [
+        {
+          "allow": [
+            "eslint-disable-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable-next-line */",
+      "options": [
+        {
+          "allow": [
+            "eslint-disable-next-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* exported */",
+      "options": [
+        {
+          "allow": [
+            "exported"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* global */",
+      "options": [
+        {
+          "allow": [
+            "global"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* globals */",
+      "options": [
+        {
+          "allow": [
+            "globals"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable */ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-enable */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-next-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 28
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-line */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-next-line */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* exported */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* global */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* globals */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "disallow",
+          "message": "Unexpected ESLint directive comment.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable */ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-eslint-comments/require-description.json
+++ b/tools/parity/corpora/eslint-plugin-eslint-comments/require-description.json
@@ -1,0 +1,630 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-eslint-comments",
+    "rule": "require-description",
+    "pinnedRef": "v4.7.2",
+    "submoduleSha": "62a2c3a4ee304a8383f170369c9999198d9bdac8",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Toru Nagashima",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "/* eslint eqeqeq: \"off\", curly: \"error\" -- Here's a description about why this configuration is necessary. */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-enable -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* exported -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* global -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* globals -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* just eslint in a normal comment */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-line -- description",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-next-line -- description",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable-line -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable-next-line -- description */",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-line eqeqeq -- description",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-next-line eqeqeq -- description",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint */",
+      "options": [
+        {
+          "ignore": [
+            "eslint"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-enable */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-enable"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-line",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-next-line",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-next-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable-line */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable-next-line */",
+      "options": [
+        {
+          "ignore": [
+            "eslint-disable-next-line"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* exported */",
+      "options": [
+        {
+          "ignore": [
+            "exported"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* global */",
+      "options": [
+        {
+          "ignore": [
+            "global"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* globals */",
+      "options": [
+        {
+          "ignore": [
+            "globals"
+          ]
+        }
+      ],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "/* eslint-disable */ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint eqeqeq: \"off\", curly: \"error\" */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 43
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-enable */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-enable eqeqeq */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 21
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable eqeqeq */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 28
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 23
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-line eqeqeq",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 30
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-next-line",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 28
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// eslint-disable-next-line eqeqeq",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 35
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-line */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-line eqeqeq */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 33
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-next-line */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-next-line eqeqeq */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 38
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* exported */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* global */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 13
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* global _ */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 15
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* globals */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 14
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* globals _ */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 16
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable-next-line eqeqeq -- */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "missingDescription",
+          "message": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+          "line": 1,
+          "column": 0,
+          "endLine": 1,
+          "endColumn": 41
+        }
+      ],
+      "fixOutput": null,
+      "upstreamAssertion": {
+        "style": "plain-string"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* eslint-disable */ a {}",
+      "outOfScope": {
+        "reason": "non-JS language: css/css"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-simple-import-sort/exports.json
+++ b/tools/parity/corpora/eslint-plugin-simple-import-sort/exports.json
@@ -1,0 +1,508 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-simple-import-sort",
+    "rule": "exports",
+    "pinnedRef": "v13.0.0",
+    "submoduleSha": "90078e7fce900b6860ab7cd1800c6ff055601d88",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Simon Lydell",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "export {a} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {a,b} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {    } from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export * as a from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export var one = 1;",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export let two = 2;",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export const three = 3;",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export function f() {}",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export class C {}",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export { a, b as c }; var a, b;",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export default whatever;",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {x1} from \"a\";\nexport {x2} from \"b\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-next-line\nexport {x2} from \"b\"\nexport {x1} from \"a\";",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {\n  a, // a\n  b // b\n} from \"specifiers-comment-space\"\nexport {\n  c, // c\n  d, // d\n} from \"specifiers-comment-space-2\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {a} from \"a\"    \nexport {b} from \"b\";    \nexport {c} from \"c\";  /* comment */  ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "export {a} from \"a\"\n// export {b} from \"b\";\nexport {c} from \"c\";",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "invalid",
+      "code": "export {x2} from \"b\"\nexport {x1} from \"a\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": "export {x1} from \"a\";\nexport {x2} from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export * from \"g\"\nexport * from \"f\";\n// Group 2\nexport * from \"e\"\nexport * from \"d\"\n/* Group 3 */\n\nexport * from \"c\"\n\n\nexport * from \"b\"\n\n\n /* Group 4\n */\n\n   export * from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 19
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 4,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 18
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 8,
+          "column": 1,
+          "endLine": 11,
+          "endColumn": 18
+        }
+      ],
+      "fixOutput": "export * from \"f\";\nexport * from \"g\"\n// Group 2\nexport * from \"d\"\nexport * from \"e\"\n/* Group 3 */\n\nexport * from \"b\"\nexport * from \"c\"\n\n\n /* Group 4\n */\n\n   export * from \"a\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export { d, a as c, a as b2, b, a } from \"specifiers\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 54
+        }
+      ],
+      "fixOutput": "export { a,b, a as b2, a as c, d } from \"specifiers\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export { d, a as c, a as b2, b, a, }; var d, a, b;",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 38
+        }
+      ],
+      "fixOutput": "export { a,b, a as b2, a as c, d,  }; var d, a, b;",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export * from \"g\"\n/* f1 */export * from \"f\"; // f2\nexport * from \"e\" /* d\n */\nexport * from \"d\"\nexport * from \"c\" /*\n b */ export * from \"b\"\n /* a\n */ export * from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 9,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": " /* a\n */ export * from \"a\"\n/*\n b */ export * from \"b\"\nexport * from \"c\" \n/* d\n */\nexport * from \"d\"\nexport * from \"e\" \n/* f1 */export * from \"f\"; // f2\nexport * from \"g\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*1*//*2*/export/*3*/*/*4*/as/*as*/foo/*foo1*//*foo2*/from/*6*/\"specifiers-lots-of-comments\"/*7*//*8*/\nexport { // start\n  /* c1 */ c /* c2 */, // c3\n  // b1\n\n  b as /* b2 */ renamed\n  , /* b3 */ /* a1\n  */ a /* not-a\n  */ // comment at end\n} from \"specifiers-lots-of-comments-multiline\";\nexport {\n  e,\n  d, /* d */ /* not-d\n  */ // comment at end after trailing comma\n};\nvar e, d;",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 10,
+          "endColumn": 48
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 11,
+          "column": 1,
+          "endLine": 15,
+          "endColumn": 3
+        }
+      ],
+      "fixOutput": "/*1*//*2*/export/*3*/*/*4*/as/*as*/foo/*foo1*//*foo2*/from/*6*/\"specifiers-lots-of-comments\"/*7*//*8*/\nexport { // start\n/* a1\n  */ a, \n  /* c1 */ c /* c2 */, // c3\n  // b1\n  b as /* b2 */ renamed\n  /* b3 */ /* not-a\n  */ // comment at end\n} from \"specifiers-lots-of-comments-multiline\";\nexport {\n  d, /* d */   e,\n/* not-d\n  */ // comment at end after trailing comma\n};\nvar e, d;",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export\n\n// export\n\n/* default */\n\n\n\n// default\n\n {\n\n  // c\n\n  c /*c*/,\n\n  /* b\n   */\n\n  b // b\n  ,\n\n  // a1\n\n  // a2\n\n  a\n\n  // a3\n\n  as\n\n  // a4\n\n  d\n\n  // a5\n\n  , // a6\n\n  // last\n\n}\n\n// from1\n\nfrom\n\n// from2\n\n\"c\"\n\n// final\n\n;",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 55,
+          "endColumn": 2
+        }
+      ],
+      "fixOutput": "export\n// export\n/* default */\n// default\n {\n  /* b\n   */\n  b // b\n  ,\n  // c\n  c /*c*/,\n  // a1\n  // a2\n  a\n  // a3\n  as\n  // a4\n  d\n  // a5\n  , // a6\n  // last\n}\n// from1\nfrom\n// from2\n\"c\"\n// final\n;",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export {\n\n    } from \"specifiers-empty\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 30
+        }
+      ],
+      "fixOutput": "export {\n    } from \"specifiers-empty\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export const options = {\n\n    a: 1,\n\n    b: 2\n    }, a = 1\nexport {options as options2, a as a2}",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 7,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 38
+        }
+      ],
+      "fixOutput": "export const options = {\n\n    a: 1,\n\n    b: 2\n    }, a = 1\nexport {a as a2,options as options2}",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "  export {e} from \"e\"\n  export {\n    b4, b3,\n    b2\n  } from \"b\";\n  /* a */ export {a} from \"a\"; export {c} from \"c\"\n  \n    export {d} from \"d\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 8,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": "  /* a */ export {a} from \"a\"; \n  export {\n    b2,\nb3,\n    b4  } from \"b\";\nexport {c} from \"c\"\n    export {d} from \"d\"\n  export {e} from \"e\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export {x2} from \"b\"\nexport {x1} from \"a\"\n\n;[].forEach()",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 21
+        }
+      ],
+      "fixOutput": "export {x1} from \"a\"\nexport {x2} from \"b\"\n\n;[].forEach()",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export { something, something as default } from './something'",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 62
+        }
+      ],
+      "fixOutput": "export { something as default,something } from './something'",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export {default as default, default as def, default as fault} from \"b\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 71
+        }
+      ],
+      "fixOutput": "export {default as def, default as default, default as fault} from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// before\n/* also\nbefore */ export * from \"b\";\nexport * from \"a\"; /*a*/ /* comment\nafter */ // after",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 3,
+          "column": 11,
+          "endLine": 4,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": "// before\n/* also\nbefore */ export * from \"a\"; /*a*/ \nexport * from \"b\";/* comment\nafter */ // after",
+      "upstreamAssertion": {
+        "style": "messageId"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export { default as djedi } from \"./djedi\";\nexport { default as Node, NodeContext } from \"./Node\";\nexport { default as ForceNodes } from \"./ForceNodes\";\nexport { default as md } from \"dedent-js\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 43
+        }
+      ],
+      "fixOutput": "export { default as djedi } from \"./djedi\";\nexport { default as ForceNodes } from \"./ForceNodes\";\nexport { default as Node, NodeContext } from \"./Node\";\nexport { default as md } from \"dedent-js\";",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "export * from './logger';\nexport * from './AppsembleError';\nexport * from './basicAuth';\nexport * from './commandDirOptions';\nexport * from './getWorkspaces';\nexport * from './handleError';\nexport * from './interceptors';\nexport * from './loggerMiddleware';\nexport * from './readFileOrString';\nexport * from './fs';",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 10,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": "export * from './AppsembleError';\nexport * from './basicAuth';\nexport * from './commandDirOptions';\nexport * from './fs';\nexport * from './getWorkspaces';\nexport * from './handleError';\nexport * from './interceptors';\nexport * from './logger';\nexport * from './loggerMiddleware';\nexport * from './readFileOrString';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "var\n  createPortal,\n  batchedUpdates,\n  flushSync,\n  Internals,\n  ReactVersion,\n  findDOMNode,\n  hydrate,\n  render,\n  unmountComponentAtNode,\n  createRoot,\n  createBlockingRoot,\n  flushControlled,\n  scheduleHydration,\n  renderSubtreeIntoContainer,\n  unstable_createPortal,\n  createEventHandle\n;\nexport {\n  createPortal,\n  batchedUpdates as unstable_batchedUpdates,\n  flushSync,\n  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,\n  ReactVersion as version,\n  // Disabled behind disableLegacyReactDOMAPIs\n  findDOMNode,\n  hydrate,\n  render,\n  unmountComponentAtNode,\n  // exposeConcurrentModeAPIs\n  createRoot,\n  createBlockingRoot,\n  flushControlled as unstable_flushControlled,\n  scheduleHydration as unstable_scheduleHydration,\n  // Disabled behind disableUnstableRenderSubtreeIntoContainer\n  renderSubtreeIntoContainer as unstable_renderSubtreeIntoContainer,\n  // Disabled behind disableUnstableCreatePortal\n  // Temporary alias since we already shipped React 16 RC with it.\n  // Todo: remove in React 18.\n  unstable_createPortal,\n  // enableCreateEventHandleAPI\n  createEventHandle as unstable_createEventHandle,\n};",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 19,
+          "column": 1,
+          "endLine": 43,
+          "endColumn": 3
+        }
+      ],
+      "fixOutput": "var\n  createPortal,\n  batchedUpdates,\n  flushSync,\n  Internals,\n  ReactVersion,\n  findDOMNode,\n  hydrate,\n  render,\n  unmountComponentAtNode,\n  createRoot,\n  createBlockingRoot,\n  flushControlled,\n  scheduleHydration,\n  renderSubtreeIntoContainer,\n  unstable_createPortal,\n  createEventHandle\n;\nexport {\n  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,\n  createBlockingRoot,\n  createPortal,\n  // exposeConcurrentModeAPIs\n  createRoot,\n  // Disabled behind disableLegacyReactDOMAPIs\n  findDOMNode,\n  flushSync,\n  hydrate,\n  render,\n  unmountComponentAtNode,\n  batchedUpdates as unstable_batchedUpdates,\n  // enableCreateEventHandleAPI\n  createEventHandle as unstable_createEventHandle,\n  // Disabled behind disableUnstableCreatePortal\n  // Temporary alias since we already shipped React 16 RC with it.\n  // Todo: remove in React 18.\n  unstable_createPortal,\n  flushControlled as unstable_flushControlled,\n  // Disabled behind disableUnstableRenderSubtreeIntoContainer\n  renderSubtreeIntoContainer as unstable_renderSubtreeIntoContainer,\n  scheduleHydration as unstable_scheduleHydration,\n  ReactVersion as version,\n};",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/* Core */\n\nexport {\n  ApolloClient,\n  ApolloClientOptions,\n  DefaultOptions\n} from '../ApolloClient';\nexport {\n  ObservableQuery,\n  FetchMoreOptions,\n  UpdateQueryOptions,\n  ApolloCurrentQueryResult,\n} from '../core/ObservableQuery';\nexport {\n  QueryBaseOptions,\n  QueryOptions,\n  WatchQueryOptions,\n  MutationOptions,\n  SubscriptionOptions,\n  FetchPolicy,\n  WatchQueryFetchPolicy,\n  ErrorPolicy,\n  FetchMoreQueryOptions,\n  SubscribeToMoreOptions,\n  MutationUpdaterFn,\n} from '../core/watchQueryOptions';\nexport { NetworkStatus } from '../core/networkStatus';\nexport * from '../core/types';\nexport {\n  Resolver,\n  FragmentMatcher as LocalStateFragmentMatcher,\n} from '../core/LocalState';\nexport { isApolloError, ApolloError } from '../errors/ApolloError';\n\n/* Cache */\n\nexport * from '../cache';\n\n/* Link */\n\nexport { empty } from '../link/core/empty';\nexport { from } from '../link/core/from';\nexport { split } from '../link/core/split';\nexport { concat } from '../link/core/concat';\nexport { execute } from '../link/core/execute';\nexport { ApolloLink } from '../link/core/ApolloLink';\nexport * from '../link/core/types';\nexport {\n  parseAndCheckHttpResponse,\n  ServerParseError\n} from '../link/http/parseAndCheckHttpResponse';\nexport {\n  serializeFetchParameter,\n  ClientParseError\n} from '../link/http/serializeFetchParameter';\nexport {\n  HttpOptions,\n  fallbackHttpConfig,\n  selectHttpOptionsAndBody,\n  UriFunction\n} from '../link/http/selectHttpOptionsAndBody';\nexport { checkFetcher } from '../link/http/checkFetcher';\nexport { createSignalIfSupported } from '../link/http/createSignalIfSupported';\nexport { selectURI } from '../link/http/selectURI';\nexport { createHttpLink } from '../link/http/createHttpLink';\nexport { HttpLink } from '../link/http/HttpLink';\nexport { fromError } from '../link/utils/fromError';\nexport { toPromise } from '../link/utils/toPromise';\nexport { fromPromise } from '../link/utils/fromPromise';\nexport { ServerError, throwServerError } from '../link/utils/throwServerError';\nexport {\n  Observable,\n  Observer,\n  ObservableSubscription\n} from '../utilities/observables/Observable';\n\n/* Supporting */\n\n// Note that importing `gql` by itself, then destructuring\n// additional properties separately before exporting, is intentional...\nimport gql from 'graphql-tag';\nexport const {\n  resetCaches,\n  disableFragmentWarnings,\n  enableExperimentalFragmentVariables,\n  disableExperimentalFragmentVariables\n} = gql;\nexport { gql };",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 3,
+          "column": 1,
+          "endLine": 33,
+          "endColumn": 68
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these exports!",
+          "line": 41,
+          "column": 1,
+          "endLine": 75,
+          "endColumn": 46
+        }
+      ],
+      "fixOutput": "/* Core */\n\nexport {\n  ApolloClient,\n  ApolloClientOptions,\n  DefaultOptions\n} from '../ApolloClient';\nexport {\n  FragmentMatcher as LocalStateFragmentMatcher,\n  Resolver,\n} from '../core/LocalState';\nexport { NetworkStatus } from '../core/networkStatus';\nexport {\n  ApolloCurrentQueryResult,\n  FetchMoreOptions,\n  ObservableQuery,\n  UpdateQueryOptions,\n} from '../core/ObservableQuery';\nexport * from '../core/types';\nexport {\n  ErrorPolicy,\n  FetchMoreQueryOptions,\n  FetchPolicy,\n  MutationOptions,\n  MutationUpdaterFn,\n  QueryBaseOptions,\n  QueryOptions,\n  SubscribeToMoreOptions,\n  SubscriptionOptions,\n  WatchQueryFetchPolicy,\n  WatchQueryOptions,\n} from '../core/watchQueryOptions';\nexport { ApolloError,isApolloError } from '../errors/ApolloError';\n\n/* Cache */\n\nexport * from '../cache';\n\n/* Link */\n\nexport { ApolloLink } from '../link/core/ApolloLink';\nexport { concat } from '../link/core/concat';\nexport { empty } from '../link/core/empty';\nexport { execute } from '../link/core/execute';\nexport { from } from '../link/core/from';\nexport { split } from '../link/core/split';\nexport * from '../link/core/types';\nexport { checkFetcher } from '../link/http/checkFetcher';\nexport { createHttpLink } from '../link/http/createHttpLink';\nexport { createSignalIfSupported } from '../link/http/createSignalIfSupported';\nexport { HttpLink } from '../link/http/HttpLink';\nexport {\n  parseAndCheckHttpResponse,\n  ServerParseError\n} from '../link/http/parseAndCheckHttpResponse';\nexport {\n  fallbackHttpConfig,\n  HttpOptions,\n  selectHttpOptionsAndBody,\n  UriFunction\n} from '../link/http/selectHttpOptionsAndBody';\nexport { selectURI } from '../link/http/selectURI';\nexport {\n  ClientParseError,\n  serializeFetchParameter} from '../link/http/serializeFetchParameter';\nexport { fromError } from '../link/utils/fromError';\nexport { fromPromise } from '../link/utils/fromPromise';\nexport { ServerError, throwServerError } from '../link/utils/throwServerError';\nexport { toPromise } from '../link/utils/toPromise';\nexport {\n  Observable,\n  ObservableSubscription,\n  Observer} from '../utilities/observables/Observable';\n\n/* Supporting */\n\n// Note that importing `gql` by itself, then destructuring\n// additional properties separately before exporting, is intentional...\nimport gql from 'graphql-tag';\nexport const {\n  resetCaches,\n  disableFragmentWarnings,\n  enableExperimentalFragmentVariables,\n  disableExperimentalFragmentVariables\n} = gql;\nexport { gql };",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    }
+  ]
+}

--- a/tools/parity/corpora/eslint-plugin-simple-import-sort/imports.json
+++ b/tools/parity/corpora/eslint-plugin-simple-import-sort/imports.json
@@ -1,0 +1,1343 @@
+{
+  "corpusVersion": 1,
+  "provenance": {
+    "plugin": "eslint-plugin-simple-import-sort",
+    "rule": "imports",
+    "pinnedRef": "v13.0.0",
+    "submoduleSha": "90078e7fce900b6860ab7cd1800c6ff055601d88",
+    "eslintVersion": "9.39.4",
+    "license": "MIT",
+    "copyright": "Simon Lydell",
+    "note": "Test fixtures converted/derived from upstream; see tools/parity/corpora/NOTICE."
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "code": "import \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import a from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import {a} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import a, {b} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import {a,b} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import {} from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import {    } from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import * as a from \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import \"b\";\nimport \"a\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import \"codemirror/addon/fold/brace-fold\"\nimport \"codemirror/addon/edit/closebrackets\"\nimport \"codemirror/addon/fold/foldgutter\"\nimport \"codemirror/addon/fold/foldgutter.css\"\nimport \"codemirror/addon/lint/json-lint\"\nimport \"codemirror/addon/lint/lint\"\nimport \"codemirror/addon/lint/lint.css\"\nimport \"codemirror/addon/scroll/simplescrollbars\"\nimport \"codemirror/addon/scroll/simplescrollbars.css\"\nimport \"codemirror/lib/codemirror.css\"\nimport \"codemirror/mode/javascript/javascript\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import x1 from \"a\";\nimport x2 from \"b\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "// eslint-disable-next-line\nimport x2 from \"b\"\nimport x1 from \"a\";",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import {\n  a, // a\n  b // b\n} from \"specifiers-comment-space\"\nimport {\n  c, // c\n  d, // d\n} from \"specifiers-comment-space-2\"",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "valid",
+      "code": "import a from \"a\"    \nimport b from \"b\";    \nimport c from \"c\";  /* comment */  ",
+      "options": [],
+      "expectedErrors": [],
+      "fixOutput": null
+    },
+    {
+      "kind": "invalid",
+      "code": "import x2 from \"b\"\nimport x1 from \"a\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": "import x1 from \"a\";\nimport x2 from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import x2 from \"b\"\nimport x1 from \"a\"\n\n;[].forEach()",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": "import x1 from \"a\"\nimport x2 from \"b\"\n\n;[].forEach()",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { foo } from \"bar\"\nimport a from \"a\"\n\n;(async function() {\n  await foo()\n})()",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 18
+        }
+      ],
+      "fixOutput": "import a from \"a\"\nimport { foo } from \"bar\"\n\n;(async function() {\n  await foo()\n})()",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import x2 from \"b\"\nimport x7 from \"g\";\nimport x6 from \"f\"\n;import x5 from \"e\"\nimport x4 from \"d\" ; import x3 from \"c\"\nimport x1 from \"a\" ; [].forEach()",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": "import x1 from \"a\" ; \nimport x2 from \"b\"\nimport x3 from \"c\"\nimport x4 from \"d\" ; \nimport x5 from \"e\"\nimport x6 from \"f\"\n;\nimport x7 from \"g\";[].forEach()",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import x2 from \"b\"\nimport x1 from \"a\" // a\n\n;/* comment */[].forEach()",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 24
+        }
+      ],
+      "fixOutput": "import x1 from \"a\" // a\nimport x2 from \"b\"\n\n;/* comment */[].forEach()",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import x2 from \"b\"\nimport x1 from \"a\"\n\n;",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 2
+        }
+      ],
+      "fixOutput": "import x1 from \"a\"\n;\nimport x2 from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { e, b, a as c } from \"specifiers\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 42
+        }
+      ],
+      "fixOutput": "import { a as c,b, e } from \"specifiers\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import d, { e, b, a as c } from \"specifiers-default\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 53
+        }
+      ],
+      "fixOutput": "import d, { a as c,b, e } from \"specifiers-default\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import d, { e, b, a as c, } from \"specifiers-trailing-comma\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 61
+        }
+      ],
+      "fixOutput": "import d, { a as c,b, e,  } from \"specifiers-trailing-comma\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { a as c, a as b2, b, a } from \"specifiers-renames\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 59
+        }
+      ],
+      "fixOutput": "import { a,a as b2, a as c, b } from \"specifiers-renames\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  B,\n  a,\n  A,\n  b,\n  B2,\n  bb,\n  BB,\n  bB,\n  Bb,\n  ab,\n  ba,\n  Ba,\n  BA,\n  bA,\n  x as d,\n  x as C,\n  img10,\n  img2,\n  img1,\n  img10_black,\n} from \"specifiers-human-sort\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 22,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": "import {\n  A,\n  a,\n  ab,\n  B,\n  b,\n  B2,\n  BA,\n  Ba,\n  bA,\n  ba,\n  BB,\n  Bb,\n  bB,\n  bb,\n  img1,\n  img2,\n  img10,\n  img10_black,\n  x as C,\n  x as d,\n} from \"specifiers-human-sort\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { aaNotKeyword, zzNotKeyword, abstract, as, asserts, any, async, /*await,*/ boolean, constructor, declare, get, infer, is, keyof, module, namespace, never, readonly, require, number, object, set, string, symbol, type, undefined, unique, unknown, from, global, bigint, of } from 'keyword-identifiers';",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 308
+        }
+      ],
+      "fixOutput": "import { aaNotKeyword, abstract, any, as, asserts, async, /*await,*/ bigint, boolean, constructor, declare, from, get, global, infer, is, keyof, module, namespace, never, number, object, of,readonly, require, set, string, symbol, type, undefined, unique, unknown, zzNotKeyword } from 'keyword-identifiers';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {e,b,a as c} from \"specifiers-no-spaces\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 48
+        }
+      ],
+      "fixOutput": "import {a as c,b,e} from \"specifiers-no-spaces\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { b,a} from \"specifiers-no-space-before\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 48
+        }
+      ],
+      "fixOutput": "import { a,b} from \"specifiers-no-space-before\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {b,a } from \"specifiers-no-space-after\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 47
+        }
+      ],
+      "fixOutput": "import {a,b } from \"specifiers-no-space-after\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {b,a, } from \"specifiers-no-space-after-trailing\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 57
+        }
+      ],
+      "fixOutput": "import {a,b, } from \"specifiers-no-space-after-trailing\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  // c\n  c,\n  b, // b\n  a\n  // last\n} from \"specifiers-comments\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": "import {\n  a,\n  b, // b\n  // c\n  c\n  // last\n} from \"specifiers-comments\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  // c\n  c,b, // b\n  a\n  // last\n} from \"specifiers-comments-last\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 34
+        }
+      ],
+      "fixOutput": "import {\n  a,\nb, // b\n  // c\n  c\n  // last\n} from \"specifiers-comments-last\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { b /* b */, a } from \"specifiers-comment-between\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 58
+        }
+      ],
+      "fixOutput": "import { a,b /* b */ } from \"specifiers-comment-between\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  c,\n  a,\n  // x\n  // y\n} from \"specifiers-trailing\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": "import {\n  a,\n  c,\n  // x\n  // y\n} from \"specifiers-trailing\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  /*c1*/ c, /*c2*/ /*a1\n  */a, /*a2*/ /*\n  after */\n  // x\n  // y\n} from \"specifiers-multiline-comments\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 39
+        }
+      ],
+      "fixOutput": "import {\n/*a1\n  */a, /*a2*/ \n  /*c1*/ c, /*c2*/ /*\n  after */\n  // x\n  // y\n} from \"specifiers-multiline-comments\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  b,\n  a /*\n  after */\n} from \"specifiers-multiline-end-comment\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 42
+        }
+      ],
+      "fixOutput": "import {\n  a,   b/*\n  after */\n} from \"specifiers-multiline-end-comment\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  b,\n  a /*a*/\n  /*\n  after */\n} from \"specifiers-multiline-end-comment-after-newline\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 56
+        }
+      ],
+      "fixOutput": "import {\n  a, /*a*/\n  b  /*\n  after */\n} from \"specifiers-multiline-end-comment-after-newline\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  b,\n  a /*\n  after */ } from \"specifiers-multiline-end-comment-no-newline\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 64
+        }
+      ],
+      "fixOutput": "import {\n  a,   b/*\n  after */ } from \"specifiers-multiline-end-comment-no-newline\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "/*1*//*2*/import/*3*/def,/*4*/{/*{*/e/*e1*/,/*e2*//*e3*/b/*b1*/,/*b2*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/}/*5*/from/*6*/\"specifiers-lots-of-comments\"/*7*//*8*/",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 1,
+          "endColumn": 154
+        }
+      ],
+      "fixOutput": "/*1*//*2*/import/*3*/def,/*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*/from/*6*/\"specifiers-lots-of-comments\"/*7*//*8*/",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import { // start\n  /* c1 */ c /* c2 */, // c3\n  // b1\n\n  b as /* b2 */ renamed\n  , /* b3 */ /* a1\n  */ a /* not-a\n  */ // comment at end\n} from \"specifiers-lots-of-comments-multiline\";\nimport {\n  e,\n  d, /* d */ /* not-d\n  */ // comment at end after trailing comma\n} from \"specifiers-lots-of-comments-multiline-2\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 14,
+          "endColumn": 50
+        }
+      ],
+      "fixOutput": "import { // start\n/* a1\n  */ a, \n  // b1\n  b as /* b2 */ renamed\n  , /* b3 */ \n  /* c1 */ c /* c2 */// c3\n/* not-a\n  */ // comment at end\n} from \"specifiers-lots-of-comments-multiline\";\nimport {\n  d, /* d */   e,\n/* not-d\n  */ // comment at end after trailing comma\n} from \"specifiers-lots-of-comments-multiline-2\";",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n  b/*b*/\n  ,\n  a\n} from \"specifiers-blank\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": "import {\n  a,\n  b/*b*/\n  } from \"specifiers-blank\";",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {z, y,\n  x,\n\nw,\n    v\n  as /*v*/\n\n    u , t /*t*/, // t\n    s\n} from \"specifiers-inline-multiline\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 10,
+          "endColumn": 37
+        }
+      ],
+      "fixOutput": "import {    s,\nt /*t*/, // t\n    v\n  as /*v*/\n    u , w,\n  x,\ny,\nz} from \"specifiers-inline-multiline\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\nb,\na,\n} from \"specifiers-indent-0\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": "import {\na,\nb,\n} from \"specifiers-indent-0\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n    b,\n    a,\n} from \"specifiers-indent-4\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 29
+        }
+      ],
+      "fixOutput": "import {\n    a,\n    b,\n} from \"specifiers-indent-4\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n\tb,\n\ta,\n} from \"specifiers-indent-tab\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 31
+        }
+      ],
+      "fixOutput": "import {\n\ta,\n\tb,\n} from \"specifiers-indent-tab\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n //\n\tb,\n  a,\n\n    c,\n} from \"specifiers-indent-mixed\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 33
+        }
+      ],
+      "fixOutput": "import {\n  a,\n //\n\tb,\n    c,\n} from \"specifiers-indent-mixed\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "require(\"c\");\n\nimport x1 from \"b\"\nimport x2 from \"a\"\nrequire(\"c\");\n\nimport x3 from \"b\"\nimport x4 from \"a\" // x4\n\n// c1\nrequire(\"c\");\nimport x5 from \"b\"\n// x6-1\nimport x6 from \"a\" /* after\n*/\n\nrequire(\"c\"); import x7 from \"b\"; import x8 from \"a\"; require(\"c\")",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 3,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 19
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 7,
+          "column": 1,
+          "endLine": 8,
+          "endColumn": 25
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 12,
+          "column": 1,
+          "endLine": 14,
+          "endColumn": 20
+        },
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 17,
+          "column": 15,
+          "endLine": 17,
+          "endColumn": 55
+        }
+      ],
+      "fixOutput": "require(\"c\");\n\nimport x2 from \"a\"\nimport x1 from \"b\"\nrequire(\"c\");\n\nimport x4 from \"a\" // x4\nimport x3 from \"b\"\n\n// c1\nrequire(\"c\");\n// x6-1\nimport x6 from \"a\" \nimport x5 from \"b\"/* after\n*/\n\nrequire(\"c\"); import x8 from \"a\"; \nimport x7 from \"b\"; require(\"c\")",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from \"b\"\nimport a1 from \"a\"\nimport a2 from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": "import a1 from \"a\"\nimport a2 from \"a\"\nimport b from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from \"b\"\nimport a2 from \"a\"\nimport a1 from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": "import a2 from \"a\"\nimport a1 from \"a\"\nimport b from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from \"b\"\nimport {a2} from \"a\"\nimport a1 from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": "import a1 from \"a\"\nimport {a2} from \"a\"\nimport b from \"b\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {x} from \"a\"\nimport {} from \"a\"\nimport w1, {} from \"a\"\nimport w2 from \"a\"\nimport w3, {z} from \"a\"\nimport * as v from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 23
+        }
+      ],
+      "fixOutput": "import * as v from \"a\"\nimport w1, {} from \"a\"\nimport w2 from \"a\"\nimport w3, {z} from \"a\"\nimport {x} from \"a\"\nimport {} from \"a\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {} from \"\";\nimport {} from \".\";\nimport {} from \".//\";\nimport {} from \"./\";\nimport {} from \"./B\"; // B1\nimport {} from \"./b\";\nimport {} from \"./B\"; // B2\nimport {} from \"./A\";\nimport {} from \"./a\";\nimport {} from \"./_a\";\nimport {} from \"./-a\";\nimport {} from \"./[id]\";\nimport {} from \"./,\";\nimport {} from \"./ä\";\nimport {} from \"./ä\"; // “a” followed by “̈̈” (COMBINING DIAERESIS).\nimport {} from \"..\";\nimport {} from \"../\";\nimport {} from \"../a\";\nimport {} from \"../_a\";\nimport {} from \"../-a\";\nimport {} from \"../[id]\";\nimport {} from \"../,\";\nimport {} from \"../a/..\";\nimport {} from \"../a/../\";\nimport {} from \"../a/...\";\nimport {} from \"../a/../b\";\nimport {} from \"../../\";\nimport {} from \"../..\";\nimport {} from \"../../a\";\nimport {} from \"../../_a\";\nimport {} from \"../../-a\";\nimport {} from \"../../[id]\";\nimport {} from \"../../,\";\nimport {} from \"../../utils\";\nimport {} from \"../../..\";\nimport {} from \"../../../\";\nimport {} from \"../../../a\";\nimport {} from \"../../../_a\";\nimport {} from \"../../../[id]\";\nimport {} from \"../../../,\";\nimport {} from \"../../../utils\";\nimport {} from \"...\";\nimport {} from \".../\";\nimport {} from \".a\";\nimport {} from \"/\";\nimport {} from \"/a\";\nimport {} from \"/a/b\";\nimport {} from \"https://example.com/script.js\";\nimport {} from \"http://example.com/script.js\";\nimport {} from \"react\";\nimport {} from \"async\";\nimport {} from \"./a/-\";\nimport {} from \"./a/.\";\nimport {} from \"./a/0\";\nimport {} from \"@/components/error.vue\"\nimport {} from \"@/components/Alert\"\nimport {} from \"~/test\"\nimport {} from \"#/test\"\nimport {} from \"fs\";\nimport {} from \"fs/something\";\nimport {} from \"node:fs/something\";\nimport {} from \"node:fs\";\nimport {} from \"Fs\";\nimport {} from \"lodash/fp\";\nimport {} from \"@storybook/react\";\nimport {} from \"@storybook/react/something\";\nimport {} from \"1\";\nimport {} from \"1*\";\nimport {} from \"a*\";\nimport img2 from \"./img2\";\nimport img10 from \"./img10\";\nimport img1 from \"./img1\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 72,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": "import {} from \"node:fs\";\nimport {} from \"node:fs/something\";\n\nimport {} from \"@storybook/react\";\nimport {} from \"@storybook/react/something\";\nimport {} from \"1\";\nimport {} from \"1*\";\nimport {} from \"a*\";\nimport {} from \"async\";\nimport {} from \"Fs\";\nimport {} from \"fs\";\nimport {} from \"fs/something\";\nimport {} from \"http://example.com/script.js\";\nimport {} from \"https://example.com/script.js\";\nimport {} from \"lodash/fp\";\nimport {} from \"react\";\n\nimport {} from \"\";\nimport {} from \"/\";\nimport {} from \"/a\";\nimport {} from \"/a/b\";\nimport {} from \"@/components/Alert\"\nimport {} from \"@/components/error.vue\"\nimport {} from \"#/test\"\nimport {} from \"~/test\"\n\nimport {} from \"...\";\nimport {} from \".../\";\nimport {} from \"../../..\";\nimport {} from \"../../../\";\nimport {} from \"../../../,\";\nimport {} from \"../../../_a\";\nimport {} from \"../../../[id]\";\nimport {} from \"../../../a\";\nimport {} from \"../../../utils\";\nimport {} from \"../..\";\nimport {} from \"../../\";\nimport {} from \"../../,\";\nimport {} from \"../../_a\";\nimport {} from \"../../[id]\";\nimport {} from \"../../-a\";\nimport {} from \"../../a\";\nimport {} from \"../../utils\";\nimport {} from \"..\";\nimport {} from \"../\";\nimport {} from \"../,\";\nimport {} from \"../_a\";\nimport {} from \"../[id]\";\nimport {} from \"../-a\";\nimport {} from \"../a\";\nimport {} from \"../a/..\";\nimport {} from \"../a/...\";\nimport {} from \"../a/../\";\nimport {} from \"../a/../b\";\nimport {} from \".//\";\nimport {} from \".\";\nimport {} from \"./\";\nimport {} from \"./,\";\nimport {} from \"./_a\";\nimport {} from \"./[id]\";\nimport {} from \"./-a\";\nimport {} from \"./A\";\nimport {} from \"./a\";\nimport {} from \"./ä\"; // “a” followed by “̈̈” (COMBINING DIAERESIS).\nimport {} from \"./ä\";\nimport {} from \"./a/.\";\nimport {} from \"./a/-\";\nimport {} from \"./a/0\";\nimport {} from \"./B\"; // B1\nimport {} from \"./B\"; // B2\nimport {} from \"./b\";\nimport img1 from \"./img1\";\nimport img2 from \"./img2\";\nimport img10 from \"./img10\";\nimport {} from \".a\";",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// before\n\n/* also\nbefore */ /* b */ import b from \"b\" // b\n// above d\n  import d /*d1*/ from   \"d\" ; /* d2 */ /* before\n  c0 */ // before c1\n  /* c0\n*/ /*c1*/ /*c2*/import c from 'c' ; /*c3*/ import a from \"a\" /*a*/ /*\n   x1 */ /* x2 */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 4,
+          "column": 11,
+          "endLine": 9,
+          "endColumn": 68
+        }
+      ],
+      "fixOutput": "// before\n\n/* also\nbefore */ import a from \"a\" /*a*/ \n/* b */ import b from \"b\" // b\n/* before\n  c0 */ // before c1\n  /* c0\n*/ /*c1*/ /*c2*/import c from 'c' ; /*c3*/ \n// above d\n  import d /*d1*/ from   \"d\" ; /* d2 */ /*\n   x1 */ /* x2 */",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from \"b\"; // b\nimport a from \"a\"; code();",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": "import a from \"a\"; \nimport b from \"b\"; // b\ncode();",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from \"b\"; // b\nimport a from \"a\"; /*\nafter */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": "import a from \"a\"; \nimport b from \"b\"; // b\n/*\nafter */",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from \"b\"; // b\nimport a from \"a\"; /* a */",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 27
+        }
+      ],
+      "fixOutput": "import a from \"a\"; /* a */\nimport b from \"b\"; // b",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "// before\n/* also\nbefore */ import b from \"b\";\nimport a from \"a\"; /*a*/ /* comment\nafter */ // after",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 3,
+          "column": 11,
+          "endLine": 4,
+          "endColumn": 26
+        }
+      ],
+      "fixOutput": "// before\n/* also\nbefore */ import a from \"a\"; /*a*/ \nimport b from \"b\";/* comment\nafter */ // after",
+      "upstreamAssertion": {
+        "style": "messageId"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import c from \"c\"\n// b1\n\n// b2\nimport b from \"b\"\n// a\n\nimport a from \"a\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 8,
+          "endColumn": 18
+        }
+      ],
+      "fixOutput": "// a\nimport a from \"a\"\n// b1\n// b2\nimport b from \"b\"\nimport c from \"c\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import c from \"c\"\r\n// b1\r\n\r\n// b2\r\nimport b from \"b\"\r\n// a\r\n\r\nimport a from \"a\"\r\nafter();\r",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 8,
+          "endColumn": 18
+        }
+      ],
+      "fixOutput": "// a\r\nimport a from \"a\"\r\n// b1\r\n// b2\r\nimport b from \"b\"\r\nimport c from \"c\"\r\nafter();\r",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import\n\n// import\n\ndef /* default */\n\n,\n\n// default\n\n {\n\n  // c\n\n  c /*c*/,\n\n  /* b\n   */\n\n  b // b\n  ,\n\n  // a1\n\n  // a2\n\n  a\n\n  // a3\n\n  as\n\n  // a4\n\n  d\n\n  // a5\n\n  , // a6\n\n  // last\n\n}\n\n// from1\n\nfrom\n\n// from2\n\n\"c\"\n\n// final\n\n;",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 55,
+          "endColumn": 2
+        }
+      ],
+      "fixOutput": "import\n// import\ndef /* default */\n,\n// default\n {\n  // a1\n  // a2\n  a\n  // a3\n  as\n  // a4\n  d\n  // a5\n  , // a6\n  /* b\n   */\n  b // b\n  ,\n  // c\n  c /*c*/,\n  // last\n}\n// from1\nfrom\n// from2\n\"c\"\n// final\n;",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n\n    } from \"specifiers-empty\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 30
+        }
+      ],
+      "fixOutput": "import {\n    } from \"specifiers-empty\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import {\n\n  b // b\n  ,a} from \"specifiers-line-comment\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 37
+        }
+      ],
+      "fixOutput": "import {\na,  b // b\n  } from \"specifiers-line-comment\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "  import e from \"e\"\n  // b\n  import {\n    b4, b3,\n    b2\n  } from \"b\";\n  /* a */ import a from \"a\"; import c from \"c\"\n  \n    // d\n    import d from \"d\"",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 10,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": "  /* a */ import a from \"a\"; \n  // b\n  import {\n    b2,\nb3,\n    b4  } from \"b\";\nimport c from \"c\"\n    // d\n    import d from \"d\"\n  import e from \"e\"",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "      \r\n  import e from \"e\"\r\n  // b\r\n  import {\r\n    b4, b3,\r\n    b2\r\n  } from \"b\";\r\n  /* a */ import a from \"a\"; import c from \"c\"\r\n \r\n    // d\r\n    import d from \"d\"\r\n",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 2,
+          "column": 1,
+          "endLine": 11,
+          "endColumn": 22
+        }
+      ],
+      "fixOutput": "      \r\n  /* a */ import a from \"a\"; \r\n  // b\r\n  import {\r\n    b2,\r\nb3,\r\n    b4  } from \"b\";\r\nimport c from \"c\"\r\n    // d\r\n    import d from \"d\"\r\n  import e from \"e\"\r\n",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import c from \"c\";  /* comment */  \nimport b from \"b\";    \nimport d from \"d\";  /* multiline\ncomment */  \nimport a from \"a\"    \nimport e from \"e\"; /* multiline\ncomment 2 */ import f from \"f\";",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 32
+        }
+      ],
+      "fixOutput": "/* multiline\ncomment */  \nimport a from \"a\"    \nimport b from \"b\";    \nimport c from \"c\";  /* comment */  \nimport d from \"d\";  \nimport e from \"e\"; \n/* multiline\ncomment 2 */ import f from \"f\";",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import FloatingActionButton from 'src/components/FloatingActionButton'\nimport { Select, linkButton, buttonPrimary, spinnerOverlay } from 'src/components/common'\nimport { icon, spinner } from 'src/components/icons'\nimport { notify } from 'src/components/Notifications'\nimport { IGVBrowser } from 'src/components/IGVBrowser'\nimport { IGVFileSelector } from 'src/components/IGVFileSelector'\nimport { DelayedSearchInput, TextInput } from 'src/components/input'\nimport DataTable from 'src/components/DataTable'\nimport { FlexTable, SimpleTable, HeaderCell, TextCell } from 'src/components/table'\nimport Modal from 'src/components/Modal'\nimport ExportDataModal from 'src/components/ExportDataModal'",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 11,
+          "endColumn": 61
+        }
+      ],
+      "fixOutput": "import { buttonPrimary, linkButton, Select, spinnerOverlay } from 'src/components/common'\nimport DataTable from 'src/components/DataTable'\nimport ExportDataModal from 'src/components/ExportDataModal'\nimport FloatingActionButton from 'src/components/FloatingActionButton'\nimport { icon, spinner } from 'src/components/icons'\nimport { IGVBrowser } from 'src/components/IGVBrowser'\nimport { IGVFileSelector } from 'src/components/IGVFileSelector'\nimport { DelayedSearchInput, TextInput } from 'src/components/input'\nimport Modal from 'src/components/Modal'\nimport { notify } from 'src/components/Notifications'\nimport { FlexTable, HeaderCell, SimpleTable, TextCell } from 'src/components/table'",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import agent from '../agent';\nimport Header from './Header';\nimport React from 'react';\nimport { connect } from 'react-redux';\nimport { APP_LOAD, REDIRECT } from '../constants/actionTypes';\nimport { Route, Switch } from 'react-router-dom';\nimport Article from '../components/Article';\nimport Editor from '../components/Editor';\nimport Home from '../components/Home';\nimport Login from '../components/Login';\nimport Profile from '../components/Profile';\nimport ProfileFavorites from '../components/ProfileFavorites';\nimport Register from '../components/Register';\nimport Settings from '../components/Settings';\nimport { store } from '../store';\nimport { push } from 'react-router-redux';",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 16,
+          "endColumn": 43
+        }
+      ],
+      "fixOutput": "import React from 'react';\nimport { connect } from 'react-redux';\nimport { Route, Switch } from 'react-router-dom';\nimport { push } from 'react-router-redux';\n\nimport agent from '../agent';\nimport Article from '../components/Article';\nimport Editor from '../components/Editor';\nimport Home from '../components/Home';\nimport Login from '../components/Login';\nimport Profile from '../components/Profile';\nimport ProfileFavorites from '../components/ProfileFavorites';\nimport Register from '../components/Register';\nimport Settings from '../components/Settings';\nimport { APP_LOAD, REDIRECT } from '../constants/actionTypes';\nimport { store } from '../store';\nimport Header from './Header';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import ListErrors from './ListErrors';\nimport React from 'react';\nimport agent from '../agent';\nimport { connect } from 'react-redux';\nimport {\n  ADD_TAG,\n  EDITOR_PAGE_LOADED,\n  REMOVE_TAG,\n  ARTICLE_SUBMITTED,\n  EDITOR_PAGE_UNLOADED,\n  UPDATE_FIELD_EDITOR\n} from '../constants/actionTypes';",
+      "options": [],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 12,
+          "endColumn": 35
+        }
+      ],
+      "fixOutput": "import React from 'react';\nimport { connect } from 'react-redux';\n\nimport agent from '../agent';\nimport {\n  ADD_TAG,\n  ARTICLE_SUBMITTED,\n  EDITOR_PAGE_LOADED,\n  EDITOR_PAGE_UNLOADED,\n  REMOVE_TAG,\n  UPDATE_FIELD_EDITOR\n} from '../constants/actionTypes';\nimport ListErrors from './ListErrors';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from '.';\nimport a from 'ä';",
+      "options": [
+        {
+          "groups": [
+            [
+              "^\\p{L}"
+            ],
+            [
+              "^\\."
+            ]
+          ]
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 2,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": "import a from 'ä';\n\nimport b from '.';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import c from '';\nimport b from '.';\nimport a from 'a';\nimport d from '@/a';",
+      "options": [
+        {
+          "groups": [
+            [
+              "^\\w"
+            ],
+            [
+              "^\\."
+            ]
+          ]
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 4,
+          "endColumn": 21
+        }
+      ],
+      "fixOutput": "import a from 'a';\n\nimport b from '.';\n\nimport c from '';\nimport d from '@/a';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import c from './';\nimport b from 'bx';\nimport a from 'a';",
+      "options": [
+        {
+          "groups": [
+            [
+              "^\\w"
+            ],
+            [
+              "^\\w{2}"
+            ],
+            [
+              "^.{2}"
+            ]
+          ]
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "fixOutput": "import a from 'a';\n\nimport b from 'bx';\n\nimport c from './';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import '@/';\nimport c from '@/';\nimport b from './';\nimport './';\nimport a from 'a';\nimport 'a';\nimport {} from 'a';",
+      "options": [
+        {
+          "groups": [
+            [
+              "^\\w"
+            ],
+            [
+              "^\\."
+            ],
+            [
+              "^\\u0000"
+            ]
+          ]
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 7,
+          "endColumn": 20
+        }
+      ],
+      "fixOutput": "import a from 'a';\nimport {} from 'a';\n\nimport b from './';\n\nimport '@/';\nimport './';\nimport 'a';\n\nimport c from '@/';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import b from 'b';\nimport 'c';\nimport d from 'd';\nimport 'a';\nimport '.';\nimport x from './x';",
+      "options": [
+        {
+          "groups": []
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 6,
+          "endColumn": 21
+        }
+      ],
+      "fixOutput": "import 'c';\nimport 'a';\nimport '.';\nimport x from './x';\nimport b from 'b';\nimport d from 'd';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    },
+    {
+      "kind": "invalid",
+      "code": "import react from 'react';\nimport a from 'a';\nimport webpack from \"webpack\"\nimport Select from 'react-select';\nimport App from './App';",
+      "options": [
+        {
+          "groups": [
+            [
+              "^\\w",
+              "^react"
+            ],
+            [
+              "^\\."
+            ]
+          ]
+        }
+      ],
+      "expectedErrors": [
+        {
+          "messageId": "sort",
+          "message": "Run autofix to sort these imports!",
+          "line": 1,
+          "column": 1,
+          "endLine": 5,
+          "endColumn": 25
+        }
+      ],
+      "fixOutput": "import a from 'a';\nimport webpack from \"webpack\"\nimport react from 'react';\nimport Select from 'react-select';\n\nimport App from './App';",
+      "upstreamAssertion": {
+        "style": "count"
+      }
+    }
+  ]
+}

--- a/tools/parity/divergences.json
+++ b/tools/parity/divergences.json
@@ -1,0 +1,25 @@
+{
+  "$note": "Known-divergences ledger. Each entry is an explicit, reviewed exception that tells the replay runner which expectations to relax for specific ported rules. An xfail that starts passing should also be cleaned up. Admissible classes: parser-ast-quirk, location-coordinate, core-rule-dependency, harness-directive.",
+  "eslint-plugin-eslint-comments/no-unlimited-disable": {
+    "class": "location-coordinate",
+    "suppressFields": ["column"],
+    "caseScope": "all",
+    "reason": "Upstream reports through utils.toForceLocation(), which sets the start column to a -1 sentinel that ESLint clamps to 0. The oxc port reports the comment's real start column (1 under eslintCompat). Start column is therefore intentionally not asserted; line, endLine, and endColumn still are, and messageId/message must match exactly.",
+    "expires": null,
+    "ledgerReviewedSha": "pending"
+  },
+  "eslint-plugin-simple-import-sort/imports": {
+    "class": "harness-directive",
+    "skipValidWithDisableDirective": true,
+    "reason": "Upstream marks an import block valid when an `eslint-disable*` directive suppresses the sort report. ESLint's RuleTester applies inline disable directives; oxlint's plugin RuleTester does not, so the (identical) report surfaces. The port's rule behavior matches upstream — only the harness's directive suppression differs — so valid cases that are valid solely due to a disable directive are skipped.",
+    "expires": null,
+    "ledgerReviewedSha": "pending"
+  },
+  "eslint-plugin-simple-import-sort/exports": {
+    "class": "harness-directive",
+    "skipValidWithDisableDirective": true,
+    "reason": "Same as eslint-plugin-simple-import-sort/imports: oxlint's RuleTester does not apply inline `eslint-disable*` directives, so a valid case that relies on directive suppression cannot be replayed as valid.",
+    "expires": null,
+    "ledgerReviewedSha": "pending"
+  }
+}

--- a/tools/parity/replay/runner.mjs
+++ b/tools/parity/replay/runner.mjs
@@ -1,0 +1,118 @@
+// Generic parity replay runner.
+//
+// Loads a committed corpus and drives a ported oxlint rule through `RuleTester` from
+// `oxlint/plugins-dev`. The caller injects `RuleTester` (so it resolves from the port
+// package that depends on oxlint) and the rule object under test.
+//
+// Comparison policy:
+//   - Expected diagnostics assert `message` (the rendered upstream text, which embeds all
+//     interpolated data and is the most discriminating single key) plus `line`/`endLine`/
+//     `endColumn`. We assert `column` too unless the divergences ledger suppresses it.
+//   - `fixOutput` (when present) is fed as RuleTester's `output`; RuleTester applies the
+//     port's fixer and asserts the resulting source string.
+//   - `outOfScope` cases (non-JS language / custom parser) are skipped and counted.
+
+import { readFileSync } from 'node:fs';
+
+export function loadCorpus(corpusPath) {
+  return JSON.parse(readFileSync(corpusPath, 'utf8'));
+}
+
+export function loadLedgerEntry(ledgerPath, pluginId, ruleName) {
+  let ledger;
+  try {
+    ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  return ledger[`${pluginId}/${ruleName}`] ?? null;
+}
+
+function buildExpectedError(e, suppress) {
+  // `message` and `messageId` are mutually exclusive in RuleTester; prefer the rendered
+  // message because it embeds the interpolated `{{data}}` and is strictly more discriminating.
+  const out = { message: e.message };
+  if (!suppress.has('column') && typeof e.column === 'number') out.column = e.column;
+  if (!suppress.has('line') && typeof e.line === 'number') out.line = e.line;
+  if (!suppress.has('endLine') && typeof e.endLine === 'number') out.endLine = e.endLine;
+  if (!suppress.has('endColumn') && typeof e.endColumn === 'number') out.endColumn = e.endColumn;
+  if (Array.isArray(e.suggestions)) {
+    out.suggestions = e.suggestions.map((s) => ({
+      ...(s.messageId ? { messageId: s.messageId } : { desc: s.desc }),
+      output: s.output,
+    }));
+  }
+  return out;
+}
+
+function carryCaseConfig(target, c) {
+  if (c.filename) target.filename = c.filename;
+  if (c.settings) target.settings = c.settings;
+  if (c.languageOptions) target.languageOptions = c.languageOptions;
+  if (Array.isArray(c.options) && c.options.length > 0) target.options = c.options;
+}
+
+// Matches an inline ESLint disable directive that can suppress a report.
+const DISABLE_DIRECTIVE = /\beslint-disable(?:-next-line|-line)?\b/u;
+
+export function buildTestCases(corpus, ledgerEntry) {
+  const suppress = new Set(ledgerEntry?.suppressFields ?? []);
+  const skipDirectiveValid = ledgerEntry?.skipValidWithDisableDirective === true;
+  const valid = [];
+  const invalid = [];
+  let skipped = 0;
+
+  for (const c of corpus.cases) {
+    if (c.outOfScope) {
+      skipped++;
+      continue;
+    }
+    // oxlint's plugin RuleTester does not apply inline `eslint-disable*` directives, so a valid
+    // case that is valid only because a directive suppresses the report cannot be replayed.
+    if (c.kind === 'valid' && skipDirectiveValid && DISABLE_DIRECTIVE.test(c.code)) {
+      skipped++;
+      continue;
+    }
+    if (c.kind === 'valid') {
+      const tc = { code: c.code };
+      carryCaseConfig(tc, c);
+      valid.push(tc);
+    } else {
+      const tc = {
+        code: c.code,
+        errors: c.expectedErrors.map((e) => buildExpectedError(e, suppress)),
+      };
+      carryCaseConfig(tc, c);
+      if (c.fixOutput != null) tc.output = c.fixOutput;
+      // The oracle captures the multi-pass fixpoint (verifyAndFix). RuleTester applies a single
+      // fix pass by default, so honor a per-case `recursive` to reproduce convergent fixers.
+      if (c.recursive != null) tc.recursive = c.recursive;
+      invalid.push(tc);
+    }
+  }
+  return { valid, invalid, skipped };
+}
+
+/**
+ * Run a corpus against a ported rule. Throws (via RuleTester) on the first mismatch.
+ * Returns counts on success.
+ */
+export function runRuleParity({
+  RuleTester,
+  rule,
+  ruleName,
+  corpus,
+  ledgerEntry,
+  eslintCompat = true,
+}) {
+  // Make RuleTester execute synchronously instead of registering nested test-runner hooks,
+  // so a single outer test owns the assertion and a failure surfaces as a thrown AssertionError.
+  RuleTester.describe = (_name, fn) => fn();
+  RuleTester.it = (_name, fn) => fn();
+  RuleTester.itOnly = (_name, fn) => fn();
+
+  const { valid, invalid, skipped } = buildTestCases(corpus, ledgerEntry);
+  const tester = new RuleTester({ eslintCompat });
+  tester.run(ruleName, rule, { valid, invalid });
+  return { valid: valid.length, invalid: invalid.length, skipped };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
       'upstream/**',
       'npm/**/native.js',
       'npm/**/native.d.ts',
+      // Machine-generated parity ground truth; must stay byte-stable for the drift gate.
+      'tools/parity/corpora/**',
+      '.playwright-mcp/**',
     ],
     singleQuote: true,
     semi: true,
@@ -53,6 +56,8 @@ export default defineConfig({
       'upstream/**',
       'npm/**/native.js',
       'npm/**/native.d.ts',
+      'tools/parity/corpora/**',
+      '.playwright-mcp/**',
     ],
     options: {
       typeAware: true,
@@ -60,7 +65,13 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['npm/**/*.test.ts', 'npm/**/*.test.mjs', 'test/**/*.test.mjs', 'tools/**/*.test.ts'],
+    include: [
+      'npm/**/*.test.ts',
+      'npm/**/*.test.mjs',
+      'test/**/*.test.mjs',
+      'tools/**/*.test.ts',
+      'tools/**/*.test.mjs',
+    ],
     setupFiles: ['test/setup.mjs'],
     testTimeout: 120_000,
   },


### PR DESCRIPTION
## What

Adds an **upstream parity testing harness** that guarantees ported oxlint rules behave identically to the upstream ESLint plugins they replace, plus the first two real ports built on it.

The approach: capture each upstream plugin's own test suite, run the **real upstream rule** as an oracle to materialize ground truth, freeze it into a committed JSON corpus, and **replay** it against the port through oxlint's `RuleTester`. Design rationale lives in `docs/guides/parity-testing.md`.

## Harness (`tools/parity`)

- **Capture** — monkeypatch `RuleTester.run` to harvest fully-resolved cases (after semver gates / spreads / builders run), then run the real rule via ESLint `Linter` to fill in messageId / location / fix / suggestions. Self-validates against the upstream's own assertion before freezing; aborts rather than commit unverified ground truth. Deterministic output (no timestamps).
- **Two loaders, shared `core.cjs`** — `run.cjs` for `require()`-loadable CJS upstreams; a vitest-hosted path for ESM / transform-required ones (`simple-import-sort`, and the `@typescript-eslint/rule-tester` family).
- **Replay** — drives the port through `oxlint/plugins-dev` `RuleTester`, asserting message + location + applied `fixOutput` (with `recursive` multi-pass), honoring a reviewed **known-divergences ledger**.
- **Drift gate** — `check-drift.mjs` + `.github/workflows/parity.yml` regenerate corpora from the pinned submodules and fail on drift. Kept as a separate job (needs submodules) so `verify` stays hermetic.

## Ports

| Plugin / rule | Result |
| --- | --- |
| `eslint-comments/no-unlimited-disable` (pure JS) | green; start-column divergence ledgered |
| `simple-import-sort` `imports` + `exports` | faithful 1.2k-line port, **byte-exact autofix parity on all 108 replayable cases** |

`simple-import-sort` was reused largely as-is because oxlint's `sourceCode`/token/comment API is ESLint-compatible. Two `eslint-disable`-directive valid cases are ledgered (oxlint's `RuleTester` does not apply inline disable directives).

## Validation

- 9 parity vitest tests green; corpora self-validated; drift gate green; `status:check`, `license`, `fmt`, and `lint` (port files) all pass.
- The harness is proven not false-green: removing a ledger entry or breaking a port turns the suite red.

## Notes

- Capture-only dev deps added (`eslint`, parsers, `@typescript-eslint/rule-tester`) with audited entries in `tools/license-exceptions.json`; never bundled into published packages.
- Real `storybook`/`functional` corpora are deferred (their rules import heavy upstream runtimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVyyGEK4mB6rFJvWFsExmq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785222410&installation_id=136613492&pr_number=585&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F585&signature=b252ccaacd9a6a2092d903b67c613e4e89a1f011dc1988699989cdcbdc65f284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->