### PR TITLE
ci: use stable sticky-disk cache keys

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,19 +42,19 @@ jobs:
       - name: Mount pnpm store
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-bench-pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ github.repository }}-bench-pnpm-store-${{ runner.os }}-${{ runner.arch }}
           path: ~/.local/share/pnpm/store
 
       - name: Mount node_modules
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-bench-node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ github.repository }}-bench-node-modules-${{ runner.os }}-${{ runner.arch }}
           path: ./node_modules
 
       - name: Mount Cargo target
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-bench-cargo-target-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ github.repository }}-bench-cargo-target-${{ runner.os }}-${{ runner.arch }}
           path: ./target
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,19 @@ jobs:
       - name: Mount pnpm store
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-${{ matrix.cache_scope }}-pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ github.repository }}-${{ matrix.cache_scope }}-pnpm-store-${{ runner.os }}-${{ runner.arch }}
           path: ~/.local/share/pnpm/store
 
       - name: Mount node_modules
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-${{ matrix.cache_scope }}-node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ github.repository }}-${{ matrix.cache_scope }}-node-modules-${{ runner.os }}-${{ runner.arch }}
           path: ./node_modules
 
       - name: Mount Cargo target
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-${{ matrix.cache_scope }}-cargo-target-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ github.repository }}-${{ matrix.cache_scope }}-cargo-target-${{ runner.os }}-${{ runner.arch }}
           path: ./target
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

- remove lockfile hashes from all Blacksmith sticky-disk keys
- retain job-specific namespaces while separating persistent disks by runner OS and architecture
- keep pnpm and Cargo build state warm across dependency lockfile updates

## Why

Blacksmith sticky disks are persistent block devices keyed by identity rather than lookup caches with prefix fallback. Including lockfile hashes creates a new empty disk whenever a lockfile changes, discarding the warm state when it is most useful and leaving old disks for retention cleanup.

This applies the same correction as https://github.com/ubugeeei-prod/vize/pull/3353 to this repository. Package installation and Cargo incremental compilation already handle stale content on the persistent paths.

## Validation

- actionlint v1.7.7 on ci.yml and bench.yml; ignored only the expected unknown Blacksmith custom runner label
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->