### PR TITLE
fix(tools): always surface unexpected ESLint messages in jsx-curly-newline sync

### DIFF
--- a/tools/tasks/sync-stylistic-jsx-curly-newline-tests.ts
+++ b/tools/tasks/sync-stylistic-jsx-curly-newline-tests.ts
@@ -292,11 +292,9 @@ function verify(testCase) {
     filename: filenameFor(testCase),
   });
   const ruleMessages = messages.filter(message => message.ruleId === 'stylistic/${RULE}');
-  if (ruleMessages.length === 0 && messages.length !== 0) {
-    const unexpected = messages.filter(message => message.ruleId !== 'stylistic/${RULE}');
-    if (unexpected.length !== 0) {
-      throw new Error('Unexpected ESLint messages: ' + JSON.stringify(unexpected));
-    }
+  const unexpected = messages.filter(message => message.ruleId !== 'stylistic/${RULE}');
+  if (unexpected.length !== 0) {
+    throw new Error('Unexpected ESLint messages: ' + JSON.stringify(unexpected));
   }
   return ruleMessages;
 }


### PR DESCRIPTION
Follow-up to #647 (already merged), addressing a CodeRabbit review finding on `tools/tasks/sync-stylistic-jsx-curly-newline-tests.ts`.

The generated corpus script guarded its "unexpected ESLint messages" check behind `ruleMessages.length === 0`, so the inner check was dead whenever the rule reported at least one message. Parse errors and other diagnostics were silently dropped for exactly the cases where they matter most: the invalid cases, which always produce rule messages. The check is now independent of whether the rule fired.

```js
const ruleMessages = messages.filter(message => message.ruleId === 'stylistic/${RULE}');
const unexpected = messages.filter(message => message.ruleId !== 'stylistic/${RULE}');
if (unexpected.length !== 0) {
  throw new Error('Unexpected ESLint messages: ' + JSON.stringify(unexpected));
}
return ruleMessages;
```

This only tightens validation in the fixture-generation tool; the pinned fixture JSON and the Rust rule are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->