### PR TITLE
feat(stylistic): port jsx-closing-bracket-location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is unofficial community work. It is not an official Oxlint project, and bui
 
 <!-- This section is generated from `status.json` by `tools/tasks/generate-readme-coverage.ts`. Do not edit by hand; run `pnpm run docs:readme`. -->
 
-**25** ESLint plugins are being ported · **791 / 981** rules implemented (**81%**).
+**25** ESLint plugins are being ported · **792 / 981** rules implemented (**81%**).
 
 | Plugin                                                     | Upstream                                                                                                               | Implemented | Total | Coverage |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- | ----- | -------- |
@@ -29,7 +29,7 @@ This is unofficial community work. It is not an official Oxlint project, and bui
 | [`perfectionist`](npm/perfectionist)                       | [`eslint-plugin-perfectionist`](https://github.com/azat-io/eslint-plugin-perfectionist)                                | 23          | 23    | 100%     |
 | [`playwright`](npm/playwright)                             | [`eslint-plugin-playwright`](https://github.com/mskelton/eslint-plugin-playwright)                                     | 58          | 58    | 100%     |
 | [`postgresql`](npm/postgresql)                             | [`eslint-plugin-postgresql`](https://github.com/baseballyama/eslint-plugin-postgresql)                                 | 89          | 89    | 100%     |
-| [`react`](npm/react)                                       | [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react)                                             | 0           | 46    | 0%       |
+| [`react`](npm/react)                                       | [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react)                                             | 1           | 46    | 2%       |
 | [`react-hooks`](npm/react-hooks)                           | [`eslint-plugin-react-hooks`](https://github.com/facebook/react)                                                       | 0           | 27    | 0%       |
 | [`regexp`](npm/regexp)                                     | [`eslint-plugin-regexp`](https://github.com/ota-meshi/eslint-plugin-regexp)                                            | 82          | 82    | 100%     |
 | [`security`](npm/security)                                 | [`eslint-plugin-security`](https://github.com/eslint-community/eslint-plugin-security)                                 | 14          | 14    | 100%     |
@@ -123,9 +123,11 @@ This is unofficial community work. It is not an official Oxlint project, and bui
 
 </details>
 <details>
-<summary><code>react</code> — 0/46 implemented</summary>
+<summary><code>react</code> — 1/46 implemented</summary>
 
-**Not implemented (46):** `boolean-prop-naming`, `default-props-match-prop-types`, `destructuring-assignment`, `forbid-foreign-prop-types`, `forbid-prop-types`, `function-component-definition`, `jsx-child-element-spacing`, `jsx-closing-bracket-location`, `jsx-closing-tag-location`, `jsx-curly-newline`, `jsx-curly-spacing`, `jsx-equals-spacing`, `jsx-first-prop-new-line`, `jsx-indent`, `jsx-indent-props`, `jsx-max-props-per-line`, `jsx-newline`, `jsx-no-bind`, `jsx-no-leaked-render`, `jsx-no-literals`, `jsx-one-expression-per-line`, `jsx-props-no-multi-spaces`, `jsx-sort-default-props`, `jsx-sort-props`, `jsx-space-before-closing`, `jsx-tag-spacing`, `jsx-uses-react`, `jsx-uses-vars`, `jsx-wrap-multilines`, `no-access-state-in-setstate`, `no-adjacent-inline-elements`, `no-arrow-function-lifecycle`, `no-invalid-html-attribute`, `no-unused-class-component-methods`, `no-unused-prop-types`, `no-unused-state`, `prefer-exact-props`, `prefer-read-only-props`, `prefer-stateless-function`, `prop-types`, `require-default-props`, `require-optimization`, `sort-comp`, `sort-default-props`, `sort-prop-types`, `static-property-placement`
+**Implemented (1):** `jsx-closing-bracket-location`
+
+**Not implemented (45):** `boolean-prop-naming`, `default-props-match-prop-types`, `destructuring-assignment`, `forbid-foreign-prop-types`, `forbid-prop-types`, `function-component-definition`, `jsx-child-element-spacing`, `jsx-closing-tag-location`, `jsx-curly-newline`, `jsx-curly-spacing`, `jsx-equals-spacing`, `jsx-first-prop-new-line`, `jsx-indent`, `jsx-indent-props`, `jsx-max-props-per-line`, `jsx-newline`, `jsx-no-bind`, `jsx-no-leaked-render`, `jsx-no-literals`, `jsx-one-expression-per-line`, `jsx-props-no-multi-spaces`, `jsx-sort-default-props`, `jsx-sort-props`, `jsx-space-before-closing`, `jsx-tag-spacing`, `jsx-uses-react`, `jsx-uses-vars`, `jsx-wrap-multilines`, `no-access-state-in-setstate`, `no-adjacent-inline-elements`, `no-arrow-function-lifecycle`, `no-invalid-html-attribute`, `no-unused-class-component-methods`, `no-unused-prop-types`, `no-unused-state`, `prefer-exact-props`, `prefer-read-only-props`, `prefer-stateless-function`, `prop-types`, `require-default-props`, `require-optimization`, `sort-comp`, `sort-default-props`, `sort-prop-types`, `static-property-placement`
 
 </details>
 <details>

--- a/crates/stylistic/src/native_stylistic.rs
+++ b/crates/stylistic/src/native_stylistic.rs
@@ -18,6 +18,7 @@ mod function_paren_newline;
 mod helpers;
 mod indent_binary_ops;
 mod jsx_child_element_spacing;
+mod jsx_closing_bracket_location;
 mod jsx_quotes;
 mod jsx_rules;
 mod lexer;
@@ -573,6 +574,10 @@ const JSX_EQUALS_SPACING_MESSAGES: &[(&str, &str)] = &[
     ("insertSpace", "Insert a space."),
     ("removeSpace", "Remove the whitespace."),
 ];
+const JSX_CLOSING_BRACKET_LOCATION_MESSAGES: &[(&str, &str)] = &[(
+    "bracketLocation",
+    "The closing bracket must be {{location}}{{details}}",
+)];
 const LINE_COMMENT_POSITION_MESSAGES: &[(&str, &str)] = &[
     ("above", "Expected comment to be above code."),
     ("beside", "Expected comment to be beside code."),
@@ -1032,6 +1037,11 @@ const STYLISTIC_RULES: &[StylisticRuleDefinition] = &[
         messages: JSX_EQUALS_SPACING_MESSAGES,
     },
     StylisticRuleDefinition {
+        name: "jsx-closing-bracket-location",
+        docs_description: "Enforce closing bracket location in JSX",
+        messages: JSX_CLOSING_BRACKET_LOCATION_MESSAGES,
+    },
+    StylisticRuleDefinition {
         name: "jsx-quotes",
         docs_description: "Enforce the consistent use of either double or single quotes in JSX attributes.",
         messages: JSX_QUOTES_MESSAGES,
@@ -1228,6 +1238,14 @@ pub fn run_stylistic_lint(
             }
             "jsx-child-element-spacing" => {
                 jsx_child_element_spacing::check_jsx_child_element_spacing(
+                    source_text,
+                    config.filename.as_deref(),
+                    &rule.options,
+                    &mut diagnostics,
+                )
+            }
+            "jsx-closing-bracket-location" => {
+                jsx_closing_bracket_location::check_jsx_closing_bracket_location(
                     source_text,
                     config.filename.as_deref(),
                     &rule.options,

--- a/crates/stylistic/src/native_stylistic/jsx_closing_bracket_location.rs
+++ b/crates/stylistic/src/native_stylistic/jsx_closing_bracket_location.rs
@@ -1,0 +1,774 @@
+//! Native implementation of stable `@stylistic/jsx-closing-bracket-location`.
+//!
+//! Oxc supplies exact JSX opening-element and attribute boundaries. A small
+//! UTF-16-aware line map reproduces ESLint columns, including tabs, while
+//! a trailing-gap comment scan preserves upstream's fallback and fixes.
+
+use std::{collections::BTreeMap, fmt::Write};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::JSXOpeningElement;
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+use oxlint_plugins_carton::SmallVec;
+use serde_json::Value;
+
+use crate::{LintDiagnostic, LintFix, LintSuggestion, TextRange};
+
+const RULE: &str = "jsx-closing-bracket-location";
+const MESSAGE_ID: &str = "bracketLocation";
+
+fn joined(prefix: &str, suffix: &str) -> String {
+    let mut value = String::with_capacity(prefix.len() + suffix.len());
+    value.push_str(prefix);
+    value.push_str(suffix);
+    value
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Location {
+    AfterProps,
+    AfterTag,
+    PropsAligned,
+    TagAligned,
+    LineAligned,
+    Ignore,
+}
+
+impl Location {
+    fn from_value(value: &Value) -> Option<Self> {
+        if value == &Value::Bool(false) {
+            return Some(Self::Ignore);
+        }
+        match value.as_str()? {
+            "after-props" => Some(Self::AfterProps),
+            "props-aligned" => Some(Self::PropsAligned),
+            "tag-aligned" => Some(Self::TagAligned),
+            "line-aligned" => Some(Self::LineAligned),
+            _ => None,
+        }
+    }
+
+    const fn description(self) -> &'static str {
+        match self {
+            Self::AfterProps => "placed after the last prop",
+            Self::AfterTag => "placed after the opening tag",
+            Self::PropsAligned => "aligned with the last prop",
+            Self::TagAligned => "aligned with the opening tag",
+            Self::LineAligned => "aligned with the line containing the opening tag",
+            Self::Ignore => "",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Options {
+    non_empty: Location,
+    self_closing: Location,
+}
+
+impl Options {
+    fn from_json(options: &Value) -> Self {
+        let config = match options {
+            Value::Array(items) => items.first(),
+            Value::Null => None,
+            value => Some(value),
+        };
+        if let Some(location) = config.and_then(Location::from_value) {
+            return Self {
+                non_empty: location,
+                self_closing: location,
+            };
+        }
+        let object = config.and_then(Value::as_object);
+        if let Some(location) = object
+            .and_then(|object| object.get("location"))
+            .and_then(Location::from_value)
+        {
+            return Self {
+                non_empty: location,
+                self_closing: location,
+            };
+        }
+        Self {
+            non_empty: object
+                .and_then(|object| object.get("nonEmpty"))
+                .and_then(Location::from_value)
+                .unwrap_or(Location::TagAligned),
+            self_closing: object
+                .and_then(|object| object.get("selfClosing"))
+                .and_then(Location::from_value)
+                .unwrap_or(Location::TagAligned),
+        }
+    }
+}
+
+pub(crate) fn check_jsx_closing_bracket_location(
+    source: &str,
+    filename: Option<&str>,
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    if let Some(source_type) = filename.and_then(|path| SourceType::from_path(path).ok()) {
+        let _ = parse_and_check(source, source_type, options, diagnostics);
+    } else {
+        for source_type in [
+            SourceType::tsx(),
+            SourceType::jsx().with_unambiguous(true),
+            SourceType::jsx().with_script(true),
+        ] {
+            if parse_and_check(source, source_type, options, diagnostics) {
+                break;
+            }
+        }
+    }
+}
+
+fn parse_and_check(
+    source: &str,
+    source_type: SourceType,
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) -> bool {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if !parsed.errors.is_empty() {
+        return false;
+    }
+    let mut visitor = ClosingBracketVisitor {
+        source,
+        lines: LineMap::new(source),
+        options: Options::from_json(options),
+        diagnostics,
+    };
+    visitor.visit_program(&parsed.program);
+    true
+}
+
+struct ClosingBracketVisitor<'source, 'diagnostics> {
+    source: &'source str,
+    lines: LineMap<'source>,
+    options: Options,
+    diagnostics: &'diagnostics mut Vec<LintDiagnostic>,
+}
+
+impl<'ast> Visit<'ast> for ClosingBracketVisitor<'_, '_> {
+    fn visit_jsx_opening_element(&mut self, element: &JSXOpeningElement<'ast>) {
+        // Upstream listens on `JSXOpeningElement:exit`; preserve nested report
+        // order by walking children before checking the current opening tag.
+        walk::walk_jsx_opening_element(self, element);
+        self.check(element);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TokenLocations {
+    opening: Position,
+    opening_start_column: usize,
+    tag: Position,
+    closing: Position,
+    last_prop: Option<PropLocation>,
+    self_closing: bool,
+}
+
+#[derive(Clone, Copy)]
+struct PropLocation {
+    span: Span,
+    column: usize,
+    first_line: usize,
+    last_line: usize,
+}
+
+#[derive(Clone, Copy)]
+struct Position {
+    offset: usize,
+    line: usize,
+    column: usize,
+}
+
+impl ClosingBracketVisitor<'_, '_> {
+    fn check(&mut self, element: &JSXOpeningElement<'_>) {
+        let Some(tokens) = self.locations(element) else {
+            return;
+        };
+        let mut expected = self.expected_location(tokens);
+        let same_tab_indentation = expected != Location::TagAligned
+            || self.lines.starts_with_tab(tokens.opening.line)
+                == self.lines.starts_with_tab(tokens.closing.line);
+        let last_boundary = tokens
+            .last_prop
+            .map_or_else(|| element.name.span().end, |prop| prop.span.end);
+        let trailing_comment = usize::try_from(last_boundary)
+            .ok()
+            .and_then(|boundary| self.last_trailing_comment(boundary, tokens.closing.offset));
+        let has_trailing_comment = trailing_comment.is_some();
+
+        if matches!(expected, Location::AfterProps | Location::AfterTag)
+            && !(self.has_correct_location(tokens, expected) && same_tab_indentation)
+            && has_trailing_comment
+        {
+            expected = Location::LineAligned;
+        }
+        if self.has_correct_location(tokens, expected) && same_tab_indentation {
+            return;
+        }
+
+        let correct_column = self.correct_column(tokens, expected);
+        let expected_next_line = correct_column.is_some()
+            && tokens
+                .last_prop
+                .is_some_and(|prop| prop.last_line == tokens.closing.line);
+        let details = correct_column.map_or_else(String::new, |column| {
+            let mut details = String::from(" (expected column ");
+            let _ = write!(details, "{}", column + 1);
+            if expected_next_line {
+                details.push_str(" on the next line");
+            }
+            details.push(')');
+            details
+        });
+        let location = expected.description();
+        let mut message = String::from("The closing bracket must be ");
+        message.push_str(location);
+        message.push_str(&details);
+        let Some(fix) = self.make_fix(
+            element,
+            tokens,
+            expected,
+            correct_column,
+            expected_next_line,
+            trailing_comment,
+        ) else {
+            return;
+        };
+        let Ok(range_start) = u32::try_from(tokens.closing.offset) else {
+            return;
+        };
+        let Some(range_end) = range_start.checked_add(1) else {
+            return;
+        };
+        let range = TextRange::new(range_start, range_end);
+        let data = BTreeMap::from([
+            ("details".to_owned(), details),
+            ("location".to_owned(), location.to_owned()),
+        ]);
+        self.diagnostics.push(LintDiagnostic {
+            rule_name: RULE.to_owned(),
+            message_id: MESSAGE_ID.to_owned(),
+            message: message.clone(),
+            data,
+            range,
+            suggestions: std::iter::once(LintSuggestion {
+                message_id: MESSAGE_ID.to_owned(),
+                message,
+                fixes: std::iter::once(fix).collect(),
+            })
+            .collect(),
+        });
+    }
+
+    fn locations(&self, element: &JSXOpeningElement<'_>) -> Option<TokenLocations> {
+        let start = usize::try_from(element.span.start).ok()?;
+        let end = usize::try_from(element.span.end).ok()?;
+        let code = self.source.get(start..end)?;
+        let self_closing = code.ends_with("/>");
+        let closing_offset = end.checked_sub(if self_closing { 2 } else { 1 })?;
+        let name_start = usize::try_from(element.name.span().start).ok()?;
+        let opening = self.lines.position(start)?;
+        let last_prop = element.attributes.last().and_then(|attribute| {
+            let span = attribute.span();
+            let start = usize::try_from(span.start).ok()?;
+            let end = usize::try_from(span.end).ok()?;
+            let first = self.lines.position(start)?;
+            let last = self.lines.position(end)?;
+            Some(PropLocation {
+                span,
+                column: first.column,
+                first_line: first.line,
+                last_line: last.line,
+            })
+        });
+        Some(TokenLocations {
+            opening,
+            opening_start_column: self.lines.leading_column(opening.line),
+            tag: self.lines.position(name_start)?,
+            closing: self.lines.position(closing_offset)?,
+            last_prop,
+            self_closing,
+        })
+    }
+
+    fn expected_location(&self, tokens: TokenLocations) -> Location {
+        let Some(last_prop) = tokens.last_prop else {
+            return Location::AfterTag;
+        };
+        if tokens.opening.line == last_prop.last_line {
+            return Location::AfterProps;
+        }
+        if tokens.self_closing {
+            self.options.self_closing
+        } else {
+            self.options.non_empty
+        }
+    }
+
+    fn has_correct_location(&self, tokens: TokenLocations, expected: Location) -> bool {
+        match expected {
+            Location::AfterTag => tokens.tag.line == tokens.closing.line,
+            Location::AfterProps => tokens
+                .last_prop
+                .is_some_and(|prop| prop.last_line == tokens.closing.line),
+            Location::PropsAligned | Location::TagAligned | Location::LineAligned => self
+                .correct_column(tokens, expected)
+                .is_some_and(|column| column == tokens.closing.column),
+            Location::Ignore => true,
+        }
+    }
+
+    fn correct_column(&self, tokens: TokenLocations, expected: Location) -> Option<usize> {
+        match expected {
+            Location::PropsAligned => tokens.last_prop.map(|prop| prop.column),
+            Location::TagAligned => Some(tokens.opening.column),
+            Location::LineAligned => Some(tokens.opening_start_column),
+            Location::AfterProps | Location::AfterTag | Location::Ignore => None,
+        }
+    }
+
+    fn make_fix(
+        &self,
+        element: &JSXOpeningElement<'_>,
+        tokens: TokenLocations,
+        expected: Location,
+        correct_column: Option<usize>,
+        expected_next_line: bool,
+        trailing_comment: Option<Span>,
+    ) -> Option<LintFix> {
+        let closing_tag = if tokens.self_closing { "/>" } else { ">" };
+        let end = element.span.end;
+        let (start, replacement) = match expected {
+            Location::AfterTag => {
+                let start = tokens
+                    .last_prop
+                    .map_or_else(|| element.name.span().end, |prop| prop.span.end);
+                let prefix = if expected_next_line { "\n" } else { " " };
+                (start, joined(prefix, closing_tag))
+            }
+            Location::AfterProps => (
+                tokens.last_prop?.span.end,
+                joined(if expected_next_line { "\n" } else { "" }, closing_tag),
+            ),
+            Location::PropsAligned | Location::TagAligned | Location::LineAligned => {
+                let start = if let Some(comment) = trailing_comment {
+                    comment.end
+                } else {
+                    tokens.last_prop?.span.end
+                };
+                let indentation =
+                    self.indentation(tokens, expected, correct_column.unwrap_or_default());
+                let mut replacement =
+                    String::with_capacity(1 + indentation.len() + closing_tag.len());
+                replacement.push('\n');
+                replacement.push_str(&indentation);
+                replacement.push_str(closing_tag);
+                (start, replacement)
+            }
+            Location::Ignore => return None,
+        };
+        Some(LintFix::replace_range(
+            TextRange::new(start, end),
+            replacement,
+        ))
+    }
+
+    fn last_trailing_comment(&self, start: usize, end: usize) -> Option<Span> {
+        let mut cursor = start;
+        let mut last = None;
+        while cursor < end {
+            let rest = self.source.get(cursor..end)?;
+            if rest.starts_with("//") {
+                let length = rest
+                    .find(['\r', '\n', '\u{2028}', '\u{2029}'])
+                    .unwrap_or(rest.len());
+                let comment_end = cursor.checked_add(length)?;
+                last = Some(Span::new(
+                    u32::try_from(cursor).ok()?,
+                    u32::try_from(comment_end).ok()?,
+                ));
+                cursor = comment_end;
+                continue;
+            }
+            if rest.starts_with("/*") {
+                let close = rest.find("*/")?;
+                let comment_end = cursor.checked_add(close)?.checked_add(2)?;
+                last = Some(Span::new(
+                    u32::try_from(cursor).ok()?,
+                    u32::try_from(comment_end).ok()?,
+                ));
+                cursor = comment_end;
+                continue;
+            }
+            let character = rest.chars().next()?;
+            cursor = cursor.checked_add(character.len_utf8())?;
+        }
+        last
+    }
+
+    fn indentation(
+        &self,
+        tokens: TokenLocations,
+        expected: Location,
+        correct_column: usize,
+    ) -> String {
+        let line = match expected {
+            Location::PropsAligned => tokens
+                .last_prop
+                .map_or(tokens.opening.line, |prop| prop.first_line),
+            Location::TagAligned | Location::LineAligned => tokens.opening.line,
+            Location::AfterProps | Location::AfterTag | Location::Ignore => {
+                return String::new();
+            }
+        };
+        let mut indentation = self.lines.leading_text(line).to_owned();
+        let indentation_column = indentation.encode_utf16().count();
+        if correct_column > indentation_column {
+            indentation.extend(std::iter::repeat_n(
+                ' ',
+                correct_column - indentation_column,
+            ));
+        }
+        indentation
+    }
+}
+
+struct LineMap<'source> {
+    source: &'source str,
+    starts: SmallVec<[usize; 64]>,
+    ends: SmallVec<[usize; 64]>,
+}
+
+impl<'source> LineMap<'source> {
+    fn new(source: &'source str) -> Self {
+        let mut starts = SmallVec::new();
+        starts.push(0);
+        let mut ends = SmallVec::new();
+        let mut characters = source.char_indices().peekable();
+        while let Some((offset, character)) = characters.next() {
+            match character {
+                '\r' => {
+                    ends.push(offset);
+                    if characters.peek().is_some_and(|(_, next)| *next == '\n') {
+                        let _ = characters.next();
+                    }
+                    let next_start = characters.peek().map_or(source.len(), |(next, _)| *next);
+                    starts.push(next_start);
+                }
+                '\n' | '\u{2028}' | '\u{2029}' => {
+                    ends.push(offset);
+                    let next_start = characters.peek().map_or(source.len(), |(next, _)| *next);
+                    starts.push(next_start);
+                }
+                _ => {}
+            }
+        }
+        while ends.len() < starts.len() {
+            ends.push(source.len());
+        }
+        Self {
+            source,
+            starts,
+            ends,
+        }
+    }
+
+    fn position(&self, offset: usize) -> Option<Position> {
+        let line_index = self
+            .starts
+            .partition_point(|start| *start <= offset)
+            .checked_sub(1)?;
+        let line_start = *self.starts.get(line_index)?;
+        Some(Position {
+            offset,
+            line: line_index + 1,
+            column: self.column_between(line_start, offset),
+        })
+    }
+
+    fn leading_column(&self, line: usize) -> usize {
+        self.leading_range(line)
+            .map_or(0, |(start, end)| self.column_between(start, end))
+    }
+
+    fn leading_text(&self, line: usize) -> &'source str {
+        self.leading_range(line)
+            .and_then(|(start, end)| self.source.get(start..end))
+            .unwrap_or("")
+    }
+
+    fn starts_with_tab(&self, line: usize) -> bool {
+        line.checked_sub(1)
+            .and_then(|index| self.starts.get(index))
+            .and_then(|start| self.source.as_bytes().get(*start))
+            == Some(&b'\t')
+    }
+
+    fn leading_range(&self, line: usize) -> Option<(usize, usize)> {
+        let start = *self.starts.get(line.checked_sub(1)?)?;
+        let end = *self.ends.get(line - 1)?;
+        let text = self.source.get(start..end)?;
+        let mut leading_end = start;
+        for (relative, character) in text.char_indices() {
+            if !character.is_whitespace() && character != '\u{feff}' {
+                break;
+            }
+            leading_end = start + relative + character.len_utf8();
+        }
+        Some((start, leading_end))
+    }
+
+    fn column_between(&self, start: usize, end: usize) -> usize {
+        self.source
+            .get(start..end)
+            .map_or(0, |text| text.encode_utf16().count())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    reason = "serde_json::json keeps JSX option matrices concise"
+)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    const FIXTURE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../npm/stylistic/test/fixtures/jsx-closing-bracket-location-v5.10.0.json"
+    ));
+
+    #[derive(Deserialize)]
+    struct Fixture {
+        valid: Vec<TestCase>,
+        invalid: Vec<TestCase>,
+    }
+
+    #[derive(Deserialize)]
+    struct TestCase {
+        code: String,
+        #[serde(default)]
+        options: Value,
+        output: Option<String>,
+        #[serde(default)]
+        errors: Vec<ExpectedError>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ExpectedError {
+        message_id: String,
+        message: String,
+        data: BTreeMap<String, String>,
+        line: Option<usize>,
+        column: Option<usize>,
+    }
+
+    fn run(source: &str, options: Value) -> Vec<LintDiagnostic> {
+        let mut diagnostics = Vec::new();
+        check_jsx_closing_bracket_location(source, Some("fixture.tsx"), &options, &mut diagnostics);
+        diagnostics
+    }
+
+    fn fixed(source: &str, diagnostics: &[LintDiagnostic]) -> Option<String> {
+        let mut fixes = diagnostics
+            .iter()
+            .filter_map(|diagnostic| diagnostic.suggestions.first())
+            .filter_map(|suggestion| suggestion.fixes.first())
+            .collect::<Vec<_>>();
+        if fixes.is_empty() {
+            return None;
+        }
+        fixes.sort_by_key(|fix| std::cmp::Reverse((fix.range.start, fix.range.end)));
+        let mut output = source.to_owned();
+        for fix in fixes {
+            output.replace_range(
+                usize::try_from(fix.range.start).ok()?..usize::try_from(fix.range.end).ok()?,
+                &fix.replacement_text,
+            );
+        }
+        Some(output)
+    }
+
+    #[test]
+    fn replays_every_authored_pinned_upstream_case_exactly() {
+        let fixture: Fixture = serde_json::from_str(FIXTURE).expect("fixture is valid");
+        assert_eq!(fixture.valid.len(), 44);
+        assert_eq!(fixture.invalid.len(), 65);
+        assert_eq!(
+            fixture
+                .invalid
+                .iter()
+                .flat_map(|test_case| &test_case.errors)
+                .count(),
+            65
+        );
+
+        for (index, test_case) in fixture.valid.iter().enumerate() {
+            assert!(
+                run(&test_case.code, test_case.options.clone()).is_empty(),
+                "valid case {index}: {}",
+                test_case.code
+            );
+        }
+        for (index, test_case) in fixture.invalid.iter().enumerate() {
+            let diagnostics = run(&test_case.code, test_case.options.clone());
+            assert_eq!(
+                diagnostics.len(),
+                test_case.errors.len(),
+                "invalid case {index}: {}",
+                test_case.code
+            );
+            for (diagnostic, expected) in diagnostics.iter().zip(&test_case.errors) {
+                assert_eq!(diagnostic.message_id, expected.message_id, "case {index}");
+                assert_eq!(diagnostic.message, expected.message, "case {index}");
+                assert_eq!(diagnostic.data, expected.data, "case {index}");
+                let start = usize::try_from(diagnostic.range.start).expect("range start");
+                let end = usize::try_from(diagnostic.range.end).expect("range end");
+                assert!(
+                    matches!(test_case.code.get(start..end), Some("/" | ">")),
+                    "case {index} must report the closing bracket"
+                );
+                if let (Some(line), Some(column)) = (expected.line, expected.column) {
+                    let position = LineMap::new(&test_case.code)
+                        .position(start)
+                        .expect("diagnostic position");
+                    assert_eq!((position.line, position.column + 1), (line, column));
+                }
+            }
+            assert_eq!(
+                fixed(&test_case.code, &diagnostics),
+                test_case.output,
+                "invalid case {index}: {}",
+                test_case.code
+            );
+        }
+    }
+
+    #[test]
+    fn reports_nested_opening_elements_in_exit_order_and_converges() {
+        let source = "<Outer\n  prop={<Inner\n    value />}\n  />";
+        let diagnostics = run(source, json!([{ "location": "line-aligned" }]));
+        assert_eq!(diagnostics.len(), 2);
+        let reported = diagnostics
+            .iter()
+            .map(|diagnostic| {
+                source
+                    .get(
+                        usize::try_from(diagnostic.range.start).expect("start")
+                            ..usize::try_from(diagnostic.range.end).expect("end"),
+                    )
+                    .expect("reported token")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(reported, vec!["/", "/"]);
+        let output = fixed(source, &diagnostics).expect("fixes");
+        assert_eq!(output, "<Outer\n  prop={<Inner\n    value\n  />}\n/>");
+        assert!(run(&output, json!([{ "location": "line-aligned" }])).is_empty());
+    }
+
+    #[test]
+    fn preserves_utf8_byte_ranges_and_utf16_message_columns() {
+        let source = "const prefix = \"😀\"; const view = <日本語\n  属性 />;";
+        let diagnostics = run(source, json!([{ "location": "tag-aligned" }]));
+        assert_eq!(diagnostics.len(), 1);
+        let slash = source.rfind('/').expect("slash");
+        assert_eq!(
+            diagnostics[0].range,
+            TextRange::new(slash as u32, slash as u32 + 1)
+        );
+        assert_eq!(
+            diagnostics[0].message,
+            "The closing bracket must be aligned with the opening tag (expected column 35 on the next line)"
+        );
+        assert_eq!(
+            fixed(source, &diagnostics).as_deref(),
+            Some(
+                "const prefix = \"😀\"; const view = <日本語\n  属性\n                                  />;"
+            )
+        );
+    }
+
+    #[test]
+    fn handles_crlf_cr_and_ecmascript_unicode_line_terminators() {
+        for newline in ["\r\n", "\r", "\n", "\u{2028}", "\u{2029}"] {
+            let source = format!("<App{newline}  prop />");
+            let diagnostics = run(&source, json!([{ "location": "tag-aligned" }]));
+            assert_eq!(diagnostics.len(), 1, "{newline:?}");
+            assert_eq!(
+                fixed(&source, &diagnostics).as_deref(),
+                Some(format!("<App{newline}  prop\n/>")).as_deref(),
+                "{newline:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn honors_independent_non_empty_and_self_closing_disable_switches() {
+        let options = json!([{ "nonEmpty": false, "selfClosing": "after-props" }]);
+        assert!(run("<App\n  prop\n></App>", options.clone()).is_empty());
+        assert_eq!(
+            fixed("<App\n  prop\n/>", &run("<App\n  prop\n/>", options)).as_deref(),
+            Some("<App\n  prop/>")
+        );
+
+        let options = json!([{ "nonEmpty": "after-props", "selfClosing": false }]);
+        assert_eq!(
+            fixed(
+                "<App\n  prop\n></App>",
+                &run("<App\n  prop\n></App>", options.clone())
+            )
+            .as_deref(),
+            Some("<App\n  prop></App>")
+        );
+        assert!(run("<App\n  prop\n/>", options).is_empty());
+    }
+
+    #[test]
+    fn trailing_comments_fall_back_to_line_alignment_without_deleting_comments() {
+        for source in [
+            "<App\n  prop\n  // preserve\n  />",
+            "<App\n  /* preserve */\n  />",
+        ] {
+            let diagnostics = run(source, json!([{ "location": "after-props" }]));
+            assert_eq!(diagnostics.len(), 1, "{source}");
+            assert_eq!(
+                diagnostics[0].data.get("location").map(String::as_str),
+                Some("aligned with the line containing the opening tag")
+            );
+            let output = fixed(source, &diagnostics).expect("fix");
+            assert!(output.contains("preserve"));
+            assert!(output.ends_with("\n/>"));
+        }
+    }
+
+    #[test]
+    fn ignores_non_jsx_invalid_syntax_and_unknown_option_payloads_safely() {
+        for source in [
+            "const comparison = left < right > value;",
+            "const value = '<App\\n/>';",
+            "const broken = <App",
+        ] {
+            assert!(run(source, json!([])).is_empty(), "{source}");
+        }
+        let diagnostics = run(
+            "<App\n  prop />",
+            json!([{ "location": "future-mode", "extra": true }]),
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].data.get("location").map(String::as_str),
+            Some("aligned with the opening tag")
+        );
+    }
+}

--- a/npm/stylistic/index.js
+++ b/npm/stylistic/index.js
@@ -53,7 +53,9 @@ function createStylisticRule(ruleName) {
       },
       ...(meta.hasSuggestions
         ? {
-            fixable: ['jsx-quotes', 'no-confusing-arrow'].includes(ruleName)
+            fixable: ['jsx-closing-bracket-location', 'jsx-quotes', 'no-confusing-arrow'].includes(
+              ruleName,
+            )
               ? 'code'
               : 'whitespace',
           }

--- a/npm/stylistic/test/api.test.mjs
+++ b/npm/stylistic/test/api.test.mjs
@@ -1068,4 +1068,47 @@ describe('stylistic native API', () => {
       },
     ]);
   });
+
+  it('runs jsx-closing-bracket-location with exact UTF-8 ranges, data, and fixes', () => {
+    const source = 'const marker = "😀"; const view = <Panel\n  prop />;';
+    const slash = Buffer.byteLength(source.slice(0, source.indexOf('/>')));
+    const propEnd = Buffer.byteLength(source.slice(0, source.indexOf('prop') + 'prop'.length));
+    const elementEnd = Buffer.byteLength(source.slice(0, source.indexOf('/>') + 2));
+    const message =
+      'The closing bracket must be aligned with the opening tag (expected column 35 on the next line)';
+    const diagnostics = runNativeStylisticLint(source, {
+      filename: 'fixture.tsx',
+      rules: [
+        {
+          name: 'jsx-closing-bracket-location',
+          options: [{ location: 'tag-aligned' }],
+        },
+      ],
+    });
+
+    expect(diagnostics).toEqual([
+      {
+        ruleName: 'jsx-closing-bracket-location',
+        messageId: 'bracketLocation',
+        message,
+        data: {
+          details: ' (expected column 35 on the next line)',
+          location: 'aligned with the opening tag',
+        },
+        range: { start: slash, end: slash + 1 },
+        suggestions: [
+          {
+            messageId: 'bracketLocation',
+            message,
+            fixes: [
+              {
+                range: { start: propEnd, end: elementEnd },
+                replacementText: `\n${' '.repeat(34)}/>`,
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/npm/stylistic/test/fixtures/jsx-closing-bracket-location-v5.10.0.json
+++ b/npm/stylistic/test/fixtures/jsx-closing-bracket-location-v5.10.0.json
@@ -1,0 +1,1624 @@
+{
+  "__generated": {
+    "source": "@stylistic/eslint-plugin",
+    "version": "v5.10.0",
+    "commit": "efbb1bc0e5aaedc4695c44a03f46f4fcbbe58712",
+    "sourceFile": "packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.test.ts",
+    "license": "MIT",
+    "parserMatrix": "authored semantic cases; replayed with Oxc JSX/TSX",
+    "tool": "tools/tasks/sync-stylistic-jsx-closing-bracket-location-tests.ts",
+    "inventory": {
+      "valid": 44,
+      "invalid": 65,
+      "diagnostics": 65,
+      "fixableInvalid": 65,
+      "unfixableInvalid": 0,
+      "total": 109
+    }
+  },
+  "valid": [
+    {
+      "code": "\n        <App />\n      "
+    },
+    {
+      "code": "\n        <App\n          // comment\n        />\n      "
+    },
+    {
+      "code": "\n        <App /** comment */ />\n      "
+    },
+    {
+      "code": "\n        <App foo />\n      "
+    },
+    {
+      "code": "\n        <App\n          foo\n        />\n      "
+    },
+    {
+      "code": "\n        <App\n          foo\n          // comment\n        />\n      "
+    },
+    {
+      "code": "\n        <App\n          {...foo}\n        />\n      "
+    },
+    {
+      "code": "\n        <App\n          {...foo}\n          // comment\n        />\n      "
+    },
+    {
+      "code": "\n        <App foo />\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo />\n      ",
+      "options": ["after-props"]
+    },
+    {
+      "code": "\n        <App\n          foo\n          />\n      ",
+      "options": ["props-aligned"]
+    },
+    {
+      "code": "\n        <App\n          foo />\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          />\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo></App>\n      "
+    },
+    {
+      "code": "\n        <App\n          foo\n        ></App>\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        ></App>\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          ></App>\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo={function() {\n            console.log('bar');\n          }} />\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo={function() {\n            console.log('bar');\n          }}\n          />\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo={function() {\n            console.log('bar');\n          }}\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo={function() {\n            console.log('bar');\n          }}\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo={function() {\n          console.log('bar');\n        }}/>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n         <App foo={function() {\n                console.log('bar');\n              }}\n              />\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo={function() {\n          console.log('bar');\n        }}\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo={function() {\n          console.log('bar');\n        }}\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider store>\n          <App\n            foo />\n        </Provider>\n      ",
+      "options": [
+        {
+          "selfClosing": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store\n        >\n          <App\n            foo />\n        </Provider>\n      ",
+      "options": [
+        {
+          "selfClosing": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store>\n          <App\n            foo\n          />\n        </Provider>\n      ",
+      "options": [
+        {
+          "nonEmpty": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider store>\n          <App\n            foo\n            />\n        </Provider>\n      ",
+      "options": [
+        {
+          "selfClosing": "props-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store\n          >\n          <App\n            foo\n          />\n        </Provider>\n      ",
+      "options": [
+        {
+          "nonEmpty": "props-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = function() {\n          return <App\n            foo\n                 >\n              bar\n                 </App>\n        }\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = function() {\n          return <App\n            foo\n                 />\n        }\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = <App\n          foo\n                />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = function() {\n          return <App\n            foo={function() {\n              console.log('bar');\n            }}\n          />\n        }\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = <App\n          foo={function() {\n            console.log('bar');\n          }}\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store\n        >\n          <App\n            foo={function() {\n              console.log('bar');\n            }}\n          />\n        </Provider>\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store\n        >\n          {baz && <App\n            foo={function() {\n              console.log('bar');\n            }}\n          />}\n        </Provider>\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App>\n          <Foo\n            bar\n          >\n          </Foo>\n          <Foo\n            bar />\n        </App>\n      ",
+      "options": [
+        {
+          "nonEmpty": false,
+          "selfClosing": "after-props"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App>\n          <Foo\n            bar>\n          </Foo>\n          <Foo\n            bar\n          />\n        </App>\n      ",
+      "options": [
+        {
+          "nonEmpty": "after-props",
+          "selfClosing": false
+        }
+      ]
+    },
+    {
+      "code": "\n        <div className={[\n          \"some\",\n          \"stuff\",\n          2 ]}\n        >\n          Some text\n        </div>\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "code": "\n        <App\n        />\n      ",
+      "output": "\n        <App />\n      ",
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the opening tag",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the opening tag"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo\n        />\n      ",
+      "output": "\n        <App foo/>\n      ",
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App foo\n        ></App>\n      ",
+      "output": "\n        <App foo></App>\n      ",
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo />\n      ",
+      "output": "\n        <App\n          foo\n          />\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 11 on the next line)"
+          },
+          "line": 3,
+          "column": 15,
+          "message": "The closing bracket must be aligned with the last prop (expected column 11 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo />\n      ",
+      "output": "\n        <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9 on the next line)"
+          },
+          "line": 3,
+          "column": 15,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo />\n      ",
+      "output": "\n        <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 9 on the next line)"
+          },
+          "line": 3,
+          "column": 15,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 9 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        />\n      ",
+      "output": "\n        <App\n          foo/>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        />\n      ",
+      "output": "\n        <App\n          foo\n          />\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 11)"
+          },
+          "line": 4,
+          "column": 9,
+          "message": "The closing bracket must be aligned with the last prop (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          />\n      ",
+      "output": "\n        <App\n          foo/>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          />\n      ",
+      "output": "\n        <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 4,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          />\n      ",
+      "output": "\n        <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 4,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        ></App>\n      ",
+      "output": "\n        <App\n          foo></App>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n        ></App>\n      ",
+      "output": "\n        <App\n          foo\n          ></App>\n      ",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 11)"
+          },
+          "line": 4,
+          "column": 9,
+          "message": "The closing bracket must be aligned with the last prop (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          ></App>\n      ",
+      "output": "\n        <App\n          foo></App>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          ></App>\n      ",
+      "output": "\n        <App\n          foo\n        ></App>\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 4,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <App\n          foo\n          ></App>\n      ",
+      "output": "\n        <App\n          foo\n        ></App>\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 4,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store>\n          <App\n            foo\n            />\n        </Provider>\n      ",
+      "output": "\n        <Provider\n          store\n        >\n          <App\n            foo\n            />\n        </Provider>\n      ",
+      "options": [
+        {
+          "selfClosing": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9 on the next line)"
+          },
+          "line": 3,
+          "column": 16,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n                                            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+      "output": "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n              >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+      "options": ["props-aligned"],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 15)"
+          },
+          "line": 7,
+          "column": 45,
+          "message": "The closing bracket must be aligned with the last prop (expected column 15)"
+        }
+      ]
+    },
+    {
+      "code": "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n                                            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+      "output": "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+      "options": ["tag-aligned"],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 13)"
+          },
+          "line": 7,
+          "column": 45,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 13)"
+        }
+      ]
+    },
+    {
+      "code": "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n                                            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+      "output": "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+      "options": ["line-aligned"],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 13)"
+          },
+          "line": 7,
+          "column": 45,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 13)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store\n          >\n          <App\n            foo\n            />\n        </Provider>\n      ",
+      "output": "\n        <Provider\n          store\n          >\n          <App\n            foo\n          />\n        </Provider>\n      ",
+      "options": [
+        {
+          "nonEmpty": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 11)"
+          },
+          "line": 7,
+          "column": 13,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store>\n          <App\n            foo />\n        </Provider>\n      ",
+      "output": "\n        <Provider\n          store\n        >\n          <App\n            foo />\n        </Provider>\n      ",
+      "options": [
+        {
+          "selfClosing": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9 on the next line)"
+          },
+          "line": 3,
+          "column": 16,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <Provider\n          store>\n          <App\n            foo\n            />\n        </Provider>\n      ",
+      "output": "\n        <Provider\n          store>\n          <App\n            foo\n          />\n        </Provider>\n      ",
+      "options": [
+        {
+          "nonEmpty": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 11)"
+          },
+          "line": 6,
+          "column": 13,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = function() {\n          return <App\n            foo\n                />\n        }\n      ",
+      "output": "\n        var x = function() {\n          return <App\n            foo\n          />\n        }\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 11)"
+          },
+          "line": 5,
+          "column": 17,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = <App\n          foo\n                />\n      ",
+      "output": "\n        var x = <App\n          foo\n        />\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 4,
+          "column": 17,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = (\n          <div\n            className=\"MyComponent\"\n            {...props} />\n        )\n      ",
+      "output": "\n        var x = (\n          <div\n            className=\"MyComponent\"\n            {...props}\n          />\n        )\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 11 on the next line)"
+          },
+          "line": 5,
+          "column": 24,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 11 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = (\n          <Something\n            content={<Foo />} />\n        )\n      ",
+      "output": "\n        var x = (\n          <Something\n            content={<Foo />}\n          />\n        )\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 11 on the next line)"
+          },
+          "line": 4,
+          "column": 31,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 11 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n        var x = (\n          <Something\n            />\n        )\n      ",
+      "output": "\n        var x = (\n          <Something />\n        )\n      ",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the opening tag",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the opening tag"
+        }
+      ]
+    },
+    {
+      "code": "\n        <div className={[\n          \"some\",\n          \"stuff\",\n          2 ]}>\n          Some text\n        </div>\n      ",
+      "output": "\n        <div className={[\n          \"some\",\n          \"stuff\",\n          2 ]}\n        >\n          Some text\n        </div>\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9 on the next line)"
+          },
+          "line": 5,
+          "column": 15,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 6 on the next line)"
+          },
+          "line": 3,
+          "column": 10,
+          "message": "The closing bracket must be aligned with the last prop (expected column 6 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 5 on the next line)"
+          },
+          "line": 3,
+          "column": 10,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 5 on the next line)"
+          },
+          "line": 3,
+          "column": 10,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 5 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo/>\n\t\t\t",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 6)"
+          },
+          "line": 4,
+          "column": 5,
+          "message": "The closing bracket must be aligned with the last prop (expected column 6)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo/>\n\t\t\t",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 5)"
+          },
+          "line": 4,
+          "column": 6,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 5)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 5)"
+          },
+          "line": 4,
+          "column": 6,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 5)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo></App>\n\t\t\t",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+      "options": [
+        {
+          "location": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 6)"
+          },
+          "line": 4,
+          "column": 5,
+          "message": "The closing bracket must be aligned with the last prop (expected column 6)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo></App>\n\t\t\t",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 5)"
+          },
+          "line": 4,
+          "column": 6,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 5)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+      "output": "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 5)"
+          },
+          "line": 4,
+          "column": 6,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 5)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+      "output": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+      "options": [
+        {
+          "selfClosing": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 5 on the next line)"
+          },
+          "line": 3,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+      "output": "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+      "options": ["props-aligned"],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the last prop",
+            "details": " (expected column 8)"
+          },
+          "line": 7,
+          "column": 23,
+          "message": "The closing bracket must be aligned with the last prop (expected column 8)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+      "output": "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+      "options": ["tag-aligned"],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 7)"
+          },
+          "line": 7,
+          "column": 23,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 7)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+      "output": "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+      "options": ["line-aligned"],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 7)"
+          },
+          "line": 7,
+          "column": 23,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 7)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+      "output": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+      "options": [
+        {
+          "nonEmpty": "props-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 6)"
+          },
+          "line": 7,
+          "column": 7,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 6)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo />\n\t\t\t\t</Provider>\n\t\t\t",
+      "output": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo />\n\t\t\t\t</Provider>\n\t\t\t",
+      "options": [
+        {
+          "selfClosing": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 5 on the next line)"
+          },
+          "line": 3,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+      "output": "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+      "options": [
+        {
+          "nonEmpty": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 6)"
+          },
+          "line": 6,
+          "column": 7,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 6)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tvar x = function() {\n\t\t\t\t\treturn <App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t\t\t/>\n\t\t\t\t}\n\t\t\t",
+      "output": "\n\t\t\t\tvar x = function() {\n\t\t\t\t\treturn <App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t}\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 6)"
+          },
+          "line": 5,
+          "column": 9,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 6)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tvar x = <App\n\t\t\t\t\tfoo\n\t\t\t\t\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\tvar x = <App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 5)"
+          },
+          "line": 4,
+          "column": 9,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 5)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tvar x = (\n\t\t\t\t\t<div\n\t\t\t\t\t\tclassName=\"MyComponent\"\n\t\t\t\t\t\t{...props} />\n\t\t\t\t)\n\t\t\t",
+      "output": "\n\t\t\t\tvar x = (\n\t\t\t\t\t<div\n\t\t\t\t\t\tclassName=\"MyComponent\"\n\t\t\t\t\t\t{...props}\n\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 6 on the next line)"
+          },
+          "line": 5,
+          "column": 18,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 6 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\tcontent={<Foo />} />\n\t\t\t\t)\n\t\t\t",
+      "output": "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\tcontent={<Foo />}\n\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 6 on the next line)"
+          },
+          "line": 4,
+          "column": 25,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 6 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+      "output": "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something />\n\t\t\t\t)\n\t\t\t",
+      "options": [
+        {
+          "location": "line-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the opening tag",
+            "details": ""
+          },
+          "message": "The closing bracket must be placed after the opening tag"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<div className={[\n\t\t\t\t\t\"some\",\n\t\t\t\t\t\"stuff\",\n\t\t\t\t\t2 ]}>\n\t\t\t\t\tSome text\n\t\t\t\t</div>\n\t\t\t",
+      "output": "\n\t\t\t\t<div className={[\n\t\t\t\t\t\"some\",\n\t\t\t\t\t\"stuff\",\n\t\t\t\t\t2 ]}\n\t\t\t\t>\n\t\t\t\t\tSome text\n\t\t\t\t</div>\n\t\t\t",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 5 on the next line)"
+          },
+          "line": 5,
+          "column": 10,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t\t\t\t<div\n\t\t\t\t\t\t\t\tclassName={styles}\n\t\t\t\t\t >\n\t\t\t\t\t\t\t\t{props}\n\t\t\t\t\t\t\t</div>\n\t\t\t",
+      "output": "\n\t\t\t\t\t\t\t<div\n\t\t\t\t\t\t\t\tclassName={styles}\n\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\t\t{props}\n\t\t\t\t\t\t\t</div>\n\t\t\t",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 8)"
+          },
+          "line": 4,
+          "column": 7,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 8)"
+        }
+      ]
+    },
+    {
+      "code": "\n          <div\n            className={styles}\n            >\n            {props}\n          </div>\n      ",
+      "output": "\n          <div\n            className={styles}\n          >\n            {props}\n          </div>\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 11)"
+          },
+          "line": 4,
+          "column": 13,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n          <App\n            foo\n            />\n      ",
+      "output": "\n          <App\n            foo\n          />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 11)"
+          },
+          "line": 4,
+          "column": 13,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 11)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+      "output": "\n\t\t\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 7)"
+          },
+          "line": 4,
+          "column": 6,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 7)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <input\n          // comment\n          type=\"text\"\n          // comment\n          />\n      ",
+      "output": "\n        <input\n          // comment\n          type=\"text\"\n          // comment\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 6,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <input\n          // comment\n          type=\"text\"\n          /**\n           * \n           * comment\n           * \n           */\n          />\n      ",
+      "output": "\n        <input\n          // comment\n          type=\"text\"\n          /**\n           * \n           * comment\n           * \n           */\n        />\n      ",
+      "options": [
+        {
+          "location": "tag-aligned"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 10,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <input\n          // comment\n          type=\"text\"\n\n        />\n      ",
+      "output": "\n        <input\n          // comment\n          type=\"text\"/>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "placed after the last prop",
+            "details": ""
+          },
+          "line": 6,
+          "column": 9,
+          "message": "The closing bracket must be placed after the last prop"
+        }
+      ]
+    },
+    {
+      "code": "\n        <input\n          // comment\n          type=\"text\"\n          // comment\n          />\n      ",
+      "output": "\n        <input\n          // comment\n          type=\"text\"\n          // comment\n        />\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 6,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n        <input\n          // comment\n          // comment\n          />\n      ",
+      "output": "\n        <input\n          // comment\n          // comment\n        />\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 9)"
+          },
+          "line": 5,
+          "column": 11,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 9)"
+        }
+      ]
+    },
+    {
+      "code": "\n\t\t\t\t<a\n\t\t\t\t\thref=\"javascript:;\"\n\t\t\t\t\t// comment\n\t\t\t\t\t// comment\n\t\t\t\t\t>\n\t\t\t\t\ttext\n\t\t\t\t</a>\n      ",
+      "output": "\n\t\t\t\t<a\n\t\t\t\t\thref=\"javascript:;\"\n\t\t\t\t\t// comment\n\t\t\t\t\t// comment\n\t\t\t\t>\n\t\t\t\t\ttext\n\t\t\t\t</a>\n      ",
+      "options": [
+        {
+          "location": "after-props"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "bracketLocation",
+          "data": {
+            "location": "aligned with the line containing the opening tag",
+            "details": " (expected column 5)"
+          },
+          "line": 6,
+          "column": 6,
+          "message": "The closing bracket must be aligned with the line containing the opening tag (expected column 5)"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/stylistic/test/jsx-closing-bracket-location-upstream.test.mjs
+++ b/npm/stylistic/test/jsx-closing-bracket-location-upstream.test.mjs
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/jsx-closing-bracket-location-v5.10.0.json', import.meta.url),
+    'utf8',
+  ),
+);
+
+function runRule(sourceText, options) {
+  const reports = [];
+  const visitor = plugin.rules['jsx-closing-bracket-location'].createOnce({
+    filename: 'fixture.tsx',
+    options: options ?? [],
+    sourceCode: {
+      text: sourceText,
+      getText() {
+        return this.text;
+      },
+    },
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function renderedMessage(report) {
+  let message = plugin.rules['jsx-closing-bracket-location'].meta.messages[report.messageId];
+  for (const [key, value] of Object.entries(report.data ?? {})) {
+    message = message.replaceAll(`{{${key}}}`, value);
+  }
+  return message;
+}
+
+function locationAt(source, offset) {
+  const prefix = source.slice(0, offset);
+  const terminators = [...prefix.matchAll(/\r\n|[\n\r\u2028\u2029]/gu)];
+  const lastTerminator = terminators.at(-1);
+  const lineStart = lastTerminator ? lastTerminator.index + lastTerminator[0].length : 0;
+  return {
+    line: terminators.length + 1,
+    column: source.slice(lineStart, offset).length + 1,
+  };
+}
+
+function fixedOutput(sourceText, reports) {
+  const edits = reports
+    .flatMap((report) =>
+      (report.suggest ?? []).flatMap((suggestion) =>
+        suggestion.fix({
+          replaceTextRange(range, replacementText) {
+            return { range, replacementText };
+          },
+        }),
+      ),
+    )
+    .sort((left, right) => right.range[0] - left.range[0] || right.range[1] - left.range[1]);
+  if (edits.length === 0) {
+    return null;
+  }
+  let output = sourceText;
+  for (const edit of edits) {
+    output = output.slice(0, edit.range[0]) + edit.replacementText + output.slice(edit.range[1]);
+  }
+  return output;
+}
+
+describe('@stylistic/jsx-closing-bracket-location v5.10.0 upstream parity', () => {
+  it('keeps the exact pinned authored inventory complete and reproducible', () => {
+    expect(fixture.__generated).toEqual({
+      source: '@stylistic/eslint-plugin',
+      version: 'v5.10.0',
+      commit: 'efbb1bc0e5aaedc4695c44a03f46f4fcbbe58712',
+      sourceFile:
+        'packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.test.ts',
+      license: 'MIT',
+      parserMatrix: 'authored semantic cases; replayed with Oxc JSX/TSX',
+      tool: 'tools/tasks/sync-stylistic-jsx-closing-bracket-location-tests.ts',
+      inventory: {
+        valid: 44,
+        invalid: 65,
+        diagnostics: 65,
+        fixableInvalid: 65,
+        unfixableInvalid: 0,
+        total: 109,
+      },
+    });
+  });
+
+  it.each(fixture.valid.map((testCase, index) => [index, testCase]))(
+    'accepts upstream valid case %i',
+    (_index, testCase) => {
+      expect(runRule(testCase.code, testCase.options), testCase.code).toEqual([]);
+    },
+  );
+
+  it.each(fixture.invalid.map((testCase, index) => [index, testCase]))(
+    'replays invalid case %i with exact messages, data, bracket ranges, and output',
+    (_index, testCase) => {
+      const reports = runRule(testCase.code, testCase.options);
+      expect(
+        reports.map((report) => report.messageId),
+        testCase.code,
+      ).toEqual(testCase.errors.map((error) => error.messageId));
+      expect(
+        reports.map((report) => report.data),
+        testCase.code,
+      ).toEqual(testCase.errors.map((error) => error.data));
+      expect(reports.map(renderedMessage), testCase.code).toEqual(
+        testCase.errors.map((error) => error.message),
+      );
+      expect(
+        reports
+          .map((report) => testCase.code.slice(...report.node.range))
+          .every((token) => token === '/' || token === '>'),
+        testCase.code,
+      ).toBe(true);
+      for (const [report, error] of reports.map((report, index) => [
+        report,
+        testCase.errors[index],
+      ])) {
+        if (error.line !== undefined && error.column !== undefined) {
+          expect(locationAt(testCase.code, report.node.range[0])).toEqual({
+            line: error.line,
+            column: error.column,
+          });
+        }
+      }
+      expect(fixedOutput(testCase.code, reports), testCase.code).toBe(testCase.output);
+      expect(runRule(testCase.output, testCase.options), testCase.output).toEqual([]);
+    },
+  );
+
+  it('maps Unicode prefixes to UTF-16 report/fix ranges and keeps nested exit order', () => {
+    const source = [
+      'const prefix = "😀";',
+      'const view = <外側',
+      '  child={<内側',
+      '    value />}',
+      '  />;',
+    ].join('\n');
+    const reports = runRule(source, [{ location: 'line-aligned' }]);
+    expect(reports).toHaveLength(2);
+    expect(reports.map((report) => source.slice(...report.node.range))).toEqual(['/', '/']);
+    expect(reports[0].node.range[0]).toBe(source.indexOf('/>'));
+    expect(reports[1].node.range[0]).toBe(source.lastIndexOf('/>'));
+    const output = fixedOutput(source, reports);
+    expect(output).toContain('"😀"');
+    expect(runRule(output, [{ location: 'line-aligned' }])).toEqual([]);
+  });
+});

--- a/npm/stylistic/test/meta.test.mjs
+++ b/npm/stylistic/test/meta.test.mjs
@@ -44,7 +44,9 @@ describe('stylistic plugin meta contract', () => {
       expect(rule.meta.hasSuggestions).toBe(false);
     } else {
       expect(rule.meta.fixable).toBe(
-        ['jsx-quotes', 'no-confusing-arrow'].includes(ruleName) ? 'code' : 'whitespace',
+        ['jsx-closing-bracket-location', 'jsx-quotes', 'no-confusing-arrow'].includes(ruleName)
+          ? 'code'
+          : 'whitespace',
       );
     }
     expect(typeof rule.meta.hasSuggestions).toBe('boolean');
@@ -207,6 +209,23 @@ describe('stylistic plugin meta contract', () => {
         expectedLinebreakBeforeClosingBrace: 'Expected a line break before this closing brace.',
         expectedLinebreakAfterOpeningBrace: 'Expected a line break after this opening brace.',
       },
+    });
+  });
+
+  it('preserves the stable jsx-closing-bracket-location metadata contract', () => {
+    expect(plugin.rules['jsx-closing-bracket-location'].meta).toMatchObject({
+      type: 'layout',
+      docs: {
+        description: 'Enforce closing bracket location in JSX',
+        recommended: false,
+        requiresTypeChecking: false,
+      },
+      fixable: 'code',
+      hasSuggestions: true,
+      messages: {
+        bracketLocation: 'The closing bracket must be {{location}}{{details}}',
+      },
+      schema: { type: 'array' },
     });
   });
 

--- a/npm/stylistic/test/plugin.test.mjs
+++ b/npm/stylistic/test/plugin.test.mjs
@@ -106,6 +106,12 @@ const stylisticRuleFixtures = [
   ['line-comment-position', 'value; // inline\n// above\n', [], ['above']],
   ['lines-around-comment', 'before();\n/** docs */\nafter();\n', [], ['before']],
   ['jsx-child-element-spacing', '<App>word\n<a>link</a></App>;\n', [], ['spacingBeforeNext']],
+  [
+    'jsx-closing-bracket-location',
+    '<App\n  prop />;\n',
+    [{ location: 'tag-aligned' }],
+    ['bracketLocation'],
+  ],
   ['jsx-quotes', "<App title='value' />;\n", [], ['unexpected']],
   ['multiline-comment-style', '// first\n// second\n', [], ['expectedBlock']],
   ['lines-between-class-members', 'class C { a() {}\nb() {} }\n', [], ['always']],
@@ -2512,6 +2518,83 @@ const parenthesized = (a + b) * c;
           message: 'Expected a line break before this closing brace.',
         },
       ]);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it('supports jsx-closing-bracket-location shared settings, data, UTF-16 ranges, and fixes', () => {
+    const source = 'const marker = "😀"; const view = <Panel\n  prop />;\n';
+    const slash = source.indexOf('/>');
+    const reports = runRule('jsx-closing-bracket-location', source, [], {
+      corsaStylistic: {
+        rules: {
+          'jsx-closing-bracket-location': [{ location: 'tag-aligned' }],
+        },
+      },
+    });
+
+    expect(messageIds(reports)).toEqual(['bracketLocation']);
+    expect(reports[0].data).toEqual({
+      location: 'aligned with the opening tag',
+      details: ' (expected column 35 on the next line)',
+    });
+    expect(reports[0].node.range).toEqual([slash, slash + 1]);
+    expect(
+      reports[0].suggest[0].fix({
+        replaceTextRange(range, replacementText) {
+          return { range, replacementText };
+        },
+      }),
+    ).toEqual([
+      {
+        range: [source.indexOf('prop') + 'prop'.length, slash + 2],
+        replacementText: `\n${' '.repeat(34)}/>`,
+      },
+    ]);
+  });
+
+  it('runs jsx-closing-bracket-location through real oxlint TSX lint and fixes', () => {
+    const oxlint = findOxlintCli();
+    const temp = mkdtempSync(join(tmpdir(), 'stylistic-jsx-closing-bracket-location-'));
+
+    try {
+      const sourcePath = join(temp, 'sample.tsx');
+      const configPath = join(temp, 'oxlint.config.jsonc');
+      writeFileSync(sourcePath, 'export const view = <Panel\n  title="日本語" />;\n');
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          jsPlugins: [{ name: 'stylistic', specifier: join(packageRoot, 'index.js') }],
+          rules: {
+            'stylistic/jsx-closing-bracket-location': ['error', { location: 'tag-aligned' }],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        oxlint,
+        ['-c', configPath, '--quiet', '--format', 'json', sourcePath],
+        { encoding: 'utf8' },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(JSON.parse(result.stdout).diagnostics).toMatchObject([
+        {
+          code: 'stylistic(jsx-closing-bracket-location)',
+          message:
+            'The closing bracket must be aligned with the opening tag (expected column 21 on the next line)',
+        },
+      ]);
+
+      const fixed = spawnSync(oxlint, ['-c', configPath, '--fix-suggestions', sourcePath], {
+        encoding: 'utf8',
+      });
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(sourcePath, 'utf8')).toBe(
+        `export const view = <Panel\n  title="日本語"\n${' '.repeat(20)}/>;\n`,
+      );
     } finally {
       rmSync(temp, { recursive: true, force: true });
     }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "port:tests:stylistic:function-paren-newline": "node tools/tasks/sync-stylistic-function-paren-newline-tests.ts",
     "port:tests:stylistic:indent-binary-ops": "node tools/tasks/sync-stylistic-indent-binary-ops-tests.ts",
     "port:tests:stylistic:jsx-child-element-spacing": "node tools/tasks/sync-stylistic-jsx-child-element-spacing-tests.ts",
+    "port:tests:stylistic:jsx-closing-bracket-location": "node tools/tasks/sync-stylistic-jsx-closing-bracket-location-tests.ts",
     "port:tests:stylistic:multiline-comment-style": "node tools/tasks/sync-stylistic-multiline-comment-style-tests.ts",
     "port:tests:stylistic:nonblock-statement-body-position": "node tools/tasks/sync-stylistic-nonblock-statement-body-position-tests.ts",
     "port:tests:stylistic:object-curly-newline": "node tools/tasks/sync-stylistic-object-curly-newline-tests.ts",

--- a/status.json
+++ b/status.json
@@ -6392,19 +6392,19 @@
       },
       {
         "name": "jsx-closing-bracket-location",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
-          "insta": false,
-          "vitest": false,
+          "insta": true,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule jsx-closing-bracket-location."
+        "notes": "Native Oxc JSX/TSX AST port of stable @stylistic/jsx-closing-bracket-location v5.10.0. The pinned synchronizer and Rust/Vitest suites replay all 44 valid and 65 invalid authored upstream cases with 65 exact diagnostics, data and fixes across the upstream parser matrix semantics, plus Unicode UTF-8/UTF-16 ranges, CRLF/CR/LS/PS, tabs, nested JSX exit order, independent nonEmpty/selfClosing options, trailing-comment safety, shared settings, metadata/API, and real Oxlint lint/fix coverage."
       },
       {
         "name": "jsx-closing-tag-location",

--- a/tools/tasks/sync-stylistic-jsx-closing-bracket-location-tests.ts
+++ b/tools/tasks/sync-stylistic-jsx-closing-bracket-location-tests.ts
@@ -1,0 +1,168 @@
+// Captures every authored stable @stylistic/jsx-closing-bracket-location
+// v5.10.0 RuleTester case from the exact pinned upstream commit. The upstream
+// parser matrix repeats each authored JSX case across compatible parsers; this
+// fixture stores each semantic case once and the native replay runs it through
+// Oxc's JSX/TSX parser.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { registerHooks } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+type RawCase = string | Record<string, unknown>;
+type CapturedRun = { name: string; valid: RawCase[]; invalid: RawCase[] };
+
+const ROOT = process.cwd();
+const RULE = 'jsx-closing-bracket-location';
+const VERSION = 'v5.10.0';
+const COMMIT = 'efbb1bc0e5aaedc4695c44a03f46f4fcbbe58712';
+const UPSTREAM = join(ROOT, 'upstream', 'eslint-stylistic');
+const SOURCE_FILE = `packages/eslint-plugin/rules/${RULE}/${RULE}.test.ts`;
+const FIXTURE = join(ROOT, 'npm', 'stylistic', 'test', 'fixtures', `${RULE}-v5.10.0.json`);
+const CAPTURE_KEY = '__stylisticJsxClosingBracketLocationCapture__';
+
+if (!existsSync(UPSTREAM)) {
+  throw new Error(`Missing ${UPSTREAM}; initialize upstream/eslint-stylistic.`);
+}
+const actualCommit = execFileSync('git', ['-C', UPSTREAM, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== COMMIT) {
+  throw new Error(`Expected eslint-stylistic ${COMMIT}, received ${actualCommit}.`);
+}
+
+registerCaptureHooks();
+const temp = mkdtempSync(join(tmpdir(), 'stylistic-jsx-closing-bracket-sync-'));
+const sourcePath = join(temp, `${RULE}.test.ts`);
+writeFileSync(
+  sourcePath,
+  execFileSync('git', ['-C', UPSTREAM, 'show', `${COMMIT}:${SOURCE_FILE}`], {
+    encoding: 'utf8',
+  }),
+);
+(globalThis as Record<string, unknown>)[CAPTURE_KEY] = [];
+try {
+  await import(`${pathToFileURL(sourcePath).href}?commit=${COMMIT}`);
+} finally {
+  rmSync(temp, { recursive: true, force: true });
+}
+
+const runs = (globalThis as Record<string, unknown>)[CAPTURE_KEY] as CapturedRun[];
+if (runs.length !== 1 || runs[0].name !== RULE) {
+  throw new Error(`Expected one ${RULE} suite, received ${runs.length}.`);
+}
+const valid = runs[0].valid.map((value, index) => normalizeCase(value, false, index));
+const invalid = runs[0].invalid.map((value, index) => normalizeCase(value, true, index));
+const diagnostics = invalid.reduce(
+  (count, testCase) => count + (testCase.errors as unknown[]).length,
+  0,
+);
+const fixture = {
+  __generated: {
+    source: '@stylistic/eslint-plugin',
+    version: VERSION,
+    commit: COMMIT,
+    sourceFile: SOURCE_FILE,
+    license: 'MIT',
+    parserMatrix: 'authored semantic cases; replayed with Oxc JSX/TSX',
+    tool: 'tools/tasks/sync-stylistic-jsx-closing-bracket-location-tests.ts',
+    inventory: {
+      valid: valid.length,
+      invalid: invalid.length,
+      diagnostics,
+      fixableInvalid: invalid.filter((testCase) => typeof testCase.output === 'string').length,
+      unfixableInvalid: invalid.filter((testCase) => testCase.output === null).length,
+      total: valid.length + invalid.length,
+    },
+  },
+  valid,
+  invalid,
+};
+mkdirSync(join(ROOT, 'npm', 'stylistic', 'test', 'fixtures'), { recursive: true });
+writeFileSync(FIXTURE, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', FIXTURE], { stdio: 'inherit' });
+console.log(
+  `Synced ${RULE} ${VERSION}: ${valid.length} valid, ${invalid.length} invalid, ${diagnostics} diagnostics.`,
+);
+
+function normalizeCase(raw: RawCase, invalid: boolean, index: number): Record<string, unknown> {
+  const value = typeof raw === 'string' ? { code: raw } : raw;
+  if (!value || typeof value !== 'object' || typeof value.code !== 'string') {
+    throw new Error(`${invalid ? 'invalid' : 'valid'} case ${index} has no code.`);
+  }
+  const allowed = new Set(
+    invalid
+      ? ['code', 'output', 'errors', 'options', 'parserOptions', 'settings', 'languageOptions']
+      : ['code', 'options', 'parserOptions', 'settings', 'languageOptions'],
+  );
+  const unsupported = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unsupported.length > 0) {
+    throw new Error(`Unsupported case ${index} keys: ${unsupported.join(', ')}`);
+  }
+  if (
+    invalid &&
+    ((typeof value.output !== 'string' && value.output !== null) || !Array.isArray(value.errors))
+  ) {
+    throw new Error(`Invalid case ${index} is missing output/errors.`);
+  }
+  const normalized = JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+  if (invalid) {
+    normalized.errors = (normalized.errors as Array<Record<string, unknown>>).map((error) => {
+      const data = error.data as { location?: unknown; details?: unknown } | undefined;
+      if (
+        error.messageId !== 'bracketLocation' ||
+        typeof data?.location !== 'string' ||
+        typeof data.details !== 'string'
+      ) {
+        throw new Error(`Invalid case ${index} has an unsupported error contract.`);
+      }
+      return {
+        ...error,
+        message: `The closing bracket must be ${data.location}${data.details}`,
+      };
+    });
+  }
+  return normalized;
+}
+
+function registerCaptureHooks(): void {
+  const testStub = [
+    `const key = ${JSON.stringify(CAPTURE_KEY)};`,
+    'export function run(options) {',
+    '  globalThis[key].push({ name: options.name, valid: options.valid || [], invalid: options.invalid || [] });',
+    '}',
+  ].join('\n');
+  const parserStub = [
+    'function authored(tests) { return tests.flat(Infinity).filter(Boolean); }',
+    'export function valids(...tests) { return authored(tests); }',
+    'export function invalids(...tests) { return authored(tests); }',
+  ].join('\n');
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (specifier === '#test') {
+        return { url: 'stub:///stylistic-test', shortCircuit: true };
+      }
+      if (specifier === '#test/parsers-jsx') {
+        return { url: 'stub:///stylistic-parsers-jsx', shortCircuit: true };
+      }
+      if (specifier === `./${RULE}` || specifier === './types' || specifier === './types.d.ts') {
+        return { url: 'stub:///stylistic-rule', shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+    load(url, context, nextLoad) {
+      if (url === 'stub:///stylistic-test') {
+        return { format: 'module', source: testStub, shortCircuit: true };
+      }
+      if (url === 'stub:///stylistic-parsers-jsx') {
+        return { format: 'module', source: parserStub, shortCircuit: true };
+      }
+      if (url === 'stub:///stylistic-rule') {
+        return { format: 'module', source: 'export default {};', shortCircuit: true };
+      }
+      return nextLoad(url, context);
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- port stable `@stylistic/jsx-closing-bracket-location` to native Oxc JSX/TSX AST traversal
- pin and replay all 44 valid and 65 invalid authored v5.10.0 cases with 65 exact diagnostics and fixes
- cover option modes, comments, tabs, all ECMAScript line terminators, nested exit order, Unicode ranges, metadata/API, and real Oxlint lint/fix integration

## Verification
- deterministic fixture SHA-256 `ab89ed425357c05591b975711bfdf31d59567621c8320c73037ab27ce622116b`
- `pnpm verify`: 72 JS files, 9,134 passed / 1,159 skipped; 256 Stylistic Rust tests
- post-rebase: native release build, 7 focused Rust tests, 615 targeted Vitest tests, clippy, README/status checks
- real Oxlint TSX diagnostic and `--fix` convergence

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->