### PR TITLE
feat(perfectionist): support sort-named-imports options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
  "which",
 ]
 
@@ -200,6 +200,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "divan"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +232,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -344,7 +355,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -432,6 +443,140 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "icu_collator"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -545,6 +690,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +762,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -624,7 +775,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -721,7 +872,7 @@ checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -763,7 +914,7 @@ dependencies = [
  "phf",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1042,6 +1193,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxlint-plugins-perfectionist",
+ "serde_json",
 ]
 
 [[package]]
@@ -1269,11 +1421,15 @@ dependencies = [
 name = "oxlint-plugins-perfectionist"
 version = "0.0.0"
 dependencies = [
+ "icu_collator",
+ "icu_locale_core",
  "oxc_allocator",
+ "oxc_ast",
  "oxc_parser",
  "oxc_span",
  "oxlint-plugins-_carton",
  "regex",
+ "serde_json",
 ]
 
 [[package]]
@@ -1532,7 +1688,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1561,13 +1717,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "serde_core",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1605,7 +1772,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -1619,7 +1786,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1776,7 +1943,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1839,6 +2006,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,6 +2026,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1915,7 +2110,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1926,7 +2121,18 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
 ]
 
 [[package]]
@@ -1996,6 +2202,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,7 +2263,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2228,7 +2446,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2244,7 +2462,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2284,6 +2502,97 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,8 @@ oxlint-plugins-unused-imports = { path = "crates/unused_imports", version = "0.0
 regex = "1.12.2"
 phf = { version = "0.13.1", features = ["macros"] }
 pg_query = "6.1.1"
+icu_collator = "2.2.1"
+icu_locale_core = "2.2.0"
 rustc-hash = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }

--- a/crates/perfectionist/Cargo.toml
+++ b/crates/perfectionist/Cargo.toml
@@ -9,11 +9,15 @@ version.workspace = true
 publish = false
 
 [dependencies]
+icu_collator.workspace = true
+icu_locale_core.workspace = true
 oxc_allocator.workspace = true
+oxc_ast.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true
 regex.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perfectionist/src/lib.rs
+++ b/crates/perfectionist/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod helpers;
 mod scanner;
+mod sort_named_imports;
+mod sort_options;
 mod types;
 
 #[cfg(test)]
@@ -15,7 +17,9 @@ use oxlint_plugins_carton::SmallVec;
 use crate::scanner::Scanner;
 use crate::types::LineIndex;
 
-pub use crate::types::{Diagnostic, DiagnosticLoc};
+pub use crate::types::{
+    Diagnostic, DiagnosticLoc, RuleDiagnostic, RuleDiagnosticData, RuleDiagnosticFix,
+};
 
 pub const RULE_NAMES: [&str; 23] = [
     "sort-array-includes",
@@ -64,4 +68,29 @@ pub fn scan_perfectionist(source_text: &str, filename: &str) -> SmallVec<[Diagno
     };
     scanner.scan();
     scanner.diagnostics
+}
+
+pub fn scan_perfectionist_rule(
+    source_text: &str,
+    filename: &str,
+    rule_name: &str,
+    options: &serde_json::Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    if rule_name != "sort-named-imports" {
+        return SmallVec::new();
+    }
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_else(|_| SourceType::tsx())
+        .with_module(true);
+    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+    sort_named_imports::check(
+        source_text,
+        &parser_return.program.body,
+        &parser_return.program.comments,
+        options,
+    )
 }

--- a/crates/perfectionist/src/sort_named_imports.rs
+++ b/crates/perfectionist/src/sort_named_imports.rs
@@ -1,0 +1,230 @@
+//! Configurable `sort-named-imports` slice pinned to Perfectionist v5.9.1.
+
+use std::cmp::Ordering;
+
+use oxc_ast::{
+    Comment,
+    ast::{ImportDeclarationSpecifier, ImportSpecifier, ModuleExportName, Statement},
+};
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::sort_options::SortOptions;
+use crate::types::{LineIndex, RuleDiagnostic, RuleDiagnosticData, RuleDiagnosticFix};
+
+const RULE: &str = "sort-named-imports";
+const MESSAGE_ID: &str = "unexpectedNamedImportsOrder";
+
+struct NamedImport<'a> {
+    span: Span,
+    name: CompactString,
+    source: &'a str,
+    source_start: u32,
+    source_end: u32,
+    size: usize,
+}
+
+pub(crate) fn check(
+    source_text: &str,
+    body: &[Statement<'_>],
+    comments: &[Comment],
+    raw_options: &Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    let options = SortOptions::from_json(raw_options);
+    let lines = LineIndex::new(source_text);
+    let mut diagnostics = SmallVec::new();
+
+    for statement in body {
+        let Statement::ImportDeclaration(declaration) = statement else {
+            continue;
+        };
+        let Some(specifiers) = declaration.specifiers.as_ref() else {
+            continue;
+        };
+        let named_specifiers: SmallVec<[&ImportSpecifier<'_>; 8]> = specifiers
+            .iter()
+            .filter_map(|specifier| {
+                let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                    return None;
+                };
+                Some(&**specifier)
+            })
+            .collect();
+        let imports: SmallVec<[NamedImport<'_>; 8]> = named_specifiers
+            .iter()
+            .enumerate()
+            .filter_map(|(index, specifier)| {
+                let boundary = named_specifiers
+                    .get(index + 1)
+                    .map_or(declaration.span.end, |next| next.span.start);
+                named_import(
+                    source_text,
+                    comments,
+                    specifier,
+                    boundary,
+                    options.ignore_alias,
+                )
+            })
+            .collect();
+        if imports.len() < 2 {
+            continue;
+        }
+
+        let mut sorted_indices: SmallVec<[usize; 8]> = (0..imports.len()).collect();
+        sorted_indices.sort_by(|&left, &right| {
+            compare_imports(&options, &imports[left], &imports[right])
+                .then_with(|| left.cmp(&right))
+        });
+        if sorted_indices
+            .iter()
+            .enumerate()
+            .all(|(position, &original)| position == original)
+        {
+            continue;
+        }
+
+        let Some(fix) = build_fix(source_text, &imports, &sorted_indices) else {
+            continue;
+        };
+        for pair in imports.windows(2) {
+            let [left, right] = pair else {
+                continue;
+            };
+            if compare_imports(&options, left, right) != Ordering::Greater {
+                continue;
+            }
+            diagnostics.push(RuleDiagnostic {
+                rule_name: RULE,
+                message_id: MESSAGE_ID,
+                data: RuleDiagnosticData {
+                    left: left.name.clone(),
+                    right: right.name.clone(),
+                },
+                loc: lines.loc_for_span(source_text, right.span),
+                fix: fix.clone(),
+            });
+        }
+    }
+    diagnostics
+}
+
+fn named_import<'a>(
+    source_text: &'a str,
+    comments: &[Comment],
+    specifier: &ImportSpecifier<'_>,
+    boundary: u32,
+    ignore_alias: bool,
+) -> Option<NamedImport<'a>> {
+    let source_start = comments
+        .iter()
+        .filter(|comment| {
+            comment.attached_to == specifier.span.start && comment.span.end <= specifier.span.start
+        })
+        .map(|comment| comment.span.start)
+        .min()
+        .unwrap_or(specifier.span.start);
+    let source_end = comments
+        .iter()
+        .filter(|comment| {
+            comment.span.start >= specifier.span.end
+                && comment.span.end <= boundary
+                && is_same_line(source_text, specifier.span.end, comment.span.start)
+        })
+        .map(|comment| comment.span.end)
+        .max()
+        .unwrap_or(specifier.span.end);
+    let start = usize::try_from(source_start).ok()?;
+    let end = usize::try_from(source_end).ok()?;
+    let source = source_text.get(start..end)?;
+    let node_start = usize::try_from(specifier.span.start).ok()?;
+    let node_end = usize::try_from(specifier.span.end).ok()?;
+    let size = source_text
+        .get(node_start..node_end)?
+        .encode_utf16()
+        .count();
+    let name = if ignore_alias {
+        module_export_name(&specifier.imported)
+    } else {
+        CompactString::from(specifier.local.name.as_str())
+    };
+    Some(NamedImport {
+        span: specifier.span,
+        name,
+        source,
+        source_start,
+        source_end,
+        size,
+    })
+}
+
+fn compare_imports(
+    options: &SortOptions,
+    left: &NamedImport<'_>,
+    right: &NamedImport<'_>,
+) -> Ordering {
+    options.compare(
+        left.name.as_str(),
+        left.size,
+        right.name.as_str(),
+        right.size,
+    )
+}
+
+fn build_fix(
+    source_text: &str,
+    imports: &[NamedImport<'_>],
+    sorted_indices: &[usize],
+) -> Option<RuleDiagnosticFix> {
+    let first = sorted_indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, &original)| (position != original).then_some(position))?;
+    let last = sorted_indices
+        .iter()
+        .enumerate()
+        .rfind(|(position, original)| *position != **original)
+        .map(|(position, _)| position)?;
+    let start = usize::try_from(imports[first].source_start).ok()?;
+    let end = usize::try_from(imports[last].source_end).ok()?;
+    let mut replacement = CompactString::new("");
+    for position in first..=last {
+        if position > first {
+            let separator_start = usize::try_from(imports[position - 1].source_end).ok()?;
+            let separator_end = usize::try_from(imports[position].source_start).ok()?;
+            replacement.push_str(source_text.get(separator_start..separator_end)?);
+        }
+        replacement.push_str(imports[*sorted_indices.get(position)?].source);
+    }
+    Some(RuleDiagnosticFix {
+        start: LineIndex::utf16_offset(source_text, u32::try_from(start).ok()?),
+        end: LineIndex::utf16_offset(source_text, u32::try_from(end).ok()?),
+        replacement,
+    })
+}
+
+fn is_same_line(source_text: &str, left: u32, right: u32) -> bool {
+    let Ok(left) = usize::try_from(left) else {
+        return false;
+    };
+    let Ok(right) = usize::try_from(right) else {
+        return false;
+    };
+    source_text.get(left..right).is_some_and(|between| {
+        !between
+            .chars()
+            .any(|character| matches!(character, '\n' | '\r' | '\u{2028}' | '\u{2029}'))
+    })
+}
+
+fn module_export_name(name: &ModuleExportName<'_>) -> CompactString {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => {
+            CompactString::from(identifier.name.as_str())
+        }
+        ModuleExportName::IdentifierReference(identifier) => {
+            CompactString::from(identifier.name.as_str())
+        }
+        ModuleExportName::StringLiteral(literal) => CompactString::from(literal.value.as_str()),
+    }
+}

--- a/crates/perfectionist/src/sort_options.rs
+++ b/crates/perfectionist/src/sort_options.rs
@@ -1,0 +1,524 @@
+//! Truthful supported option subset for the first configurable sort engine.
+//!
+//! Upstream exposes additional grouping, partition, conditional-configuration,
+//! and locale options. They remain rejected by the adapter schema until the
+//! corresponding core semantics exist.
+
+use std::cmp::Ordering;
+
+use icu_collator::{CollatorBorrowed, CollatorPreferences, options::CollatorOptions};
+use icu_locale_core::Locale;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SortType {
+    Alphabetical,
+    Natural,
+    LineLength,
+    Custom,
+    Unsorted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SpecialCharacters {
+    Keep,
+    Trim,
+    Remove,
+}
+
+#[derive(Clone, Debug)]
+struct FallbackSort {
+    kind: SortType,
+    order: SortOrder,
+}
+
+#[derive(Debug)]
+pub(crate) struct SortOptions {
+    kind: SortType,
+    order: SortOrder,
+    fallback: FallbackSort,
+    special_characters: SpecialCharacters,
+    alphabet: CompactString,
+    pub(crate) ignore_alias: bool,
+    ignore_case: bool,
+    collator: Option<CollatorBorrowed<'static>>,
+}
+
+impl Default for SortOptions {
+    fn default() -> Self {
+        Self {
+            kind: SortType::Alphabetical,
+            order: SortOrder::Ascending,
+            fallback: FallbackSort {
+                kind: SortType::Unsorted,
+                order: SortOrder::Ascending,
+            },
+            special_characters: SpecialCharacters::Keep,
+            alphabet: CompactString::new(""),
+            ignore_alias: false,
+            ignore_case: true,
+            collator: collator_for_locale("en-US"),
+        }
+    }
+}
+
+impl SortOptions {
+    pub(crate) fn from_json(options: &Value) -> Self {
+        let Some(object) = options
+            .as_array()
+            .and_then(|values| values.first())
+            .and_then(Value::as_object)
+            .or_else(|| options.as_object())
+        else {
+            return Self::default();
+        };
+
+        let mut parsed = Self::default();
+        parsed.kind = object
+            .get("type")
+            .and_then(Value::as_str)
+            .and_then(parse_sort_type)
+            .unwrap_or(parsed.kind);
+        parsed.order = object
+            .get("order")
+            .and_then(Value::as_str)
+            .and_then(parse_order)
+            .unwrap_or(parsed.order);
+        parsed.ignore_case = object
+            .get("ignoreCase")
+            .and_then(Value::as_bool)
+            .unwrap_or(parsed.ignore_case);
+        parsed.ignore_alias = object
+            .get("ignoreAlias")
+            .and_then(Value::as_bool)
+            .unwrap_or(parsed.ignore_alias);
+        parsed.special_characters = object
+            .get("specialCharacters")
+            .and_then(Value::as_str)
+            .and_then(parse_special_characters)
+            .unwrap_or(parsed.special_characters);
+        if let Some(alphabet) = object.get("alphabet").and_then(Value::as_str) {
+            parsed.alphabet = CompactString::from(alphabet);
+        }
+        if let Some(locale) = first_locale(object.get("locales")) {
+            parsed.collator = collator_for_locale(locale);
+        }
+        if let Some(fallback) = object.get("fallbackSort").and_then(Value::as_object) {
+            parsed.fallback.kind = fallback
+                .get("type")
+                .and_then(Value::as_str)
+                .and_then(parse_sort_type)
+                .unwrap_or(parsed.fallback.kind);
+            parsed.fallback.order = fallback
+                .get("order")
+                .and_then(Value::as_str)
+                .and_then(parse_order)
+                .unwrap_or(parsed.fallback.order);
+        }
+        parsed
+    }
+
+    pub(crate) fn compare(
+        &self,
+        left_name: &str,
+        left_size: usize,
+        right_name: &str,
+        right_size: usize,
+    ) -> Ordering {
+        // Upstream deliberately ignores `fallbackSort` when the primary sorter
+        // is `unsorted`.
+        if self.kind == SortType::Unsorted {
+            return Ordering::Equal;
+        }
+        let primary = self.compare_with(
+            self.kind, self.order, left_name, left_size, right_name, right_size,
+        );
+        if primary != Ordering::Equal {
+            return primary;
+        }
+        self.compare_with(
+            self.fallback.kind,
+            self.fallback.order,
+            left_name,
+            left_size,
+            right_name,
+            right_size,
+        )
+    }
+
+    fn compare_with(
+        &self,
+        kind: SortType,
+        order: SortOrder,
+        left_name: &str,
+        left_size: usize,
+        right_name: &str,
+        right_size: usize,
+    ) -> Ordering {
+        let ordering = match kind {
+            SortType::Alphabetical => {
+                let left = self.normalize(left_name);
+                let right = self.normalize(right_name);
+                self.collator.as_ref().map_or_else(
+                    || compare_en_us(left.as_str(), right.as_str()),
+                    |collator| collator.compare(left.as_str(), right.as_str()),
+                )
+            }
+            SortType::Natural => {
+                let left = self.normalize(left_name);
+                let right = self.normalize(right_name);
+                natural_compare(left.as_str(), right.as_str())
+            }
+            SortType::LineLength => left_size.cmp(&right_size),
+            SortType::Custom => {
+                let left = self.normalize(left_name);
+                let right = self.normalize(right_name);
+                custom_compare(left.as_str(), right.as_str(), self.alphabet.as_str())
+            }
+            SortType::Unsorted => Ordering::Equal,
+        };
+        match order {
+            SortOrder::Ascending => ordering,
+            SortOrder::Descending => ordering.reverse(),
+        }
+    }
+
+    fn normalize(&self, value: &str) -> CompactString {
+        let normalized: CompactString = if self.ignore_case {
+            value.chars().flat_map(char::to_lowercase).collect()
+        } else {
+            CompactString::from(value)
+        };
+
+        let mut formatted = CompactString::new("");
+        let mut found_letter = false;
+        for character in normalized.chars() {
+            if character.is_whitespace() {
+                continue;
+            }
+            let is_letter = is_perfectionist_letter(character);
+            match self.special_characters {
+                SpecialCharacters::Keep => formatted.push(character),
+                SpecialCharacters::Trim if found_letter || is_letter => {
+                    found_letter = true;
+                    formatted.push(character);
+                }
+                SpecialCharacters::Trim => {}
+                SpecialCharacters::Remove if is_letter => formatted.push(character),
+                SpecialCharacters::Remove => {}
+            }
+        }
+        formatted
+    }
+}
+
+fn first_locale(value: Option<&Value>) -> Option<&str> {
+    match value {
+        Some(Value::String(locale)) => Some(locale),
+        Some(Value::Array(locales)) => locales.iter().find_map(Value::as_str),
+        _ => None,
+    }
+}
+
+fn collator_for_locale(locale: &str) -> Option<CollatorBorrowed<'static>> {
+    let preferences = locale
+        .parse::<Locale>()
+        .map(CollatorPreferences::from)
+        .unwrap_or_default();
+    CollatorBorrowed::try_new(preferences, CollatorOptions::default()).ok()
+}
+
+fn is_perfectionist_letter(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x0041..=0x005A
+            | 0x0061..=0x007A
+            | 0x00C0..=0x024F
+            | 0x1E00..=0x1EFF
+    )
+}
+
+/// Identifier-focused approximation of `localeCompare(..., "en-US")`.
+///
+/// The named-import rule overwhelmingly compares JavaScript identifiers.
+/// Folding ASCII letters first and using lowercase-before-uppercase as the
+/// variant tiebreak matches the ICU collation used by Node for those names,
+/// while keeping the implementation deterministic and allocation free.
+fn compare_en_us(left: &str, right: &str) -> Ordering {
+    let mut left_characters = left.chars();
+    let mut right_characters = right.chars();
+    loop {
+        match (left_characters.next(), right_characters.next()) {
+            (Some(left_character), Some(right_character)) => {
+                let folded = ascii_collation_rank(left_character)
+                    .cmp(&ascii_collation_rank(right_character));
+                if folded != Ordering::Equal {
+                    return folded;
+                }
+                if left_character != right_character {
+                    let variant =
+                        ascii_case_rank(left_character).cmp(&ascii_case_rank(right_character));
+                    if variant != Ordering::Equal {
+                        return variant;
+                    }
+                    return left_character.cmp(&right_character);
+                }
+            }
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            (None, None) => return Ordering::Equal,
+        }
+    }
+}
+
+fn ascii_collation_rank(character: char) -> (u8, char) {
+    match character {
+        '_' => (0, character),
+        '$' => (1, character),
+        '0'..='9' => (2, character),
+        'A'..='Z' | 'a'..='z' => (3, character.to_ascii_lowercase()),
+        _ => (4, character),
+    }
+}
+
+fn ascii_case_rank(character: char) -> u8 {
+    if character.is_ascii_lowercase() {
+        0
+    } else if character.is_ascii_uppercase() {
+        1
+    } else {
+        0
+    }
+}
+
+fn parse_sort_type(value: &str) -> Option<SortType> {
+    match value {
+        "alphabetical" => Some(SortType::Alphabetical),
+        "natural" => Some(SortType::Natural),
+        "line-length" => Some(SortType::LineLength),
+        "custom" => Some(SortType::Custom),
+        "unsorted" => Some(SortType::Unsorted),
+        _ => None,
+    }
+}
+
+fn parse_order(value: &str) -> Option<SortOrder> {
+    match value {
+        "asc" => Some(SortOrder::Ascending),
+        "desc" => Some(SortOrder::Descending),
+        _ => None,
+    }
+}
+
+fn parse_special_characters(value: &str) -> Option<SpecialCharacters> {
+    match value {
+        "keep" => Some(SpecialCharacters::Keep),
+        "trim" => Some(SpecialCharacters::Trim),
+        "remove" => Some(SpecialCharacters::Remove),
+        _ => None,
+    }
+}
+
+fn natural_compare(left: &str, right: &str) -> Ordering {
+    // `natural-orderby` lowercases strings internally, even when
+    // Perfectionist's `ignoreCase` formatter was disabled.
+    let left = left.to_lowercase();
+    let right = right.to_lowercase();
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    let mut left_index = 0;
+    let mut right_index = 0;
+    while left_index < left.len() && right_index < right.len() {
+        if left[left_index].is_ascii_digit() && right[right_index].is_ascii_digit() {
+            let left_end = digit_run_end(left, left_index);
+            let right_end = digit_run_end(right, right_index);
+            let left_digits = trim_zeroes(&left[left_index..left_end]);
+            let right_digits = trim_zeroes(&right[right_index..right_end]);
+            let ordering = left_digits
+                .len()
+                .cmp(&right_digits.len())
+                .then_with(|| left_digits.cmp(right_digits))
+                // Equal numeric values are ordered by their original chunk
+                // text, e.g. `01` before `1`.
+                .then_with(|| left[left_index..left_end].cmp(&right[right_index..right_end]));
+            if ordering != Ordering::Equal {
+                return ordering;
+            }
+            left_index = left_end;
+            right_index = right_end;
+            continue;
+        }
+        let ordering = left[left_index].cmp(&right[right_index]);
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+        left_index += 1;
+        right_index += 1;
+    }
+    left.len().cmp(&right.len())
+}
+
+fn digit_run_end(value: &[u8], mut index: usize) -> usize {
+    while value.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+    }
+    index
+}
+
+fn trim_zeroes(value: &[u8]) -> &[u8] {
+    let first_non_zero = value
+        .iter()
+        .position(|&character| character != b'0')
+        .unwrap_or(value.len().saturating_sub(1));
+    &value[first_non_zero..]
+}
+
+fn custom_compare(left: &str, right: &str, alphabet: &str) -> Ordering {
+    let alphabet: SmallVec<[u16; 128]> = alphabet.encode_utf16().collect();
+    let left: SmallVec<[u16; 32]> = left.encode_utf16().collect();
+    let right: SmallVec<[u16; 32]> = right.encode_utf16().collect();
+    for (&left_character, &right_character) in left.iter().zip(&right) {
+        let left_rank = alphabet
+            .iter()
+            .position(|&candidate| candidate == left_character);
+        let right_rank = alphabet
+            .iter()
+            .position(|&candidate| candidate == right_character);
+        let ordering = match (left_rank, right_rank) {
+            (Some(left), Some(right)) => left.cmp(&right),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            // Upstream assigns Infinity to all characters outside the custom
+            // alphabet, so two unknown characters compare equal.
+            (None, None) => Ordering::Equal,
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    left.len().cmp(&right.len())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "serde_json::json! intentionally constructs public option payloads in tests."
+)]
+mod tests {
+    use super::{SortOptions, SortType};
+    use serde_json::json;
+    use std::cmp::Ordering;
+
+    fn compare(options: serde_json::Value, left: &str, right: &str) -> Ordering {
+        SortOptions::from_json(&options).compare(left, left.len(), right, right.len())
+    }
+
+    #[test]
+    fn defaults_to_case_insensitive_ascending_alphabetical_order() {
+        assert_eq!(compare(json!([]), "A", "b"), Ordering::Less);
+        assert_eq!(compare(json!([]), "a", "A"), Ordering::Equal);
+    }
+
+    #[test]
+    fn reverses_the_configured_order() {
+        assert_eq!(
+            compare(json!([{ "order": "desc" }]), "a", "b"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn compares_natural_numeric_chunks_and_leading_zeroes() {
+        assert_eq!(
+            compare(json!([{ "type": "natural" }]), "item2", "item10"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare(json!([{ "type": "natural" }]), "item01", "item1"),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn compares_the_full_specifier_length() {
+        let options = SortOptions::from_json(&json!([{ "type": "line-length" }]));
+        assert_eq!(options.compare("A", 9, "B", 1), Ordering::Greater);
+    }
+
+    #[test]
+    fn honors_a_custom_alphabet() {
+        assert_eq!(
+            compare(json!([{ "type": "custom", "alphabet": "cba" }]), "c", "a"),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn applies_the_fallback_only_after_a_primary_tie() {
+        assert_eq!(
+            compare(
+                json!([{
+                    "type": "line-length",
+                    "fallbackSort": { "type": "alphabetical", "order": "desc" }
+                }]),
+                "a",
+                "b"
+            ),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn leaves_unsorted_input_stable_even_with_a_fallback() {
+        let options = SortOptions::from_json(&json!([{
+            "type": "unsorted",
+            "fallbackSort": { "type": "alphabetical" }
+        }]));
+        assert_eq!(options.kind, SortType::Unsorted);
+        assert_eq!(options.compare("z", 1, "a", 1), Ordering::Equal);
+    }
+
+    #[test]
+    fn trims_or_removes_special_characters_before_comparing() {
+        assert_eq!(
+            compare(json!([{ "specialCharacters": "trim" }]), "_a", "b"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare(json!([{ "specialCharacters": "remove" }]), "a_b", "ab"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn uses_locale_aware_chinese_collation() {
+        assert_eq!(
+            compare(json!([{ "locales": "zh-CN" }]), "你好", "世界"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare(json!([{ "locales": "zh-CN" }]), "世界", "a"),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn accepts_locale_preference_arrays_and_swedish_collation() {
+        assert_eq!(
+            compare(json!([{ "locales": ["zh-CN", "en-US"] }]), "世界", "a"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare(json!([{ "locales": "sv" }]), "z", "å"),
+            Ordering::Less
+        );
+    }
+}

--- a/crates/perfectionist/src/types.rs
+++ b/crates/perfectionist/src/types.rs
@@ -1,7 +1,7 @@
 //! Diagnostic types and line indexing for the perfectionist port.
 
 use oxc_span::Span;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiagnosticLoc {
@@ -16,6 +16,30 @@ pub struct Diagnostic {
     pub rule_name: &'static str,
     pub message_id: &'static str,
     pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuleDiagnosticData {
+    pub left: CompactString,
+    pub right: CompactString,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuleDiagnosticFix {
+    /// UTF-16 source offset expected by ESLint/Oxlint fixers.
+    pub start: u32,
+    /// UTF-16 source offset expected by ESLint/Oxlint fixers.
+    pub end: u32,
+    pub replacement: CompactString,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuleDiagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub data: RuleDiagnosticData,
+    pub loc: DiagnosticLoc,
+    pub fix: RuleDiagnosticFix,
 }
 
 pub(crate) struct LineIndex {
@@ -43,6 +67,12 @@ impl LineIndex {
             end_line,
             end_column,
         }
+    }
+
+    pub(crate) fn utf16_offset(source_text: &str, byte_offset: u32) -> u32 {
+        let byte_offset = (byte_offset as usize).min(source_text.len());
+        let units = source_text[..byte_offset].encode_utf16().count();
+        u32::try_from(units).unwrap_or(u32::MAX)
     }
 
     fn position_for_offset(&self, source_text: &str, offset: u32) -> (u32, u32) {

--- a/npm/perfectionist/Cargo.toml
+++ b/npm/perfectionist/Cargo.toml
@@ -16,6 +16,7 @@ name = "oxlint_plugin_perfectionist"
 napi.workspace = true
 napi-derive.workspace = true
 oxlint-plugins-perfectionist.workspace = true
+serde_json.workspace = true
 
 [build-dependencies]
 napi-build.workspace = true

--- a/npm/perfectionist/api.d.ts
+++ b/npm/perfectionist/api.d.ts
@@ -9,7 +9,22 @@ export type PerfectionistDiagnostic = {
   ruleName: string;
   messageId: string;
   loc: PerfectionistDiagnosticLoc;
+  data?: {
+    left: string;
+    right: string;
+  };
+  fix?: {
+    start: number;
+    end: number;
+    replacement: string;
+  };
 };
 
 export function implementedPerfectionistRuleNames(): string[];
 export function scanPerfectionist(sourceText: string, filename?: string): PerfectionistDiagnostic[];
+export function scanPerfectionistRule(
+  sourceText: string,
+  filename?: string,
+  ruleName?: string,
+  options?: unknown[],
+): PerfectionistDiagnostic[];

--- a/npm/perfectionist/api.js
+++ b/npm/perfectionist/api.js
@@ -12,8 +12,27 @@ function scanPerfectionist(sourceText, filename = 'file.tsx') {
   return native.scanPerfectionist(sourceText, filename);
 }
 
+function scanPerfectionistRule(
+  sourceText,
+  filename = 'file.tsx',
+  ruleName = 'sort-named-imports',
+  options = [],
+) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  if (typeof ruleName !== 'string') {
+    throw new TypeError('ruleName must be a string.');
+  }
+  return native.scanPerfectionistRule(sourceText, filename, ruleName, options);
+}
+
 module.exports = {
   implementedPerfectionistRuleNames: native.implementedPerfectionistRuleNames,
   scanPerfectionist,
+  scanPerfectionistRule,
 };
 module.exports.default = module.exports;

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -5,7 +5,11 @@
 // checks run in Rust through Oxc.
 
 const { eslintCompatPlugin } = require('@oxlint/plugins');
-const { implementedPerfectionistRuleNames, scanPerfectionist } = require('./api.js');
+const {
+  implementedPerfectionistRuleNames,
+  scanPerfectionist,
+  scanPerfectionistRule,
+} = require('./api.js');
 
 const PLUGIN_NAME = 'perfectionist';
 const DOCS_BASE = 'https://perfectionist.dev/rules';
@@ -64,13 +68,12 @@ function createLegacyConfig(options) {
   };
 }
 
-function recommendedRules() {
-  // The core sorts with fixed defaults and does not honor option values yet, so
-  // configs enable rules at `error` without an (ignored) options payload — which
-  // would also violate the now-empty per-rule schema. The `recommended-*`
-  // variants therefore behave identically until the sort engine lands.
+function recommendedRules(options) {
   return Object.fromEntries(
-    recommendedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
+    recommendedRuleNames.map((ruleName) => [
+      `${PLUGIN_NAME}/${ruleName}`,
+      ruleName === 'sort-named-imports' ? ['error', options] : 'error',
+    ]),
   );
 }
 
@@ -85,13 +88,15 @@ function createPerfectionistRule(ruleName) {
         url: `${DOCS_BASE}/${ruleName}`,
       },
       fixable: 'code',
-      messages: {
-        unexpected: 'Expected sorted order.',
-      },
-      // The core sorts with fixed defaults and does not honor upstream options
-      // yet, so declare no schema rather than silently ignore configured
-      // options. Tracked for implementation of the configurable sort engine.
-      schema: [],
+      messages:
+        ruleName === 'sort-named-imports'
+          ? {
+              unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+            }
+          : {
+              unexpected: 'Expected sorted order.',
+            },
+      schema: schemaForRule(ruleName),
     },
     createOnce(context) {
       return {
@@ -106,7 +111,30 @@ function createPerfectionistRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
+  if (ruleName === 'sort-named-imports') {
+    return configuredDiagnosticsForRule(context, ruleName);
+  }
   return diagnosticsForContext(context).filter((diagnostic) => diagnostic.ruleName === ruleName);
+}
+
+function configuredDiagnosticsForRule(context, ruleName) {
+  const sourceCode = context.sourceCode || {};
+  const sourceText = sourceTextForContext(context);
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.tsx';
+  const options = Array.isArray(context.options) ? context.options : [];
+  const key = JSON.stringify({ filename, options, ruleName, sourceText });
+  let cache = diagnosticsCache.get(sourceCode);
+
+  if (!cache || !(cache instanceof Map)) {
+    cache = new Map();
+    diagnosticsCache.set(sourceCode, cache);
+  }
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+  const diagnostics = scanPerfectionistRule(sourceText, filename, ruleName, options);
+  cache.set(key, diagnostics);
+  return diagnostics;
 }
 
 function diagnosticsForContext(context) {
@@ -115,7 +143,12 @@ function diagnosticsForContext(context) {
   const filename = typeof context.filename === 'string' ? context.filename : 'file.tsx';
   let cached = diagnosticsCache.get(sourceCode);
 
-  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+  if (
+    cached &&
+    !(cached instanceof Map) &&
+    cached.sourceText === sourceText &&
+    cached.filename === filename
+  ) {
     return cached.diagnostics;
   }
 
@@ -128,6 +161,7 @@ function diagnosticsForContext(context) {
 function reportDiagnostic(context, diagnostic) {
   context.report({
     messageId: diagnostic.messageId,
+    data: diagnostic.data,
     loc: {
       start: {
         line: diagnostic.loc.startLine,
@@ -138,7 +172,63 @@ function reportDiagnostic(context, diagnostic) {
         column: diagnostic.loc.endColumn,
       },
     },
+    fix: diagnostic.fix
+      ? (fixer) =>
+          fixer.replaceTextRange(
+            [diagnostic.fix.start, diagnostic.fix.end],
+            diagnostic.fix.replacement,
+          )
+      : undefined,
   });
+}
+
+function schemaForRule(ruleName) {
+  if (ruleName !== 'sort-named-imports') {
+    return [];
+  }
+  const sortType = {
+    type: 'string',
+    enum: ['alphabetical', 'natural', 'line-length', 'custom', 'unsorted'],
+  };
+  const order = {
+    type: 'string',
+    enum: ['asc', 'desc'],
+  };
+  return [
+    {
+      type: 'object',
+      properties: {
+        type: sortType,
+        order,
+        ignoreCase: { type: 'boolean' },
+        specialCharacters: {
+          type: 'string',
+          enum: ['keep', 'trim', 'remove'],
+        },
+        locales: {
+          oneOf: [
+            { type: 'string' },
+            {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          ],
+        },
+        alphabet: { type: 'string' },
+        fallbackSort: {
+          type: 'object',
+          properties: {
+            type: sortType,
+            order,
+          },
+          required: ['type'],
+          additionalProperties: false,
+        },
+        ignoreAlias: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+  ];
 }
 
 function sourceTextForContext(context) {
@@ -156,3 +246,4 @@ module.exports = plugin;
 module.exports.default = plugin;
 module.exports.implementedPerfectionistRuleNames = implementedRuleNames;
 module.exports.scanPerfectionist = scanPerfectionist;
+module.exports.scanPerfectionistRule = scanPerfectionistRule;

--- a/npm/perfectionist/src/lib.rs
+++ b/npm/perfectionist/src/lib.rs
@@ -1,7 +1,8 @@
 //! NAPI boundary for the perfectionist oxlint plugin.
 
 pub use napi_abi::{
-    Diagnostic, DiagnosticLoc, implemented_perfectionist_rule_names, scan_perfectionist,
+    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, implemented_perfectionist_rule_names,
+    scan_perfectionist, scan_perfectionist_rule,
 };
 
 #[allow(
@@ -10,8 +11,10 @@ pub use napi_abi::{
     reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
 )]
 mod napi_abi {
+    use napi::Result;
     use napi_derive::napi;
     use oxlint_plugins_perfectionist as core;
+    use serde_json::Value;
 
     #[napi(object)]
     #[derive(Clone, Debug)]
@@ -28,6 +31,23 @@ mod napi_abi {
         pub rule_name: String,
         pub message_id: String,
         pub loc: DiagnosticLoc,
+        pub data: Option<DiagnosticData>,
+        pub fix: Option<DiagnosticFix>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticData {
+        pub left: String,
+        pub right: String,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticFix {
+        pub start: u32,
+        pub end: u32,
+        pub replacement: String,
     }
 
     #[napi]
@@ -51,7 +71,42 @@ mod napi_abi {
                     end_line: diagnostic.loc.end_line,
                     end_column: diagnostic.loc.end_column,
                 },
+                data: None,
+                fix: None,
             })
             .collect()
+    }
+
+    #[napi]
+    pub fn scan_perfectionist_rule(
+        source_text: String,
+        filename: String,
+        rule_name: String,
+        options: Value,
+    ) -> Result<Vec<Diagnostic>> {
+        Ok(
+            core::scan_perfectionist_rule(&source_text, &filename, &rule_name, &options)
+                .into_iter()
+                .map(|diagnostic| Diagnostic {
+                    rule_name: diagnostic.rule_name.to_owned(),
+                    message_id: diagnostic.message_id.to_owned(),
+                    loc: DiagnosticLoc {
+                        start_line: diagnostic.loc.start_line,
+                        start_column: diagnostic.loc.start_column,
+                        end_line: diagnostic.loc.end_line,
+                        end_column: diagnostic.loc.end_column,
+                    },
+                    data: Some(DiagnosticData {
+                        left: diagnostic.data.left.into_string(),
+                        right: diagnostic.data.right.into_string(),
+                    }),
+                    fix: Some(DiagnosticFix {
+                        start: diagnostic.fix.start,
+                        end: diagnostic.fix.end,
+                        replacement: diagnostic.fix.replacement.into_string(),
+                    }),
+                })
+                .collect(),
+        )
     }
 }

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { implementedPerfectionistRuleNames, scanPerfectionist } from '../api.js';
+import {
+  implementedPerfectionistRuleNames,
+  scanPerfectionist,
+  scanPerfectionistRule,
+} from '../api.js';
 
 const expectedRuleNames = [
   'sort-array-includes',
@@ -82,5 +86,52 @@ describe('perfectionist native API', () => {
         endLine: 1,
       },
     });
+  });
+
+  it('returns exact configured data and UTF-16 fix offsets', () => {
+    const source = `'😀';\r\nimport { item2, item10 } from "pkg";\r\n`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-named-imports', [
+      { type: 'natural', order: 'desc' },
+    ]);
+    const start = source.indexOf('item2');
+    const end = source.indexOf('item10') + 'item10'.length;
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-named-imports',
+      messageId: 'unexpectedNamedImportsOrder',
+      data: {
+        left: 'item2',
+        right: 'item10',
+      },
+      loc: {
+        startLine: 2,
+        startColumn: 16,
+        endLine: 2,
+        endColumn: 22,
+      },
+      fix: {
+        start,
+        end,
+        replacement: 'item10, item2',
+      },
+    });
+  });
+
+  it('isolates configured scanning to its implemented rule', () => {
+    expect(
+      scanPerfectionistRule('import { b, a } from "pkg";', 'fixture.ts', 'sort-objects', [
+        { order: 'desc' },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('validates public API scalar arguments', () => {
+    expect(() => scanPerfectionistRule(null)).toThrowError('sourceText must be a string.');
+    expect(() => scanPerfectionistRule('import {} from "pkg";', null)).toThrowError(
+      'filename must be a string.',
+    );
+    expect(() => scanPerfectionistRule('import {} from "pkg";', 'fixture.ts', null)).toThrowError(
+      'ruleName must be a string.',
+    );
   });
 });

--- a/npm/perfectionist/test/fixtures/sort-named-imports-options-v5.9.1.json
+++ b/npm/perfectionist/test/fixtures/sort-named-imports-options-v5.9.1.json
@@ -1,0 +1,1349 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-perfectionist",
+    "version": "5.9.1",
+    "sourceCommit": "b35e8e4caf0c8d350cf386e504241f21827dd60b",
+    "sourceHashes": {
+      "rules/sort-named-imports.ts": "ef0f575cb4aca0248120e8eb831748b2fb7a170e2e2220b8cdee66f1c2740ae6",
+      "rules/sort-named-imports/sort-named-import.ts": "3e35c4b385cab6e07acac20e2ee4f5049e3cfc1fb05403ac0158cd360e4b3415",
+      "test/rules/sort-named-imports.test.ts": "a5fe43752e460a2d29432e01e01a21aaa92bf9bc6d5193840dc593c6767ddeee"
+    },
+    "license": "MIT",
+    "eslintVersion": "9.39.2",
+    "typescriptEslintParserVersion": "8.60.0",
+    "capturePolicy": "Curated exact parity for the supported scalar comparator option subset; grouping, partition, newline, and conditional options are intentionally excluded.",
+    "tool": "tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
+    "inventory": {
+      "valid": 23,
+      "invalid": 28,
+      "diagnostics": 41,
+      "total": 51
+    }
+  },
+  "cases": [
+    {
+      "name": "default alphabetical order",
+      "code": "import { AAA, BB, C } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "default alphabetical inversion",
+      "code": "import { BB, AAA, C } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"AAA\" to come before \"BB\".",
+          "data": {
+            "right": "AAA",
+            "left": "BB"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 14,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "AAA, BB"
+          }
+        }
+      ],
+      "output": "import { AAA, BB, C } from 'module'"
+    },
+    {
+      "name": "default complete reversal",
+      "code": "import { C, BB, AAA } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"BB\" to come before \"C\".",
+          "data": {
+            "right": "BB",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 15
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "AAA, BB, C"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"AAA\" to come before \"BB\".",
+          "data": {
+            "right": "AAA",
+            "left": "BB"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "AAA, BB, C"
+          }
+        }
+      ],
+      "output": "import { AAA, BB, C } from 'module'"
+    },
+    {
+      "name": "multiline alphabetical order",
+      "code": "import {\n  AAAA,\n  BBB,\n  CC,\n  D,\n} from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "multiline alphabetical inversion",
+      "code": "import {\n  AAAA,\n  CC,\n  BBB,\n  D,\n} from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"BBB\" to come before \"CC\".",
+          "data": {
+            "right": "BBB",
+            "left": "CC"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [19, 28],
+            "text": "BBB,\n  CC"
+          }
+        }
+      ],
+      "output": "import {\n  AAAA,\n  BBB,\n  CC,\n  D,\n} from 'module'"
+    },
+    {
+      "name": "default ignores default import",
+      "code": "import Default, { A, B } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "default sorts by local alias",
+      "code": "import { c as A, b as B, a as C } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "default local alias inversion",
+      "code": "import { a as C, b as B, c as A } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "c as A, b as B, a as C"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 26,
+            "endLine": 1,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "c as A, b as B, a as C"
+          }
+        }
+      ],
+      "output": "import { c as A, b as B, a as C } from 'module'"
+    },
+    {
+      "name": "ignoreAlias original names",
+      "code": "import { A as C, B as B, C as A } from 'module'",
+      "options": [
+        {
+          "ignoreAlias": true
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "ignoreAlias inversion",
+      "code": "import { C as A, B as B, A as C } from 'module'",
+      "options": [
+        {
+          "ignoreAlias": true
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "A as C, B as B, C as A"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 26,
+            "endLine": 1,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "A as C, B as B, C as A"
+          }
+        }
+      ],
+      "output": "import { A as C, B as B, C as A } from 'module'"
+    },
+    {
+      "name": "ignoreCase stable equivalent aliases",
+      "code": "import { b as a, a as A } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "case-sensitive lowercase before uppercase",
+      "code": "import { b as a, a as A } from 'module'",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "case-sensitive inversion",
+      "code": "import { a as A, b as a } from 'module'",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"a\" to come before \"A\".",
+          "data": {
+            "right": "a",
+            "left": "A"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 23],
+            "text": "b as a, a as A"
+          }
+        }
+      ],
+      "output": "import { b as a, a as A } from 'module'"
+    },
+    {
+      "name": "alphabetical descending",
+      "code": "import { C, BB, AAA } from 'module'",
+      "options": [
+        {
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "alphabetical descending inversion",
+      "code": "import { AAA, BB, C } from 'module'",
+      "options": [
+        {
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"BB\" to come before \"AAA\".",
+          "data": {
+            "right": "BB",
+            "left": "AAA"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 15,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "C, BB, AAA"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"C\" to come before \"BB\".",
+          "data": {
+            "right": "C",
+            "left": "BB"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 19,
+            "endLine": 1,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "C, BB, AAA"
+          }
+        }
+      ],
+      "output": "import { C, BB, AAA } from 'module'"
+    },
+    {
+      "name": "natural numeric order",
+      "code": "import { item1, item2, item10 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "natural numeric inversion",
+      "code": "import { item10, item2, item1 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"item2\" to come before \"item10\".",
+          "data": {
+            "right": "item2",
+            "left": "item10"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item1, item2, item10"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"item1\" to come before \"item2\".",
+          "data": {
+            "right": "item1",
+            "left": "item2"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 25,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item1, item2, item10"
+          }
+        }
+      ],
+      "output": "import { item1, item2, item10 } from 'module'"
+    },
+    {
+      "name": "natural leading zero order",
+      "code": "import { item01, item1, item2 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "natural leading zero inversion",
+      "code": "import { item2, item1, item01 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"item1\" to come before \"item2\".",
+          "data": {
+            "right": "item1",
+            "left": "item2"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item01, item1, item2"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"item01\" to come before \"item1\".",
+          "data": {
+            "right": "item01",
+            "left": "item1"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item01, item1, item2"
+          }
+        }
+      ],
+      "output": "import { item01, item1, item2 } from 'module'"
+    },
+    {
+      "name": "natural descending inversion",
+      "code": "import { item1, item2, item10 } from 'module'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"item2\" to come before \"item1\".",
+          "data": {
+            "right": "item2",
+            "left": "item1"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item10, item2, item1"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"item10\" to come before \"item2\".",
+          "data": {
+            "right": "item10",
+            "left": "item2"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item10, item2, item1"
+          }
+        }
+      ],
+      "output": "import { item10, item2, item1 } from 'module'"
+    },
+    {
+      "name": "line length descending",
+      "code": "import { AAA, BB, C } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "line length descending inversion",
+      "code": "import { C, AAA, BB } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"AAA\" to come before \"C\".",
+          "data": {
+            "right": "AAA",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 16
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "AAA, BB, C"
+          }
+        }
+      ],
+      "output": "import { AAA, BB, C } from 'module'"
+    },
+    {
+      "name": "line length ascending",
+      "code": "import { C, BB, AAA } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "line length counts alias source",
+      "code": "import { long as A, B } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"B\" to come before \"A\".",
+          "data": {
+            "right": "B",
+            "left": "A"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 21,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 21],
+            "text": "B, long as A"
+          }
+        }
+      ],
+      "output": "import { B, long as A } from 'module'"
+    },
+    {
+      "name": "custom reverse alphabet",
+      "code": "import { c, b, a } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "cba"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "custom reverse alphabet inversion",
+      "code": "import { a, b, c } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "cba"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "c, b, a"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"c\" to come before \"b\".",
+          "data": {
+            "right": "c",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "c, b, a"
+          }
+        }
+      ],
+      "output": "import { c, b, a } from 'module'"
+    },
+    {
+      "name": "custom unknown characters remain stable",
+      "code": "import { x, y, z } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "abc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "custom unknown characters compare length",
+      "code": "import { xx, y, zzz } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "abc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"y\" to come before \"xx\".",
+          "data": {
+            "right": "y",
+            "left": "xx"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 14,
+            "endLine": 1,
+            "endColumn": 15
+          },
+          "fix": {
+            "range": [9, 14],
+            "text": "y, xx"
+          }
+        }
+      ],
+      "output": "import { y, xx, zzz } from 'module'"
+    },
+    {
+      "name": "custom descending inversion",
+      "code": "import { c, b, a } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "abc",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "unsorted preserves arbitrary order",
+      "code": "import { c, a, b } from 'module'",
+      "options": [
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "unsorted ignores configured fallback",
+      "code": "import { c, a, b } from 'module'",
+      "options": [
+        {
+          "type": "unsorted",
+          "fallbackSort": {
+            "type": "alphabetical"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "special characters keep identifier punctuation",
+      "code": "import { _a, $a, a } from 'module'",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "special characters trim",
+      "code": "import { _a, b, _c } from 'module'",
+      "options": [
+        {
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "special characters trim inversion",
+      "code": "import { _b, a, _c } from 'module'",
+      "options": [
+        {
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"a\" to come before \"_b\".",
+          "data": {
+            "right": "a",
+            "left": "_b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 14,
+            "endLine": 1,
+            "endColumn": 15
+          },
+          "fix": {
+            "range": [9, 14],
+            "text": "a, _b"
+          }
+        }
+      ],
+      "output": "import { a, _b, _c } from 'module'"
+    },
+    {
+      "name": "special characters remove stable equality",
+      "code": "import { ab, a_b } from 'module'",
+      "options": [
+        {
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "Chinese locale order",
+      "code": "import { 你好, 世界, a, A, b, B } from 'module'",
+      "options": [
+        {
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "Chinese locale inversion",
+      "code": "import { b, B, a, A, 世界, 你好 } from 'module'",
+      "options": [
+        {
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"a\" to come before \"B\".",
+          "data": {
+            "right": "a",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "你好, 世界, a, A, b, B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"世界\" to come before \"A\".",
+          "data": {
+            "right": "世界",
+            "left": "A"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 22,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "你好, 世界, a, A, b, B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"你好\" to come before \"世界\".",
+          "data": {
+            "right": "你好",
+            "left": "世界"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 26,
+            "endLine": 1,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "你好, 世界, a, A, b, B"
+          }
+        }
+      ],
+      "output": "import { 你好, 世界, a, A, b, B } from 'module'"
+    },
+    {
+      "name": "locale preference array",
+      "code": "import { 你好, 世界, a, A, b, B } from 'module'",
+      "options": [
+        {
+          "locales": ["zh-CN", "en-US"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "Swedish locale inversion",
+      "code": "import { ä, å, z, a } from 'module'",
+      "options": [
+        {
+          "locales": "sv"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"å\" to come before \"ä\".",
+          "data": {
+            "right": "å",
+            "left": "ä"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "a, z, å, ä"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"z\" to come before \"å\".",
+          "data": {
+            "right": "z",
+            "left": "å"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "a, z, å, ä"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"a\" to come before \"z\".",
+          "data": {
+            "right": "a",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 19,
+            "endLine": 1,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "a, z, å, ä"
+          }
+        }
+      ],
+      "output": "import { a, z, å, ä } from 'module'"
+    },
+    {
+      "name": "fallback resolves case-insensitive tie",
+      "code": "import { bb as a, a as A } from 'module'",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "line-length",
+            "order": "asc"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"a\".",
+          "data": {
+            "right": "A",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 19,
+            "endLine": 1,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [9, 24],
+            "text": "a as A, bb as a"
+          }
+        }
+      ],
+      "output": "import { a as A, bb as a } from 'module'"
+    },
+    {
+      "name": "fallback descending resolves line-length tie",
+      "code": "import { c, a, b } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc",
+          "fallbackSort": {
+            "type": "alphabetical",
+            "order": "desc"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 16],
+            "text": "b, a"
+          }
+        }
+      ],
+      "output": "import { c, b, a } from 'module'"
+    },
+    {
+      "name": "type-only import",
+      "code": "import type { A, B } from 'module'",
+      "filename": "fixture.ts",
+      "options": [],
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "type specifier inversion",
+      "code": "import { type B, type A } from 'module'",
+      "filename": "fixture.ts",
+      "options": [],
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 23],
+            "text": "type A, type B"
+          }
+        }
+      ],
+      "output": "import { type A, type B } from 'module'"
+    },
+    {
+      "name": "arbitrary string import inversion",
+      "code": "import { \"B\" as b, \"A\" as a } from 'module'",
+      "options": [
+        {
+          "ignoreAlias": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 20,
+            "endLine": 1,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "\"A\" as a, \"B\" as b"
+          }
+        }
+      ],
+      "output": "import { \"A\" as a, \"B\" as b } from 'module'"
+    },
+    {
+      "name": "multiple declarations",
+      "code": "import { B, A } from 'one';\nimport { D, C } from 'two';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 13],
+            "text": "A, B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"C\" to come before \"D\".",
+          "data": {
+            "right": "C",
+            "left": "D"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 13,
+            "endLine": 2,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [37, 41],
+            "text": "C, D"
+          }
+        }
+      ],
+      "output": "import { A, B } from 'one';\nimport { C, D } from 'two';"
+    },
+    {
+      "name": "CRLF multiline inversion",
+      "code": "import {\r\n  B,\r\n  A,\r\n} from 'module';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 19],
+            "text": "A,\r\n  B"
+          }
+        }
+      ],
+      "output": "import {\r\n  A,\r\n  B,\r\n} from 'module';"
+    },
+    {
+      "name": "UTF-16 prefix keeps fix offsets",
+      "code": "'😀';\nimport { B, A } from 'module';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 13,
+            "endLine": 2,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [15, 19],
+            "text": "A, B"
+          }
+        }
+      ],
+      "output": "'😀';\nimport { A, B } from 'module';"
+    },
+    {
+      "name": "inline trailing comma inversion",
+      "code": "import { B, A, } from 'module';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 13],
+            "text": "A, B"
+          }
+        }
+      ],
+      "output": "import { A, B, } from 'module';"
+    },
+    {
+      "name": "multiline without trailing comma",
+      "code": "import {\n  B,\n  A\n} from 'module';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 17],
+            "text": "A,\n  B"
+          }
+        }
+      ],
+      "output": "import {\n  A,\n  B\n} from 'module';"
+    },
+    {
+      "name": "leading comments move with imports",
+      "code": "import {\n  // B docs\n  B,\n  // A docs\n  A,\n} from 'module';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 41],
+            "text": "// A docs\n  A,\n  // B docs\n  B"
+          }
+        }
+      ],
+      "output": "import {\n  // A docs\n  A,\n  // B docs\n  B,\n} from 'module';"
+    },
+    {
+      "name": "trailing comments stay attached to slots",
+      "code": "import {\n  B, // first\n  A, // second\n} from 'module';",
+      "options": [],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 37],
+            "text": "A, // second\n  B, // first"
+          }
+        }
+      ],
+      "output": "import {\n  A, // second\n  B, // first\n} from 'module';"
+    }
+  ]
+}

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -66,7 +66,7 @@ const invalidCases = [
   ['sort-variable-declarations', 'const b = 1, a = 2;'],
 ];
 
-function runRule(ruleName, sourceText, filename = 'fixture.tsx') {
+function runRule(ruleName, sourceText, filename = 'fixture.tsx', options = []) {
   const reports = [];
   const sourceCode = {
     text: sourceText,
@@ -77,7 +77,7 @@ function runRule(ruleName, sourceText, filename = 'fixture.tsx') {
   const rule = plugin.rules[ruleName];
   const visitor = rule.createOnce({
     filename,
-    options: [],
+    options,
     sourceCode,
     report(descriptor) {
       reports.push(descriptor);
@@ -120,14 +120,58 @@ describe('perfectionist plugin adapter', () => {
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      'Expected sorted order.',
+      ruleName === 'sort-named-imports'
+        ? 'Expected "{{right}}" to come before "{{left}}".'
+        : 'Expected sorted order.',
     );
   });
 
-  it('loads through oxlint jsPlugins', () => {
+  it('declares only the implemented scalar option schema', () => {
+    const schema = plugin.rules['sort-named-imports'].meta.schema;
+
+    expect(schema).toHaveLength(1);
+    expect(Object.keys(schema[0].properties).sort()).toEqual([
+      'alphabet',
+      'fallbackSort',
+      'ignoreAlias',
+      'ignoreCase',
+      'locales',
+      'order',
+      'specialCharacters',
+      'type',
+    ]);
+    expect(schema[0].additionalProperties).toBe(false);
+    expect(schema[0].properties.locales).toEqual({
+      oneOf: [
+        { type: 'string' },
+        {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      ],
+    });
+    expect(schema[0].properties.fallbackSort).toMatchObject({
+      required: ['type'],
+      additionalProperties: false,
+    });
+    expect(plugin.rules['sort-imports'].meta.schema).toEqual([]);
+  });
+
+  it('threads recommended comparator options only into sort-named-imports', () => {
+    const rules = plugin.configs['recommended-natural'].rules;
+
+    expect(rules['perfectionist/sort-named-imports']).toEqual([
+      'error',
+      { type: 'natural', order: 'asc' },
+    ]);
+    expect(rules['perfectionist/sort-imports']).toBe('error');
+  });
+
+  it('loads configured options and fixes through real oxlint jsPlugins', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-'));
     try {
-      writeFileSync(join(tempDir, 'fixture.ts'), 'import { b, a } from "pkg";\n');
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(fixturePath, 'import { item2, item10 } from "pkg";\n');
       writeFileSync(
         join(tempDir, 'oxlint.config.jsonc'),
         JSON.stringify({
@@ -138,7 +182,7 @@ describe('perfectionist plugin adapter', () => {
             },
           ],
           rules: {
-            'perfectionist/sort-named-imports': 'error',
+            'perfectionist/sort-named-imports': ['error', { type: 'natural', order: 'desc' }],
           },
         }),
       );
@@ -156,7 +200,22 @@ describe('perfectionist plugin adapter', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toBe('');
       expect(payload.diagnostics).toHaveLength(1);
-      expect(payload.diagnostics[0].message).toBe('Expected sorted order.');
+      expect(payload.diagnostics[0]).toMatchObject({
+        code: 'perfectionist(sort-named-imports)',
+        message: 'Expected "item10" to come before "item2".',
+      });
+
+      const fixed = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe('import { item10, item2 } from "pkg";\n');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/npm/perfectionist/test/sort-named-imports-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-named-imports-options-upstream.test.mjs
@@ -1,0 +1,150 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/sort-named-imports-options-v5.9.1.json', import.meta.url),
+    'utf8',
+  ),
+);
+const rule = plugin.rules['sort-named-imports'];
+
+describe('perfectionist/sort-named-imports v5.9.1 scalar option parity', () => {
+  it('pins the reviewed upstream source and exact fixture inventory', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-perfectionist',
+      version: '5.9.1',
+      sourceCommit: 'b35e8e4caf0c8d350cf386e504241f21827dd60b',
+      sourceHashes: {
+        'rules/sort-named-imports.ts':
+          'ef0f575cb4aca0248120e8eb831748b2fb7a170e2e2220b8cdee66f1c2740ae6',
+        'rules/sort-named-imports/sort-named-import.ts':
+          '3e35c4b385cab6e07acac20e2ee4f5049e3cfc1fb05403ac0158cd360e4b3415',
+        'test/rules/sort-named-imports.test.ts':
+          'a5fe43752e460a2d29432e01e01a21aaa92bf9bc6d5193840dc593c6767ddeee',
+      },
+      inventory: {
+        valid: 23,
+        invalid: 28,
+        diagnostics: 41,
+        total: 51,
+      },
+    });
+    expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
+    expect(
+      fixture.cases.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+    ).toBe(fixture.__generated.inventory.diagnostics);
+  });
+
+  for (const [index, testCase] of fixture.cases.entries()) {
+    it(`replays case ${index + 1}/${fixture.cases.length}: ${testCase.name}`, () => {
+      const reports = runRule(testCase.code, testCase.options, testCase.filename);
+      expect(
+        reports.map((report) => exactDiagnostic(report)),
+        testCase.name,
+      ).toEqual(testCase.expectedDiagnostics);
+
+      if (testCase.output === null) {
+        expect(reports, testCase.name).toEqual([]);
+        return;
+      }
+
+      const convergence = applyIteratively(testCase.code, testCase.options, testCase.filename);
+      expect(convergence.output, testCase.name).toBe(testCase.output);
+      expect(convergence.remainingReports, testCase.name).toEqual([]);
+      expect(convergence.passes, testCase.name).toBeGreaterThanOrEqual(1);
+      expect(convergence.passes, testCase.name).toBeLessThanOrEqual(8);
+    });
+  }
+});
+
+function runRule(sourceText, options, filename) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    options,
+    sourceCode,
+    filename,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function exactDiagnostic(report) {
+  const replacement = report.fix?.({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return {
+    messageId: report.messageId,
+    message: rule.meta.messages[report.messageId]
+      .replace('{{right}}', report.data.right)
+      .replace('{{left}}', report.data.left),
+    data: report.data,
+    loc: {
+      startLine: report.loc.start.line,
+      startColumn: report.loc.start.column + 1,
+      endLine: report.loc.end.line,
+      endColumn: report.loc.end.column + 1,
+    },
+    fix: replacement ?? null,
+  };
+}
+
+function applyIteratively(sourceText, options, filename) {
+  let output = sourceText;
+  let passes = 0;
+  for (; passes < 8; passes += 1) {
+    const reports = runRule(output, options, filename);
+    const next = applyFixPass(output, reports);
+    if (next === null) {
+      return { output, passes, remainingReports: reports };
+    }
+    output = next;
+  }
+  throw new Error(`Fixes did not converge for ${JSON.stringify(sourceText)}`);
+}
+
+function applyFixPass(sourceText, reports) {
+  const fixes = reports
+    .flatMap((report) => {
+      const fix = report.fix?.({
+        replaceTextRange(range, text) {
+          return { range, text };
+        },
+      });
+      return fix ? [fix] : [];
+    })
+    .sort((left, right) => left.range[0] - right.range[0] || left.range[1] - right.range[1]);
+  if (fixes.length === 0) {
+    return null;
+  }
+
+  const accepted = [];
+  let lastEnd = -1;
+  for (const fix of fixes) {
+    if (fix.range[0] < lastEnd) {
+      continue;
+    }
+    accepted.push(fix);
+    lastEnd = fix.range[1];
+  }
+
+  let output = sourceText;
+  for (const fix of accepted.toReversed()) {
+    output = output.slice(0, fix.range[0]) + fix.text + output.slice(fix.range[1]);
+  }
+  return output;
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "port:tests:functional": "node tools/tasks/sync-functional-tests.ts",
     "port:tests:postgresql": "node tools/tasks/sync-postgresql-tests.ts",
     "port:tests:postgresql-parser": "node tools/tasks/sync-postgresql-parser-tests.ts",
+    "port:tests:perfectionist:sort-named-imports": "node tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",
     "port:tests:simple-import-sort": "node tools/tasks/sync-simple-import-sort-tests.ts",

--- a/tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts
@@ -1,0 +1,473 @@
+// Captures a curated scalar-option contract for
+// eslint-plugin-perfectionist/sort-named-imports v5.9.1 from the published
+// package. The exact submodule commit and source hashes prevent the fixture
+// from silently drifting away from the reviewed upstream implementation.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+type TestCase = {
+  name: string;
+  code: string;
+  options?: Array<Record<string, unknown>>;
+  filename?: string;
+};
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+const ROOT = process.cwd();
+const RULE = 'sort-named-imports';
+const PINNED_COMMIT = 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
+const ESLINT_VERSION = '9.39.2';
+const TYPESCRIPT_ESLINT_VERSION = '8.60.0';
+const SOURCE_HASHES = {
+  'rules/sort-named-imports.ts': 'ef0f575cb4aca0248120e8eb831748b2fb7a170e2e2220b8cdee66f1c2740ae6',
+  'rules/sort-named-imports/sort-named-import.ts':
+    '3e35c4b385cab6e07acac20e2ee4f5049e3cfc1fb05403ac0158cd360e4b3415',
+  'test/rules/sort-named-imports.test.ts':
+    'a5fe43752e460a2d29432e01e01a21aaa92bf9bc6d5193840dc593c6767ddeee',
+} as const;
+
+const cases: TestCase[] = [
+  {
+    name: 'default alphabetical order',
+    code: `import { AAA, BB, C } from 'module'`,
+  },
+  {
+    name: 'default alphabetical inversion',
+    code: `import { BB, AAA, C } from 'module'`,
+  },
+  {
+    name: 'default complete reversal',
+    code: `import { C, BB, AAA } from 'module'`,
+  },
+  {
+    name: 'multiline alphabetical order',
+    code: `import {\n  AAAA,\n  BBB,\n  CC,\n  D,\n} from 'module'`,
+  },
+  {
+    name: 'multiline alphabetical inversion',
+    code: `import {\n  AAAA,\n  CC,\n  BBB,\n  D,\n} from 'module'`,
+  },
+  {
+    name: 'default ignores default import',
+    code: `import Default, { A, B } from 'module'`,
+  },
+  {
+    name: 'default sorts by local alias',
+    code: `import { c as A, b as B, a as C } from 'module'`,
+  },
+  {
+    name: 'default local alias inversion',
+    code: `import { a as C, b as B, c as A } from 'module'`,
+  },
+  {
+    name: 'ignoreAlias original names',
+    code: `import { A as C, B as B, C as A } from 'module'`,
+    options: [{ ignoreAlias: true }],
+  },
+  {
+    name: 'ignoreAlias inversion',
+    code: `import { C as A, B as B, A as C } from 'module'`,
+    options: [{ ignoreAlias: true }],
+  },
+  {
+    name: 'ignoreCase stable equivalent aliases',
+    code: `import { b as a, a as A } from 'module'`,
+  },
+  {
+    name: 'case-sensitive lowercase before uppercase',
+    code: `import { b as a, a as A } from 'module'`,
+    options: [{ ignoreCase: false }],
+  },
+  {
+    name: 'case-sensitive inversion',
+    code: `import { a as A, b as a } from 'module'`,
+    options: [{ ignoreCase: false }],
+  },
+  {
+    name: 'alphabetical descending',
+    code: `import { C, BB, AAA } from 'module'`,
+    options: [{ order: 'desc' }],
+  },
+  {
+    name: 'alphabetical descending inversion',
+    code: `import { AAA, BB, C } from 'module'`,
+    options: [{ order: 'desc' }],
+  },
+  {
+    name: 'natural numeric order',
+    code: `import { item1, item2, item10 } from 'module'`,
+    options: [{ type: 'natural' }],
+  },
+  {
+    name: 'natural numeric inversion',
+    code: `import { item10, item2, item1 } from 'module'`,
+    options: [{ type: 'natural' }],
+  },
+  {
+    name: 'natural leading zero order',
+    code: `import { item01, item1, item2 } from 'module'`,
+    options: [{ type: 'natural' }],
+  },
+  {
+    name: 'natural leading zero inversion',
+    code: `import { item2, item1, item01 } from 'module'`,
+    options: [{ type: 'natural' }],
+  },
+  {
+    name: 'natural descending inversion',
+    code: `import { item1, item2, item10 } from 'module'`,
+    options: [{ type: 'natural', order: 'desc' }],
+  },
+  {
+    name: 'line length descending',
+    code: `import { AAA, BB, C } from 'module'`,
+    options: [{ type: 'line-length', order: 'desc' }],
+  },
+  {
+    name: 'line length descending inversion',
+    code: `import { C, AAA, BB } from 'module'`,
+    options: [{ type: 'line-length', order: 'desc' }],
+  },
+  {
+    name: 'line length ascending',
+    code: `import { C, BB, AAA } from 'module'`,
+    options: [{ type: 'line-length', order: 'asc' }],
+  },
+  {
+    name: 'line length counts alias source',
+    code: `import { long as A, B } from 'module'`,
+    options: [{ type: 'line-length', order: 'asc' }],
+  },
+  {
+    name: 'custom reverse alphabet',
+    code: `import { c, b, a } from 'module'`,
+    options: [{ type: 'custom', alphabet: 'cba' }],
+  },
+  {
+    name: 'custom reverse alphabet inversion',
+    code: `import { a, b, c } from 'module'`,
+    options: [{ type: 'custom', alphabet: 'cba' }],
+  },
+  {
+    name: 'custom unknown characters remain stable',
+    code: `import { x, y, z } from 'module'`,
+    options: [{ type: 'custom', alphabet: 'abc' }],
+  },
+  {
+    name: 'custom unknown characters compare length',
+    code: `import { xx, y, zzz } from 'module'`,
+    options: [{ type: 'custom', alphabet: 'abc' }],
+  },
+  {
+    name: 'custom descending inversion',
+    code: `import { c, b, a } from 'module'`,
+    options: [{ type: 'custom', alphabet: 'abc', order: 'desc' }],
+  },
+  {
+    name: 'unsorted preserves arbitrary order',
+    code: `import { c, a, b } from 'module'`,
+    options: [{ type: 'unsorted' }],
+  },
+  {
+    name: 'unsorted ignores configured fallback',
+    code: `import { c, a, b } from 'module'`,
+    options: [{ type: 'unsorted', fallbackSort: { type: 'alphabetical' } }],
+  },
+  {
+    name: 'special characters keep identifier punctuation',
+    code: `import { _a, $a, a } from 'module'`,
+  },
+  {
+    name: 'special characters trim',
+    code: `import { _a, b, _c } from 'module'`,
+    options: [{ specialCharacters: 'trim' }],
+  },
+  {
+    name: 'special characters trim inversion',
+    code: `import { _b, a, _c } from 'module'`,
+    options: [{ specialCharacters: 'trim' }],
+  },
+  {
+    name: 'special characters remove stable equality',
+    code: `import { ab, a_b } from 'module'`,
+    options: [{ specialCharacters: 'remove' }],
+  },
+  {
+    name: 'Chinese locale order',
+    code: `import { 你好, 世界, a, A, b, B } from 'module'`,
+    options: [{ locales: 'zh-CN' }],
+  },
+  {
+    name: 'Chinese locale inversion',
+    code: `import { b, B, a, A, 世界, 你好 } from 'module'`,
+    options: [{ locales: 'zh-CN' }],
+  },
+  {
+    name: 'locale preference array',
+    code: `import { 你好, 世界, a, A, b, B } from 'module'`,
+    options: [{ locales: ['zh-CN', 'en-US'] }],
+  },
+  {
+    name: 'Swedish locale inversion',
+    code: `import { ä, å, z, a } from 'module'`,
+    options: [{ locales: 'sv' }],
+  },
+  {
+    name: 'fallback resolves case-insensitive tie',
+    code: `import { bb as a, a as A } from 'module'`,
+    options: [
+      {
+        fallbackSort: { type: 'line-length', order: 'asc' },
+      },
+    ],
+  },
+  {
+    name: 'fallback descending resolves line-length tie',
+    code: `import { c, a, b } from 'module'`,
+    options: [
+      {
+        type: 'line-length',
+        order: 'asc',
+        fallbackSort: { type: 'alphabetical', order: 'desc' },
+      },
+    ],
+  },
+  {
+    name: 'type-only import',
+    code: `import type { A, B } from 'module'`,
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'type specifier inversion',
+    code: `import { type B, type A } from 'module'`,
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'arbitrary string import inversion',
+    code: `import { "B" as b, "A" as a } from 'module'`,
+    options: [{ ignoreAlias: true }],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'multiple declarations',
+    code: `import { B, A } from 'one';\nimport { D, C } from 'two';`,
+  },
+  {
+    name: 'CRLF multiline inversion',
+    code: `import {\r\n  B,\r\n  A,\r\n} from 'module';`,
+  },
+  {
+    name: 'UTF-16 prefix keeps fix offsets',
+    code: `'😀';\nimport { B, A } from 'module';`,
+  },
+  {
+    name: 'inline trailing comma inversion',
+    code: `import { B, A, } from 'module';`,
+  },
+  {
+    name: 'multiline without trailing comma',
+    code: `import {\n  B,\n  A\n} from 'module';`,
+  },
+  {
+    name: 'leading comments move with imports',
+    code: `import {\n  // B docs\n  B,\n  // A docs\n  A,\n} from 'module';`,
+  },
+  {
+    name: 'trailing comments stay attached to slots',
+    code: `import {\n  B, // first\n  A, // second\n} from 'module';`,
+  },
+];
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-perfectionist');
+if (!plugin) {
+  throw new Error('eslint-plugin-perfectionist is not registered in tools/port-targets.json');
+}
+if (plugin.baselineVersion !== '5.9.1' || plugin.pinnedRef !== 'v5.9.1') {
+  throw new Error(
+    `Expected perfectionist v5.9.1 manifest pin, received ${plugin.baselineVersion} / ${plugin.pinnedRef}`,
+  );
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Upstream checkout not found: ${plugin.submodule}`);
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}`);
+}
+for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
+  const actualHash = createHash('sha256')
+    .update(readFileSync(join(submodule, sourceFile)))
+    .digest('hex');
+  if (actualHash !== expectedHash) {
+    throw new Error(`Expected ${sourceFile} hash ${expectedHash}, received ${actualHash}`);
+  }
+}
+
+const runnerDirectory = mkdtempSync(join(tmpdir(), 'perfectionist-named-imports-'));
+try {
+  writeFileSync(
+    join(runnerDirectory, 'package.json'),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@typescript-eslint/parser': TYPESCRIPT_ESLINT_VERSION,
+          eslint: ESLINT_VERSION,
+          'eslint-plugin-perfectionist': plugin.baselineVersion,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(join(runnerDirectory, 'cases.json'), `${JSON.stringify(cases)}\n`);
+  writeFileSync(join(runnerDirectory, 'runner.mjs'), runnerSource());
+  execFileSync(
+    'pnpm',
+    ['install', '--dir', runnerDirectory, '--ignore-workspace', '--lockfile=false', '--silent'],
+    { stdio: 'inherit' },
+  );
+  execFileSync('node', [join(runnerDirectory, 'runner.mjs')], { stdio: 'inherit' });
+  const captured = JSON.parse(
+    readFileSync(join(runnerDirectory, 'captured.json'), 'utf8'),
+  ) as Array<{ expectedDiagnostics: unknown[] }>;
+  const valid = captured.filter((testCase) => testCase.expectedDiagnostics.length === 0).length;
+  const invalid = captured.length - valid;
+  const diagnostics = captured.reduce(
+    (total, testCase) => total + testCase.expectedDiagnostics.length,
+    0,
+  );
+  const fixture = {
+    __generated: {
+      source: plugin.npm,
+      version: plugin.baselineVersion,
+      sourceCommit: PINNED_COMMIT,
+      sourceHashes: SOURCE_HASHES,
+      license: plugin.license,
+      eslintVersion: ESLINT_VERSION,
+      typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
+      capturePolicy:
+        'Curated exact parity for the supported scalar comparator option subset; grouping, partition, newline, and conditional options are intentionally excluded.',
+      tool: 'tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts',
+      inventory: {
+        valid,
+        invalid,
+        diagnostics,
+        total: captured.length,
+      },
+    },
+    cases: captured,
+  };
+  const fixturesDirectory = join(ROOT, 'npm', 'perfectionist', 'test', 'fixtures');
+  mkdirSync(fixturesDirectory, { recursive: true });
+  const fixturePath = join(fixturesDirectory, `${RULE}-options-v${plugin.baselineVersion}.json`);
+  writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  execFileSync('pnpm', ['exec', 'vp', 'fmt', fixturePath], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  console.log(
+    `Captured ${RULE} v${plugin.baselineVersion}: ${valid} valid, ${invalid} invalid, ${diagnostics} diagnostics.`,
+  );
+} finally {
+  rmSync(runnerDirectory, { recursive: true, force: true });
+}
+
+function runnerSource(): string {
+  return `
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import perfectionistModule from 'eslint-plugin-perfectionist';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const cases = JSON.parse(readFileSync(join(here, 'cases.json'), 'utf8'));
+const perfectionist = perfectionistModule.default ?? perfectionistModule;
+const linter = new Linter();
+
+function configFor(testCase) {
+  return [{
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: { perfectionist },
+    rules: {
+      'perfectionist/${RULE}': ['error', ...(testCase.options ?? [])],
+    },
+  }];
+}
+
+const captured = cases.map(testCase => {
+  const filename = testCase.filename ?? 'fixture.tsx';
+  const config = configFor(testCase);
+  const diagnostics = linter.verify(testCase.code, config, { filename });
+  const unexpected = diagnostics.filter(problem => problem.ruleId !== 'perfectionist/${RULE}');
+  if (unexpected.length > 0) {
+    throw new Error(
+      testCase.name + ' produced non-rule diagnostics: ' + JSON.stringify(unexpected),
+    );
+  }
+  const fixed = linter.verifyAndFix(testCase.code, config, { filename });
+  return {
+    ...testCase,
+    options: testCase.options ?? [],
+    filename,
+    expectedDiagnostics: diagnostics.map(problem => ({
+      messageId: problem.messageId,
+      message: problem.message,
+      data: dataFromMessage(problem.message),
+      loc: {
+        startLine: problem.line,
+        startColumn: problem.column,
+        endLine: problem.endLine,
+        endColumn: problem.endColumn,
+      },
+      fix: problem.fix
+        ? {
+            range: problem.fix.range,
+            text: problem.fix.text,
+          }
+        : null,
+    })),
+    output: fixed.fixed ? fixed.output : null,
+  };
+});
+
+writeFileSync(join(here, 'captured.json'), JSON.stringify(captured));
+
+function dataFromMessage(message) {
+  const match = /^Expected "(.+)" to come before "(.+)"\\.$/u.exec(message);
+  return match ? { right: match[1], left: match[2] } : {};
+}
+`;
+}


### PR DESCRIPTION
## Summary
- add native `sort-named-imports` scalar comparator options: `type`, `order`, `ignoreCase`, `specialCharacters`, `locales`, `alphabet`, `fallbackSort`, and `ignoreAlias`
- preserve locale-aware ordering with ICU4X and expose the options through the NAPI API and plugin schema
- import the pinned Perfectionist v5.9.1 option fixture and reject not-yet-supported grouping/partition options truthfully in the schema

## Tests
- 51 upstream-authored option cases: 23 valid, 28 invalid, 41 diagnostics
- Perfectionist JS: 85 passed
- Perfectionist Rust: 12 passed
- full `pnpm verify`: 15,870 JS passed, 1,159 skipped; workspace Rust, Clippy, docs, benches, security, licenses, status, and publish-ready package checks passed

This is the scalar-options slice of #418. Grouping and partition behavior remains a separate small follow-up PR. React and JSX plugins are intentionally out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->