### PR TITLE
fix(stylistic): detect root JSX after logical operators and export default

### DIFF
--- a/crates/stylistic/src/native_stylistic/jsx_rules.rs
+++ b/crates/stylistic/src/native_stylistic/jsx_rules.rs
@@ -502,6 +502,24 @@ mod tests {
     }
 
     #[test]
+    fn checks_root_jsx_after_conditional_operators_and_export_default() {
+        for source in [
+            "const x = ready && <App foo = \"bar\" />;",
+            "const x = fallback || <App foo = \"bar\" />;",
+            "const x = maybe ?? <App foo = \"bar\" />;",
+            "const x = !<App foo = \"bar\" />;",
+            "export default <App foo = \"bar\" />;",
+            "const x = await <App foo = \"bar\" />;",
+        ] {
+            assert_eq!(
+                ids(&run(source, None)),
+                ["noSpaceBefore", "noSpaceAfter"],
+                "missed root JSX in {source}"
+            );
+        }
+    }
+
+    #[test]
     fn ignores_non_jsx_assignments_comparisons_and_typescript_generics() {
         for source in [
             "const value = other;",


### PR DESCRIPTION
Follow-up to #617 (already merged) addressing review feedback on `jsx-equals-spacing`.

`can_start_jsx_root` gates every depth-0 opening tag by looking at the preceding significant token, but the allowed-prefix set omitted the most common conditional-render idioms and `export default`. As a result `const x = ready && <App foo = "bar" />;` and `export default <App foo = "bar" />;` produced no diagnostics, while the equivalent nested markup did.

```rust
if token.kind == TokenKind::Identifier {
    return matches!(
        scan.token_text(previous),
        "return" | "yield" | "case" | "default" | "await"
    );
}
token.kind == TokenKind::Punctuator
    && matches!(
        scan.token_text(previous),
        "=" | "=>" | "(" | "[" | "{" | "," | ":" | ";" | "?" | ">" | "&&" | "||" | "??" | "!"
    )
```

I deliberately left out `typeof`, `void`, `in`, and `of` from the reviewer's suggestion: they are not realistic JSX prefixes, and `in`/`of` are legal identifiers, so allowing them widens the false-positive surface for ordinary comparisons without buying any real coverage.

A new `checks_root_jsx_after_conditional_operators_and_export_default` test covers `&&`, `||`, `??`, `!`, `await`, and `export default` roots; the existing false-positive suite still passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->