### PR TITLE
ci: profile native package sizes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -63,6 +63,18 @@ jobs:
 
       - run: vp install --frozen-lockfile
       - run: vp build
+      - name: Profile native package sizes
+        run: pnpm run profile:native-sizes
+        env:
+          NATIVE_SIZE_SOURCE_REVISION: ${{ github.sha }}
+      - name: Add native package sizes to job summary
+        run: cat profiles/native-package-sizes/native-package-sizes.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload native package size profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-package-size-profile
+          path: profiles/native-package-sizes/
+          if-no-files-found: error
       - run: pnpm run bench | tee bench-output.txt
         env:
           NO_COLOR: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
       - run: vp install --frozen-lockfile
       - run: node tools/tasks/verify-release-tag.ts
       - run: pnpm run verify
+      - name: Profile native package sizes
+        run: pnpm run profile:native-sizes
+        env:
+          NATIVE_SIZE_SOURCE_REVISION: ${{ github.sha }}
+      - name: Add native package sizes to job summary
+        run: cat profiles/native-package-sizes/native-package-sizes.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload native package size profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-package-size-profile
+          path: profiles/native-package-sizes/
+          if-no-files-found: error
 
   publish:
     name: Publish to npm

--- a/docs/guides/testing-strategy.md
+++ b/docs/guides/testing-strategy.md
@@ -15,6 +15,24 @@ Required layers for every real plugin or rule port:
 
 The CI contract is `pnpm run verify`. Keep workflow YAML thin: setup the runner, install with `vp install --frozen-lockfile`, then run the workspace verification script. This prevents local, PR, and release checks from drifting.
 
+## Native package size signal
+
+Strategy A remains the distribution shape: every native plugin is independently
+installable and ships its own `.node` addon. `pnpm run profile:native-sizes`
+measures that shape after `vp build` without changing it.
+
+The benchmark and release workflows retain both
+`native-package-sizes.json` and `native-package-sizes.md` as artifacts. They
+record each package's raw and gzip-compressed `.node` bytes, npm tarball and
+unpacked bytes, plus the aggregate cost of installing every current native
+package on the measured platform. The JSON also records the source revision,
+runtime/toolchain, platform, compression level, and packaging command so results
+can be compared only when their environments are compatible.
+
+This signal intentionally has no size threshold. Use it to gather evidence
+before changing the distribution strategy; a size change alone does not fail CI
+or imply that a shared native core should be merged.
+
 Performance-sensitive rules should include tests that prove file-level skipping works. Prefer a Rust pre-scan or batched Rust result over one NAPI call per AST node.
 
 Do not use `std::collections::HashMap` or `std::collections::HashSet` in rule crates. Use `oxlint_plugins_carton::FastHashMap` or `FastHashSet` when a map is actually necessary.

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "port:tests:stylistic:wrap-iife": "node tools/tasks/sync-stylistic-wrap-iife-tests.ts",
     "port:tests:unocss": "node tools/tasks/sync-unocss-tests.ts",
     "profile": "node tools/tasks/profile.ts",
+    "profile:native-sizes": "node tools/tasks/profile-native-package-sizes.ts",
     "release": "node tools/tasks/release.ts",
     "security:audit": "node tools/tasks/security-audit.ts",
     "status:check": "node tools/tasks/verify-status.ts",

--- a/tools/tasks/profile-native-package-sizes.test.ts
+++ b/tools/tasks/profile-native-package-sizes.test.ts
@@ -1,0 +1,664 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  GZIP_LEVEL,
+  NATIVE_SIZE_PROFILE_ID,
+  NATIVE_SIZE_SCHEMA_VERSION,
+  NATIVE_SIZE_STRATEGY,
+  binaryTarget,
+  buildNativeSizeReport,
+  declaresNativeArtifact,
+  discoverNativePackages,
+  formatBytes,
+  measureNativeBinary,
+  packNativePackage,
+  parseCliArguments,
+  parseNpmPackJson,
+  profileNativePackageSizes,
+  renderNativeSizeMarkdown,
+  resolvePackArtifactPath,
+  resolveSourceRevision,
+  summarizeCommonInstall,
+  usage,
+  writeNativeSizeArtifacts,
+  type NativePackageMeasurement,
+  type NativeSizeToolchain,
+} from './profile-native-package-sizes.js';
+
+const temporaryDirectories: string[] = [];
+const toolchain: NativeSizeToolchain = {
+  node: 'v24.0.0',
+  npm: '11.0.0',
+  pnpm: '11.5.2',
+  rustc: 'rustc 1.96.0\ncommit-hash: example',
+  zlib: '1.3.1',
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('declaresNativeArtifact', () => {
+  it.each([
+    [['*.node'], true],
+    [['index.js', '*.node'], true],
+    [['dist/*.node'], true],
+    [['native.darwin-arm64.node'], true],
+    [['native.js'], false],
+    [[], false],
+    [undefined, false],
+    ['*.node', false],
+  ])('classifies %j as %s', (files, expected) => {
+    expect(declaresNativeArtifact(files)).toBe(expected);
+  });
+});
+
+describe('discoverNativePackages', () => {
+  it('finds publishable packages with built native artifacts in stable name order', () => {
+    const root = workspace();
+    writePackage(root, 'zeta', {
+      name: '@scope/zeta',
+      version: '2.0.0',
+      files: ['index.js', '*.node'],
+      binaries: ['zeta.linux-x64-gnu.node', 'zeta.darwin-arm64.node'],
+    });
+    writePackage(root, 'alpha', {
+      name: '@scope/alpha',
+      version: '1.0.0',
+      files: ['*.node'],
+      binaries: ['alpha.linux-x64-gnu.node'],
+    });
+
+    expect(discoverNativePackages(root)).toMatchObject([
+      {
+        name: '@scope/alpha',
+        version: '1.0.0',
+        directory: 'npm/alpha',
+        binaryFiles: ['alpha.linux-x64-gnu.node'],
+      },
+      {
+        name: '@scope/zeta',
+        version: '2.0.0',
+        directory: 'npm/zeta',
+        binaryFiles: ['zeta.darwin-arm64.node', 'zeta.linux-x64-gnu.node'],
+      },
+    ]);
+  });
+
+  it('ignores non-package directories, non-native packages, and private packages', () => {
+    const root = workspace();
+    mkdirSync(join(root, 'npm', 'empty'));
+    writePackage(root, 'javascript', {
+      name: '@scope/javascript',
+      version: '1.0.0',
+      files: ['index.js'],
+    });
+    writePackage(root, 'private-native', {
+      name: '@scope/private-native',
+      version: '1.0.0',
+      private: true,
+      files: ['*.node'],
+      binaries: ['private.node'],
+    });
+    writePackage(root, 'public-native', {
+      name: '@scope/public-native',
+      version: '1.0.0',
+      files: ['*.node'],
+      binaries: ['public.node'],
+    });
+
+    expect(discoverNativePackages(root).map((entry) => entry.name)).toEqual([
+      '@scope/public-native',
+    ]);
+  });
+
+  it('rejects a missing npm workspace', () => {
+    const root = temporaryDirectory();
+    expect(() => discoverNativePackages(root)).toThrow('Missing npm workspace directory');
+  });
+
+  it('rejects malformed package JSON with its relative path', () => {
+    const root = workspace();
+    const directory = join(root, 'npm', 'broken');
+    mkdirSync(directory);
+    writeFileSync(join(directory, 'package.json'), '{');
+    expect(() => discoverNativePackages(root)).toThrow('Cannot parse npm/broken/package.json');
+  });
+
+  it('rejects a native package without a name', () => {
+    const root = workspace();
+    writePackage(root, 'missing-name', {
+      version: '1.0.0',
+      files: ['*.node'],
+      binaries: ['native.node'],
+    });
+    expect(() => discoverNativePackages(root)).toThrow('missing a package name');
+  });
+
+  it('rejects a native package without a version', () => {
+    const root = workspace();
+    writePackage(root, 'missing-version', {
+      name: '@scope/missing-version',
+      files: ['*.node'],
+      binaries: ['native.node'],
+    });
+    expect(() => discoverNativePackages(root)).toThrow('missing a package version');
+  });
+
+  it('rejects duplicate native package names', () => {
+    const root = workspace();
+    for (const directory of ['one', 'two']) {
+      writePackage(root, directory, {
+        name: '@scope/duplicate',
+        version: '1.0.0',
+        files: ['*.node'],
+        binaries: [`${directory}.node`],
+      });
+    }
+    expect(() => discoverNativePackages(root)).toThrow(
+      'Duplicate native package name: @scope/duplicate',
+    );
+  });
+
+  it('requires a built artifact for every selected package', () => {
+    const root = workspace();
+    writePackage(root, 'not-built', {
+      name: '@scope/not-built',
+      version: '1.0.0',
+      files: ['*.node'],
+    });
+    expect(() => discoverNativePackages(root)).toThrow(
+      '@scope/not-built has no built .node artifact',
+    );
+  });
+
+  it('rejects an npm workspace without publishable native packages', () => {
+    const root = workspace();
+    writePackage(root, 'javascript', {
+      name: '@scope/javascript',
+      version: '1.0.0',
+      files: ['index.js'],
+    });
+    expect(() => discoverNativePackages(root)).toThrow(
+      'No publishable native npm packages were discovered',
+    );
+  });
+});
+
+describe('native binary measurement', () => {
+  it.each([
+    ['binding.darwin-arm64.node', 'darwin-arm64'],
+    ['binding.linux-x64-gnu.node', 'linux-x64-gnu'],
+    ['binding.win32-x64-msvc.node', 'win32-x64-msvc'],
+    ['binding.node', null],
+    ['binding.js', null],
+  ])('extracts the target from %s', (filename, target) => {
+    expect(binaryTarget(filename)).toBe(target);
+  });
+
+  it('records exact raw bytes, deterministic gzip bytes, and hashes', () => {
+    const directory = temporaryDirectory();
+    const path = join(directory, 'binding.linux-x64-gnu.node');
+    writeFileSync(path, Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+
+    const first = measureNativeBinary(path);
+    const second = measureNativeBinary(path);
+
+    expect(first).toEqual(second);
+    expect(first.file).toBe('binding.linux-x64-gnu.node');
+    expect(first.target).toBe('linux-x64-gnu');
+    expect(first.rawBytes).toBe(32);
+    expect(first.gzipBytes).toBeGreaterThan(0);
+    expect(first.gzipBytes).toBeLessThan(first.rawBytes);
+    expect(first.sha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first.gzipSha256).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it('supports an empty native artifact without inventing bytes', () => {
+    const directory = temporaryDirectory();
+    const path = join(directory, 'empty.node');
+    writeFileSync(path, Buffer.alloc(0));
+    const measurement = measureNativeBinary(path);
+    expect(measurement.rawBytes).toBe(0);
+    expect(measurement.gzipBytes).toBeGreaterThan(0);
+  });
+});
+
+describe('parseNpmPackJson', () => {
+  const entry = {
+    name: '@scope/plugin',
+    version: '1.2.3',
+    filename: 'scope-plugin-1.2.3.tgz',
+    size: 123,
+    unpackedSize: 456,
+    entryCount: 7,
+    files: [{ path: 'index.js' }],
+  };
+
+  it('parses the npm 12 object keyed by package name', () => {
+    expect(parseNpmPackJson(JSON.stringify({ '@scope/plugin': entry }))).toEqual({
+      name: '@scope/plugin',
+      version: '1.2.3',
+      filename: 'scope-plugin-1.2.3.tgz',
+      size: 123,
+      unpackedSize: 456,
+      entryCount: 7,
+    });
+  });
+
+  it('parses npm array output', () => {
+    expect(parseNpmPackJson(JSON.stringify([entry])).name).toBe('@scope/plugin');
+  });
+
+  it('parses a direct pack result object', () => {
+    expect(parseNpmPackJson(JSON.stringify(entry)).version).toBe('1.2.3');
+  });
+
+  it('uses the files array when entryCount is absent', () => {
+    const { entryCount: _, ...withoutCount } = entry;
+    expect(
+      parseNpmPackJson(
+        JSON.stringify({ ...withoutCount, files: [{ path: 'one' }, { path: 'two' }] }),
+      ).entryCount,
+    ).toBe(2);
+  });
+
+  it('uses zero when neither entryCount nor files are available', () => {
+    const { entryCount: _, files: __, ...minimal } = entry;
+    expect(parseNpmPackJson(JSON.stringify(minimal)).entryCount).toBe(0);
+  });
+
+  it('rejects invalid JSON', () => {
+    expect(() => parseNpmPackJson('{')).toThrow('did not return valid JSON');
+  });
+
+  it('rejects zero and multiple pack results', () => {
+    expect(() => parseNpmPackJson('{}')).toThrow('received 0');
+    expect(() => parseNpmPackJson(JSON.stringify([entry, entry]))).toThrow('received 2');
+  });
+
+  it.each([
+    [{ ...entry, name: '' }, 'name'],
+    [{ ...entry, version: null }, 'version'],
+    [{ ...entry, filename: 1 }, 'filename'],
+    [{ ...entry, size: -1 }, 'size'],
+    [{ ...entry, size: 1.5 }, 'size'],
+    [{ ...entry, unpackedSize: Number.MAX_SAFE_INTEGER + 1 }, 'unpackedSize'],
+    [{ ...entry, entryCount: -1 }, 'entryCount'],
+  ])('rejects invalid %s metadata', (candidate, field) => {
+    expect(() => parseNpmPackJson(JSON.stringify(candidate))).toThrow(`invalid ${String(field)}`);
+  });
+});
+
+describe('npm tarball measurement', () => {
+  it('keeps artifacts inside the requested destination', () => {
+    const destination = temporaryDirectory();
+    expect(resolvePackArtifactPath(destination, 'plugin.tgz')).toBe(
+      join(destination, 'plugin.tgz'),
+    );
+    expect(resolvePackArtifactPath(destination, join(destination, 'plugin.tgz'))).toBe(
+      join(destination, 'plugin.tgz'),
+    );
+  });
+
+  it('rejects relative and absolute traversal outside the destination', () => {
+    const destination = temporaryDirectory();
+    expect(() => resolvePackArtifactPath(destination, '../plugin.tgz')).toThrow(
+      'outside its destination',
+    );
+    expect(() =>
+      resolvePackArtifactPath(destination, resolve(destination, '..', 'plugin.tgz')),
+    ).toThrow('outside its destination');
+  });
+
+  it('packs a built package without running lifecycle scripts', () => {
+    const root = temporaryDirectory();
+    const packageDirectory = join(root, 'package');
+    const destination = join(root, 'artifacts');
+    mkdirSync(packageDirectory);
+    writeFileSync(join(packageDirectory, 'binding.node'), 'native');
+    writeFileSync(join(packageDirectory, 'index.js'), 'export default true;\n');
+    writeFileSync(
+      join(packageDirectory, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: '@scope/pack-fixture',
+          version: '1.0.0',
+          files: ['binding.node', 'index.js'],
+          scripts: {
+            prepack: "node -e \"require('node:fs').writeFileSync('prepack-ran', 'yes')\"",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const first = packNativePackage(packageDirectory, join(destination, 'first'));
+    const second = packNativePackage(packageDirectory, join(destination, 'second'));
+
+    expect(first).toEqual(second);
+    expect(first.bytes).toBeGreaterThan(0);
+    expect(first.unpackedBytes).toBeGreaterThanOrEqual('native'.length);
+    expect(first.fileCount).toBeGreaterThanOrEqual(3);
+    expect(first.sha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(() => readFileSync(join(packageDirectory, 'prepack-ran'))).toThrow();
+  });
+});
+
+describe('report construction', () => {
+  it('sums every common-install size axis independently', () => {
+    const packages = [packageMeasurement('b', 10), packageMeasurement('a', 20)];
+    const summary = summarizeCommonInstall(packages);
+    expect(summary).toMatchObject({
+      id: NATIVE_SIZE_PROFILE_ID,
+      packageCount: 2,
+      binaryCount: 2,
+      rawNativeBytes: 30,
+      gzipNativeBytes: 15,
+      npmTarballBytes: 90,
+      npmUnpackedBytes: 120,
+    });
+  });
+
+  it('returns explicit zero totals for an empty package list', () => {
+    expect(summarizeCommonInstall([])).toMatchObject({
+      packageCount: 0,
+      binaryCount: 0,
+      rawNativeBytes: 0,
+      gzipNativeBytes: 0,
+      npmTarballBytes: 0,
+      npmUnpackedBytes: 0,
+    });
+  });
+
+  it('sorts packages and records comparable measurement metadata without a timestamp', () => {
+    const report = buildNativeSizeReport(
+      [packageMeasurement('zeta', 2), packageMeasurement('alpha', 1)],
+      {
+        revision: 'abc123',
+        platform: 'linux',
+        architecture: 'x64',
+        runnerOs: 'Linux',
+        runnerArchitecture: 'X64',
+        toolchain,
+      },
+    );
+
+    expect(report.schemaVersion).toBe(NATIVE_SIZE_SCHEMA_VERSION);
+    expect(report.strategy).toBe(NATIVE_SIZE_STRATEGY);
+    expect(report.thresholdPolicy).toBe('measurement-only');
+    expect(report.packages.map((entry) => entry.name)).toEqual(['@scope/alpha', '@scope/zeta']);
+    expect(report.compression).toEqual({ format: 'gzip', level: GZIP_LEVEL });
+    expect(report.packaging.lifecycleScripts).toBe(false);
+    expect(JSON.stringify(report)).not.toMatch(/generatedAt|timestamp|thresholdBytes/u);
+  });
+
+  it('profiles injected packages deterministically and uses separate pack destinations', () => {
+    const root = temporaryDirectory();
+    const packageA = join(root, 'npm', 'a');
+    const packageB = join(root, 'npm', 'b');
+    mkdirSync(packageA, { recursive: true });
+    mkdirSync(packageB, { recursive: true });
+    const destinations: string[] = [];
+
+    const report = profileNativePackageSizes(
+      {
+        workspaceRoot: root,
+        outputDirectory: join(root, 'output'),
+        sourceRevision: 'explicit-sha',
+      },
+      {
+        discoverPackages: () => [
+          {
+            name: '@scope/b',
+            version: '1.0.0',
+            directory: 'npm/b',
+            absoluteDirectory: packageB,
+            binaryFiles: ['b.node'],
+          },
+          {
+            name: '@scope/a',
+            version: '1.0.0',
+            directory: 'npm/a',
+            absoluteDirectory: packageA,
+            binaryFiles: ['a.node'],
+          },
+        ],
+        measureBinary: (path) => ({
+          file: path.endsWith('a.node') ? 'a.node' : 'b.node',
+          target: null,
+          rawBytes: path.endsWith('a.node') ? 1 : 2,
+          gzipBytes: 1,
+          sha256: 'a'.repeat(64),
+          gzipSha256: 'b'.repeat(64),
+        }),
+        packPackage: (_packageDirectory, destination) => {
+          destinations.push(destination);
+          return {
+            bytes: 3,
+            unpackedBytes: 4,
+            fileCount: 2,
+            sha256: 'c'.repeat(64),
+          };
+        },
+        toolchain: () => toolchain,
+        resolveRevision: (_workspaceRoot, explicit) => explicit ?? 'fallback',
+        platform: 'linux',
+        architecture: 'x64',
+        runnerOs: 'Linux',
+        runnerArchitecture: 'X64',
+        temporaryDirectory: join(root, 'temporary'),
+      },
+    );
+
+    expect(report.source.revision).toBe('explicit-sha');
+    expect(report.packages.map((entry) => entry.name)).toEqual(['@scope/a', '@scope/b']);
+    expect(report.commonInstall).toMatchObject({
+      rawNativeBytes: 3,
+      gzipNativeBytes: 2,
+      npmTarballBytes: 6,
+      npmUnpackedBytes: 8,
+    });
+    expect(destinations).toHaveLength(2);
+    expect(new Set(destinations).size).toBe(2);
+  });
+});
+
+describe('Markdown and artifact output', () => {
+  it('renders the strategy, comparability metadata, table, totals, and no-threshold policy', () => {
+    const report = buildNativeSizeReport([packageMeasurement('pipe|name', 2048)], {
+      revision: 'deadbeef',
+      platform: 'darwin',
+      architecture: 'arm64',
+      runnerOs: null,
+      runnerArchitecture: null,
+      toolchain,
+    });
+    const markdown = renderNativeSizeMarkdown(report);
+
+    expect(markdown).toContain('# Native package size profile');
+    expect(markdown).toContain(`\`${NATIVE_SIZE_STRATEGY}\``);
+    expect(markdown).toContain('`deadbeef`');
+    expect(markdown).toContain('`darwin/arm64`');
+    expect(markdown).toContain('measurement only');
+    expect(markdown).toContain('@scope/pipe\\|name');
+    expect(markdown).toContain('2.00 KiB');
+    expect(markdown).toContain(`## Common install: ${NATIVE_SIZE_PROFILE_ID}`);
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+
+  it('writes stable newline-terminated JSON and Markdown artifacts', () => {
+    const directory = join(temporaryDirectory(), 'nested', 'output');
+    const report = buildNativeSizeReport([packageMeasurement('plugin', 1)], {
+      revision: 'revision',
+      platform: 'linux',
+      architecture: 'x64',
+      runnerOs: 'Linux',
+      runnerArchitecture: 'X64',
+      toolchain,
+    });
+    const paths = writeNativeSizeArtifacts(directory, report);
+    const json = readFileSync(paths.jsonPath, 'utf8');
+    const markdown = readFileSync(paths.markdownPath, 'utf8');
+
+    expect(json.endsWith('\n')).toBe(true);
+    expect(JSON.parse(json)).toEqual(report);
+    expect(markdown).toBe(renderNativeSizeMarkdown(report));
+    expect(markdown.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('formatBytes', () => {
+  it.each([
+    [0, '0 B'],
+    [1, '1 B'],
+    [1023, '1023 B'],
+    [1024, '1.00 KiB'],
+    [1536, '1.50 KiB'],
+    [1024 ** 2, '1.00 MiB'],
+    [1024 ** 3, '1.00 GiB'],
+    [1024 ** 4, '1.00 TiB'],
+  ])('formats %d as %s', (bytes, expected) => {
+    expect(formatBytes(bytes)).toBe(expected);
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid byte count %s',
+    (bytes) => {
+      expect(() => formatBytes(bytes)).toThrow('non-negative safe integer');
+    },
+  );
+});
+
+describe('revision and CLI handling', () => {
+  it('prefers a trimmed explicit revision', () => {
+    expect(resolveSourceRevision('/not/used', '  explicit  ')).toBe('explicit');
+  });
+
+  it('reads the current Git revision when no override is supplied', () => {
+    expect(resolveSourceRevision(resolve(import.meta.dirname, '..', '..'))).toMatch(
+      /^[a-f0-9]{40}$/u,
+    );
+  });
+
+  it('provides workspace-relative defaults', () => {
+    const options = parseCliArguments([], '/tmp/current');
+    expect(options.help).toBe(false);
+    expect(options.workspaceRoot).toBe(resolve(import.meta.dirname, '..', '..'));
+    expect(options.outputDirectory).toBe(
+      join(options.workspaceRoot, 'profiles', 'native-package-sizes'),
+    );
+  });
+
+  it('parses spaced and inline argument values', () => {
+    const options = parseCliArguments(
+      [
+        '--workspace-root',
+        './workspace',
+        '--output-dir=./artifacts',
+        '--source-revision',
+        'abc123',
+      ],
+      '/tmp/current',
+    );
+    expect(options).toMatchObject({
+      workspaceRoot: '/tmp/current/workspace',
+      outputDirectory: '/tmp/current/artifacts',
+      sourceRevision: 'abc123',
+    });
+  });
+
+  it('accepts the package-manager option separator', () => {
+    expect(parseCliArguments(['--', '--source-revision', 'abc123']).sourceRevision).toBe('abc123');
+  });
+
+  it.each(['--help', '-h'])('recognizes %s', (argument) => {
+    expect(parseCliArguments([argument]).help).toBe(true);
+  });
+
+  it('rejects unknown arguments', () => {
+    expect(() => parseCliArguments(['--threshold', '1'])).toThrow('Unknown argument: --threshold');
+  });
+
+  it.each(['--workspace-root', '--output-dir', '--source-revision'])(
+    'requires a value for %s',
+    (argument) => {
+      expect(() => parseCliArguments([argument])).toThrow(`${argument} requires a value`);
+      expect(() => parseCliArguments([argument, '--help'])).toThrow(`${argument} requires a value`);
+    },
+  );
+
+  it('rejects an empty source revision', () => {
+    expect(() => parseCliArguments(['--source-revision='])).toThrow('non-empty value');
+  });
+
+  it('documents measurement options without exposing a threshold option', () => {
+    expect(usage()).toContain('profile:native-sizes');
+    expect(usage()).toContain('--source-revision');
+    expect(usage()).not.toContain('--threshold');
+    expect(usage().endsWith('\n')).toBe(true);
+  });
+});
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'native-package-sizes-test-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function workspace(): string {
+  const root = temporaryDirectory();
+  mkdirSync(join(root, 'npm'));
+  return root;
+}
+
+function writePackage(
+  root: string,
+  directoryName: string,
+  options: {
+    name?: string;
+    version?: string;
+    private?: boolean;
+    files?: string[];
+    binaries?: string[];
+  },
+): void {
+  const directory = join(root, 'npm', directoryName);
+  mkdirSync(directory);
+  const { binaries = [], ...packageJson } = options;
+  writeFileSync(join(directory, 'package.json'), `${JSON.stringify(packageJson, null, 2)}\n`);
+  for (const binary of binaries) {
+    writeFileSync(join(directory, binary), `binary:${binary}`);
+  }
+}
+
+function packageMeasurement(name: string, rawBytes: number): NativePackageMeasurement {
+  return {
+    name: `@scope/${name}`,
+    version: '1.0.0',
+    directory: `npm/${name}`,
+    binaries: [
+      {
+        file: `${name}.linux-x64-gnu.node`,
+        target: 'linux-x64-gnu',
+        rawBytes,
+        gzipBytes: Math.floor(rawBytes / 2),
+        sha256: 'a'.repeat(64),
+        gzipSha256: 'b'.repeat(64),
+      },
+    ],
+    rawNativeBytes: rawBytes,
+    gzipNativeBytes: Math.floor(rawBytes / 2),
+    npmTarballBytes: rawBytes * 3,
+    npmUnpackedBytes: rawBytes * 4,
+    npmTarballFileCount: 5,
+    npmTarballSha256: 'c'.repeat(64),
+  };
+}

--- a/tools/tasks/profile-native-package-sizes.ts
+++ b/tools/tasks/profile-native-package-sizes.ts
@@ -1,0 +1,698 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+export const NATIVE_SIZE_SCHEMA_VERSION = 1;
+export const NATIVE_SIZE_STRATEGY = 'A-per-plugin-native-addon';
+export const NATIVE_SIZE_PROFILE_ID = 'all-native-packages';
+export const GZIP_LEVEL = 9;
+
+type PackageJson = {
+  name?: unknown;
+  version?: unknown;
+  private?: unknown;
+  files?: unknown;
+};
+
+export type NativePackageDescriptor = {
+  name: string;
+  version: string;
+  directory: string;
+  absoluteDirectory: string;
+  binaryFiles: string[];
+};
+
+export type BinaryMeasurement = {
+  file: string;
+  target: string | null;
+  rawBytes: number;
+  gzipBytes: number;
+  sha256: string;
+  gzipSha256: string;
+};
+
+export type NpmPackEntry = {
+  name: string;
+  version: string;
+  filename: string;
+  size: number;
+  unpackedSize: number;
+  entryCount: number;
+};
+
+export type TarballMeasurement = {
+  bytes: number;
+  unpackedBytes: number;
+  fileCount: number;
+  sha256: string;
+};
+
+export type NativePackageMeasurement = {
+  name: string;
+  version: string;
+  directory: string;
+  binaries: BinaryMeasurement[];
+  rawNativeBytes: number;
+  gzipNativeBytes: number;
+  npmTarballBytes: number;
+  npmUnpackedBytes: number;
+  npmTarballFileCount: number;
+  npmTarballSha256: string;
+};
+
+export type NativeSizeToolchain = {
+  node: string;
+  npm: string;
+  pnpm: string;
+  rustc: string;
+  zlib: string;
+};
+
+export type NativeSizeReport = {
+  schemaVersion: number;
+  measurement: 'native-package-size';
+  strategy: typeof NATIVE_SIZE_STRATEGY;
+  thresholdPolicy: 'measurement-only';
+  source: {
+    revision: string;
+  };
+  environment: {
+    platform: NodeJS.Platform;
+    architecture: string;
+    runnerOs: string | null;
+    runnerArchitecture: string | null;
+    toolchain: NativeSizeToolchain;
+  };
+  compression: {
+    format: 'gzip';
+    level: typeof GZIP_LEVEL;
+  };
+  packaging: {
+    command: 'npm pack --ignore-scripts --json';
+    lifecycleScripts: false;
+  };
+  packages: NativePackageMeasurement[];
+  commonInstall: {
+    id: typeof NATIVE_SIZE_PROFILE_ID;
+    description: string;
+    packageCount: number;
+    binaryCount: number;
+    rawNativeBytes: number;
+    gzipNativeBytes: number;
+    npmTarballBytes: number;
+    npmUnpackedBytes: number;
+  };
+};
+
+export type ProfileOptions = {
+  workspaceRoot: string;
+  outputDirectory: string;
+  sourceRevision?: string;
+};
+
+export type ProfileDependencies = {
+  discoverPackages?: (workspaceRoot: string) => NativePackageDescriptor[];
+  measureBinary?: (path: string) => BinaryMeasurement;
+  packPackage?: (packageDirectory: string, destination: string) => TarballMeasurement;
+  toolchain?: () => NativeSizeToolchain;
+  resolveRevision?: (workspaceRoot: string, explicit?: string) => string;
+  platform?: NodeJS.Platform;
+  architecture?: string;
+  runnerOs?: string | null;
+  runnerArchitecture?: string | null;
+  temporaryDirectory?: string;
+};
+
+export type CliOptions = ProfileOptions & {
+  help: boolean;
+};
+
+const WORKSPACE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function declaresNativeArtifact(files: unknown): boolean {
+  return (
+    Array.isArray(files) &&
+    files.some(
+      (entry) =>
+        typeof entry === 'string' &&
+        (entry === '*.node' || entry.endsWith('/*.node') || entry.endsWith('.node')),
+    )
+  );
+}
+
+export function discoverNativePackages(workspaceRoot: string): NativePackageDescriptor[] {
+  const npmDirectory = join(workspaceRoot, 'npm');
+  if (!existsSync(npmDirectory)) {
+    throw new Error(`Missing npm workspace directory: ${npmDirectory}`);
+  }
+
+  const packages: NativePackageDescriptor[] = [];
+  const names = new Set<string>();
+  const directories = readdirSync(npmDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const directoryName of directories) {
+    const absoluteDirectory = join(npmDirectory, directoryName);
+    const packageJsonPath = join(absoluteDirectory, 'package.json');
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    let packageJson: PackageJson;
+    try {
+      packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+    } catch (error) {
+      throw new Error(`Cannot parse ${relative(workspaceRoot, packageJsonPath)}: ${String(error)}`);
+    }
+
+    if (packageJson.private === true || !declaresNativeArtifact(packageJson.files)) {
+      continue;
+    }
+    if (typeof packageJson.name !== 'string' || packageJson.name.length === 0) {
+      throw new Error(`${relative(workspaceRoot, packageJsonPath)} is missing a package name.`);
+    }
+    if (typeof packageJson.version !== 'string' || packageJson.version.length === 0) {
+      throw new Error(`${relative(workspaceRoot, packageJsonPath)} is missing a package version.`);
+    }
+    if (names.has(packageJson.name)) {
+      throw new Error(`Duplicate native package name: ${packageJson.name}`);
+    }
+
+    const binaryFiles = readdirSync(absoluteDirectory)
+      .filter((entry) => entry.endsWith('.node'))
+      .sort();
+    if (binaryFiles.length === 0) {
+      throw new Error(
+        `${packageJson.name} has no built .node artifact in ${relative(
+          workspaceRoot,
+          absoluteDirectory,
+        )}. Run vp build first.`,
+      );
+    }
+
+    names.add(packageJson.name);
+    packages.push({
+      name: packageJson.name,
+      version: packageJson.version,
+      directory: toPosixPath(relative(workspaceRoot, absoluteDirectory)),
+      absoluteDirectory,
+      binaryFiles,
+    });
+  }
+
+  if (packages.length === 0) {
+    throw new Error('No publishable native npm packages were discovered. Run vp build first.');
+  }
+
+  return packages.sort(
+    (left, right) =>
+      left.name.localeCompare(right.name, 'en') ||
+      left.directory.localeCompare(right.directory, 'en'),
+  );
+}
+
+export function binaryTarget(filename: string): string | null {
+  const match = /\.([^.]+)\.node$/u.exec(filename);
+  return match?.[1] ?? null;
+}
+
+export function measureNativeBinary(path: string): BinaryMeasurement {
+  const contents = readFileSync(path);
+  const compressed = gzipSync(contents, { level: GZIP_LEVEL });
+  return {
+    file: basename(path),
+    target: binaryTarget(basename(path)),
+    rawBytes: contents.byteLength,
+    gzipBytes: compressed.byteLength,
+    sha256: sha256(contents),
+    gzipSha256: sha256(compressed),
+  };
+}
+
+export function parseNpmPackJson(output: string): NpmPackEntry {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`npm pack did not return valid JSON: ${String(error)}`);
+  }
+
+  const candidates = packCandidates(parsed);
+  if (candidates.length !== 1) {
+    throw new Error(`Expected exactly one npm pack result, received ${candidates.length}.`);
+  }
+
+  const candidate = candidates[0];
+  if (!isRecord(candidate)) {
+    throw new Error('npm pack result is not an object.');
+  }
+
+  const name = requiredString(candidate.name, 'name');
+  const version = requiredString(candidate.version, 'version');
+  const filename = requiredString(candidate.filename, 'filename');
+  const size = requiredNonNegativeInteger(candidate.size, 'size');
+  const unpackedSize = requiredNonNegativeInteger(candidate.unpackedSize, 'unpackedSize');
+  const files = candidate.files;
+  const entryCount =
+    candidate.entryCount === undefined
+      ? Array.isArray(files)
+        ? files.length
+        : 0
+      : requiredNonNegativeInteger(candidate.entryCount, 'entryCount');
+
+  return { name, version, filename, size, unpackedSize, entryCount };
+}
+
+export function resolvePackArtifactPath(destination: string, filename: string): string {
+  const destinationRoot = resolve(destination);
+  const artifactPath = resolve(
+    destinationRoot,
+    isAbsolute(filename) ? relative(destinationRoot, filename) : filename,
+  );
+  const pathFromDestination = relative(destinationRoot, artifactPath);
+  if (
+    pathFromDestination === '..' ||
+    pathFromDestination.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromDestination)
+  ) {
+    throw new Error(`npm pack returned an artifact outside its destination: ${filename}`);
+  }
+  return artifactPath;
+}
+
+export function packNativePackage(
+  packageDirectory: string,
+  destination: string,
+): TarballMeasurement {
+  mkdirSync(destination, { recursive: true });
+  const output = execFileSync(
+    npmCommand(),
+    ['pack', '--ignore-scripts', '--json', '--pack-destination', destination],
+    {
+      cwd: packageDirectory,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const result = parseNpmPackJson(output);
+  const artifactPath = resolvePackArtifactPath(destination, result.filename);
+  if (!existsSync(artifactPath)) {
+    throw new Error(`npm pack did not create ${artifactPath}.`);
+  }
+
+  const contents = readFileSync(artifactPath);
+  if (contents.byteLength !== result.size) {
+    throw new Error(
+      `npm pack size mismatch for ${result.name}: JSON reported ${result.size}, file has ${contents.byteLength}.`,
+    );
+  }
+
+  return {
+    bytes: contents.byteLength,
+    unpackedBytes: result.unpackedSize,
+    fileCount: result.entryCount,
+    sha256: sha256(contents),
+  };
+}
+
+export function collectToolchainMetadata(): NativeSizeToolchain {
+  return {
+    node: process.version,
+    npm: commandVersion(npmCommand(), ['--version']),
+    pnpm: commandVersion(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', ['--version']),
+    rustc: commandVersion('rustc', ['--version', '--verbose']),
+    zlib: process.versions.zlib,
+  };
+}
+
+export function resolveSourceRevision(workspaceRoot: string, explicit?: string): string {
+  const revision = explicit?.trim();
+  if (revision) {
+    return revision;
+  }
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: workspaceRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+export function summarizeCommonInstall(
+  packages: NativePackageMeasurement[],
+): NativeSizeReport['commonInstall'] {
+  return packages.reduce<NativeSizeReport['commonInstall']>(
+    (summary, packageMeasurement) => {
+      summary.packageCount += 1;
+      summary.binaryCount += packageMeasurement.binaries.length;
+      summary.rawNativeBytes += packageMeasurement.rawNativeBytes;
+      summary.gzipNativeBytes += packageMeasurement.gzipNativeBytes;
+      summary.npmTarballBytes += packageMeasurement.npmTarballBytes;
+      summary.npmUnpackedBytes += packageMeasurement.npmUnpackedBytes;
+      return summary;
+    },
+    {
+      id: NATIVE_SIZE_PROFILE_ID,
+      description:
+        'Strategy A upper-bound/meta-equivalent install: every publishable npm package that ships its own native addon on this platform.',
+      packageCount: 0,
+      binaryCount: 0,
+      rawNativeBytes: 0,
+      gzipNativeBytes: 0,
+      npmTarballBytes: 0,
+      npmUnpackedBytes: 0,
+    },
+  );
+}
+
+export function buildNativeSizeReport(
+  packages: NativePackageMeasurement[],
+  metadata: {
+    revision: string;
+    platform: NodeJS.Platform;
+    architecture: string;
+    runnerOs: string | null;
+    runnerArchitecture: string | null;
+    toolchain: NativeSizeToolchain;
+  },
+): NativeSizeReport {
+  const sortedPackages = [...packages].sort(
+    (left, right) =>
+      left.name.localeCompare(right.name, 'en') ||
+      left.directory.localeCompare(right.directory, 'en'),
+  );
+  return {
+    schemaVersion: NATIVE_SIZE_SCHEMA_VERSION,
+    measurement: 'native-package-size',
+    strategy: NATIVE_SIZE_STRATEGY,
+    thresholdPolicy: 'measurement-only',
+    source: { revision: metadata.revision },
+    environment: {
+      platform: metadata.platform,
+      architecture: metadata.architecture,
+      runnerOs: metadata.runnerOs,
+      runnerArchitecture: metadata.runnerArchitecture,
+      toolchain: metadata.toolchain,
+    },
+    compression: {
+      format: 'gzip',
+      level: GZIP_LEVEL,
+    },
+    packaging: {
+      command: 'npm pack --ignore-scripts --json',
+      lifecycleScripts: false,
+    },
+    packages: sortedPackages,
+    commonInstall: summarizeCommonInstall(sortedPackages),
+  };
+}
+
+export function profileNativePackageSizes(
+  options: ProfileOptions,
+  dependencies: ProfileDependencies = {},
+): NativeSizeReport {
+  const discoverPackages = dependencies.discoverPackages ?? discoverNativePackages;
+  const measureBinary = dependencies.measureBinary ?? measureNativeBinary;
+  const packPackage = dependencies.packPackage ?? packNativePackage;
+  const descriptors = discoverPackages(options.workspaceRoot);
+  const temporaryDirectory =
+    dependencies.temporaryDirectory ??
+    mkdtempSync(join(tmpdir(), 'oxlint-plugins-native-package-sizes-'));
+  const ownsTemporaryDirectory = dependencies.temporaryDirectory === undefined;
+
+  try {
+    const packages = descriptors.map((descriptor, index) => {
+      const binaries = descriptor.binaryFiles
+        .map((filename) => measureBinary(join(descriptor.absoluteDirectory, filename)))
+        .sort((left, right) => left.file.localeCompare(right.file, 'en'));
+      const tarball = packPackage(
+        descriptor.absoluteDirectory,
+        join(temporaryDirectory, String(index).padStart(3, '0')),
+      );
+      return {
+        name: descriptor.name,
+        version: descriptor.version,
+        directory: descriptor.directory,
+        binaries,
+        rawNativeBytes: sum(binaries.map((binary) => binary.rawBytes)),
+        gzipNativeBytes: sum(binaries.map((binary) => binary.gzipBytes)),
+        npmTarballBytes: tarball.bytes,
+        npmUnpackedBytes: tarball.unpackedBytes,
+        npmTarballFileCount: tarball.fileCount,
+        npmTarballSha256: tarball.sha256,
+      };
+    });
+
+    return buildNativeSizeReport(packages, {
+      revision: (dependencies.resolveRevision ?? resolveSourceRevision)(
+        options.workspaceRoot,
+        options.sourceRevision,
+      ),
+      platform: dependencies.platform ?? process.platform,
+      architecture: dependencies.architecture ?? process.arch,
+      runnerOs: dependencies.runnerOs ?? process.env.RUNNER_OS ?? null,
+      runnerArchitecture: dependencies.runnerArchitecture ?? process.env.RUNNER_ARCH ?? null,
+      toolchain: (dependencies.toolchain ?? collectToolchainMetadata)(),
+    });
+  } finally {
+    if (ownsTemporaryDirectory) {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  }
+}
+
+export function renderNativeSizeMarkdown(report: NativeSizeReport): string {
+  const lines = [
+    '# Native package size profile',
+    '',
+    `- Strategy: \`${report.strategy}\``,
+    `- Source revision: \`${report.source.revision}\``,
+    `- Environment: \`${report.environment.platform}/${report.environment.architecture}\``,
+    `- Node/npm/pnpm: \`${firstLine(report.environment.toolchain.node)}\` / \`${firstLine(
+      report.environment.toolchain.npm,
+    )}\` / \`${firstLine(report.environment.toolchain.pnpm)}\``,
+    `- Compression: \`${report.compression.format}\` level \`${report.compression.level}\``,
+    '- Policy: measurement only; this report intentionally has no pass/fail size threshold.',
+    '',
+    '| Package | Native binaries | Raw .node | gzip .node | npm tarball | npm unpacked |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+    ...report.packages.map(
+      (packageMeasurement) =>
+        `| ${escapeMarkdownCell(packageMeasurement.name)} | ${
+          packageMeasurement.binaries.length
+        } | ${formatBytes(packageMeasurement.rawNativeBytes)} | ${formatBytes(
+          packageMeasurement.gzipNativeBytes,
+        )} | ${formatBytes(packageMeasurement.npmTarballBytes)} | ${formatBytes(
+          packageMeasurement.npmUnpackedBytes,
+        )} |`,
+    ),
+    '',
+    `## Common install: ${report.commonInstall.id}`,
+    '',
+    report.commonInstall.description,
+    '',
+    `- Packages: ${report.commonInstall.packageCount}`,
+    `- Native binaries: ${report.commonInstall.binaryCount}`,
+    `- Raw native total: ${formatBytes(report.commonInstall.rawNativeBytes)}`,
+    `- gzip native total: ${formatBytes(report.commonInstall.gzipNativeBytes)}`,
+    `- npm tarball total: ${formatBytes(report.commonInstall.npmTarballBytes)}`,
+    `- npm unpacked total: ${formatBytes(report.commonInstall.npmUnpackedBytes)}`,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+export function writeNativeSizeArtifacts(
+  outputDirectory: string,
+  report: NativeSizeReport,
+): { jsonPath: string; markdownPath: string } {
+  mkdirSync(outputDirectory, { recursive: true });
+  const jsonPath = join(outputDirectory, 'native-package-sizes.json');
+  const markdownPath = join(outputDirectory, 'native-package-sizes.md');
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  writeFileSync(markdownPath, renderNativeSizeMarkdown(report));
+  return { jsonPath, markdownPath };
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isSafeInteger(bytes) || bytes < 0) {
+    throw new Error(`Byte count must be a non-negative safe integer: ${bytes}`);
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unit = units[0];
+  for (let index = 1; index < units.length && value >= 1024; index += 1) {
+    value /= 1024;
+    unit = units[index];
+  }
+  return `${value.toFixed(2)} ${unit}`;
+}
+
+export function parseCliArguments(
+  arguments_: string[],
+  currentWorkingDirectory = process.cwd(),
+): CliOptions {
+  const options: CliOptions = {
+    workspaceRoot: WORKSPACE_ROOT,
+    outputDirectory: join(WORKSPACE_ROOT, 'profiles', 'native-package-sizes'),
+    help: false,
+  };
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === '--') {
+      continue;
+    }
+    if (argument === '--help' || argument === '-h') {
+      options.help = true;
+      continue;
+    }
+    const [name, inlineValue] = splitArgument(argument);
+    if (!['--workspace-root', '--output-dir', '--source-revision'].includes(name)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = inlineValue ?? arguments_[++index];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`${name} requires a value.`);
+    }
+    if (name === '--workspace-root') {
+      options.workspaceRoot = resolve(currentWorkingDirectory, value);
+    } else if (name === '--output-dir') {
+      options.outputDirectory = resolve(currentWorkingDirectory, value);
+    } else {
+      const revision = value.trim();
+      if (revision.length === 0) {
+        throw new Error('--source-revision requires a non-empty value.');
+      }
+      options.sourceRevision = revision;
+    }
+  }
+  return options;
+}
+
+export function usage(): string {
+  return [
+    'Usage: pnpm run profile:native-sizes -- [options]',
+    '',
+    'Options:',
+    '  --workspace-root <path>    Workspace root containing npm/* packages.',
+    '  --output-dir <path>        Directory for JSON and Markdown artifacts.',
+    '  --source-revision <sha>    Revision recorded in comparable metadata.',
+    '  -h, --help                 Show this help.',
+    '',
+  ].join('\n');
+}
+
+function packCandidates(parsed: unknown): unknown[] {
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+  if (!isRecord(parsed)) {
+    return [];
+  }
+  if (typeof parsed.name === 'string') {
+    return [parsed];
+  }
+  return Object.values(parsed).filter((value) => isRecord(value) && typeof value.name === 'string');
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`npm pack result has an invalid ${field}.`);
+  }
+  return value;
+}
+
+function requiredNonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`npm pack result has an invalid ${field}.`);
+  }
+  return value as number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sha256(contents: NodeJS.ArrayBufferView): string {
+  return createHash('sha256').update(contents).digest('hex');
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function commandVersion(command: string, arguments_: string[]): string {
+  return execFileSync(command, arguments_, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function npmCommand(): string {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function toPosixPath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/u, 1)[0];
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function splitArgument(argument: string): [string, string | undefined] {
+  const equals = argument.indexOf('=');
+  return equals === -1
+    ? [argument, undefined]
+    : [argument.slice(0, equals), argument.slice(equals + 1)];
+}
+
+function isDirectExecution(): boolean {
+  return (
+    process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isDirectExecution()) {
+  try {
+    const options = parseCliArguments(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(usage());
+    } else {
+      const report = profileNativePackageSizes({
+        ...options,
+        sourceRevision: options.sourceRevision ?? process.env.NATIVE_SIZE_SOURCE_REVISION,
+      });
+      const artifacts = writeNativeSizeArtifacts(options.outputDirectory, report);
+      process.stdout.write(
+        `${renderNativeSizeMarkdown(report)}\nArtifacts:\n- ${artifacts.jsonPath}\n- ${
+          artifacts.markdownPath
+        }\n`,
+      );
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- keep Strategy A (one native binary package per plugin) and add deterministic size profiling for every publishable native package
- measure raw `.node`, gzip level 9, actual `npm pack --ignore-scripts` tarball/unpacked size, file count, SHA256, and the common-install total
- publish stable JSON/Markdown artifacts and job summaries from benchmark and release workflows, with platform/runtime/toolchain/revision metadata and no pass/fail threshold

## Validation
- 73 new discovery, validation, sorting, error, hashing, gzip, npm JSON, traversal, integration, metadata, Markdown, CLI, and no-threshold tests passed
- two real 22-package runs produced byte-identical JSON and Markdown
- measured 22 binaries: 35.82 MiB raw, 15.34 MiB gzip, 15.58 MiB npm tarballs, 36.93 MiB unpacked
- `VITEST_MAX_WORKERS=1 pnpm verify`: all gates passed
- full JS: 14,372 passed, 1,159 skipped
- full Rust, Clippy, build, bench compile, audit, licenses, status, and publish dry-runs passed
- draft shared-core PR #36 was not modified; no React paths/status entries changed

Closes #27

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->