### PR TITLE
feat(playground): support eslint-comments in the browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,10 +1280,14 @@ dependencies = [
 name = "oxlint-plugins-playground-wasm"
 version = "0.0.0"
 dependencies = [
+ "oxc_allocator",
+ "oxc_parser",
+ "oxc_span",
  "oxlint-plugins-_carton",
  "oxlint-plugins-angular-eslint",
  "oxlint-plugins-cypress",
  "oxlint-plugins-e18e",
+ "oxlint-plugins-eslint-comments",
  "oxlint-plugins-eslint-json",
  "oxlint-plugins-eslint-markdown",
  "oxlint-plugins-functional",

--- a/README.md
+++ b/README.md
@@ -302,5 +302,5 @@ pnpm --filter @oxlint-plugins/playground build
 module compiled with `wasm-pack`. It is excluded from the recursive workspace
 build, so `vp build` does not require the wasm toolchain; it is built and
 deployed to GitHub Pages by `.github/workflows/deploy-playground.yml`. See
-`playground/README.md` for details, including the two plugins it cannot run
-(`postgresql` and `eslint-comments`).
+`playground/README.md` for details, including the one plugin it cannot run
+(`postgresql`, whose native `libpg_query` C parser has no `wasm32` build).

--- a/crates/playground_wasm/Cargo.toml
+++ b/crates/playground_wasm/Cargo.toml
@@ -21,10 +21,14 @@ name = "oxlint_plugins_playground_wasm"
 wasm-opt = false
 
 [dependencies]
+oxc_allocator.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
 oxlint-plugins-angular-eslint.workspace = true
 oxlint-plugins-carton.workspace = true
 oxlint-plugins-cypress.workspace = true
 oxlint-plugins-e18e.workspace = true
+oxlint-plugins-eslint-comments.workspace = true
 oxlint-plugins-eslint-json.workspace = true
 oxlint-plugins-eslint-markdown.workspace = true
 oxlint-plugins-functional.workspace = true

--- a/crates/playground_wasm/src/plugins.rs
+++ b/crates/playground_wasm/src/plugins.rs
@@ -23,6 +23,7 @@ pub(super) fn push(
 mod angular_eslint;
 mod cypress;
 mod e18e;
+mod eslint_comments;
 mod eslint_json;
 mod eslint_markdown;
 mod functional;
@@ -180,6 +181,14 @@ const REGISTRY: &[(&str, Language, InfoFn, ScanFn)] = &[
         Language::JavaScript,
         unused_imports::info,
         unused_imports::scan,
+    ),
+    // eslint-comments runs last so its `no-unused-disable` rule can treat the
+    // other plugins' diagnostics as the file's lint problems.
+    (
+        eslint_comments::PLUGIN,
+        Language::JavaScript,
+        eslint_comments::info,
+        eslint_comments::scan,
     ),
 ];
 

--- a/crates/playground_wasm/src/plugins/eslint_comments.rs
+++ b/crates/playground_wasm/src/plugins/eslint_comments.rs
@@ -1,0 +1,276 @@
+//! Adapter for the `eslint-comments` plugin (port of
+//! @eslint-community/eslint-plugin-eslint-comments).
+//!
+//! The core works on the file's comments (and, for `no-unused-disable`, the
+//! other rules' problems) rather than on source text, so this adapter parses
+//! with oxc to recover the comment list and first-token position the npm
+//! wrapper normally gets from `sourceCode`.
+
+use std::collections::BTreeMap;
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use oxlint_plugins_eslint_comments::directive::CommentKind;
+use oxlint_plugins_eslint_comments::{
+    Comment, Diagnostic as CoreDiagnostic, Location, Position, Problem, disable_enable_pair,
+    no_aggregating_enable, no_duplicate_disable, no_restricted_disable, no_unlimited_disable,
+    no_unused_disable, no_unused_enable, no_use, require_description,
+};
+
+use super::EnabledFilter;
+use crate::{PlaygroundDiagnostic, PluginInfo};
+
+pub const PLUGIN: &str = "eslint-comments";
+
+// The core crate exposes no rule-name accessor; mirror the names registered in
+// `npm/eslint-comments/index.js`.
+const RULE_NAMES: [&str; 9] = [
+    "disable-enable-pair",
+    "no-aggregating-enable",
+    "no-duplicate-disable",
+    "no-restricted-disable",
+    "no-unlimited-disable",
+    "no-unused-disable",
+    "no-unused-enable",
+    "no-use",
+    "require-description",
+];
+
+pub fn info() -> PluginInfo {
+    PluginInfo {
+        plugin: PLUGIN,
+        rules: RULE_NAMES.iter().map(|name| (*name).to_owned()).collect(),
+    }
+}
+
+pub fn scan(
+    source_text: &str,
+    filename: &str,
+    filter: &EnabledFilter,
+    out: &mut Vec<PlaygroundDiagnostic>,
+) {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename).unwrap_or_default();
+    let parsed = Parser::new(&allocator, source_text, source_type).parse();
+
+    let line_index = LineIndex::new(source_text);
+    let comments: Vec<Comment> = parsed
+        .program
+        .comments
+        .iter()
+        .map(|comment| {
+            let content = comment.content_span();
+            let value = source_text
+                .get(content.start as usize..content.end as usize)
+                .unwrap_or("");
+            Comment {
+                kind: if comment.is_line() {
+                    CommentKind::Line
+                } else {
+                    CommentKind::Block
+                },
+                value,
+                loc: Location {
+                    start: line_index.position(source_text, comment.span.start),
+                    end: line_index.position(source_text, comment.span.end),
+                },
+            }
+        })
+        .collect();
+    if comments.is_empty() {
+        return;
+    }
+
+    let enabled = |rule: &str| filter.rule_enabled(PLUGIN, rule);
+    let mut results: Vec<PlaygroundDiagnostic> = Vec::new();
+
+    if enabled("no-unlimited-disable") {
+        collect(
+            &mut results,
+            "no-unlimited-disable",
+            no_unlimited_disable(&comments),
+        );
+    }
+    // No options UI: every option-bearing rule runs with upstream's defaults
+    // (empty allow/ignore/patterns, `allowWholeFile: false`).
+    if enabled("no-use") {
+        collect(&mut results, "no-use", no_use(&comments, &[]));
+    }
+    if enabled("require-description") {
+        collect(
+            &mut results,
+            "require-description",
+            require_description(&comments, &[]),
+        );
+    }
+    if enabled("no-aggregating-enable") {
+        collect(
+            &mut results,
+            "no-aggregating-enable",
+            no_aggregating_enable(&comments),
+        );
+    }
+    if enabled("no-duplicate-disable") {
+        collect(
+            &mut results,
+            "no-duplicate-disable",
+            no_duplicate_disable(&comments),
+        );
+    }
+    if enabled("no-unused-enable") {
+        collect(
+            &mut results,
+            "no-unused-enable",
+            no_unused_enable(&comments),
+        );
+    }
+    if enabled("no-restricted-disable") {
+        collect(
+            &mut results,
+            "no-restricted-disable",
+            no_restricted_disable(&comments, &[]),
+        );
+    }
+    if enabled("disable-enable-pair") {
+        let first_token = first_token_position(source_text, &parsed, &line_index);
+        collect(
+            &mut results,
+            "disable-enable-pair",
+            disable_enable_pair(&comments, false, first_token),
+        );
+    }
+    if enabled("no-unused-disable") {
+        // The playground's analog of `sourceCode.getDisableDirectives().problems`
+        // is every diagnostic the other enabled plugins already reported.
+        let rule_ids: Vec<String> = out
+            .iter()
+            .map(|diagnostic| {
+                let mut id =
+                    String::with_capacity(diagnostic.plugin.len() + 1 + diagnostic.rule.len());
+                id.push_str(diagnostic.plugin);
+                id.push('/');
+                id.push_str(&diagnostic.rule);
+                id
+            })
+            .collect();
+        let problems: Vec<Problem> = out
+            .iter()
+            .zip(&rule_ids)
+            .map(|(diagnostic, id)| Problem {
+                rule_id: Some(id.as_str()),
+                position: Position {
+                    line: diagnostic.start_line,
+                    column: diagnostic.start_column as i32,
+                },
+            })
+            .collect();
+        collect(
+            &mut results,
+            "no-unused-disable",
+            no_unused_disable(&comments, &problems),
+        );
+    }
+
+    out.append(&mut results);
+}
+
+/// Converts core diagnostics for `rule` into playground diagnostics.
+fn collect(
+    out: &mut Vec<PlaygroundDiagnostic>,
+    rule: &str,
+    diagnostics: impl IntoIterator<Item = CoreDiagnostic>,
+) {
+    for diagnostic in diagnostics {
+        let mut data: BTreeMap<&'static str, String> = BTreeMap::new();
+        if let Some(kind) = diagnostic.data.kind {
+            data.insert("kind", kind.as_str().to_owned());
+        }
+        if let Some(rule_id) = diagnostic.data.rule_id {
+            data.insert("ruleId", rule_id.as_str().to_owned());
+        }
+        if let Some(count) = diagnostic.data.count {
+            data.insert("count", count.to_string());
+        }
+        out.push(PlaygroundDiagnostic {
+            plugin: PLUGIN,
+            rule: rule.to_owned(),
+            message_id: diagnostic.message_id.as_str().to_owned(),
+            data,
+            start_line: diagnostic.loc.start.line,
+            start_column: column_to_u32(diagnostic.loc.start.column),
+            end_line: diagnostic.loc.end.line,
+            end_column: column_to_u32(diagnostic.loc.end.column),
+        });
+    }
+}
+
+/// Clamps the core's `i32` column (which uses `-1` as a "whole line" sentinel)
+/// to a non-negative value the editor can place.
+fn column_to_u32(column: i32) -> u32 {
+    column.max(0) as u32
+}
+
+/// The position of the first non-comment, non-whitespace token, mirroring
+/// `sourceCode.ast.tokens[0]`. `None` for a comment-only or empty file.
+fn first_token_position(
+    source_text: &str,
+    parsed: &oxc_parser::ParserReturn,
+    line_index: &LineIndex,
+) -> Option<Position> {
+    let bytes = source_text.as_bytes();
+    let len = bytes.len();
+    let mut offset = 0usize;
+    loop {
+        while offset < len && bytes[offset].is_ascii_whitespace() {
+            offset += 1;
+        }
+        if offset >= len {
+            return None;
+        }
+        if let Some(comment) = parsed.program.comments.iter().find(|comment| {
+            (comment.span.start as usize) <= offset && offset < comment.span.end as usize
+        }) {
+            offset = comment.span.end as usize;
+            continue;
+        }
+        return Some(line_index.position(source_text, offset as u32));
+    }
+}
+
+/// Byte-offset → 1-based line / 0-based UTF-16 column index, matching ESLint's
+/// comment locations.
+struct LineIndex {
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(source_text: &str) -> Self {
+        let mut line_starts = vec![0usize];
+        for (index, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn position(&self, source_text: &str, offset: u32) -> Position {
+        let offset = (offset as usize).min(source_text.len());
+        let line_index = self
+            .line_starts
+            .partition_point(|start| *start <= offset)
+            .saturating_sub(1);
+        let line_start = self.line_starts.get(line_index).copied().unwrap_or(0);
+        let column = source_text
+            .get(line_start..offset)
+            .unwrap_or("")
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        Position {
+            line: (line_index + 1) as u32,
+            column: column as i32,
+        }
+    }
+}

--- a/playground/README.md
+++ b/playground/README.md
@@ -38,10 +38,10 @@ The output in `dist/` is deployed to GitHub Pages by
 
 ## Coverage
 
-Every plugin whose rule logic compiles to WebAssembly is included. Two are not:
+Every plugin whose rule logic compiles to WebAssembly is included, including
+`eslint-comments` (the adapter recovers the comment list and first-token
+position from an oxc parse, and feeds the other plugins' diagnostics to
+`no-unused-disable` as the file's lint problems).
 
-- `postgresql` depends on the native `libpg_query` C library, which does not
-  compile to `wasm32`.
-- `eslint-comments` operates on comment tokens and disable-directive results
-  supplied by the full lint run rather than on source text, so several of its
-  rules cannot be reproduced standalone in the browser.
+One plugin is excluded: `postgresql` depends on the native `libpg_query` C
+library, which does not compile to `wasm32-unknown-unknown` (no libc/sysroot).

--- a/playground/src/catalog.json
+++ b/playground/src/catalog.json
@@ -764,6 +764,89 @@
       ]
     },
     {
+      "plugin": "eslint-comments",
+      "npm": "@oxlint-plugins/oxlint-plugin-eslint-comments",
+      "description": "Rust-backed oxlint plugin port of @eslint-community/eslint-plugin-eslint-comments.",
+      "rules": [
+        {
+          "name": "disable-enable-pair",
+          "description": "require a `eslint-enable` comment for every `eslint-disable` comment",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#disable-enable-pair",
+          "messages": {
+            "missingPair": "Requires 'eslint-enable' directive.",
+            "missingRulePair": "Requires 'eslint-enable' directive for '{{ruleId}}'."
+          }
+        },
+        {
+          "name": "no-aggregating-enable",
+          "description": "disallow a `eslint-enable` comment for multiple `eslint-disable` comments",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-aggregating-enable",
+          "messages": {
+            "aggregatingEnable": "This `eslint-enable` comment affects {{count}} `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment."
+          }
+        },
+        {
+          "name": "no-duplicate-disable",
+          "description": "disallow duplicate `eslint-disable` comments",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-duplicate-disable",
+          "messages": {
+            "duplicate": "ESLint rules have been disabled already.",
+            "duplicateRule": "'{{ruleId}}' rule has been disabled already."
+          }
+        },
+        {
+          "name": "no-restricted-disable",
+          "description": "disallow `eslint-disable` comments about specific rules",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-restricted-disable",
+          "messages": {
+            "disallow": "Disabling '{{ruleId}}' is not allowed."
+          }
+        },
+        {
+          "name": "no-unlimited-disable",
+          "description": "disallow `eslint-disable` comments without rule names",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-unlimited-disable",
+          "messages": {
+            "unexpected": "Unexpected unlimited '{{kind}}' comment. Specify some rule names to disable."
+          }
+        },
+        {
+          "name": "no-unused-disable",
+          "description": "disallow unused `eslint-disable` comments",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-unused-disable",
+          "messages": {
+            "unused": "Unused eslint-disable directive (no problems were reported).",
+            "unusedRule": "Unused eslint-disable directive (no problems were reported from '{{ruleId}}')."
+          }
+        },
+        {
+          "name": "no-unused-enable",
+          "description": "disallow unused `eslint-enable` comments",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-unused-enable",
+          "messages": {
+            "unused": "ESLint rules are re-enabled but those have not been disabled.",
+            "unusedRule": "'{{ruleId}}' rule is re-enabled but it has not been disabled."
+          }
+        },
+        {
+          "name": "no-use",
+          "description": "disallow ESLint directive-comments",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#no-use",
+          "messages": {
+            "disallow": "Unexpected ESLint directive comment."
+          }
+        },
+        {
+          "name": "require-description",
+          "description": "require include descriptions in ESLint directive-comments",
+          "docsUrl": "https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/eslint-comments#require-description",
+          "messages": {
+            "missingDescription": "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary."
+          }
+        }
+      ]
+    },
+    {
       "plugin": "functional",
       "npm": "@oxlint-plugins/oxlint-plugin-functional",
       "description": "Rust-backed Oxlint plugin port of eslint-plugin-functional.",

--- a/playground/src/samples.ts
+++ b/playground/src/samples.ts
@@ -50,4 +50,14 @@ export function Counter() {
 }
 `,
   },
+  {
+    label: 'ESLint comments',
+    filename: 'directives.js',
+    code: `/* eslint-disable */
+const cp = require('child_process');
+
+// eslint-disable-next-line security/detect-child-process
+cp.exec(userInput);
+`,
+  },
 ];


### PR DESCRIPTION
## What

Adds the `eslint-comments` plugin to the browser playground (all **9 rules**), so the playground now runs **19 plugins / 710 rules**.

## How

`eslint-comments`' core operates on the file's *comments* — and, for `no-unused-disable`, on the other rules' *problems* — rather than on source text (the npm wrapper feeds it `sourceCode.getAllComments()`, the first token, and `getDisableDirectives().problems`). The new adapter (`crates/playground_wasm/src/plugins/eslint_comments.rs`):

- parses the source with **oxc** to recover the comment list (kind/value/loc via a UTF-16 line index) and the first-token position;
- maps them to the core's `Comment`/`Position` inputs and runs each rule with upstream's default options;
- feeds the **other enabled plugins' diagnostics** to `no-unused-disable` as the file's lint problems, so an `eslint-disable` directive that actually suppresses something is correctly treated as *used*.

Verified end-to-end in a browser: e.g. `// eslint-disable-next-line security/detect-child-process` over `cp.exec(...)` is reported as used, while a directive with no matching problem is flagged unused. Rendered messages + data interpolation match the published plugin.

## Still excluded

`postgresql` — its `libpg_query` C parser does not compile to `wasm32-unknown-unknown` (no libc/sysroot). Supporting it would need a different approach (Emscripten `libpg-query` WASM in the browser + feature-gating `pg_query` out of the core); tracked separately.

## Checks

`cargo fmt --check`, `cargo clippy -p oxlint-plugins-playground-wasm -D warnings`, `vp fmt --check`, `vp lint`, `tsgo`, and the playground build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785222574&installation_id=136613492&pr_number=586&repository=ubugeeei-prod%2Foxlint-plugins&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Foxlint-plugins%2Fpull%2F586&signature=09fb5291a49b8f2f4356e28e2722fc16734347cf31ac9c31850a7510e37eb8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->