### PR TITLE
feat(perfectionist): support sort-named-imports groups

### DIFF
--- a/crates/perfectionist/src/sort_named_imports.rs
+++ b/crates/perfectionist/src/sort_named_imports.rs
@@ -1,20 +1,78 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "serde_json option maps require String keys and configured group/import collections are user-sized rather than bounded rule state."
+)]
+
 //! Configurable `sort-named-imports` slice pinned to Perfectionist v5.9.1.
 
 use std::cmp::Ordering;
+use std::sync::OnceLock;
 
 use oxc_ast::{
-    Comment,
-    ast::{ImportDeclarationSpecifier, ImportSpecifier, ModuleExportName, Statement},
+    Comment, CommentKind,
+    ast::{
+        ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind, ImportSpecifier,
+        ModuleExportName, Statement,
+    },
 };
 use oxc_span::Span;
 use oxlint_plugins_carton::{CompactString, SmallVec};
-use serde_json::Value;
+use regex::RegexBuilder;
+use serde_json::{Map, Value};
 
 use crate::sort_options::SortOptions;
 use crate::types::{LineIndex, RuleDiagnostic, RuleDiagnosticData, RuleDiagnosticFix};
 
 const RULE: &str = "sort-named-imports";
-const MESSAGE_ID: &str = "unexpectedNamedImportsOrder";
+const ORDER_MESSAGE_ID: &str = "unexpectedNamedImportsOrder";
+const GROUP_ORDER_MESSAGE_ID: &str = "unexpectedNamedImportsGroupOrder";
+const EXTRA_SPACING_MESSAGE_ID: &str = "extraSpacingBetweenNamedImports";
+const MISSED_SPACING_MESSAGE_ID: &str = "missedSpacingBetweenNamedImports";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Newlines {
+    Ignore,
+    Count(usize),
+    Between,
+}
+
+#[derive(Debug)]
+enum GroupEntry {
+    Group {
+        names: SmallVec<[CompactString; 2]>,
+        overrides: Option<Map<String, Value>>,
+        newlines_inside: Option<Newlines>,
+    },
+    Newlines(Newlines),
+}
+
+#[derive(Debug)]
+struct CustomMatch {
+    element_name_pattern: Option<Value>,
+    modifiers: SmallVec<[CompactString; 2]>,
+    selector: Option<CompactString>,
+}
+
+#[derive(Debug)]
+struct CustomGroup {
+    group_name: CompactString,
+    matches: SmallVec<[CustomMatch; 2]>,
+    overrides: Map<String, Value>,
+    newlines_inside: Option<Newlines>,
+}
+
+#[derive(Debug)]
+struct RuleOptions {
+    raw: Map<String, Value>,
+    sort: SortOptions,
+    groups: Vec<GroupEntry>,
+    custom_groups: Vec<CustomGroup>,
+    partition_by_comment: Value,
+    partition_by_new_line: bool,
+    newlines_between: Newlines,
+    newlines_inside: Newlines,
+}
 
 struct NamedImport<'a> {
     span: Span,
@@ -23,6 +81,9 @@ struct NamedImport<'a> {
     source_start: u32,
     source_end: u32,
     size: usize,
+    group: CompactString,
+    group_index: usize,
+    partition_id: usize,
 }
 
 pub(crate) fn check(
@@ -31,7 +92,6 @@ pub(crate) fn check(
     comments: &[Comment],
     raw_options: &Value,
 ) -> SmallVec<[RuleDiagnostic; 8]> {
-    let options = SortOptions::from_json(raw_options);
     let lines = LineIndex::new(source_text);
     let mut diagnostics = SmallVec::new();
 
@@ -51,7 +111,13 @@ pub(crate) fn check(
                 Some(&**specifier)
             })
             .collect();
-        let imports: SmallVec<[NamedImport<'_>; 8]> = named_specifiers
+        if named_specifiers.len() < 2 {
+            continue;
+        }
+
+        let selected = select_options(raw_options, declaration, &named_specifiers);
+        let options = RuleOptions::from_object(selected);
+        let mut imports: SmallVec<[NamedImport<'_>; 8]> = named_specifiers
             .iter()
             .enumerate()
             .filter_map(|(index, specifier)| {
@@ -61,9 +127,10 @@ pub(crate) fn check(
                 named_import(
                     source_text,
                     comments,
+                    declaration,
                     specifier,
                     boundary,
-                    options.ignore_alias,
+                    &options,
                 )
             })
             .collect();
@@ -71,35 +138,61 @@ pub(crate) fn check(
             continue;
         }
 
-        let mut sorted_indices: SmallVec<[usize; 8]> = (0..imports.len()).collect();
-        sorted_indices.sort_by(|&left, &right| {
-            compare_imports(&options, &imports[left], &imports[right])
-                .then_with(|| left.cmp(&right))
-        });
-        if sorted_indices
-            .iter()
-            .enumerate()
-            .all(|(position, &original)| position == original)
-        {
+        assign_partitions(source_text, comments, &options, &mut imports);
+        let sorted_indices = sort_imports(&options, &imports);
+        let mut sorted_positions = vec![0; imports.len()];
+        for (position, &original_index) in sorted_indices.iter().enumerate() {
+            sorted_positions[original_index] = position;
+        }
+
+        let mut pending: SmallVec<[(&'static str, usize, Option<usize>); 8]> = SmallVec::new();
+        for right_index in 1..imports.len() {
+            let left_index = right_index - 1;
+            let left = &imports[left_index];
+            let right = &imports[right_index];
+
+            if sorted_positions[left_index] > sorted_positions[right_index] {
+                let message_id = if left.group_index == right.group_index {
+                    ORDER_MESSAGE_ID
+                } else {
+                    GROUP_ORDER_MESSAGE_ID
+                };
+                pending.push((message_id, right_index, Some(left_index)));
+            }
+
+            if left.partition_id == right.partition_id
+                && left.group_index <= right.group_index
+                && let Newlines::Count(expected) = newlines_between(&options, left, right)
+            {
+                let actual = empty_lines_between(source_text, left.source_end, right.source_start);
+                if actual < expected {
+                    pending.push((MISSED_SPACING_MESSAGE_ID, right_index, Some(left_index)));
+                } else if actual > expected {
+                    pending.push((EXTRA_SPACING_MESSAGE_ID, right_index, Some(left_index)));
+                }
+            }
+        }
+        if pending.is_empty() {
             continue;
         }
 
-        let Some(fix) = build_fix(source_text, &imports, &sorted_indices) else {
+        let Some(fix) = build_fix(source_text, &options, &imports, &sorted_indices) else {
             continue;
         };
-        for pair in imports.windows(2) {
-            let [left, right] = pair else {
-                continue;
-            };
-            if compare_imports(&options, left, right) != Ordering::Greater {
-                continue;
-            }
+        for (message_id, right_index, left_index) in pending {
+            let right = &imports[right_index];
+            let left = left_index.map(|index| &imports[index]);
+            let is_group_error = message_id == GROUP_ORDER_MESSAGE_ID;
             diagnostics.push(RuleDiagnostic {
                 rule_name: RULE,
-                message_id: MESSAGE_ID,
+                message_id,
                 data: RuleDiagnosticData {
-                    left: left.name.clone(),
+                    left: left.map_or_else(|| CompactString::new(""), |node| node.name.clone()),
                     right: right.name.clone(),
+                    left_group: is_group_error.then(|| {
+                        left.map_or_else(|| CompactString::new(""), |node| node.group.clone())
+                    }),
+                    right_group: is_group_error.then(|| right.group.clone()),
                 },
                 loc: lines.loc_for_span(source_text, right.span),
                 fix: fix.clone(),
@@ -109,21 +202,243 @@ pub(crate) fn check(
     diagnostics
 }
 
+impl RuleOptions {
+    fn from_object(raw: Map<String, Value>) -> Self {
+        let value = Value::Object(raw.clone());
+        let groups = raw
+            .get("groups")
+            .and_then(Value::as_array)
+            .map_or_else(Vec::new, |groups| {
+                groups.iter().filter_map(parse_group).collect()
+            });
+        let custom_groups = raw
+            .get("customGroups")
+            .and_then(Value::as_array)
+            .map_or_else(Vec::new, |groups| {
+                groups.iter().filter_map(parse_custom_group).collect()
+            });
+        Self {
+            sort: SortOptions::from_json(&value),
+            groups,
+            custom_groups,
+            partition_by_comment: raw
+                .get("partitionByComment")
+                .cloned()
+                .unwrap_or(Value::Bool(false)),
+            partition_by_new_line: raw
+                .get("partitionByNewLine")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            newlines_between: raw
+                .get("newlinesBetween")
+                .map_or(Newlines::Ignore, parse_newlines),
+            newlines_inside: raw
+                .get("newlinesInside")
+                .map_or(Newlines::Between, parse_newlines),
+            raw,
+        }
+    }
+
+    fn group_names(&self) -> impl Iterator<Item = &str> {
+        self.groups.iter().flat_map(|group| match group {
+            GroupEntry::Group { names, .. } => names.iter().map(CompactString::as_str).collect(),
+            GroupEntry::Newlines(_) => Vec::new(),
+        })
+    }
+
+    fn group_index(&self, group_name: &str) -> usize {
+        self.groups
+            .iter()
+            .position(|group| match group {
+                GroupEntry::Group { names, .. } => {
+                    names.iter().any(|name| name.as_str() == group_name)
+                }
+                GroupEntry::Newlines(_) => false,
+            })
+            .unwrap_or(self.groups.len())
+    }
+
+    fn sort_options_for_group(&self, group_index: usize) -> (SortOptions, Value) {
+        let mut merged = self.raw.clone();
+        if let Some(GroupEntry::Group {
+            overrides: Some(overrides),
+            ..
+        }) = self.groups.get(group_index)
+        {
+            merge_sort_overrides(&mut merged, overrides);
+        }
+        let group_name = self.groups.get(group_index).and_then(|entry| match entry {
+            GroupEntry::Group { names, .. } if names.len() == 1 => {
+                names.first().map(CompactString::as_str)
+            }
+            _ => None,
+        });
+        if let Some(custom_group) = group_name.and_then(|name| {
+            self.custom_groups
+                .iter()
+                .find(|custom| custom.group_name.as_str() == name)
+        }) {
+            merge_sort_overrides(&mut merged, &custom_group.overrides);
+        }
+        let value = Value::Object(merged);
+        (SortOptions::from_json(&value), value)
+    }
+}
+
+fn select_options(
+    raw_options: &Value,
+    declaration: &ImportDeclaration<'_>,
+    specifiers: &[&ImportSpecifier<'_>],
+) -> Map<String, Value> {
+    let candidates: Vec<&Map<String, Value>> = match raw_options {
+        Value::Array(values) => values.iter().filter_map(Value::as_object).collect(),
+        Value::Object(object) => vec![object],
+        _ => Vec::new(),
+    };
+    for candidate in candidates {
+        let Some(condition) = candidate
+            .get("useConfigurationIf")
+            .and_then(Value::as_object)
+        else {
+            return candidate.clone();
+        };
+        let ignore_alias = candidate
+            .get("ignoreAlias")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let Some(pattern) = condition.get("allNamesMatchPattern")
+            && !specifiers.iter().all(|specifier| {
+                let name = import_name(specifier, ignore_alias);
+                matches_regex(name.as_str(), pattern)
+            })
+        {
+            continue;
+        }
+        if let Some(selector) = condition.get("matchesAstSelector").and_then(Value::as_str)
+            && !matches_import_selector(selector, declaration)
+        {
+            continue;
+        }
+        return candidate.clone();
+    }
+    Map::new()
+}
+
+fn matches_import_selector(selector: &str, declaration: &ImportDeclaration<'_>) -> bool {
+    let selector = selector.trim();
+    if matches!(
+        selector,
+        "ImportDeclaration"
+            | "* > ImportDeclaration"
+            | "Program > ImportDeclaration"
+            | "Program ImportDeclaration"
+    ) {
+        return true;
+    }
+    if let Some(attribute) = selector
+        .strip_prefix("ImportDeclaration[")
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        for operator in ["=", "=="] {
+            if let Some((field, expected)) = attribute.split_once(operator) {
+                let expected = expected.trim().trim_matches(['\'', '"']);
+                if matches!(field.trim(), "source.value" | "source.raw") {
+                    return declaration.source.value.as_str() == expected;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn parse_group(value: &Value) -> Option<GroupEntry> {
+    match value {
+        Value::String(name) => Some(GroupEntry::Group {
+            names: SmallVec::from_vec(vec![CompactString::from(name.as_str())]),
+            overrides: None,
+            newlines_inside: None,
+        }),
+        Value::Array(names) => Some(GroupEntry::Group {
+            names: names
+                .iter()
+                .filter_map(Value::as_str)
+                .map(CompactString::from)
+                .collect(),
+            overrides: None,
+            newlines_inside: None,
+        }),
+        Value::Object(object) if object.contains_key("group") => {
+            let names = match object.get("group") {
+                Some(Value::String(name)) => {
+                    SmallVec::from_vec(vec![CompactString::from(name.as_str())])
+                }
+                Some(Value::Array(names)) => names
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(CompactString::from)
+                    .collect(),
+                _ => SmallVec::new(),
+            };
+            Some(GroupEntry::Group {
+                names,
+                overrides: Some(object.clone()),
+                newlines_inside: object.get("newlinesInside").map(parse_newlines),
+            })
+        }
+        Value::Object(object) => object
+            .get("newlinesBetween")
+            .map(|newlines| GroupEntry::Newlines(parse_newlines(newlines))),
+        _ => None,
+    }
+}
+
+fn parse_custom_group(value: &Value) -> Option<CustomGroup> {
+    let object = value.as_object()?;
+    let group_name = CompactString::from(object.get("groupName")?.as_str()?);
+    let matches: SmallVec<[CustomMatch; 2]> =
+        if let Some(any_of) = object.get("anyOf").and_then(Value::as_array) {
+            any_of.iter().filter_map(parse_custom_match).collect()
+        } else {
+            SmallVec::from_vec(vec![parse_custom_match(value)?])
+        };
+    Some(CustomGroup {
+        group_name,
+        matches,
+        overrides: object.clone(),
+        newlines_inside: object.get("newlinesInside").map(parse_newlines),
+    })
+}
+
+fn parse_custom_match(value: &Value) -> Option<CustomMatch> {
+    let object = value.as_object()?;
+    Some(CustomMatch {
+        element_name_pattern: object.get("elementNamePattern").cloned(),
+        modifiers: object
+            .get("modifiers")
+            .and_then(Value::as_array)
+            .map_or_else(SmallVec::new, |modifiers| {
+                modifiers
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(CompactString::from)
+                    .collect()
+            }),
+        selector: object
+            .get("selector")
+            .and_then(Value::as_str)
+            .map(CompactString::from),
+    })
+}
+
 fn named_import<'a>(
     source_text: &'a str,
     comments: &[Comment],
+    declaration: &ImportDeclaration<'_>,
     specifier: &ImportSpecifier<'_>,
     boundary: u32,
-    ignore_alias: bool,
+    options: &RuleOptions,
 ) -> Option<NamedImport<'a>> {
-    let source_start = comments
-        .iter()
-        .filter(|comment| {
-            comment.attached_to == specifier.span.start && comment.span.end <= specifier.span.start
-        })
-        .map(|comment| comment.span.start)
-        .min()
-        .unwrap_or(specifier.span.start);
+    let source_start = movable_leading_comment_start(source_text, comments, specifier, options);
     let source_end = comments
         .iter()
         .filter(|comment| {
@@ -134,36 +449,225 @@ fn named_import<'a>(
         .map(|comment| comment.span.end)
         .max()
         .unwrap_or(specifier.span.end);
-    let start = usize::try_from(source_start).ok()?;
-    let end = usize::try_from(source_end).ok()?;
-    let source = source_text.get(start..end)?;
-    let node_start = usize::try_from(specifier.span.start).ok()?;
-    let node_end = usize::try_from(specifier.span.end).ok()?;
-    let size = source_text
-        .get(node_start..node_end)?
-        .encode_utf16()
-        .count();
-    let name = if ignore_alias {
-        module_export_name(&specifier.imported)
+    let source =
+        source_text.get(usize::try_from(source_start).ok()?..usize::try_from(source_end).ok()?)?;
+    let node_source = source_text.get(
+        usize::try_from(specifier.span.start).ok()?..usize::try_from(specifier.span.end).ok()?,
+    )?;
+    let name = import_name(specifier, options.sort.ignore_alias);
+    let modifier = if declaration.import_kind == ImportOrExportKind::Type
+        || specifier.import_kind == ImportOrExportKind::Type
+    {
+        "type"
     } else {
-        CompactString::from(specifier.local.name.as_str())
+        "value"
     };
+    let group = compute_group(options, name.as_str(), modifier);
+    let group_index = options.group_index(group.as_str());
     Some(NamedImport {
         span: specifier.span,
         name,
         source,
         source_start,
         source_end,
-        size,
+        size: node_source.encode_utf16().count(),
+        group,
+        group_index,
+        partition_id: 0,
     })
 }
 
-fn compare_imports(
-    options: &SortOptions,
+fn movable_leading_comment_start(
+    source_text: &str,
+    comments: &[Comment],
+    specifier: &ImportSpecifier<'_>,
+    options: &RuleOptions,
+) -> u32 {
+    let mut leading: SmallVec<[&Comment; 4]> = comments
+        .iter()
+        .filter(|comment| {
+            comment.attached_to == specifier.span.start && comment.span.end <= specifier.span.start
+        })
+        .collect();
+    leading.sort_by_key(|comment| comment.span.start);
+    let mut start = specifier.span.start;
+    for comment in leading.into_iter().rev() {
+        if is_partition_comment(source_text, comment, &options.partition_by_comment)
+            || empty_lines_between(source_text, comment.span.end, start) > 0
+        {
+            break;
+        }
+        start = comment.span.start;
+    }
+    start
+}
+
+fn compute_group(options: &RuleOptions, name: &str, modifier: &str) -> CompactString {
+    let configured: SmallVec<[&str; 8]> = options.group_names().collect();
+    for custom in &options.custom_groups {
+        if !configured
+            .iter()
+            .any(|configured_name| *configured_name == custom.group_name.as_str())
+        {
+            continue;
+        }
+        if custom
+            .matches
+            .iter()
+            .any(|matcher| custom_match(matcher, name, modifier))
+        {
+            return custom.group_name.clone();
+        }
+    }
+    for predefined in [format!("{modifier}-import"), "import".to_owned()] {
+        if configured
+            .iter()
+            .any(|configured_name| *configured_name == predefined)
+        {
+            return CompactString::from(predefined);
+        }
+    }
+    CompactString::new("unknown")
+}
+
+fn custom_match(matcher: &CustomMatch, name: &str, modifier: &str) -> bool {
+    if matcher
+        .selector
+        .as_ref()
+        .is_some_and(|selector| selector.as_str() != "import")
+    {
+        return false;
+    }
+    if !matcher.modifiers.is_empty()
+        && !matcher
+            .modifiers
+            .iter()
+            .all(|candidate| candidate.as_str() == modifier)
+    {
+        return false;
+    }
+    matcher
+        .element_name_pattern
+        .as_ref()
+        .is_none_or(|pattern| matches_regex(name, pattern))
+}
+
+fn assign_partitions(
+    source_text: &str,
+    comments: &[Comment],
+    options: &RuleOptions,
+    imports: &mut [NamedImport<'_>],
+) {
+    let mut partition_id = 1;
+    for index in 0..imports.len() {
+        if index > 0 {
+            let has_partition_comment = comments.iter().any(|comment| {
+                comment.attached_to == imports[index].span.start
+                    && comment.span.end <= imports[index].span.start
+                    && is_partition_comment(source_text, comment, &options.partition_by_comment)
+            });
+            let has_partition_newline = options.partition_by_new_line
+                && empty_lines_between(
+                    source_text,
+                    imports[index - 1].source_end,
+                    imports[index].source_start,
+                ) > 0;
+            if has_partition_comment || has_partition_newline {
+                partition_id += 1;
+            }
+        }
+        imports[index].partition_id = partition_id;
+    }
+}
+
+fn sort_imports(options: &RuleOptions, imports: &[NamedImport<'_>]) -> Vec<usize> {
+    let mut sorted = Vec::with_capacity(imports.len());
+    let mut start = 0;
+    while start < imports.len() {
+        let partition = imports[start].partition_id;
+        let mut end = start + 1;
+        while end < imports.len() && imports[end].partition_id == partition {
+            end += 1;
+        }
+        let mut partition_indices: Vec<usize> = (start..end).collect();
+        partition_indices.sort_by(|&left, &right| {
+            imports[left]
+                .group_index
+                .cmp(&imports[right].group_index)
+                .then_with(|| compare_in_group(options, &imports[left], &imports[right]))
+                .then_with(|| left.cmp(&right))
+        });
+        sorted.extend(partition_indices);
+        start = end;
+    }
+    sorted
+}
+
+fn compare_in_group(
+    options: &RuleOptions,
     left: &NamedImport<'_>,
     right: &NamedImport<'_>,
 ) -> Ordering {
-    options.compare(
+    let (sort, raw) = options.sort_options_for_group(left.group_index);
+    let object = raw.as_object();
+    let primary = object
+        .and_then(|value| value.get("type"))
+        .and_then(Value::as_str)
+        .unwrap_or("alphabetical");
+    if primary == "unsorted" {
+        return Ordering::Equal;
+    }
+    if primary == "subgroup-order" {
+        let subgroup = subgroup_compare(options, left, right, raw.as_object());
+        if subgroup != Ordering::Equal {
+            return subgroup;
+        }
+        return fallback_compare(options, left, right, raw.as_object());
+    }
+    let compared = sort.compare(
+        left.name.as_str(),
+        left.size,
+        right.name.as_str(),
+        right.size,
+    );
+    if compared == Ordering::Equal
+        && object
+            .and_then(|value| value.get("fallbackSort"))
+            .and_then(Value::as_object)
+            .and_then(|value| value.get("type"))
+            .and_then(Value::as_str)
+            == Some("subgroup-order")
+    {
+        subgroup_compare(options, left, right, object)
+    } else {
+        compared
+    }
+}
+
+fn fallback_compare(
+    options: &RuleOptions,
+    left: &NamedImport<'_>,
+    right: &NamedImport<'_>,
+    raw: Option<&Map<String, Value>>,
+) -> Ordering {
+    let Some(fallback) = raw
+        .and_then(|value| value.get("fallbackSort"))
+        .and_then(Value::as_object)
+    else {
+        return Ordering::Equal;
+    };
+    if fallback.get("type").and_then(Value::as_str) == Some("subgroup-order") {
+        return subgroup_compare(options, left, right, raw);
+    }
+    let mut value = raw.cloned().unwrap_or_default();
+    for (key, item) in fallback {
+        value.insert(key.clone(), item.clone());
+    }
+    value.insert(
+        "fallbackSort".to_owned(),
+        serde_json::json!({ "type": "unsorted" }),
+    );
+    SortOptions::from_json(&Value::Object(value)).compare(
         left.name.as_str(),
         left.size,
         right.name.as_str(),
@@ -171,36 +675,365 @@ fn compare_imports(
     )
 }
 
+fn subgroup_compare(
+    options: &RuleOptions,
+    left: &NamedImport<'_>,
+    right: &NamedImport<'_>,
+    raw: Option<&Map<String, Value>>,
+) -> Ordering {
+    let Some(GroupEntry::Group { names, .. }) = options.groups.get(left.group_index) else {
+        return Ordering::Equal;
+    };
+    if names.len() < 2 {
+        return Ordering::Equal;
+    }
+    let ordering = names
+        .iter()
+        .position(|name| name == left.group)
+        .cmp(&names.iter().position(|name| name == right.group));
+    if raw
+        .and_then(|value| value.get("order"))
+        .and_then(Value::as_str)
+        == Some("desc")
+    {
+        ordering.reverse()
+    } else {
+        ordering
+    }
+}
+
+fn newlines_between(
+    options: &RuleOptions,
+    left: &NamedImport<'_>,
+    right: &NamedImport<'_>,
+) -> Newlines {
+    if left.group_index == right.group_index {
+        if let Some(custom) = options
+            .custom_groups
+            .iter()
+            .find(|custom| custom.group_name == left.group)
+            && let Some(newlines) = custom.newlines_inside
+        {
+            return newlines;
+        }
+        if let Some(GroupEntry::Group {
+            newlines_inside: Some(newlines),
+            ..
+        }) = options.groups.get(left.group_index)
+        {
+            return *newlines;
+        }
+        return match options.newlines_inside {
+            Newlines::Between => match options.newlines_between {
+                Newlines::Ignore => Newlines::Ignore,
+                _ => Newlines::Count(0),
+            },
+            other => other,
+        };
+    }
+    if right.group_index == left.group_index + 2
+        && let Some(GroupEntry::Newlines(newlines)) = options.groups.get(left.group_index + 1)
+    {
+        return *newlines;
+    }
+    if right.group_index > left.group_index + 2 {
+        let mut maximum = None;
+        let mut ignored = false;
+        let relevant = &options.groups[left.group_index..=right.group_index];
+        for (index, entry) in relevant.iter().enumerate() {
+            let configured = match entry {
+                GroupEntry::Newlines(newlines) => Some(*newlines),
+                GroupEntry::Group { .. }
+                    if index > 0 && matches!(relevant[index - 1], GroupEntry::Group { .. }) =>
+                {
+                    Some(options.newlines_between)
+                }
+                GroupEntry::Group { .. } => None,
+            };
+            if let Some(newlines) = configured {
+                match newlines {
+                    Newlines::Count(value) => {
+                        maximum = Some(maximum.map_or(value, |current: usize| current.max(value)));
+                    }
+                    Newlines::Ignore => ignored = true,
+                    Newlines::Between => {}
+                }
+            }
+        }
+        if maximum.is_some_and(|value| value >= 1) {
+            return Newlines::Count(maximum.unwrap_or(0));
+        }
+        if ignored {
+            return Newlines::Ignore;
+        }
+        return Newlines::Count(0);
+    }
+    options.newlines_between
+}
+
 fn build_fix(
     source_text: &str,
+    options: &RuleOptions,
     imports: &[NamedImport<'_>],
     sorted_indices: &[usize],
 ) -> Option<RuleDiagnosticFix> {
-    let first = sorted_indices
-        .iter()
-        .enumerate()
-        .find_map(|(position, &original)| (position != original).then_some(position))?;
-    let last = sorted_indices
-        .iter()
-        .enumerate()
-        .rfind(|(position, original)| *position != **original)
-        .map(|(position, _)| position)?;
-    let start = usize::try_from(imports[first].source_start).ok()?;
-    let end = usize::try_from(imports[last].source_end).ok()?;
     let mut replacement = CompactString::new("");
-    for position in first..=last {
-        if position > first {
-            let separator_start = usize::try_from(imports[position - 1].source_end).ok()?;
-            let separator_end = usize::try_from(imports[position].source_start).ok()?;
-            replacement.push_str(source_text.get(separator_start..separator_end)?);
-        }
+    let mut desired_source_starts = Vec::with_capacity(imports.len());
+    let mut desired_source_ends = Vec::with_capacity(imports.len());
+    let mut changed_start: Option<u32> = None;
+    let mut changed_end: Option<u32> = None;
+    for position in 0..imports.len() {
+        desired_source_starts.push(replacement.len());
         replacement.push_str(imports[*sorted_indices.get(position)?].source);
+        desired_source_ends.push(replacement.len());
+        if sorted_indices[position] != position {
+            changed_start = Some(
+                changed_start.map_or(imports[position].source_start, |start| {
+                    start.min(imports[position].source_start)
+                }),
+            );
+            changed_end = Some(changed_end.map_or(imports[position].source_end, |end| {
+                end.max(imports[position].source_end)
+            }));
+        }
+        if position + 1 == imports.len() {
+            continue;
+        }
+        let separator_start = usize::try_from(imports[position].source_end).ok()?;
+        let separator_end = usize::try_from(imports[position + 1].source_start).ok()?;
+        let separator = source_text.get(separator_start..separator_end)?;
+        let sorted_left = &imports[*sorted_indices.get(position)?];
+        let sorted_right = &imports[*sorted_indices.get(position + 1)?];
+        let desired_separator = if sorted_left.partition_id == sorted_right.partition_id
+            && sorted_left.group_index <= sorted_right.group_index
+            && let Newlines::Count(expected) = newlines_between(options, sorted_left, sorted_right)
+        {
+            normalize_separator(
+                separator,
+                expected,
+                is_same_line(
+                    source_text,
+                    imports[position].span.end,
+                    imports[position + 1].span.start,
+                ),
+            )
+        } else {
+            CompactString::from(separator)
+        };
+        if desired_separator.as_str() != separator {
+            changed_start = Some(changed_start.map_or(imports[position].span.end, |start| {
+                start.min(imports[position].span.end)
+            }));
+            changed_end = Some(
+                changed_end.map_or(imports[position + 1].source_start, |end| {
+                    end.max(imports[position + 1].source_start)
+                }),
+            );
+        }
+        replacement.push_str(desired_separator.as_str());
     }
+    let changed_start = changed_start?;
+    let changed_end = changed_end?;
+    let replacement_start = desired_offset_for_boundary(
+        changed_start,
+        imports,
+        &desired_source_starts,
+        &desired_source_ends,
+    )?;
+    let replacement_end = desired_offset_for_boundary(
+        changed_end,
+        imports,
+        &desired_source_starts,
+        &desired_source_ends,
+    )?;
     Some(RuleDiagnosticFix {
-        start: LineIndex::utf16_offset(source_text, u32::try_from(start).ok()?),
-        end: LineIndex::utf16_offset(source_text, u32::try_from(end).ok()?),
-        replacement,
+        start: LineIndex::utf16_offset(source_text, changed_start),
+        end: LineIndex::utf16_offset(source_text, changed_end),
+        replacement: CompactString::from(
+            replacement
+                .as_str()
+                .get(replacement_start..replacement_end)?,
+        ),
     })
+}
+
+fn desired_offset_for_boundary(
+    boundary: u32,
+    imports: &[NamedImport<'_>],
+    desired_source_starts: &[usize],
+    desired_source_ends: &[usize],
+) -> Option<usize> {
+    for (index, import) in imports.iter().enumerate() {
+        if boundary == import.source_start {
+            return desired_source_starts.get(index).copied();
+        }
+        if boundary == import.source_end {
+            return desired_source_ends.get(index).copied();
+        }
+        if boundary == import.span.end {
+            let offset = usize::try_from(import.span.end.checked_sub(import.source_start)?).ok()?;
+            return desired_source_starts.get(index)?.checked_add(offset);
+        }
+    }
+    let first_start = imports.first()?.source_start;
+    usize::try_from(boundary.checked_sub(first_start)?).ok()
+}
+
+fn normalize_separator(separator: &str, newlines: usize, is_same_line: bool) -> CompactString {
+    static BLANK_LINES: OnceLock<regex::Regex> = OnceLock::new();
+    static NEWLINES: OnceLock<regex::Regex> = OnceLock::new();
+    let blank_lines = BLANK_LINES.get_or_init(|| {
+        regex::Regex::new(r"\n\s*\n").expect("static blank-line regex must compile")
+    });
+    let repeated_newlines = NEWLINES
+        .get_or_init(|| regex::Regex::new(r"\n+").expect("static newline regex must compile"));
+    let mut normalized = blank_lines.replace_all(separator, "\n").into_owned();
+    normalized = repeated_newlines
+        .replace_all(&normalized, "\n")
+        .into_owned();
+    if newlines == 0 {
+        return CompactString::from(normalized);
+    }
+    for _ in 0..newlines + usize::from(is_same_line) {
+        if let Some(index) = normalized.find('\n') {
+            normalized.insert(index, '\n');
+        } else {
+            normalized.push('\n');
+        }
+    }
+    CompactString::from(normalized)
+}
+
+fn merge_sort_overrides(target: &mut Map<String, Value>, overrides: &Map<String, Value>) {
+    for key in [
+        "type",
+        "order",
+        "ignoreCase",
+        "specialCharacters",
+        "locales",
+        "alphabet",
+    ] {
+        if let Some(value) = overrides.get(key) {
+            target.insert(key.to_owned(), value.clone());
+        }
+    }
+    if let Some(Value::Object(fallback)) = overrides.get("fallbackSort") {
+        let target_fallback = target
+            .entry("fallbackSort")
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Value::Object(target_fallback) = target_fallback {
+            for (key, value) in fallback {
+                target_fallback.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn parse_newlines(value: &Value) -> Newlines {
+    match value {
+        Value::String(value) if value == "newlinesBetween" => Newlines::Between,
+        Value::String(value) if value == "ignore" => Newlines::Ignore,
+        Value::Number(value) => value
+            .as_u64()
+            .and_then(|value| usize::try_from(value).ok())
+            .map_or(Newlines::Ignore, Newlines::Count),
+        _ => Newlines::Ignore,
+    }
+}
+
+fn import_name(specifier: &ImportSpecifier<'_>, ignore_alias: bool) -> CompactString {
+    if ignore_alias {
+        module_export_name(&specifier.imported)
+    } else {
+        CompactString::from(specifier.local.name.as_str())
+    }
+}
+
+fn matches_regex(value: &str, option: &Value) -> bool {
+    match option {
+        Value::Array(options) => options.iter().any(|option| matches_regex(value, option)),
+        Value::String(pattern) => matches_single_regex(value, pattern, ""),
+        Value::Object(object) => {
+            object
+                .get("pattern")
+                .and_then(Value::as_str)
+                .is_some_and(|pattern| {
+                    matches_single_regex(
+                        value,
+                        pattern,
+                        object.get("flags").and_then(Value::as_str).unwrap_or(""),
+                    )
+                })
+        }
+        _ => false,
+    }
+}
+
+fn matches_single_regex(value: &str, pattern: &str, flags: &str) -> bool {
+    // Rust's linear-time regex engine deliberately omits look-around. Support
+    // the common Perfectionist negative-lookahead form without weakening the
+    // rest of the matcher.
+    if let Some(needle) = pattern
+        .strip_prefix("^(?!.*")
+        .and_then(|value| value.strip_suffix(").*$"))
+    {
+        return if flags.contains('i') {
+            !value.to_lowercase().contains(&needle.to_lowercase())
+        } else {
+            !value.contains(needle)
+        };
+    }
+    let mut builder = RegexBuilder::new(pattern);
+    builder
+        .case_insensitive(flags.contains('i'))
+        .multi_line(flags.contains('m'))
+        .dot_matches_new_line(flags.contains('s'));
+    builder.build().is_ok_and(|regex| regex.is_match(value))
+}
+
+fn is_partition_comment(source_text: &str, comment: &Comment, option: &Value) -> bool {
+    if option == &Value::Bool(false) {
+        return false;
+    }
+    let content_span = comment.content_span();
+    let content = source_text
+        .get(
+            usize::try_from(content_span.start).unwrap_or(0)
+                ..usize::try_from(content_span.end).unwrap_or(0),
+        )
+        .unwrap_or("")
+        .trim();
+    if content.starts_with("eslint-") {
+        return false;
+    }
+    match option {
+        Value::Bool(value) => *value,
+        Value::String(_) | Value::Array(_) => matches_regex(content, option),
+        Value::Object(object) if object.contains_key("pattern") => matches_regex(content, option),
+        Value::Object(object) => {
+            let relevant = match comment.kind {
+                CommentKind::Line => object.get("line"),
+                CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => object.get("block"),
+            };
+            relevant.is_some_and(|value| match value {
+                Value::Bool(enabled) => *enabled,
+                _ => matches_regex(content, value),
+            })
+        }
+        _ => false,
+    }
+}
+
+fn empty_lines_between(source_text: &str, left: u32, right: u32) -> usize {
+    let Ok(left) = usize::try_from(left) else {
+        return 0;
+    };
+    let Ok(right) = usize::try_from(right) else {
+        return 0;
+    };
+    source_text
+        .get(left..right)
+        .map_or(0, |between| between.matches('\n').count().saturating_sub(1))
 }
 
 fn is_same_line(source_text: &str, left: u32, right: u32) -> bool {

--- a/crates/perfectionist/src/sort_options.rs
+++ b/crates/perfectionist/src/sort_options.rs
@@ -1,8 +1,8 @@
-//! Truthful supported option subset for the first configurable sort engine.
+//! Shared scalar comparator for the configurable `sort-named-imports` engine.
 //!
-//! Upstream exposes additional grouping, partition, conditional-configuration,
-//! and locale options. They remain rejected by the adapter schema until the
-//! corresponding core semantics exist.
+//! Group selection, partitioning, newline policies, and conditional
+//! configuration live in the rule module and reuse this comparator after
+//! applying their per-group overrides.
 
 use std::cmp::Ordering;
 
@@ -13,6 +13,7 @@ use serde_json::Value;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SortType {
+    SubgroupOrder,
     Alphabetical,
     Natural,
     LineLength,
@@ -134,7 +135,7 @@ impl SortOptions {
     ) -> Ordering {
         // Upstream deliberately ignores `fallbackSort` when the primary sorter
         // is `unsorted`.
-        if self.kind == SortType::Unsorted {
+        if matches!(self.kind, SortType::Unsorted | SortType::SubgroupOrder) {
             return Ordering::Equal;
         }
         let primary = self.compare_with(
@@ -182,7 +183,7 @@ impl SortOptions {
                 let right = self.normalize(right_name);
                 custom_compare(left.as_str(), right.as_str(), self.alphabet.as_str())
             }
-            SortType::Unsorted => Ordering::Equal,
+            SortType::SubgroupOrder | SortType::Unsorted => Ordering::Equal,
         };
         match order {
             SortOrder::Ascending => ordering,
@@ -300,6 +301,7 @@ fn ascii_case_rank(character: char) -> u8 {
 
 fn parse_sort_type(value: &str) -> Option<SortType> {
     match value {
+        "subgroup-order" => Some(SortType::SubgroupOrder),
         "alphabetical" => Some(SortType::Alphabetical),
         "natural" => Some(SortType::Natural),
         "line-length" => Some(SortType::LineLength),

--- a/crates/perfectionist/src/tests.rs
+++ b/crates/perfectionist/src/tests.rs
@@ -1,6 +1,17 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "serde_json::json! intentionally constructs public option payloads in tests."
+)]
+
 use oxlint_plugins_carton::SmallVec;
 
-use crate::{RULE_NAMES, implemented_perfectionist_rule_names, scan_perfectionist};
+use serde_json::json;
+
+use crate::{
+    RULE_NAMES, RuleDiagnostic, implemented_perfectionist_rule_names, scan_perfectionist,
+    scan_perfectionist_rule,
+};
 
 #[test]
 fn exposes_all_rule_names() {
@@ -44,4 +55,211 @@ function a() {}
         .collect();
 
     assert_eq!(names.len(), RULE_NAMES.len());
+}
+
+fn configured(source: &str, options: serde_json::Value) -> SmallVec<[RuleDiagnostic; 8]> {
+    scan_perfectionist_rule(source, "fixture.ts", "sort-named-imports", &options)
+}
+
+#[test]
+fn sorts_predefined_type_and_value_groups() {
+    let diagnostics = configured(
+        "import { value, type Type } from 'pkg';",
+        json!([{ "groups": ["type-import", "unknown"] }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].message_id,
+        "unexpectedNamedImportsGroupOrder"
+    );
+    assert_eq!(diagnostics[0].data.left_group.as_deref(), Some("unknown"));
+    assert_eq!(
+        diagnostics[0].data.right_group.as_deref(),
+        Some("type-import")
+    );
+}
+
+#[test]
+fn matches_custom_groups_by_regex_modifier_and_any_of() {
+    let diagnostics = configured(
+        "import { type other, type FooType, fooValue } from 'pkg';",
+        json!([{
+            "customGroups": [{
+                "groupName": "foo",
+                "anyOf": [
+                    { "modifiers": ["type"], "elementNamePattern": "Foo" },
+                    { "elementNamePattern": "^foo" }
+                ]
+            }],
+            "groups": ["foo", "unknown"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].data.right, "FooType");
+    assert_eq!(diagnostics[0].data.right_group.as_deref(), Some("foo"));
+}
+
+#[test]
+fn applies_custom_group_sort_overrides() {
+    let diagnostics = configured(
+        "import { type a, type bb, type cccc, value } from 'pkg';",
+        json!([{
+            "customGroups": [{
+                "groupName": "types",
+                "modifiers": ["type"],
+                "type": "line-length",
+                "order": "desc"
+            }],
+            "groups": ["types", "unknown"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.message_id == "unexpectedNamedImportsOrder")
+    );
+    assert_eq!(diagnostics[0].fix.replacement, "type cccc, type bb, type a");
+}
+
+#[test]
+fn partitions_by_newline_and_matching_comments() {
+    let diagnostics = configured(
+        "import {\n  D,\n  A,\n\n  C,\n  // Part\n  B,\n  A2,\n} from 'pkg';",
+        json!([{
+            "partitionByNewLine": true,
+            "partitionByComment": "^Part"
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].data.left, "D");
+    assert_eq!(diagnostics[0].data.right, "A");
+    assert_eq!(diagnostics[1].data.left, "B");
+    assert_eq!(diagnostics[1].data.right, "A2");
+}
+
+#[test]
+fn reports_order_and_spacing_with_one_shared_fix() {
+    let diagnostics = configured(
+        "import {\n  beta,\n\n  alpha,\n} from 'pkg';",
+        json!([{ "newlinesInside": 0 }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].message_id, "unexpectedNamedImportsOrder");
+    assert_eq!(diagnostics[1].message_id, "extraSpacingBetweenNamedImports");
+    assert_eq!(diagnostics[0].fix, diagnostics[1].fix);
+    assert_eq!(diagnostics[0].fix.replacement, "alpha,\n  beta");
+}
+
+#[test]
+fn enforces_inline_newline_directives() {
+    let diagnostics = configured(
+        "import {\n  alpha,\n\n  beta,\n  charlie,\n} from 'pkg';",
+        json!([{
+            "customGroups": [
+                { "groupName": "a", "elementNamePattern": "^alpha$" },
+                { "groupName": "b", "elementNamePattern": "^beta$" },
+                { "groupName": "c", "elementNamePattern": "^charlie$" }
+            ],
+            "groups": [
+                "a",
+                { "newlinesBetween": 0 },
+                "b",
+                { "newlinesBetween": 1 },
+                "c"
+            ],
+            "newlinesBetween": 2
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].message_id, "extraSpacingBetweenNamedImports");
+    assert_eq!(
+        diagnostics[1].message_id,
+        "missedSpacingBetweenNamedImports"
+    );
+}
+
+#[test]
+fn keeps_the_strongest_newline_policy_across_unused_groups() {
+    let diagnostics = configured(
+        "import {\n  alpha,\n  beta,\n} from 'pkg';",
+        json!([{
+            "customGroups": [
+                { "groupName": "a", "elementNamePattern": "^alpha$" },
+                { "groupName": "unused", "elementNamePattern": "^never$" },
+                { "groupName": "b", "elementNamePattern": "^beta$" }
+            ],
+            "groups": [
+                "a",
+                "unused",
+                { "newlinesBetween": 0 },
+                "b"
+            ],
+            "newlinesBetween": 2
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].message_id,
+        "missedSpacingBetweenNamedImports"
+    );
+    assert_eq!(diagnostics[0].fix.replacement, ",\n\n\n  ");
+}
+
+#[test]
+fn selects_the_first_matching_conditional_configuration() {
+    let diagnostics = configured(
+        "import { b, g, r } from 'pkg';",
+        json!([
+            {
+                "type": "unsorted",
+                "useConfigurationIf": { "allNamesMatchPattern": "^foo" }
+            },
+            {
+                "customGroups": [
+                    { "groupName": "r", "elementNamePattern": "^r$" },
+                    { "groupName": "g", "elementNamePattern": "^g$" },
+                    { "groupName": "b", "elementNamePattern": "^b$" }
+                ],
+                "groups": ["r", "g", "b"],
+                "useConfigurationIf": {
+                    "matchesAstSelector": "ImportDeclaration",
+                    "allNamesMatchPattern": "^[rgb]$"
+                }
+            }
+        ]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.message_id == "unexpectedNamedImportsGroupOrder")
+    );
+    assert_eq!(diagnostics[0].fix.replacement, "r, g, b");
+}
+
+#[test]
+fn keeps_utf16_offsets_for_unicode_group_fixes() {
+    let source = "'😀';\nimport { 世界, 你好, api } from '模块';";
+    let diagnostics = configured(
+        source,
+        json!([{
+            "locales": "zh-CN",
+            "customGroups": [{ "groupName": "api", "elementNamePattern": "^api$" }],
+            "groups": ["api", "unknown"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].fix.start, 15);
+    assert_eq!(diagnostics[0].fix.end, 26);
+    assert_eq!(diagnostics[0].fix.replacement, "api, 你好, 世界");
 }

--- a/crates/perfectionist/src/types.rs
+++ b/crates/perfectionist/src/types.rs
@@ -22,6 +22,8 @@ pub struct Diagnostic {
 pub struct RuleDiagnosticData {
     pub left: CompactString,
     pub right: CompactString,
+    pub left_group: Option<CompactString>,
+    pub right_group: Option<CompactString>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/npm/perfectionist/api.d.ts
+++ b/npm/perfectionist/api.d.ts
@@ -12,6 +12,8 @@ export type PerfectionistDiagnostic = {
   data?: {
     left: string;
     right: string;
+    leftGroup?: string;
+    rightGroup?: string;
   };
   fix?: {
     start: number;

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -92,6 +92,11 @@ function createPerfectionistRule(ruleName) {
         ruleName === 'sort-named-imports'
           ? {
               unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+              unexpectedNamedImportsGroupOrder:
+                'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+              extraSpacingBetweenNamedImports: 'Extra spacing between "{{left}}" and "{{right}}".',
+              missedSpacingBetweenNamedImports:
+                'Missed spacing between "{{left}}" and "{{right}}".',
             }
           : {
               unexpected: 'Expected sorted order.',
@@ -159,9 +164,12 @@ function diagnosticsForContext(context) {
 }
 
 function reportDiagnostic(context, diagnostic) {
+  const data = Object.fromEntries(
+    Object.entries(diagnostic.data || {}).filter(([, value]) => value !== undefined),
+  );
   context.report({
     messageId: diagnostic.messageId,
-    data: diagnostic.data,
+    data,
     loc: {
       start: {
         line: diagnostic.loc.startLine,
@@ -188,11 +196,161 @@ function schemaForRule(ruleName) {
   }
   const sortType = {
     type: 'string',
-    enum: ['alphabetical', 'natural', 'line-length', 'custom', 'unsorted'],
+    enum: ['subgroup-order', 'alphabetical', 'natural', 'line-length', 'custom', 'unsorted'],
   };
   const order = {
     type: 'string',
     enum: ['asc', 'desc'],
+  };
+  const singleRegex = {
+    oneOf: [
+      { type: 'string' },
+      {
+        type: 'object',
+        properties: {
+          pattern: { type: 'string' },
+          flags: { type: 'string' },
+        },
+        required: ['pattern'],
+        additionalProperties: false,
+      },
+    ],
+  };
+  const regex = {
+    oneOf: [
+      ...singleRegex.oneOf,
+      {
+        type: 'array',
+        items: singleRegex,
+      },
+    ],
+  };
+  const newlines = {
+    oneOf: [
+      { type: 'number', minimum: 0 },
+      { type: 'string', enum: ['ignore'] },
+    ],
+  };
+  const newlinesInside = {
+    oneOf: [
+      { type: 'number', minimum: 0 },
+      { type: 'string', enum: ['ignore', 'newlinesBetween'] },
+    ],
+  };
+  const fallbackSort = {
+    type: 'object',
+    properties: {
+      type: sortType,
+      order,
+    },
+    required: ['type'],
+    additionalProperties: false,
+  };
+  const sortOverrides = {
+    type: sortType,
+    order,
+    fallbackSort,
+  };
+  const customMatch = {
+    elementNamePattern: regex,
+    modifiers: {
+      type: 'array',
+      items: { type: 'string', enum: ['value', 'type'] },
+    },
+    selector: { type: 'string', enum: ['import'] },
+  };
+  const groups = {
+    type: 'array',
+    items: {
+      oneOf: [
+        { type: 'string' },
+        {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string' },
+        },
+        {
+          type: 'object',
+          properties: { newlinesBetween: newlines },
+          required: ['newlinesBetween'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            group: {
+              oneOf: [
+                { type: 'string' },
+                {
+                  type: 'array',
+                  minItems: 1,
+                  items: { type: 'string' },
+                },
+              ],
+            },
+            ...sortOverrides,
+            newlinesInside,
+            commentAbove: { type: 'string' },
+          },
+          required: ['group'],
+          minProperties: 2,
+          additionalProperties: false,
+        },
+      ],
+    },
+  };
+  const customGroups = {
+    type: 'array',
+    items: {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            groupName: { type: 'string' },
+            ...sortOverrides,
+            newlinesInside: newlines,
+            ...customMatch,
+          },
+          required: ['groupName'],
+          minProperties: 2,
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            groupName: { type: 'string' },
+            ...sortOverrides,
+            newlinesInside: newlines,
+            anyOf: {
+              type: 'array',
+              minItems: 1,
+              items: {
+                type: 'object',
+                properties: customMatch,
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ['groupName', 'anyOf'],
+          additionalProperties: false,
+        },
+      ],
+    },
+  };
+  const partitionByComment = {
+    oneOf: [
+      { type: 'boolean' },
+      ...regex.oneOf,
+      {
+        type: 'object',
+        properties: {
+          block: { oneOf: [{ type: 'boolean' }, ...regex.oneOf] },
+          line: { oneOf: [{ type: 'boolean' }, ...regex.oneOf] },
+        },
+        minProperties: 1,
+        additionalProperties: false,
+      },
+    ],
   };
   return [
     {
@@ -215,16 +373,23 @@ function schemaForRule(ruleName) {
           ],
         },
         alphabet: { type: 'string' },
-        fallbackSort: {
+        fallbackSort,
+        ignoreAlias: { type: 'boolean' },
+        groups,
+        customGroups,
+        partitionByComment,
+        partitionByNewLine: { type: 'boolean' },
+        newlinesBetween: newlines,
+        newlinesInside,
+        useConfigurationIf: {
           type: 'object',
           properties: {
-            type: sortType,
-            order,
+            allNamesMatchPattern: regex,
+            matchesAstSelector: { type: 'string' },
           },
-          required: ['type'],
+          minProperties: 1,
           additionalProperties: false,
         },
-        ignoreAlias: { type: 'boolean' },
       },
       additionalProperties: false,
     },

--- a/npm/perfectionist/src/lib.rs
+++ b/npm/perfectionist/src/lib.rs
@@ -40,6 +40,8 @@ mod napi_abi {
     pub struct DiagnosticData {
         pub left: String,
         pub right: String,
+        pub left_group: Option<String>,
+        pub right_group: Option<String>,
     }
 
     #[napi(object)]
@@ -99,6 +101,8 @@ mod napi_abi {
                     data: Some(DiagnosticData {
                         left: diagnostic.data.left.into_string(),
                         right: diagnostic.data.right.into_string(),
+                        left_group: diagnostic.data.left_group.map(|value| value.into_string()),
+                        right_group: diagnostic.data.right_group.map(|value| value.into_string()),
                     }),
                     fix: Some(DiagnosticFix {
                         start: diagnostic.fix.start,

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -117,6 +117,39 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact group-order data and a comment-preserving fix', () => {
+    const source = `import {
+  // value docs
+  value,
+  // type docs
+  type Type,
+} from "pkg";
+`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-named-imports', [
+      { groups: ['type-import', 'unknown'] },
+    ]);
+
+    expect(diagnostic).toMatchObject({
+      ruleName: 'sort-named-imports',
+      messageId: 'unexpectedNamedImportsGroupOrder',
+      data: {
+        left: 'value',
+        right: 'Type',
+        leftGroup: 'unknown',
+        rightGroup: 'type-import',
+      },
+      loc: {
+        startLine: 5,
+        startColumn: 2,
+        endLine: 5,
+        endColumn: 11,
+      },
+      fix: {
+        replacement: '// type docs\n  type Type,\n  // value docs\n  value',
+      },
+    });
+  });
+
   it('isolates configured scanning to its implemented rule', () => {
     expect(
       scanPerfectionistRule('import { b, a } from "pkg";', 'fixture.ts', 'sort-objects', [

--- a/npm/perfectionist/test/fixtures/sort-named-imports-options-v5.9.1.json
+++ b/npm/perfectionist/test/fixtures/sort-named-imports-options-v5.9.1.json
@@ -11,13 +11,13 @@
     "license": "MIT",
     "eslintVersion": "9.39.2",
     "typescriptEslintParserVersion": "8.60.0",
-    "capturePolicy": "Curated exact parity for the supported scalar comparator option subset; grouping, partition, newline, and conditional options are intentionally excluded.",
+    "capturePolicy": "Curated exact parity for scalar comparators, groups, custom groups, partitions, newline policies, and conditional configuration.",
     "tool": "tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
     "inventory": {
-      "valid": 23,
-      "invalid": 28,
-      "diagnostics": 41,
-      "total": 51
+      "valid": 30,
+      "invalid": 65,
+      "diagnostics": 95,
+      "total": 95
     }
   },
   "cases": [
@@ -1344,6 +1344,1808 @@
         }
       ],
       "output": "import {\n  A, // second\n  B, // first\n} from 'module';"
+    },
+    {
+      "name": "predefined type group before unknown",
+      "code": "import {\n  value,\n  type Type,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-import", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"Type\" (type-import) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-import",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [11, 29],
+            "text": "type Type,\n  value"
+          }
+        }
+      ],
+      "output": "import {\n  type Type,\n  value,\n} from 'module';"
+    },
+    {
+      "name": "predefined unknown before type group",
+      "code": "import {\n  type Type,\n  value,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["unknown", "type-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"value\" (unknown) to come before \"Type\" (type-import).",
+          "data": {
+            "right": "value",
+            "rightGroup": "unknown",
+            "left": "Type",
+            "leftGroup": "type-import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 29],
+            "text": "value,\n  type Type"
+          }
+        }
+      ],
+      "output": "import {\n  value,\n  type Type,\n} from 'module';"
+    },
+    {
+      "name": "declaration type imports use type group",
+      "code": "import type {\n  B,\n  A,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-import", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [16, 22],
+            "text": "A,\n  B"
+          }
+        }
+      ],
+      "output": "import type {\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "custom element pattern orders matching group first",
+      "code": "import { zebra, alpha, apiClient } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api"
+            }
+          ],
+          "groups": ["api", "unknown"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"zebra\".",
+          "data": {
+            "right": "alpha",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "apiClient, alpha, zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"apiClient\" (api) to come before \"alpha\" (unknown).",
+          "data": {
+            "right": "apiClient",
+            "rightGroup": "api",
+            "left": "alpha",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "apiClient, alpha, zebra"
+          }
+        }
+      ],
+      "output": "import { apiClient, alpha, zebra } from 'module';"
+    },
+    {
+      "name": "custom regex flags and alias name",
+      "code": "import { zed, source as APIClient } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": {
+                "pattern": "^api",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["api", "unknown"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"APIClient\" (api) to come before \"zed\" (unknown).",
+          "data": {
+            "right": "APIClient",
+            "rightGroup": "api",
+            "left": "zed",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 15,
+            "endLine": 1,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [9, 33],
+            "text": "source as APIClient, zed"
+          }
+        }
+      ],
+      "output": "import { source as APIClient, zed } from 'module';"
+    },
+    {
+      "name": "custom regex pattern array",
+      "code": "import { zebra, beta, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "letters",
+              "elementNamePattern": ["^alpha$", "^beta$"]
+            }
+          ],
+          "groups": ["letters", "unknown"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"beta\" (letters) to come before \"zebra\" (unknown).",
+          "data": {
+            "right": "beta",
+            "rightGroup": "letters",
+            "left": "zebra",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "alpha, beta, zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 23,
+            "endLine": 1,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "alpha, beta, zebra"
+          }
+        }
+      ],
+      "output": "import { alpha, beta, zebra } from 'module';"
+    },
+    {
+      "name": "custom type modifier",
+      "code": "import { value, type Zebra, type Alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "types",
+              "modifiers": ["type"]
+            }
+          ],
+          "groups": ["types", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"Zebra\" (types) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Zebra",
+            "rightGroup": "types",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [9, 38],
+            "text": "type Alpha, type Zebra, value"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"Alpha\" to come before \"Zebra\".",
+          "data": {
+            "right": "Alpha",
+            "left": "Zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 29,
+            "endLine": 1,
+            "endColumn": 39
+          },
+          "fix": {
+            "range": [9, 38],
+            "text": "type Alpha, type Zebra, value"
+          }
+        }
+      ],
+      "output": "import { type Alpha, type Zebra, value } from 'module';"
+    },
+    {
+      "name": "custom value modifier",
+      "code": "import { type Type, zebra, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "values",
+              "modifiers": ["value"]
+            }
+          ],
+          "groups": ["values", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"zebra\" (values) to come before \"Type\" (unknown).",
+          "data": {
+            "right": "zebra",
+            "rightGroup": "values",
+            "left": "Type",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 21,
+            "endLine": 1,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, zebra, type Type"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"zebra\".",
+          "data": {
+            "right": "alpha",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 28,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, zebra, type Type"
+          }
+        }
+      ],
+      "output": "import { alpha, zebra, type Type } from 'module';"
+    },
+    {
+      "name": "custom selector import",
+      "code": "import { zebra, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "imports",
+              "selector": "import"
+            }
+          ],
+          "groups": ["imports", "unknown"],
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "custom anyOf match",
+      "code": "import { type other, type FooType, fooValue } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "foo",
+              "anyOf": [
+                {
+                  "modifiers": ["type"],
+                  "elementNamePattern": "Foo"
+                },
+                {
+                  "elementNamePattern": "^foo"
+                }
+              ]
+            }
+          ],
+          "groups": ["foo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"FooType\" (foo) to come before \"other\" (unknown).",
+          "data": {
+            "right": "FooType",
+            "rightGroup": "foo",
+            "left": "other",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 22,
+            "endLine": 1,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [9, 43],
+            "text": "type FooType, fooValue, type other"
+          }
+        }
+      ],
+      "output": "import { type FooType, fooValue, type other } from 'module';"
+    },
+    {
+      "name": "custom groups ignore names absent from groups",
+      "code": "import { zebra, apiClient, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api"
+            }
+          ],
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"apiClient\" to come before \"zebra\".",
+          "data": {
+            "right": "apiClient",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, apiClient, zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"apiClient\".",
+          "data": {
+            "right": "alpha",
+            "left": "apiClient"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 28,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, apiClient, zebra"
+          }
+        }
+      ],
+      "output": "import { alpha, apiClient, zebra } from 'module';"
+    },
+    {
+      "name": "custom group line length override",
+      "code": "import { type a, type bb, type cccc, value } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "types",
+              "modifiers": ["type"],
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["types", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [9, 35],
+            "text": "type cccc, type bb, type a"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"cccc\" to come before \"bb\".",
+          "data": {
+            "right": "cccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 27,
+            "endLine": 1,
+            "endColumn": 36
+          },
+          "fix": {
+            "range": [9, 35],
+            "text": "type cccc, type bb, type a"
+          }
+        }
+      ],
+      "output": "import { type cccc, type bb, type a, value } from 'module';"
+    },
+    {
+      "name": "custom group unsorted preserves member order",
+      "code": "import { value, type Zebra, type Alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "types",
+              "modifiers": ["type"],
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["types", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"Zebra\" (types) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Zebra",
+            "rightGroup": "types",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [9, 38],
+            "text": "type Zebra, type Alpha, value"
+          }
+        }
+      ],
+      "output": "import { type Zebra, type Alpha, value } from 'module';"
+    },
+    {
+      "name": "group object alphabetical descending override",
+      "code": "import { alpha, beta } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "groups": [
+            {
+              "group": "unknown",
+              "type": "alphabetical",
+              "order": "desc"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"beta\" to come before \"alpha\".",
+          "data": {
+            "right": "beta",
+            "left": "alpha"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "beta, alpha"
+          }
+        }
+      ],
+      "output": "import { beta, alpha } from 'module';"
+    },
+    {
+      "name": "subgroup declaration order fallback",
+      "code": "import { beta, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "a",
+              "elementNamePattern": "^alpha$"
+            },
+            {
+              "groupName": "b",
+              "elementNamePattern": "^beta$"
+            }
+          ],
+          "groups": [["a", "b"], "unknown"],
+          "fallbackSort": {
+            "type": "subgroup-order"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "alpha, beta"
+          }
+        }
+      ],
+      "output": "import { alpha, beta } from 'module';"
+    },
+    {
+      "name": "partition by newline sorts sections independently",
+      "code": "import {\n  D,\n  A,\n\n  C,\n\n  E,\n  B,\n} from 'module';",
+      "options": [
+        {
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"D\".",
+          "data": {
+            "right": "A",
+            "left": "D"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 34],
+            "text": "A,\n  D,\n\n  C,\n\n  B,\n  E"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"B\" to come before \"E\".",
+          "data": {
+            "right": "B",
+            "left": "E"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 34],
+            "text": "A,\n  D,\n\n  C,\n\n  B,\n  E"
+          }
+        }
+      ],
+      "output": "import {\n  A,\n  D,\n\n  C,\n\n  B,\n  E,\n} from 'module';"
+    },
+    {
+      "name": "partition by any comment",
+      "code": "import {\n  B,\n  // section\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "partition by string comment",
+      "code": "import {\n  C,\n  // Part: one\n  B,\n  // note\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [31, 47],
+            "text": "// note\n  A,\n  B"
+          }
+        }
+      ],
+      "output": "import {\n  C,\n  // Part: one\n  // note\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "partition by comment pattern array",
+      "code": "import {\n  D,\n  /* Section */\n  C,\n  // Part: one\n  B,\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": ["Section", "^Part"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [52, 58],
+            "text": "A,\n  B"
+          }
+        }
+      ],
+      "output": "import {\n  D,\n  /* Section */\n  C,\n  // Part: one\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "partition by line comments only",
+      "code": "import {\n  C,\n  /* block */\n  B,\n  // line\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 31],
+            "text": "/* block */\n  B,\n  C"
+          }
+        }
+      ],
+      "output": "import {\n  /* block */\n  B,\n  C,\n  // line\n  A,\n} from 'module';"
+    },
+    {
+      "name": "partition by block comments only",
+      "code": "import {\n  C,\n  // line\n  B,\n  /* block */\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 27],
+            "text": "// line\n  B,\n  C"
+          }
+        }
+      ],
+      "output": "import {\n  // line\n  B,\n  C,\n  /* block */\n  A,\n} from 'module';"
+    },
+    {
+      "name": "partition line and block patterns",
+      "code": "import {\n  D,\n  // LINE A\n  C,\n  /* BLOCK B */\n  B,\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": {
+            "line": {
+              "pattern": "^ LINE",
+              "flags": "i"
+            },
+            "block": ["BLOCK"]
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"C\" to come before \"D\".",
+          "data": {
+            "right": "C",
+            "left": "D"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 55],
+            "text": "// LINE A\n  C,\n  D,\n  /* BLOCK B */\n  A,\n  B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 55],
+            "text": "// LINE A\n  C,\n  D,\n  /* BLOCK B */\n  A,\n  B"
+          }
+        }
+      ],
+      "output": "import {\n  // LINE A\n  C,\n  D,\n  /* BLOCK B */\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "partition preserves comments with group ordering",
+      "code": "import {\n  // Part: A\n  value,\n  type Type,\n  // Part: B\n  Zebra,\n  Alpha,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": "^Part",
+          "groups": ["type-import", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"Type\" (type-import) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-import",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [24, 73],
+            "text": "type Type,\n  value,\n  // Part: B\n  Alpha,\n  Zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"Alpha\" to come before \"Zebra\".",
+          "data": {
+            "right": "Alpha",
+            "left": "Zebra"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [24, 73],
+            "text": "type Type,\n  value,\n  // Part: B\n  Alpha,\n  Zebra"
+          }
+        }
+      ],
+      "output": "import {\n  // Part: A\n  type Type,\n  value,\n  // Part: B\n  Alpha,\n  Zebra,\n} from 'module';"
+    },
+    {
+      "name": "zero newlines inside and between groups",
+      "code": "import {\n  api,\n\n  zebra,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenNamedImports",
+          "message": "Extra spacing between \"api\" and \"zebra\".",
+          "data": {
+            "left": "api",
+            "right": "zebra"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 34],
+            "text": ",\n  alpha,\n  zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"zebra\".",
+          "data": {
+            "right": "alpha",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 34],
+            "text": ",\n  alpha,\n  zebra"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenNamedImports",
+          "message": "Extra spacing between \"zebra\" and \"alpha\".",
+          "data": {
+            "left": "zebra",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 34],
+            "text": ",\n  alpha,\n  zebra"
+          }
+        }
+      ],
+      "output": "import {\n  api,\n  alpha,\n  zebra,\n} from 'module';"
+    },
+    {
+      "name": "one newline between groups",
+      "code": "import {\n  api,\n  alpha,\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedImports",
+          "message": "Missed spacing between \"api\" and \"alpha\".",
+          "data": {
+            "left": "api",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 18],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "import {\n  api,\n\n  alpha,\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "two newlines between groups",
+      "code": "import {\n  api,\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedImports",
+          "message": "Missed spacing between \"api\" and \"alpha\".",
+          "data": {
+            "left": "api",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 18],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "import {\n  api,\n\n\n  alpha,\n} from 'module';"
+    },
+    {
+      "name": "zero newlines inside group",
+      "code": "import {\n  beta,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenNamedImports",
+          "message": "Extra spacing between \"beta\" and \"alpha\".",
+          "data": {
+            "left": "beta",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        }
+      ],
+      "output": "import {\n  alpha,\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "one newline inside custom group",
+      "code": "import {\n  alpha,\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "letters",
+              "elementNamePattern": ".*",
+              "newlinesInside": 1
+            }
+          ],
+          "groups": ["letters"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedImports",
+          "message": "Missed spacing between \"alpha\" and \"beta\".",
+          "data": {
+            "left": "alpha",
+            "right": "beta"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [16, 20],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "import {\n  alpha,\n\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "group object newlinesInside override",
+      "code": "import {\n  alpha,\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "groups": [
+            {
+              "group": "unknown",
+              "newlinesInside": 1
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedImports",
+          "message": "Missed spacing between \"alpha\" and \"beta\".",
+          "data": {
+            "left": "alpha",
+            "right": "beta"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [16, 20],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "import {\n  alpha,\n\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "inline newlinesBetween override",
+      "code": "import {\n  alpha,\n\n  beta,\n  charlie,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "a",
+              "elementNamePattern": "^alpha$"
+            },
+            {
+              "groupName": "b",
+              "elementNamePattern": "^beta$"
+            },
+            {
+              "groupName": "c",
+              "elementNamePattern": "^charlie$"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenNamedImports",
+          "message": "Extra spacing between \"alpha\" and \"beta\".",
+          "data": {
+            "left": "alpha",
+            "right": "beta"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [16, 29],
+            "text": ",\n  beta,\n\n  "
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenNamedImports",
+          "message": "Missed spacing between \"beta\" and \"charlie\".",
+          "data": {
+            "left": "beta",
+            "right": "charlie"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [16, 29],
+            "text": ",\n  beta,\n\n  "
+          }
+        }
+      ],
+      "output": "import {\n  alpha,\n  beta,\n\n  charlie,\n} from 'module';"
+    },
+    {
+      "name": "newlines ignore preserves spacing",
+      "code": "import {\n  alpha,\n\n\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "newlinesInside": "ignore",
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "partition newline suppresses spacing diagnostic",
+      "code": "import {\n  beta,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "spacing and ordering diagnostics combine",
+      "code": "import {\n  beta,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenNamedImports",
+          "message": "Extra spacing between \"beta\" and \"alpha\".",
+          "data": {
+            "left": "beta",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        }
+      ],
+      "output": "import {\n  alpha,\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "conditional names picks first matching option",
+      "code": "import { b, g, r } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^foo"
+          }
+        },
+        {
+          "customGroups": [
+            {
+              "groupName": "r",
+              "elementNamePattern": "^r$"
+            },
+            {
+              "groupName": "g",
+              "elementNamePattern": "^g$"
+            },
+            {
+              "groupName": "b",
+              "elementNamePattern": "^b$"
+            }
+          ],
+          "groups": ["r", "g", "b"],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "r, g, b"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "r, g, b"
+          }
+        }
+      ],
+      "output": "import { r, g, b } from 'module';"
+    },
+    {
+      "name": "conditional names regex object and alias",
+      "code": "import { first as B, second as A } from 'module';",
+      "options": [
+        {
+          "ignoreAlias": false,
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "^[ab]$",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 22,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "second as A, first as B"
+          }
+        }
+      ],
+      "output": "import { second as A, first as B } from 'module';"
+    },
+    {
+      "name": "conditional names ignore alias",
+      "code": "import { b as y, a as z } from 'module';",
+      "options": [
+        {
+          "ignoreAlias": true,
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[ab]$"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 23],
+            "text": "a as z, b as y"
+          }
+        }
+      ],
+      "output": "import { a as z, b as y } from 'module';"
+    },
+    {
+      "name": "conditional import selector match",
+      "code": "import { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ImportDeclaration"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "conditional import selector child match",
+      "code": "import { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ImportDeclaration"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "conditional nonmatching selector falls through",
+      "code": "import { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "VariableDeclaration"
+          }
+        },
+        {
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "alpha, beta"
+          }
+        }
+      ],
+      "output": "import { alpha, beta } from 'module';"
+    },
+    {
+      "name": "conditional selector and names both required",
+      "code": "import { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ImportDeclaration",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "no conditional match uses defaults",
+      "code": "import { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^never$"
+          }
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "alpha, beta"
+          }
+        }
+      ],
+      "output": "import { alpha, beta } from 'module';"
+    },
+    {
+      "name": "unicode custom group and utf16 prefix",
+      "code": "'😀';\nimport { 世界, 你好, api } from '模块';",
+      "options": [
+        {
+          "locales": "zh-CN",
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"]
+        }
+      ],
+      "filename": "fixture.tsx",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"你好\" to come before \"世界\".",
+          "data": {
+            "right": "你好",
+            "left": "世界"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 14,
+            "endLine": 2,
+            "endColumn": 16
+          },
+          "fix": {
+            "range": [15, 26],
+            "text": "api, 你好, 世界"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"api\" (api) to come before \"你好\" (unknown).",
+          "data": {
+            "right": "api",
+            "rightGroup": "api",
+            "left": "你好",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 18,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [15, 26],
+            "text": "api, 你好, 世界"
+          }
+        }
+      ],
+      "output": "'😀';\nimport { api, 你好, 世界 } from '模块';"
+    },
+    {
+      "name": "comments move with group members",
+      "code": "import {\n  // value docs\n  value,\n  // type docs\n  type Type,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-import", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"Type\" (type-import) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-import",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [11, 60],
+            "text": "// type docs\n  type Type,\n  // value docs\n  value"
+          }
+        }
+      ],
+      "output": "import {\n  // type docs\n  type Type,\n  // value docs\n  value,\n} from 'module';"
+    },
+    {
+      "name": "inline comment survives group movement and spacing",
+      "code": "import {\n  beta,\n  alpha, // alpha docs\n  type Type,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-import", "unknown"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedImportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 51],
+            "text": "type Type,\n\n  alpha, // alpha docs\n  beta"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedImportsGroupOrder",
+          "message": "Expected \"Type\" (type-import) to come before \"alpha\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-import",
+            "left": "alpha",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [11, 51],
+            "text": "type Type,\n\n  alpha, // alpha docs\n  beta"
+          }
+        }
+      ],
+      "output": "import {\n  type Type,\n\n  alpha, // alpha docs\n  beta,\n} from 'module';"
     }
   ]
 }

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -126,19 +126,26 @@ describe('perfectionist plugin adapter', () => {
     );
   });
 
-  it('declares only the implemented scalar option schema', () => {
+  it('declares the complete implemented option schema', () => {
     const schema = plugin.rules['sort-named-imports'].meta.schema;
 
     expect(schema).toHaveLength(1);
     expect(Object.keys(schema[0].properties).sort()).toEqual([
       'alphabet',
+      'customGroups',
       'fallbackSort',
+      'groups',
       'ignoreAlias',
       'ignoreCase',
       'locales',
+      'newlinesBetween',
+      'newlinesInside',
       'order',
+      'partitionByComment',
+      'partitionByNewLine',
       'specialCharacters',
       'type',
+      'useConfigurationIf',
     ]);
     expect(schema[0].additionalProperties).toBe(false);
     expect(schema[0].properties.locales).toEqual({
@@ -152,6 +159,19 @@ describe('perfectionist plugin adapter', () => {
     });
     expect(schema[0].properties.fallbackSort).toMatchObject({
       required: ['type'],
+      additionalProperties: false,
+    });
+    expect(schema[0].properties.groups).toMatchObject({
+      type: 'array',
+      items: { oneOf: expect.any(Array) },
+    });
+    expect(schema[0].properties.customGroups).toMatchObject({
+      type: 'array',
+      items: { oneOf: expect.any(Array) },
+    });
+    expect(schema[0].properties.partitionByComment.oneOf).toHaveLength(5);
+    expect(schema[0].properties.useConfigurationIf).toMatchObject({
+      minProperties: 1,
       additionalProperties: false,
     });
     expect(plugin.rules['sort-imports'].meta.schema).toEqual([]);
@@ -216,6 +236,66 @@ describe('perfectionist plugin adapter', () => {
       expect(fixed.status).toBe(0);
       expect(fixed.stderr).toBe('');
       expect(readFileSync(fixturePath, 'utf8')).toBe('import { item10, item2 } from "pkg";\n');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads grouping and newline options through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-groups-'));
+    try {
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(fixturePath, 'import {\n  value,\n  type Type,\n} from "pkg";\n');
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'perfectionist',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'perfectionist/sort-named-imports': [
+              'error',
+              {
+                groups: ['type-import', 'unknown'],
+                newlinesBetween: 1,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+        'Expected "Type" (type-import) to come before "value" (unknown).',
+      ]);
+
+      const fixed = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe(
+        'import {\n  type Type,\n\n  value,\n} from "pkg";\n',
+      );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/npm/perfectionist/test/sort-named-imports-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-named-imports-options-upstream.test.mjs
@@ -12,7 +12,7 @@ const fixture = JSON.parse(
 );
 const rule = plugin.rules['sort-named-imports'];
 
-describe('perfectionist/sort-named-imports v5.9.1 scalar option parity', () => {
+describe('perfectionist/sort-named-imports v5.9.1 option parity', () => {
   it('pins the reviewed upstream source and exact fixture inventory', () => {
     expect(fixture.__generated).toMatchObject({
       source: 'eslint-plugin-perfectionist',
@@ -27,10 +27,10 @@ describe('perfectionist/sort-named-imports v5.9.1 scalar option parity', () => {
           'a5fe43752e460a2d29432e01e01a21aaa92bf9bc6d5193840dc593c6767ddeee',
       },
       inventory: {
-        valid: 23,
-        invalid: 28,
-        diagnostics: 41,
-        total: 51,
+        valid: 30,
+        invalid: 65,
+        diagnostics: 95,
+        total: 95,
       },
     });
     expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
@@ -89,9 +89,10 @@ function exactDiagnostic(report) {
   });
   return {
     messageId: report.messageId,
-    message: rule.meta.messages[report.messageId]
-      .replace('{{right}}', report.data.right)
-      .replace('{{left}}', report.data.left),
+    message: Object.entries(report.data).reduce(
+      (message, [key, value]) => message.replace(`{{${key}}}`, value),
+      rule.meta.messages[report.messageId],
+    ),
     data: report.data,
     loc: {
       startLine: report.loc.start.line,

--- a/tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts
@@ -290,6 +290,437 @@ const cases: TestCase[] = [
     name: 'trailing comments stay attached to slots',
     code: `import {\n  B, // first\n  A, // second\n} from 'module';`,
   },
+  {
+    name: 'predefined type group before unknown',
+    code: `import {\n  value,\n  type Type,\n} from 'module';`,
+    options: [{ groups: ['type-import', 'unknown'] }],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'predefined unknown before type group',
+    code: `import {\n  type Type,\n  value,\n} from 'module';`,
+    options: [{ groups: ['unknown', 'type-import'] }],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'declaration type imports use type group',
+    code: `import type {\n  B,\n  A,\n} from 'module';`,
+    options: [{ groups: ['type-import', 'unknown'] }],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'custom element pattern orders matching group first',
+    code: `import { zebra, alpha, apiClient } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api' }],
+        groups: ['api', 'unknown'],
+      },
+    ],
+  },
+  {
+    name: 'custom regex flags and alias name',
+    code: `import { zed, source as APIClient } from 'module';`,
+    options: [
+      {
+        customGroups: [
+          {
+            groupName: 'api',
+            elementNamePattern: { pattern: '^api', flags: 'i' },
+          },
+        ],
+        groups: ['api', 'unknown'],
+      },
+    ],
+  },
+  {
+    name: 'custom regex pattern array',
+    code: `import { zebra, beta, alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'letters', elementNamePattern: ['^alpha$', '^beta$'] }],
+        groups: ['letters', 'unknown'],
+      },
+    ],
+  },
+  {
+    name: 'custom type modifier',
+    code: `import { value, type Zebra, type Alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'types', modifiers: ['type'] }],
+        groups: ['types', 'unknown'],
+      },
+    ],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'custom value modifier',
+    code: `import { type Type, zebra, alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'values', modifiers: ['value'] }],
+        groups: ['values', 'unknown'],
+      },
+    ],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'custom selector import',
+    code: `import { zebra, alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'imports', selector: 'import' }],
+        groups: ['imports', 'unknown'],
+        order: 'desc',
+      },
+    ],
+  },
+  {
+    name: 'custom anyOf match',
+    code: `import { type other, type FooType, fooValue } from 'module';`,
+    options: [
+      {
+        customGroups: [
+          {
+            groupName: 'foo',
+            anyOf: [
+              { modifiers: ['type'], elementNamePattern: 'Foo' },
+              { elementNamePattern: '^foo' },
+            ],
+          },
+        ],
+        groups: ['foo', 'unknown'],
+      },
+    ],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'custom groups ignore names absent from groups',
+    code: `import { zebra, apiClient, alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api' }],
+        groups: ['unknown'],
+      },
+    ],
+  },
+  {
+    name: 'custom group line length override',
+    code: `import { type a, type bb, type cccc, value } from 'module';`,
+    options: [
+      {
+        customGroups: [
+          {
+            groupName: 'types',
+            modifiers: ['type'],
+            type: 'line-length',
+            order: 'desc',
+          },
+        ],
+        groups: ['types', 'unknown'],
+      },
+    ],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'custom group unsorted preserves member order',
+    code: `import { value, type Zebra, type Alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'types', modifiers: ['type'], type: 'unsorted' }],
+        groups: ['types', 'unknown'],
+      },
+    ],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'group object alphabetical descending override',
+    code: `import { alpha, beta } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        groups: [{ group: 'unknown', type: 'alphabetical', order: 'desc' }],
+      },
+    ],
+  },
+  {
+    name: 'subgroup declaration order fallback',
+    code: `import { beta, alpha } from 'module';`,
+    options: [
+      {
+        customGroups: [
+          { groupName: 'a', elementNamePattern: '^alpha$' },
+          { groupName: 'b', elementNamePattern: '^beta$' },
+        ],
+        groups: [['a', 'b'], 'unknown'],
+        fallbackSort: { type: 'subgroup-order' },
+      },
+    ],
+  },
+  {
+    name: 'partition by newline sorts sections independently',
+    code: `import {\n  D,\n  A,\n\n  C,\n\n  E,\n  B,\n} from 'module';`,
+    options: [{ partitionByNewLine: true }],
+  },
+  {
+    name: 'partition by any comment',
+    code: `import {\n  B,\n  // section\n  A,\n} from 'module';`,
+    options: [{ partitionByComment: true }],
+  },
+  {
+    name: 'partition by string comment',
+    code: `import {\n  C,\n  // Part: one\n  B,\n  // note\n  A,\n} from 'module';`,
+    options: [{ partitionByComment: '^Part' }],
+  },
+  {
+    name: 'partition by comment pattern array',
+    code: `import {\n  D,\n  /* Section */\n  C,\n  // Part: one\n  B,\n  A,\n} from 'module';`,
+    options: [{ partitionByComment: ['Section', '^Part'] }],
+  },
+  {
+    name: 'partition by line comments only',
+    code: `import {\n  C,\n  /* block */\n  B,\n  // line\n  A,\n} from 'module';`,
+    options: [{ partitionByComment: { line: true } }],
+  },
+  {
+    name: 'partition by block comments only',
+    code: `import {\n  C,\n  // line\n  B,\n  /* block */\n  A,\n} from 'module';`,
+    options: [{ partitionByComment: { block: true } }],
+  },
+  {
+    name: 'partition line and block patterns',
+    code: `import {\n  D,\n  // LINE A\n  C,\n  /* BLOCK B */\n  B,\n  A,\n} from 'module';`,
+    options: [
+      {
+        partitionByComment: {
+          line: { pattern: '^ LINE', flags: 'i' },
+          block: ['BLOCK'],
+        },
+      },
+    ],
+  },
+  {
+    name: 'partition preserves comments with group ordering',
+    code: `import {\n  // Part: A\n  value,\n  type Type,\n  // Part: B\n  Zebra,\n  Alpha,\n} from 'module';`,
+    options: [
+      {
+        partitionByComment: '^Part',
+        groups: ['type-import', 'unknown'],
+      },
+    ],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'zero newlines inside and between groups',
+    code: `import {\n  api,\n\n  zebra,\n\n  alpha,\n} from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        newlinesBetween: 0,
+      },
+    ],
+  },
+  {
+    name: 'one newline between groups',
+    code: `import {\n  api,\n  alpha,\n  beta,\n} from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        newlinesBetween: 1,
+      },
+    ],
+  },
+  {
+    name: 'two newlines between groups',
+    code: `import {\n  api,\n  alpha,\n} from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        newlinesBetween: 2,
+      },
+    ],
+  },
+  {
+    name: 'zero newlines inside group',
+    code: `import {\n  beta,\n\n  alpha,\n} from 'module';`,
+    options: [{ newlinesInside: 0 }],
+  },
+  {
+    name: 'one newline inside custom group',
+    code: `import {\n  alpha,\n  beta,\n} from 'module';`,
+    options: [
+      {
+        customGroups: [{ groupName: 'letters', elementNamePattern: '.*', newlinesInside: 1 }],
+        groups: ['letters'],
+      },
+    ],
+  },
+  {
+    name: 'group object newlinesInside override',
+    code: `import {\n  alpha,\n  beta,\n} from 'module';`,
+    options: [{ groups: [{ group: 'unknown', newlinesInside: 1 }] }],
+  },
+  {
+    name: 'inline newlinesBetween override',
+    code: `import {\n  alpha,\n\n  beta,\n  charlie,\n} from 'module';`,
+    options: [
+      {
+        customGroups: [
+          { groupName: 'a', elementNamePattern: '^alpha$' },
+          { groupName: 'b', elementNamePattern: '^beta$' },
+          { groupName: 'c', elementNamePattern: '^charlie$' },
+        ],
+        groups: ['a', { newlinesBetween: 0 }, 'b', { newlinesBetween: 1 }, 'c'],
+        newlinesBetween: 2,
+      },
+    ],
+  },
+  {
+    name: 'newlines ignore preserves spacing',
+    code: `import {\n  alpha,\n\n\n  beta,\n} from 'module';`,
+    options: [{ newlinesInside: 'ignore', newlinesBetween: 'ignore' }],
+  },
+  {
+    name: 'partition newline suppresses spacing diagnostic',
+    code: `import {\n  beta,\n\n  alpha,\n} from 'module';`,
+    options: [{ partitionByNewLine: true }],
+  },
+  {
+    name: 'spacing and ordering diagnostics combine',
+    code: `import {\n  beta,\n\n  alpha,\n} from 'module';`,
+    options: [{ newlinesInside: 0 }],
+  },
+  {
+    name: 'conditional names picks first matching option',
+    code: `import { b, g, r } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { allNamesMatchPattern: '^foo' },
+      },
+      {
+        customGroups: [
+          { groupName: 'r', elementNamePattern: '^r$' },
+          { groupName: 'g', elementNamePattern: '^g$' },
+          { groupName: 'b', elementNamePattern: '^b$' },
+        ],
+        groups: ['r', 'g', 'b'],
+        useConfigurationIf: { allNamesMatchPattern: '^[rgb]$' },
+      },
+    ],
+  },
+  {
+    name: 'conditional names regex object and alias',
+    code: `import { first as B, second as A } from 'module';`,
+    options: [
+      {
+        ignoreAlias: false,
+        useConfigurationIf: {
+          allNamesMatchPattern: { pattern: '^[ab]$', flags: 'i' },
+        },
+      },
+      { type: 'unsorted' },
+    ],
+  },
+  {
+    name: 'conditional names ignore alias',
+    code: `import { b as y, a as z } from 'module';`,
+    options: [
+      {
+        ignoreAlias: true,
+        useConfigurationIf: { allNamesMatchPattern: '^[ab]$' },
+      },
+      { type: 'unsorted' },
+    ],
+  },
+  {
+    name: 'conditional import selector match',
+    code: `import { beta, alpha } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { matchesAstSelector: 'ImportDeclaration' },
+      },
+    ],
+  },
+  {
+    name: 'conditional import selector child match',
+    code: `import { beta, alpha } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { matchesAstSelector: '* > ImportDeclaration' },
+      },
+    ],
+  },
+  {
+    name: 'conditional nonmatching selector falls through',
+    code: `import { beta, alpha } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { matchesAstSelector: 'VariableDeclaration' },
+      },
+      { type: 'alphabetical' },
+    ],
+  },
+  {
+    name: 'conditional selector and names both required',
+    code: `import { beta, alpha } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        useConfigurationIf: {
+          matchesAstSelector: 'ImportDeclaration',
+          allNamesMatchPattern: '^[ac]$',
+        },
+      },
+      { type: 'alphabetical', order: 'desc' },
+    ],
+  },
+  {
+    name: 'no conditional match uses defaults',
+    code: `import { beta, alpha } from 'module';`,
+    options: [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { allNamesMatchPattern: '^never$' },
+      },
+    ],
+  },
+  {
+    name: 'unicode custom group and utf16 prefix',
+    code: `'😀';\nimport { 世界, 你好, api } from '模块';`,
+    options: [
+      {
+        locales: 'zh-CN',
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+      },
+    ],
+  },
+  {
+    name: 'comments move with group members',
+    code: `import {\n  // value docs\n  value,\n  // type docs\n  type Type,\n} from 'module';`,
+    options: [{ groups: ['type-import', 'unknown'] }],
+    filename: 'fixture.ts',
+  },
+  {
+    name: 'inline comment survives group movement and spacing',
+    code: `import {\n  beta,\n  alpha, // alpha docs\n  type Type,\n} from 'module';`,
+    options: [
+      {
+        groups: ['type-import', 'unknown'],
+        newlinesBetween: 1,
+        newlinesInside: 0,
+      },
+    ],
+    filename: 'fixture.ts',
+  },
 ];
 
 const manifest = JSON.parse(
@@ -369,7 +800,7 @@ try {
       eslintVersion: ESLINT_VERSION,
       typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
       capturePolicy:
-        'Curated exact parity for the supported scalar comparator option subset; grouping, partition, newline, and conditional options are intentionally excluded.',
+        'Curated exact parity for scalar comparators, groups, custom groups, partitions, newline policies, and conditional configuration.',
       tool: 'tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts',
       inventory: {
         valid,
@@ -467,7 +898,23 @@ writeFileSync(join(here, 'captured.json'), JSON.stringify(captured));
 
 function dataFromMessage(message) {
   const match = /^Expected "(.+)" to come before "(.+)"\\.$/u.exec(message);
-  return match ? { right: match[1], left: match[2] } : {};
+  if (match) {
+    return { right: match[1], left: match[2] };
+  }
+  const groupMatch = /^Expected "(.+)" \\((.+)\\) to come before "(.+)" \\((.+)\\)\\.$/u.exec(message);
+  if (groupMatch) {
+    return {
+      right: groupMatch[1],
+      rightGroup: groupMatch[2],
+      left: groupMatch[3],
+      leftGroup: groupMatch[4],
+    };
+  }
+  const spacingMatch = /^(?:Extra|Missed) spacing between "(.+)" and "(.+)"\\.$/u.exec(message);
+  if (spacingMatch) {
+    return { left: spacingMatch[1], right: spacingMatch[2] };
+  }
+  return {};
 }
 `;
 }


### PR DESCRIPTION
## Summary
- add `groups` and `customGroups` support to `sort-named-imports`, including type/value/import selectors, regex arrays and flags, negative lookahead, `anyOf`, overrides, and subgroup order
- implement comment/newline partitions plus `newlinesBetween`, `newlinesInside`, inline directives, and `useConfigurationIf`
- preserve exact upstream message IDs/data, shared fixes, conditional configuration order, and UTF-16 locations
- extend the pinned Perfectionist v5.9.1 fixture to the grouping and partition option families

## Tests
- pinned option fixture: 95 cases / 95 diagnostics
- targeted Perfectionist JS: 131 passed
- targeted Perfectionist Rust: 21 passed
- full `pnpm verify`: 15,989 JS passed, 1,159 skipped; workspace Rust/doc tests, Clippy, benches, security, licenses, status, and publish-ready package checks passed
- post-rebase targeted NAPI rebuild, 131 JS tests, 21 Rust tests, and targeted Clippy passed

This is the grouping/partition slice of #418. The remaining 22 configurable sort rules stay in separate small follow-up PRs. React and JSX plugins are intentionally out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `sort-named-imports` configuration with predefined and custom groups, subgroup ordering, conditional rules, comment/newline partitioning, and spacing controls.
  * Added support for normalizing newlines between and within import groups.
* **Bug Fixes**
  * Improved diagnostics for import group ordering and spacing issues.
  * Fixes now reorder imports while preserving comments and applying the expected spacing.
  * Improved handling of Unicode text and UTF-16 fix ranges.
* **API**
  * Diagnostics now include the affected import groups when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->