### PR TITLE
feat(angular-eslint): support selector options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxlint-plugins-angular-eslint",
+ "serde_json",
 ]
 
 [[package]]
@@ -1180,10 +1181,13 @@ name = "oxlint-plugins-angular-eslint"
 version = "0.0.0"
 dependencies = [
  "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
  "oxlint-plugins-_carton",
  "regex",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/angular_eslint/Cargo.toml
+++ b/crates/angular_eslint/Cargo.toml
@@ -10,10 +10,13 @@ publish = false
 
 [dependencies]
 oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true
 regex.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/angular_eslint/src/lib.rs
+++ b/crates/angular_eslint/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = "Rust implementation of @angular-eslint/eslint-plugin rule logic."]
 
 mod scanner;
+mod selector;
 mod types;
 
 #[cfg(test)]
@@ -9,12 +10,25 @@ mod tests;
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
 
 use crate::scanner::Scanner;
 use crate::types::LineIndex;
 
-pub use crate::types::{Diagnostic, DiagnosticLoc};
+pub use crate::types::{Diagnostic, DiagnosticDatum, DiagnosticLoc};
+
+#[derive(Clone, Debug, Default)]
+pub struct ScanOptions {
+    pub rule_names: SmallVec<[CompactString; 4]>,
+    pub options: Value,
+}
+
+impl ScanOptions {
+    pub(crate) fn is_enabled(&self, rule_name: &str) -> bool {
+        self.rule_names.is_empty() || self.rule_names.iter().any(|name| name == rule_name)
+    }
+}
 
 pub const RULE_NAMES: [&str; 48] = [
     "component-class-suffix",
@@ -72,6 +86,14 @@ pub fn implemented_angular_eslint_rule_names() -> &'static [&'static str] {
 }
 
 pub fn scan_angular_eslint(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 64]> {
+    scan_angular_eslint_with_options(source_text, filename, &ScanOptions::default())
+}
+
+pub fn scan_angular_eslint_with_options(
+    source_text: &str,
+    filename: &str,
+    options: &ScanOptions,
+) -> SmallVec<[Diagnostic; 64]> {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(filename)
         .unwrap_or_else(|_| SourceType::tsx())
@@ -84,8 +106,9 @@ pub fn scan_angular_eslint(source_text: &str, filename: &str) -> SmallVec<[Diagn
     let mut scanner = Scanner {
         source_text,
         line_index: LineIndex::new(source_text),
+        options,
         diagnostics: SmallVec::new(),
     };
-    scanner.scan();
+    scanner.scan(&parser_return.program);
     scanner.diagnostics
 }

--- a/crates/angular_eslint/src/scanner.rs
+++ b/crates/angular_eslint/src/scanner.rs
@@ -1,27 +1,27 @@
 //! Regex-driven scanner for the angular-eslint port.
 
+use oxc_ast::ast::Program;
+use oxc_ast_visit::Visit;
 use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
 use regex::Regex;
 
+use crate::ScanOptions;
 use crate::types::{Diagnostic, LineIndex};
 
 pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,
     pub(crate) line_index: LineIndex,
+    pub(crate) options: &'a ScanOptions,
     pub(crate) diagnostics: SmallVec<[Diagnostic; 64]>,
 }
 
 impl<'a> Scanner<'a> {
-    pub(crate) fn scan(&mut self) {
+    pub(crate) fn scan(&mut self, program: &Program<'a>) {
         self.check_class_suffix("component-class-suffix", "@Component", "Component");
         self.check_regex(
             "component-max-inline-declarations",
             r#"(?s)template\s*:\s*`[^`]*\n[^`]*\n[^`]*`"#,
-        );
-        self.check_regex(
-            "component-selector",
-            r#"(?s)@Component\s*\(\s*\{[^}]*selector\s*:\s*['"][A-Z]"#,
         );
         self.check_regex(
             "computed-must-return",
@@ -37,10 +37,6 @@ impl<'a> Scanner<'a> {
             r#"class\s+\w+\s*\{[^}]*\bngOnInit\s*\("#,
         );
         self.check_class_suffix("directive-class-suffix", "@Directive", "Directive");
-        self.check_regex(
-            "directive-selector",
-            r#"(?s)@Directive\s*\(\s*\{[^}]*selector\s*:\s*['"][A-Z]"#,
-        );
         self.check_regex(
             "no-async-lifecycle-method",
             r#"async\s+ng(OnInit|OnDestroy|AfterViewInit|OnChanges)\s*\("#,
@@ -137,9 +133,13 @@ impl<'a> Scanner<'a> {
             "use-pipe-transform-interface",
             r#"@Pipe\s*\([^)]*\)\s*class\s+PlainPipe\s*\{[^}]*transform\s*\("#,
         );
+        self.visit_program(program);
     }
 
     fn check_contains(&mut self, rule_name: &'static str, needle: &str) {
+        if !self.options.is_enabled(rule_name) {
+            return;
+        }
         if self.has_reported(rule_name) {
             return;
         }
@@ -152,6 +152,9 @@ impl<'a> Scanner<'a> {
     }
 
     fn check_class_suffix(&mut self, rule_name: &'static str, decorator: &str, suffix: &str) {
+        if !self.options.is_enabled(rule_name) {
+            return;
+        }
         if self.has_reported(rule_name) {
             return;
         }
@@ -176,6 +179,9 @@ impl<'a> Scanner<'a> {
     }
 
     fn check_regex(&mut self, rule_name: &'static str, pattern: &str) {
+        if !self.options.is_enabled(rule_name) {
+            return;
+        }
         if self.has_reported(rule_name) {
             return;
         }
@@ -200,6 +206,7 @@ impl<'a> Scanner<'a> {
         self.diagnostics.push(Diagnostic {
             rule_name,
             message_id: "unexpected",
+            data: SmallVec::new(),
             loc: self.line_index.loc_for_span(self.source_text, span),
         });
     }

--- a/crates/angular_eslint/src/selector.rs
+++ b/crates/angular_eslint/src/selector.rs
@@ -1,0 +1,829 @@
+use oxc_ast::ast::{Class, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use regex::Regex;
+use serde_json::Value;
+
+use crate::scanner::Scanner;
+use crate::types::{Diagnostic, DiagnosticDatum};
+
+const COMPONENT_SELECTOR: &str = "component-selector";
+const DIRECTIVE_SELECTOR: &str = "directive-selector";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelectorType {
+    Attribute,
+    Element,
+}
+
+impl SelectorType {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "attribute" => Some(Self::Attribute),
+            "element" => Some(Self::Element),
+            _ => None,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Attribute => "attribute",
+            Self::Element => "element",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelectorStyle {
+    CamelCase,
+    KebabCase,
+}
+
+impl SelectorStyle {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "camelCase" => Some(Self::CamelCase),
+            "kebab-case" => Some(Self::KebabCase),
+            _ => None,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::CamelCase => "camelCase",
+            Self::KebabCase => "kebab-case",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SelectorConfig {
+    selector_type: SelectorType,
+    prefixes: Option<SmallVec<[CompactString; 4]>>,
+    style: SelectorStyle,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ParsedSelector {
+    element: Option<CompactString>,
+    attributes: SmallVec<[CompactString; 4]>,
+}
+
+impl Visit<'_> for Scanner<'_> {
+    fn visit_class(&mut self, class: &Class<'_>) {
+        self.check_selector_decorators(class);
+        walk::walk_class(self, class);
+    }
+}
+
+impl Scanner<'_> {
+    fn check_selector_decorators(&mut self, class: &Class<'_>) {
+        let options = &self.options.options;
+        for decorator in &class.decorators {
+            let Expression::CallExpression(call) = decorator.expression.get_inner_expression()
+            else {
+                continue;
+            };
+            let Expression::Identifier(callee) = call.callee.get_inner_expression() else {
+                continue;
+            };
+            let (rule_name, is_component) = match callee.name.as_str() {
+                "Component" if self.options.is_enabled(COMPONENT_SELECTOR) => {
+                    (COMPONENT_SELECTOR, true)
+                }
+                "Directive" if self.options.is_enabled(DIRECTIVE_SELECTOR) => {
+                    (DIRECTIVE_SELECTOR, false)
+                }
+                _ => continue,
+            };
+            let Some(Expression::ObjectExpression(metadata)) = call
+                .arguments
+                .first()
+                .and_then(|argument| argument.as_expression())
+            else {
+                continue;
+            };
+            let Some((selector, span)) = selector_value(metadata) else {
+                continue;
+            };
+            let parsed = parse_selectors(selector);
+            if parsed.is_empty() {
+                continue;
+            }
+            let Some(config) = selector_config(options, &parsed) else {
+                continue;
+            };
+            self.check_selector(rule_name, is_component, metadata, &parsed, &config, span);
+        }
+    }
+
+    fn check_selector(
+        &mut self,
+        rule_name: &'static str,
+        is_component: bool,
+        metadata: &ObjectExpression<'_>,
+        parsed: &[ParsedSelector],
+        config: &SelectorConfig,
+        span: Span,
+    ) {
+        let shadow_dom = is_component
+            && config.style != SelectorStyle::KebabCase
+            && has_shadow_dom_encapsulation(metadata);
+        let effective_style = if shadow_dom {
+            SelectorStyle::KebabCase
+        } else {
+            config.style
+        };
+        let valid_selectors = selector_values(parsed, config.selector_type);
+        let prefixes = config.prefixes.as_deref().unwrap_or_default();
+        let prefix_required =
+            !prefixes.is_empty() && prefixes.iter().any(|prefix| !prefix.is_empty());
+        let has_expected_type = !valid_selectors.is_empty();
+        let has_expected_prefix = !prefix_required
+            || valid_selectors.iter().any(|selector| {
+                prefixes.iter().any(|prefix| {
+                    prefix_matches(selector, prefix, effective_style, config.selector_type)
+                })
+            });
+        let has_expected_style = valid_selectors
+            .iter()
+            .any(|selector| style_matches(selector, effective_style));
+        let has_selector_after_prefix = !prefix_required
+            || valid_selectors.iter().any(|selector| {
+                prefixes
+                    .iter()
+                    .any(|prefix| selector_after_prefix(selector, prefix))
+            });
+
+        if shadow_dom
+            && !parsed.iter().any(|selector| {
+                selector
+                    .element
+                    .as_deref()
+                    .is_some_and(|value| value.contains('-'))
+            })
+        {
+            self.report_selector(
+                rule_name,
+                "shadowDomEncapsulatedStyleFailure",
+                SmallVec::new(),
+                span,
+            );
+        } else if !has_expected_type {
+            self.report_selector(
+                rule_name,
+                "typeFailure",
+                data("type", config.selector_type.as_str()),
+                span,
+            );
+        } else if !has_selector_after_prefix && prefix_required {
+            self.report_selector(
+                rule_name,
+                "selectorAfterPrefixFailure",
+                data("prefix", &human_readable_prefixes(prefixes)),
+                span,
+            );
+        } else if !has_expected_style {
+            if shadow_dom {
+                self.report_selector(
+                    rule_name,
+                    "shadowDomEncapsulatedStyleFailure",
+                    SmallVec::new(),
+                    span,
+                );
+            } else if is_component && !has_expected_prefix && prefix_required {
+                self.report_selector(
+                    rule_name,
+                    "styleAndPrefixFailure",
+                    data2(
+                        "style",
+                        config.style.as_str(),
+                        "prefix",
+                        &human_readable_prefixes(prefixes),
+                    ),
+                    span,
+                );
+            } else {
+                self.report_selector(
+                    rule_name,
+                    "styleFailure",
+                    data("style", config.style.as_str()),
+                    span,
+                );
+            }
+        } else if !has_expected_prefix && prefix_required {
+            self.report_selector(
+                rule_name,
+                "prefixFailure",
+                data("prefix", &human_readable_prefixes(prefixes)),
+                span,
+            );
+        }
+    }
+
+    fn report_selector(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        data: SmallVec<[DiagnosticDatum; 2]>,
+        span: Span,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+fn selector_value<'a>(metadata: &'a ObjectExpression<'a>) -> Option<(&'a str, Span)> {
+    for property in &metadata.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property_name(&property.key) != Some("selector") {
+            continue;
+        }
+        return match property.value.get_inner_expression() {
+            Expression::StringLiteral(literal) => Some((literal.value.as_str(), literal.span)),
+            Expression::TemplateLiteral(template) if template.expressions.is_empty() => template
+                .quasis
+                .first()
+                .map(|quasi| (quasi.value.raw.as_str(), template.span)),
+            _ => None,
+        };
+    }
+    None
+}
+
+fn property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
+fn selector_config(options: &Value, parsed: &[ParsedSelector]) -> Option<SelectorConfig> {
+    let first = options.as_array()?.first()?;
+    let mut configs: SmallVec<[SelectorConfig; 2]> = SmallVec::new();
+    if let Some(items) = first.as_array() {
+        for item in items {
+            configs.extend(configs_from_object(item));
+        }
+    } else {
+        configs.extend(configs_from_object(first));
+    }
+    if configs.is_empty() {
+        return None;
+    }
+    if configs.len() == 1 {
+        return configs.into_iter().next();
+    }
+    let actual_type = if parsed
+        .first()
+        .is_some_and(|selector| !selector.attributes.is_empty())
+    {
+        SelectorType::Attribute
+    } else if parsed
+        .first()
+        .and_then(|selector| selector.element.as_deref())
+        .is_some_and(|element| !element.is_empty() && element != "*")
+    {
+        SelectorType::Element
+    } else {
+        return None;
+    };
+    configs
+        .into_iter()
+        .find(|config| config.selector_type == actual_type)
+}
+
+fn configs_from_object(value: &Value) -> SmallVec<[SelectorConfig; 2]> {
+    let Some(object) = value.as_object() else {
+        return SmallVec::new();
+    };
+    let Some(style) = object
+        .get("style")
+        .and_then(Value::as_str)
+        .and_then(SelectorStyle::parse)
+    else {
+        return SmallVec::new();
+    };
+    let prefixes = match object.get("prefix") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) => {
+            let mut prefixes = SmallVec::new();
+            prefixes.push(CompactString::from(value.as_str()));
+            Some(prefixes)
+        }
+        Some(Value::Array(values)) => Some(
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(CompactString::from)
+                .collect(),
+        ),
+        _ => return SmallVec::new(),
+    };
+    let types: SmallVec<[SelectorType; 2]> = match object.get("type") {
+        Some(Value::String(value)) => SelectorType::parse(value).into_iter().collect(),
+        Some(Value::Array(values)) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .filter_map(SelectorType::parse)
+            .collect(),
+        _ => SmallVec::new(),
+    };
+    types
+        .into_iter()
+        .map(|selector_type| SelectorConfig {
+            selector_type,
+            prefixes: prefixes.clone(),
+            style,
+        })
+        .collect()
+}
+
+fn parse_selectors(source: &str) -> SmallVec<[ParsedSelector; 4]> {
+    source
+        .split(',')
+        .filter_map(|part| {
+            let selector = part.trim();
+            if selector.is_empty() {
+                return None;
+            }
+            let element_end = selector
+                .find(|character: char| {
+                    character == '['
+                        || character == '.'
+                        || character == '#'
+                        || character == ':'
+                        || character.is_whitespace()
+                })
+                .unwrap_or(selector.len());
+            let element = selector.get(..element_end).and_then(|value| {
+                (!value.is_empty() && value != "*").then(|| CompactString::from(value))
+            });
+            let mut attributes = SmallVec::new();
+            let mut remaining = selector;
+            while let Some(open) = remaining.find('[') {
+                remaining = &remaining[open + 1..];
+                let Some(close) = remaining.find(']') else {
+                    break;
+                };
+                let content = remaining[..close].trim();
+                let name_end = content
+                    .find(|character: char| {
+                        character.is_whitespace()
+                            || matches!(character, '=' | '~' | '|' | '^' | '$' | '*' | '!')
+                    })
+                    .unwrap_or(content.len());
+                if let Some(name) = content.get(..name_end).filter(|name| !name.is_empty()) {
+                    attributes.push(CompactString::from(name));
+                }
+                remaining = &remaining[close + 1..];
+            }
+            Some(ParsedSelector {
+                element,
+                attributes,
+            })
+        })
+        .collect()
+}
+
+fn selector_values(parsed: &[ParsedSelector], selector_type: SelectorType) -> SmallVec<[&str; 8]> {
+    match selector_type {
+        SelectorType::Attribute => parsed
+            .iter()
+            .flat_map(|selector| selector.attributes.iter().map(CompactString::as_str))
+            .collect(),
+        SelectorType::Element => parsed
+            .iter()
+            .filter_map(|selector| selector.element.as_deref())
+            .collect(),
+    }
+}
+
+fn style_matches(selector: &str, style: SelectorStyle) -> bool {
+    match style {
+        SelectorStyle::CamelCase => {
+            !selector.is_empty()
+                && selector
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric())
+        }
+        SelectorStyle::KebabCase => {
+            !selector.is_empty()
+                && selector.split('-').all(|part| {
+                    !part.is_empty()
+                        && part.chars().all(|character| {
+                            character.is_ascii_lowercase() || character.is_ascii_digit()
+                        })
+                })
+        }
+    }
+}
+
+fn prefix_regex(prefix: &str) -> Option<Regex> {
+    let mut pattern = CompactString::new("^(?:");
+    pattern.push_str(prefix);
+    pattern.push(')');
+    Regex::new(pattern.as_str()).ok()
+}
+
+fn prefix_matches(
+    selector: &str,
+    prefix: &str,
+    style: SelectorStyle,
+    selector_type: SelectorType,
+) -> bool {
+    if prefix.is_empty() {
+        return true;
+    }
+    let Some(found) = prefix_regex(prefix).and_then(|regex| regex.find(selector)) else {
+        return false;
+    };
+    if selector_type == SelectorType::Attribute {
+        return true;
+    }
+    let rest = &selector[found.end()..];
+    match style {
+        SelectorStyle::CamelCase => rest
+            .chars()
+            .next()
+            .is_none_or(|character| character.is_ascii_uppercase()),
+        SelectorStyle::KebabCase => rest.is_empty() || rest.starts_with('-'),
+    }
+}
+
+fn selector_after_prefix(selector: &str, prefix: &str) -> bool {
+    let Some(regex) = prefix_regex(prefix) else {
+        return true;
+    };
+    let replaced = regex.replace(selector, "");
+    !replaced.is_empty()
+}
+
+fn has_shadow_dom_encapsulation(metadata: &ObjectExpression<'_>) -> bool {
+    metadata.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return false;
+        };
+        if property_name(&property.key) != Some("encapsulation") {
+            return false;
+        }
+        let Expression::StaticMemberExpression(member) = property.value.get_inner_expression()
+        else {
+            return false;
+        };
+        matches!(
+            member.object.get_inner_expression(),
+            Expression::Identifier(identifier) if identifier.name == "ViewEncapsulation"
+        ) && member.property.name == "ShadowDom"
+    })
+}
+
+fn human_readable_prefixes(prefixes: &[CompactString]) -> CompactString {
+    let mut output = CompactString::new("");
+    for (index, prefix) in prefixes.iter().enumerate() {
+        if index > 0 {
+            if index + 1 == prefixes.len() {
+                output.push_str(" or ");
+            } else {
+                output.push_str(", ");
+            }
+        }
+        output.push('"');
+        output.push_str(prefix);
+        output.push('"');
+    }
+    output
+}
+
+fn data(key: &str, value: &str) -> SmallVec<[DiagnosticDatum; 2]> {
+    let mut output = SmallVec::new();
+    output.push(DiagnosticDatum {
+        key: CompactString::from(key),
+        value: CompactString::from(value),
+    });
+    output
+}
+
+fn data2(
+    first_key: &str,
+    first_value: &str,
+    second_key: &str,
+    second_value: &str,
+) -> SmallVec<[DiagnosticDatum; 2]> {
+    SmallVec::from_buf([
+        DiagnosticDatum {
+            key: CompactString::from(first_key),
+            value: CompactString::from(first_value),
+        },
+        DiagnosticDatum {
+            key: CompactString::from(second_key),
+            value: CompactString::from(second_value),
+        },
+    ])
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "Authored option fixtures use serde_json::json arrays and Vec-shaped assertions to mirror the JavaScript ABI exactly."
+)]
+mod tests {
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use serde_json::{Value, json};
+
+    use crate::{ScanOptions, scan_angular_eslint_with_options};
+
+    fn scan(rule_name: &str, source: &str, option: Value) -> Vec<crate::Diagnostic> {
+        let mut rule_names = SmallVec::new();
+        rule_names.push(CompactString::from(rule_name));
+        scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names,
+                options: json!([option]),
+            },
+        )
+        .into_vec()
+    }
+
+    #[test]
+    fn accepts_the_upstream_selector_option_families() {
+        let valid = [
+            (
+                "component-selector",
+                "@Component({ selector: 'sg-foo-bar' }) class Test {}",
+                json!({"type":"element","prefix":"sg","style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: '[ng-foo-bar]' }) class Test {}",
+                json!({"type":"attribute","prefix":["app","ng"],"style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app-foo-bar[baz].app' }) class Test {}",
+                json!({"type":"element","prefix":["app","cd","ng"],"style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'appBarFoo' }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"camelCase"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app1-foo-bar' }) class Test {}",
+                json!({"type":"element","prefix":"app1","style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: '[appFooBar]' }) class Test {}",
+                json!({"type":["attribute","element"],"prefix":["app","ng"],"style":"camelCase"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: `[appFooBar], [appBarFoo]` }) class Test {}",
+                json!({"type":["attribute","element"],"prefix":["app","ng"],"style":"camelCase"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: `button[appFooBar]` }) class Test {}",
+                json!({"type":["attribute","element"],"prefix":["app","ng"],"style":"camelCase"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'singleword' }) class Test {}",
+                json!({"type":"element","prefix":"","style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'foo-bar' }) class Test {}",
+                json!({"type":"element","prefix":[],"style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app-foo-bar' }) class Test {}",
+                json!([{"type":"element","prefix":"app","style":"kebab-case"}]),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: '[appFooBar]' }) class Test {}",
+                json!([
+                    {"type":"element","prefix":"app","style":"kebab-case"},
+                    {"type":"attribute","prefix":"app","style":"camelCase"}
+                ]),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'lib-foo-bar' }) class Test {}",
+                json!([
+                    {"type":"element","prefix":["app","lib"],"style":"kebab-case"},
+                    {"type":"attribute","prefix":"app","style":"camelCase"}
+                ]),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app-foo-bar', encapsulation: ViewEncapsulation.ShadowDom }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"camelCase"}),
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: '[appHighlight]' }) class Test {}",
+                json!({"type":"attribute","prefix":"app","style":"camelCase"}),
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: '[lib-highlight]' }) class Test {}",
+                json!({"type":"attribute","prefix":["app","lib"],"style":"kebab-case"}),
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: 'app-highlight' }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: '[highlight]' }) class Test {}",
+                json!({"type":"attribute","style":"camelCase"}),
+            ),
+            (
+                "component-selector",
+                "@Directive({ selector: 'wrong-kind' }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "const selector = 'app-x'; @Component({ selector }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: `app-${suffix}` }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+            ),
+            (
+                "component-selector",
+                "@Component({}) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+            ),
+        ];
+
+        for (rule_name, source, option) in valid {
+            assert!(
+                scan(rule_name, source, option).is_empty(),
+                "expected valid {rule_name}: {source}",
+            );
+        }
+    }
+
+    #[test]
+    fn reports_exact_selector_failures_and_message_data() {
+        let invalid = [
+            (
+                "component-selector",
+                "@Component({ selector: 'foo-bar' }) class Test {}",
+                json!({"type":"element","prefix":"sg","style":"kebab-case"}),
+                "prefixFailure",
+                vec![("prefix", "\"sg\"")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: '[app-foo-bar]' }) class Test {}",
+                json!({"type":"attribute","prefix":["cd","ng"],"style":"kebab-case"}),
+                "prefixFailure",
+                vec![("prefix", "\"cd\" or \"ng\"")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app-foo-bar[baz].app' }) class Test {}",
+                json!({"type":"element","prefix":["foo","cd","ng"],"style":"kebab-case"}),
+                "prefixFailure",
+                vec![("prefix", "\"foo\", \"cd\" or \"ng\"")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: '[ng-bar-foo]' }) class Test {}",
+                json!({"type":"attribute","prefix":"ng","style":"camelCase"}),
+                "styleFailure",
+                vec![("style", "camelCase")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'appFooBar' }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+                "styleAndPrefixFailure",
+                vec![("style", "kebab-case"), ("prefix", "\"app\"")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app' }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"kebab-case"}),
+                "selectorAfterPrefixFailure",
+                vec![("prefix", "\"app\"")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: '[appFooBar]' }) class Test {}",
+                json!({"type":"element","prefix":["app","ng"],"style":"camelCase"}),
+                "typeFailure",
+                vec![("type", "element")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'app-foo-bar' }) class Test {}",
+                json!({"type":"attribute","prefix":["app","ng"],"style":"kebab-case"}),
+                "typeFailure",
+                vec![("type", "attribute")],
+            ),
+            (
+                "component-selector",
+                "@Component({ selector: 'appFooBar', encapsulation: ViewEncapsulation.ShadowDom }) class Test {}",
+                json!({"type":"element","prefix":"app","style":"camelCase"}),
+                "shadowDomEncapsulatedStyleFailure",
+                vec![],
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: '[fooHighlight]' }) class Test {}",
+                json!({"type":"attribute","prefix":"app","style":"camelCase"}),
+                "prefixFailure",
+                vec![("prefix", "\"app\"")],
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: '[app-highlight]' }) class Test {}",
+                json!({"type":"attribute","prefix":"app","style":"camelCase"}),
+                "styleFailure",
+                vec![("style", "camelCase")],
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: 'app-highlight' }) class Test {}",
+                json!({"type":"attribute","prefix":"app","style":"kebab-case"}),
+                "typeFailure",
+                vec![("type", "attribute")],
+            ),
+            (
+                "directive-selector",
+                "@Directive({ selector: '[app]' }) class Test {}",
+                json!({"type":"attribute","prefix":"app","style":"camelCase"}),
+                "selectorAfterPrefixFailure",
+                vec![("prefix", "\"app\"")],
+            ),
+        ];
+
+        for (rule_name, source, option, message_id, expected_data) in invalid {
+            let diagnostics = scan(rule_name, source, option);
+            assert_eq!(diagnostics.len(), 1, "{rule_name}: {source}");
+            let diagnostic = &diagnostics[0];
+            assert_eq!(diagnostic.message_id, message_id, "{rule_name}: {source}");
+            let actual_data: Vec<(&str, &str)> = diagnostic
+                .data
+                .iter()
+                .map(|datum| (datum.key.as_str(), datum.value.as_str()))
+                .collect();
+            assert_eq!(actual_data, expected_data, "{rule_name}: {source}");
+        }
+    }
+
+    #[test]
+    fn keeps_rule_selection_locations_and_malformed_input_safe() {
+        let option = json!({"type":"element","prefix":"app","style":"kebab-case"});
+        assert!(
+            scan(
+                "directive-selector",
+                "@Component({ selector: 'wrong' }) class Test {}",
+                option.clone(),
+            )
+            .is_empty(),
+        );
+        assert!(
+            scan(
+                "component-selector",
+                "@Component({ selector: 'wrong' ",
+                option.clone(),
+            )
+            .is_empty(),
+        );
+        assert!(scan("component-selector", "const plain = 1;", option.clone()).is_empty(),);
+
+        let diagnostics = scan(
+            "component-selector",
+            "const emoji = '😀';\n@Component({ selector: 'wrong-name' }) class Test {}",
+            option,
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].loc.start_line, 2);
+        assert_eq!(diagnostics[0].loc.start_column, 23);
+        assert_eq!(diagnostics[0].loc.end_column, 35);
+    }
+}

--- a/crates/angular_eslint/src/tests.rs
+++ b/crates/angular_eslint/src/tests.rs
@@ -59,7 +59,10 @@ fn scans_representative_rules() {
         .iter()
         .map(|diagnostic| diagnostic.rule_name)
         .collect();
-    let mut expected: SmallVec<[&str; 64]> = RULE_NAMES.into_iter().collect();
+    let mut expected: SmallVec<[&str; 64]> = RULE_NAMES
+        .into_iter()
+        .filter(|rule_name| !matches!(*rule_name, "component-selector" | "directive-selector"))
+        .collect();
     actual.sort_unstable();
     expected.sort_unstable();
     assert_eq!(actual, expected);

--- a/crates/angular_eslint/src/types.rs
+++ b/crates/angular_eslint/src/types.rs
@@ -1,7 +1,13 @@
 //! Diagnostic types and line indexing for the angular-eslint port.
 
 use oxc_span::Span;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiagnosticDatum {
+    pub key: CompactString,
+    pub value: CompactString,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiagnosticLoc {
@@ -15,6 +21,7 @@ pub struct DiagnosticLoc {
 pub struct Diagnostic {
     pub rule_name: &'static str,
     pub message_id: &'static str,
+    pub data: SmallVec<[DiagnosticDatum; 2]>,
     pub loc: DiagnosticLoc,
 }
 

--- a/crates/playground_wasm/src/plugins/angular_eslint.rs
+++ b/crates/playground_wasm/src/plugins/angular_eslint.rs
@@ -29,7 +29,11 @@ pub fn scan(
         if !filter.rule_enabled(PLUGIN, diagnostic.rule_name) {
             continue;
         }
-        let data: BTreeMap<String, String> = BTreeMap::new();
+        let data: BTreeMap<String, String> = diagnostic
+            .data
+            .into_iter()
+            .map(|datum| (datum.key.into_string(), datum.value.into_string()))
+            .collect();
         out.push(PlaygroundDiagnostic {
             plugin: PLUGIN,
             rule: diagnostic.rule_name.to_owned(),

--- a/npm/angular-eslint/Cargo.toml
+++ b/npm/angular-eslint/Cargo.toml
@@ -16,6 +16,7 @@ name = "oxlint_plugin_angular_eslint"
 napi.workspace = true
 napi-derive.workspace = true
 oxlint-plugins-angular-eslint.workspace = true
+serde_json.workspace = true
 
 [build-dependencies]
 napi-build.workspace = true

--- a/npm/angular-eslint/api.d.ts
+++ b/npm/angular-eslint/api.d.ts
@@ -8,8 +8,16 @@ export type AngularEslintDiagnosticLoc = {
 export type AngularEslintDiagnostic = {
   ruleName: string;
   messageId: string;
+  data: Array<{ key: string; value: string }>;
   loc: AngularEslintDiagnosticLoc;
 };
 
 export function implementedAngularEslintRuleNames(): string[];
-export function scanAngularEslint(sourceText: string, filename?: string): AngularEslintDiagnostic[];
+export function scanAngularEslint(
+  sourceText: string,
+  filename?: string,
+  options?: {
+    ruleNames?: string[];
+    options?: unknown[];
+  },
+): AngularEslintDiagnostic[];

--- a/npm/angular-eslint/api.js
+++ b/npm/angular-eslint/api.js
@@ -6,7 +6,7 @@ function implementedAngularEslintRuleNames() {
   return native.implementedAngularEslintRuleNames();
 }
 
-function scanAngularEslint(sourceText, filename = 'file.ts') {
+function scanAngularEslint(sourceText, filename = 'file.ts', options = {}) {
   if (typeof sourceText !== 'string') {
     throw new TypeError('sourceText must be a string.');
   }
@@ -14,7 +14,19 @@ function scanAngularEslint(sourceText, filename = 'file.ts') {
     throw new TypeError('filename must be a string.');
   }
 
-  return native.scanAngularEslint(sourceText, filename);
+  return native.scanAngularEslint(sourceText, filename, normalizeOptions(options));
+}
+
+function normalizeOptions(options) {
+  if (!options || typeof options !== 'object') {
+    return {};
+  }
+  return {
+    ruleNames: Array.isArray(options.ruleNames)
+      ? options.ruleNames.filter((name) => typeof name === 'string' && name.length > 0)
+      : undefined,
+    options: options.options,
+  };
 }
 
 module.exports = {

--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -12,6 +12,72 @@ const DOCS_BASE =
   'https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedAngularEslintRuleNames());
+const selectorRuleNames = new Set(['component-selector', 'directive-selector']);
+
+const selectorConfigSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      oneOf: [
+        { type: 'string', enum: ['element', 'attribute'] },
+        {
+          type: 'array',
+          items: { type: 'string', enum: ['element', 'attribute'] },
+          minItems: 1,
+          uniqueItems: true,
+        },
+      ],
+    },
+    prefix: {
+      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+    },
+    style: { type: 'string', enum: ['camelCase', 'kebab-case'] },
+  },
+  required: ['type', 'style'],
+  additionalProperties: false,
+};
+
+const selectorSchema = [
+  {
+    oneOf: [
+      selectorConfigSchema,
+      {
+        type: 'array',
+        items: {
+          ...selectorConfigSchema,
+          properties: {
+            ...selectorConfigSchema.properties,
+            type: { type: 'string', enum: ['element', 'attribute'] },
+          },
+        },
+        minItems: 1,
+        maxItems: 2,
+      },
+    ],
+  },
+];
+
+const selectorMessages = {
+  'component-selector': {
+    prefixFailure:
+      'The selector should start with one of these prefixes: {{prefix}} (https://angular.dev/style-guide#choosing-component-selectors)',
+    styleFailure:
+      'The selector should be {{style}} (https://angular.dev/style-guide#choosing-component-selectors)',
+    styleAndPrefixFailure:
+      'The selector should be {{style}} and start with one of these prefixes: {{prefix}} (https://angular.dev/style-guide#choosing-component-selectors and https://angular.dev/style-guide#choosing-component-selectors)',
+    typeFailure:
+      'The selector should be used as an {{type}} (https://angular.dev/style-guide#choosing-component-selectors)',
+    shadowDomEncapsulatedStyleFailure:
+      'The selector of a ShadowDom-encapsulated component should be `kebab-case` (https://github.com/angular-eslint/angular-eslint/issues/534)',
+    selectorAfterPrefixFailure: 'There should be a selector after the {{prefix}} prefix',
+  },
+  'directive-selector': {
+    prefixFailure: 'The selector should start with one of these prefixes: {{prefix}}',
+    styleFailure: 'The selector should be {{style}}',
+    typeFailure: 'The selector should be used as an {{type}}',
+    selectorAfterPrefixFailure: 'There should be a selector after the {{prefix}} prefix',
+  },
+};
 
 const problemRules = new Set([
   'computed-must-return',
@@ -57,6 +123,7 @@ plugin.implementedAngularEslintRuleNames = implementedRuleNames;
 plugin.scanAngularEslint = scanAngularEslint;
 
 function createAngularEslintRule(ruleName) {
+  const isSelectorRule = selectorRuleNames.has(ruleName);
   return {
     meta: {
       type: problemRules.has(ruleName) ? 'problem' : 'suggestion',
@@ -66,13 +133,12 @@ function createAngularEslintRule(ruleName) {
         recommended: false,
         url: `${DOCS_BASE}/${ruleName}.md`,
       },
-      messages: {
-        unexpected: 'Unexpected Angular pattern.',
-      },
-      // These rules do not yet honor upstream options (the core is a heuristic
-      // scanner). Declare no schema so configured options are surfaced as an
-      // error rather than silently ignored. Tracked for real implementation.
-      schema: [],
+      messages: isSelectorRule
+        ? selectorMessages[ruleName]
+        : {
+            unexpected: 'Unexpected Angular pattern.',
+          },
+      schema: isSelectorRule ? selectorSchema : [],
     },
     createOnce(context) {
       return {
@@ -87,6 +153,14 @@ function createAngularEslintRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
+  if (selectorRuleNames.has(ruleName)) {
+    const sourceText = sourceTextForContext(context);
+    const filename = typeof context.filename === 'string' ? context.filename : 'file.ts';
+    return scanAngularEslint(sourceText, filename, {
+      ruleNames: [ruleName],
+      options: context.options || [],
+    });
+  }
   return diagnosticsForContext(context).filter((diagnostic) => diagnostic.ruleName === ruleName);
 }
 
@@ -109,6 +183,7 @@ function diagnosticsForContext(context) {
 function reportDiagnostic(context, diagnostic) {
   context.report({
     messageId: diagnostic.messageId,
+    data: Object.fromEntries(diagnostic.data.map(({ key, value }) => [key, value])),
     loc: {
       start: {
         line: diagnostic.loc.startLine,

--- a/npm/angular-eslint/src/lib.rs
+++ b/npm/angular-eslint/src/lib.rs
@@ -1,7 +1,8 @@
 //! NAPI boundary for the angular-eslint oxlint plugin.
 
 pub use napi_abi::{
-    Diagnostic, DiagnosticLoc, implemented_angular_eslint_rule_names, scan_angular_eslint,
+    AngularEslintScanOptions, Diagnostic, DiagnosticDatum, DiagnosticLoc,
+    implemented_angular_eslint_rule_names, scan_angular_eslint,
 };
 
 #[allow(
@@ -12,6 +13,20 @@ pub use napi_abi::{
 mod napi_abi {
     use napi_derive::napi;
     use oxlint_plugins_angular_eslint as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct AngularEslintScanOptions {
+        pub rule_names: Option<Vec<String>>,
+        pub options: Option<serde_json::Value>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticDatum {
+        pub key: String,
+        pub value: String,
+    }
 
     #[napi(object)]
     #[derive(Clone, Debug)]
@@ -27,6 +42,7 @@ mod napi_abi {
     pub struct Diagnostic {
         pub rule_name: String,
         pub message_id: String,
+        pub data: Vec<DiagnosticDatum>,
         pub loc: DiagnosticLoc,
     }
 
@@ -39,12 +55,33 @@ mod napi_abi {
     }
 
     #[napi]
-    pub fn scan_angular_eslint(source_text: String, filename: String) -> Vec<Diagnostic> {
-        core::scan_angular_eslint(&source_text, &filename)
+    pub fn scan_angular_eslint(
+        source_text: String,
+        filename: String,
+        options: AngularEslintScanOptions,
+    ) -> Vec<Diagnostic> {
+        let core_options = core::ScanOptions {
+            rule_names: options
+                .rule_names
+                .unwrap_or_default()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            options: options.options.unwrap_or(serde_json::Value::Null),
+        };
+        core::scan_angular_eslint_with_options(&source_text, &filename, &core_options)
             .into_iter()
             .map(|diagnostic| Diagnostic {
                 rule_name: diagnostic.rule_name.to_owned(),
                 message_id: diagnostic.message_id.to_owned(),
+                data: diagnostic
+                    .data
+                    .into_iter()
+                    .map(|datum| DiagnosticDatum {
+                        key: datum.key.into_string(),
+                        value: datum.value.into_string(),
+                    })
+                    .collect(),
                 loc: DiagnosticLoc {
                     start_line: diagnostic.loc.start_line,
                     start_column: diagnostic.loc.start_column,

--- a/npm/angular-eslint/test/api.test.mjs
+++ b/npm/angular-eslint/test/api.test.mjs
@@ -99,8 +99,93 @@ describe('angular-eslint native API', () => {
     const diagnostics = scanAngularEslint(representativeSource, 'fixture.ts');
 
     expect(diagnostics.map((diagnostic) => diagnostic.ruleName).sort()).toEqual(
-      [...expectedRuleNames].sort(),
+      expectedRuleNames
+        .filter((ruleName) => !['component-selector', 'directive-selector'].includes(ruleName))
+        .sort(),
     );
+  });
+
+  it.each([
+    [
+      'component-selector',
+      '@Component({ selector: "app-user-card" }) class UserCard {}',
+      { type: 'element', prefix: 'app', style: 'kebab-case' },
+      [],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "wrong-name" }) class UserCard {}',
+      { type: 'element', prefix: ['app', 'lib'], style: 'kebab-case' },
+      [{ messageId: 'prefixFailure', data: [{ key: 'prefix', value: '"app" or "lib"' }] }],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "appUserCard" }) class UserCard {}',
+      { type: 'element', prefix: 'app', style: 'kebab-case' },
+      [
+        {
+          messageId: 'styleAndPrefixFailure',
+          data: [
+            { key: 'style', value: 'kebab-case' },
+            { key: 'prefix', value: '"app"' },
+          ],
+        },
+      ],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "[appUserCard]" }) class UserCard {}',
+      { type: 'element', prefix: 'app', style: 'camelCase' },
+      [{ messageId: 'typeFailure', data: [{ key: 'type', value: 'element' }] }],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "appUserCard", encapsulation: ViewEncapsulation.ShadowDom }) class UserCard {}',
+      { type: 'element', prefix: 'app', style: 'camelCase' },
+      [{ messageId: 'shadowDomEncapsulatedStyleFailure', data: [] }],
+    ],
+    [
+      'directive-selector',
+      '@Directive({ selector: "[appHighlight]" }) class HighlightDirective {}',
+      { type: 'attribute', prefix: 'app', style: 'camelCase' },
+      [],
+    ],
+    [
+      'directive-selector',
+      '@Directive({ selector: "[app-highlight]" }) class HighlightDirective {}',
+      { type: 'attribute', prefix: 'app', style: 'camelCase' },
+      [{ messageId: 'styleFailure', data: [{ key: 'style', value: 'camelCase' }] }],
+    ],
+  ])('honors %s native options and data', (ruleName, source, option, expected) => {
+    const diagnostics = scanAngularEslint(source, 'fixture.ts', {
+      ruleNames: [ruleName],
+      options: [option],
+    });
+
+    expect(diagnostics).toMatchObject(expected);
+  });
+
+  it('supports separate element and attribute selector configs', () => {
+    const options = [
+      [
+        { type: 'element', prefix: 'app', style: 'kebab-case' },
+        { type: 'attribute', prefix: 'lib', style: 'camelCase' },
+      ],
+    ];
+    expect(
+      scanAngularEslint(
+        '@Component({ selector: "app-user-card" }) class UserCard {}',
+        'fixture.ts',
+        { ruleNames: ['component-selector'], options },
+      ),
+    ).toEqual([]);
+    expect(
+      scanAngularEslint(
+        '@Component({ selector: "[libUserCard]" }) class UserCard {}',
+        'fixture.ts',
+        { ruleNames: ['component-selector'], options },
+      ),
+    ).toEqual([]);
   });
 
   it('returns LSP-shaped locations', () => {

--- a/npm/angular-eslint/test/plugin.test.mjs
+++ b/npm/angular-eslint/test/plugin.test.mjs
@@ -68,13 +68,11 @@ const invalidCases = [
     'component-max-inline-declarations',
     '@Component({ template: `a\nb\nc` }) class AppComponent {}\n',
   ],
-  ['component-selector', '@Component({ selector: "BadSelector" }) class AppComponent {}\n'],
   ['computed-must-return', 'const total = computed(() => { totalSignal(); });\n'],
   ['consistent-component-styles', '@Component({ styleUrls: ["./x.css"] }) class AppComponent {}\n'],
   ['contextual-decorator', '@Input() class WrongContext {}\n'],
   ['contextual-lifecycle', 'class Plain { ngOnInit() {} }\n'],
   ['directive-class-suffix', '@Directive({ selector: "[x]" }) class Highlight {}\n'],
-  ['directive-selector', '@Directive({ selector: "BadDirective" }) class HighlightDirective {}\n'],
   ['no-async-lifecycle-method', 'class Life { async ngOnInit() {} }\n'],
   ['no-attribute-decorator', 'class Attr { constructor(@Attribute("role") role: string) {} }\n'],
   ['no-developer-preview', 'afterNextRender(() => {});\n'],
@@ -131,7 +129,7 @@ const invalidCases = [
   ['use-pipe-transform-interface', '@Pipe({ name: "plain" }) class PlainPipe { transform() {} }\n'],
 ];
 
-function runRule(ruleName, sourceText, filename = 'fixture.ts') {
+function runRule(ruleName, sourceText, options = [], filename = 'fixture.ts') {
   const reports = [];
   const sourceCode = {
     text: sourceText,
@@ -141,7 +139,7 @@ function runRule(ruleName, sourceText, filename = 'fixture.ts') {
   };
   const visitor = plugin.rules[ruleName].createOnce({
     filename,
-    options: [],
+    options,
     sourceCode,
     report(descriptor) {
       reports.push(descriptor);
@@ -183,6 +181,138 @@ describe('angular-eslint plugin adapter', () => {
     );
   });
 
+  it('exposes the complete selector schemas and messages', () => {
+    for (const ruleName of ['component-selector', 'directive-selector']) {
+      const { meta } = plugin.rules[ruleName];
+      expect(meta.schema).toHaveLength(1);
+      expect(meta.schema[0].oneOf).toHaveLength(2);
+      expect(meta.schema[0].oneOf[0]).toMatchObject({
+        type: 'object',
+        required: ['type', 'style'],
+        additionalProperties: false,
+      });
+      expect(meta.messages).toMatchObject({
+        prefixFailure: expect.stringContaining('{{prefix}}'),
+        styleFailure: expect.stringContaining('{{style}}'),
+        typeFailure: expect.stringContaining('{{type}}'),
+        selectorAfterPrefixFailure: expect.stringContaining('{{prefix}}'),
+      });
+    }
+    expect(plugin.rules['component-selector'].meta.messages).toMatchObject({
+      styleAndPrefixFailure: expect.stringContaining('{{style}}'),
+      shadowDomEncapsulatedStyleFailure: expect.stringContaining('ShadowDom'),
+    });
+  });
+
+  it.each([
+    [
+      'component-selector',
+      '@Component({ selector: "app-user-card" }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "[appUserCard]" }) class UserCard {}',
+      [{ type: 'attribute', prefix: 'app', style: 'camelCase' }],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "lib-user-card" }) class UserCard {}',
+      [
+        [
+          { type: 'element', prefix: ['app', 'lib'], style: 'kebab-case' },
+          { type: 'attribute', prefix: 'app', style: 'camelCase' },
+        ],
+      ],
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "app-user-card", encapsulation: ViewEncapsulation.ShadowDom }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'camelCase' }],
+    ],
+    [
+      'directive-selector',
+      '@Directive({ selector: "[appHighlight]" }) class HighlightDirective {}',
+      [{ type: 'attribute', prefix: 'app', style: 'camelCase' }],
+    ],
+    [
+      'directive-selector',
+      '@Directive({ selector: "[lib-highlight]" }) class HighlightDirective {}',
+      [{ type: 'attribute', prefix: ['app', 'lib'], style: 'kebab-case' }],
+    ],
+  ])('accepts configured %s selectors through createOnce', (ruleName, code, options) => {
+    expect(runRule(ruleName, code, options)).toEqual([]);
+  });
+
+  it.each([
+    [
+      'component-selector',
+      '@Component({ selector: "wrong-name" }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      'prefixFailure',
+      { prefix: '"app"' },
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "appUserCard" }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      'styleAndPrefixFailure',
+      { style: 'kebab-case', prefix: '"app"' },
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "[appUserCard]" }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'camelCase' }],
+      'typeFailure',
+      { type: 'element' },
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "app" }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      'selectorAfterPrefixFailure',
+      { prefix: '"app"' },
+    ],
+    [
+      'component-selector',
+      '@Component({ selector: "appUserCard", encapsulation: ViewEncapsulation.ShadowDom }) class UserCard {}',
+      [{ type: 'element', prefix: 'app', style: 'camelCase' }],
+      'shadowDomEncapsulatedStyleFailure',
+      {},
+    ],
+    [
+      'directive-selector',
+      '@Directive({ selector: "[wrongHighlight]" }) class HighlightDirective {}',
+      [{ type: 'attribute', prefix: ['app', 'lib'], style: 'camelCase' }],
+      'prefixFailure',
+      { prefix: '"app" or "lib"' },
+    ],
+    [
+      'directive-selector',
+      '@Directive({ selector: "[app-highlight]" }) class HighlightDirective {}',
+      [{ type: 'attribute', prefix: 'app', style: 'camelCase' }],
+      'styleFailure',
+      { style: 'camelCase' },
+    ],
+  ])(
+    'reports configured %s selector failures through createOnce',
+    (ruleName, code, options, messageId, data) => {
+      expect(runRule(ruleName, code, options)).toMatchObject([{ messageId, data }]);
+    },
+  );
+
+  it('does not run option-required selector rules without options', () => {
+    expect(
+      runRule('component-selector', '@Component({ selector: "WrongSelector" }) class UserCard {}'),
+    ).toEqual([]);
+    expect(
+      runRule(
+        'directive-selector',
+        '@Directive({ selector: "WrongSelector" }) class HighlightDirective {}',
+      ),
+    ).toEqual([]);
+  });
+
   it('loads through oxlint jsPlugins', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-eslint-'));
     try {
@@ -219,6 +349,55 @@ describe('angular-eslint plugin adapter', () => {
       expect(result.stderr).toBe('');
       expect(payload.diagnostics).toHaveLength(1);
       expect(payload.diagnostics[0].message).toBe('Unexpected Angular pattern.');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors selector options through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-selector-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.ts'),
+        '@Component({ selector: "wrong-name" }) class AppComponent {}\n',
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: '@angular-eslint',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            '@angular-eslint/component-selector': [
+              'error',
+              { type: 'element', prefix: ['app', 'lib'], style: 'kebab-case' },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toMatchObject([
+        {
+          code: '@angular-eslint(component-selector)',
+          message:
+            'The selector should start with one of these prefixes: "app" or "lib" (https://angular.dev/style-guide#choosing-component-selectors)',
+        },
+      ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- implement `component-selector` and `directive-selector` on the Oxc decorator AST with upstream-compatible `type`, `prefix`, and `style` options
- support scalar and array prefixes, combined element/attribute configurations, static template literals, ShadowDom overrides, rule selection, UTF-16 spans, and exact message data
- expose typed options and diagnostic data through NAPI, the plugin schema, direct API, real Oxlint integration, and playground WASM
- keep selector rules inactive when their required options are absent

## Tests
- 35+ authored Rust option cases plus rule-selection, malformed-input, UTF-16, and exact-message assertions: 5 Rust tests passed
- direct API, plugin, and real Oxlint integration: 75 JS tests passed
- full `pnpm verify`: 15,835 JS passed, 1,159 skipped; all workspace Rust/doc tests, Clippy, benches, security, licenses, status, and publish-ready package checks passed
- post-rebase targeted rebuild, 75 JS tests, 5 Rust tests, and targeted Clippy passed

This is the selector-options slice of #419. Remaining Angular option families stay in separate small follow-up PRs. React and JSX plugins are intentionally out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->