### PR TITLE
feat(playwright): support restricted rule options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,6 +1204,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "oxlint-plugins-_carton",
  "oxlint-plugins-playwright",
 ]
 
@@ -1474,6 +1475,8 @@ name = "oxlint-plugins-playwright"
 version = "0.0.0"
 dependencies = [
  "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
  "oxlint-plugins-_carton",

--- a/crates/playwright/Cargo.toml
+++ b/crates/playwright/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 
 [dependencies]
 oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = "Rust implementation of eslint-plugin-playwright rule logic."]
 
+mod restricted;
 mod scanner;
 mod types;
 
@@ -11,10 +12,11 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxlint_plugins_carton::SmallVec;
 
+use crate::restricted::scan_restricted_rules;
 use crate::scanner::Scanner;
 use crate::types::LineIndex;
 
-pub use crate::types::{Diagnostic, DiagnosticLoc};
+pub use crate::types::{Diagnostic, DiagnosticData, DiagnosticLoc, PlaywrightOptions, Restriction};
 
 pub const RULE_NAMES: [&str; 58] = [
     "consistent-spacing-between-blocks",
@@ -82,6 +84,14 @@ pub fn implemented_playwright_rule_names() -> &'static [&'static str] {
 }
 
 pub fn scan_playwright(source_text: &str, filename: &str) -> SmallVec<[Diagnostic; 64]> {
+    scan_playwright_with_options(source_text, filename, &PlaywrightOptions::default())
+}
+
+pub fn scan_playwright_with_options(
+    source_text: &str,
+    filename: &str,
+    options: &PlaywrightOptions,
+) -> SmallVec<[Diagnostic; 64]> {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(filename)
         .unwrap_or_else(|_| SourceType::tsx())
@@ -97,5 +107,12 @@ pub fn scan_playwright(source_text: &str, filename: &str) -> SmallVec<[Diagnosti
         diagnostics: SmallVec::new(),
     };
     scanner.scan();
+    scan_restricted_rules(
+        &parser_return.program,
+        source_text,
+        &scanner.line_index,
+        options,
+        &mut scanner.diagnostics,
+    );
     scanner.diagnostics
 }

--- a/crates/playwright/src/restricted.rs
+++ b/crates/playwright/src/restricted.rs
@@ -1,0 +1,322 @@
+//! Option-aware ports of Playwright's three `no-restricted-*` rules.
+
+use oxc_ast::ast::{
+    Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
+    MemberExpression, ModuleExportName, Program, match_member_expression,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::types::{Diagnostic, DiagnosticData, LineIndex, PlaywrightOptions, Restriction};
+
+const LOCATORS_RULE: &str = "no-restricted-locators";
+const MATCHERS_RULE: &str = "no-restricted-matchers";
+const ROLES_RULE: &str = "no-restricted-roles";
+
+pub(crate) fn scan_restricted_rules<'ast>(
+    program: &Program<'ast>,
+    source_text: &str,
+    line_index: &LineIndex,
+    options: &PlaywrightOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 64]>,
+) {
+    if options.restricted_locators.is_empty()
+        && options.restricted_matchers.is_empty()
+        && options.restricted_roles.is_empty()
+    {
+        return;
+    }
+
+    let mut expect_names = SmallVec::<[CompactString; 8]>::new();
+    expect_names.push(CompactString::from("expect"));
+    for alias in &options.expect_aliases {
+        push_unique(&mut expect_names, alias.as_str());
+    }
+    ExpectImportCollector {
+        expect_names: &mut expect_names,
+    }
+    .visit_program(program);
+    let mut visitor = RestrictedVisitor {
+        diagnostics,
+        expect_names,
+        line_index,
+        options,
+        source_text,
+    };
+    visitor.visit_program(program);
+}
+
+struct RestrictedVisitor<'source, 'options, 'diagnostics> {
+    source_text: &'source str,
+    line_index: &'source LineIndex,
+    options: &'options PlaywrightOptions,
+    diagnostics: &'diagnostics mut SmallVec<[Diagnostic; 64]>,
+    expect_names: SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for RestrictedVisitor<'_, '_, '_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        self.check_restricted_locator(call);
+        self.check_restricted_matchers(call);
+        self.check_restricted_role(call);
+        walk::walk_call_expression(self, call);
+    }
+}
+
+struct ExpectImportCollector<'names> {
+    expect_names: &'names mut SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for ExpectImportCollector<'_> {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
+        if declaration.source.value != "@playwright/test" {
+            return;
+        }
+        let Some(specifiers) = &declaration.specifiers else {
+            return;
+        };
+        for specifier in specifiers {
+            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                continue;
+            };
+            if module_export_name(&specifier.imported) == Some("expect") {
+                push_unique(self.expect_names, specifier.local.name.as_str());
+            }
+        }
+    }
+}
+
+impl RestrictedVisitor<'_, '_, '_> {
+    fn check_restricted_locator(&mut self, call: &CallExpression<'_>) {
+        let Some(member) = member_from_expression(&call.callee) else {
+            return;
+        };
+        let Some(method) = member.static_property_name() else {
+            return;
+        };
+        let Some(restriction) = last_restriction(&self.options.restricted_locators, method) else {
+            return;
+        };
+        self.report(
+            LOCATORS_RULE,
+            restriction,
+            call.span,
+            DiagnosticSubject::Method(method),
+        );
+    }
+
+    fn check_restricted_role(&mut self, call: &CallExpression<'_>) {
+        let Some(member) = member_from_expression(&call.callee) else {
+            return;
+        };
+        if member.static_property_name() != Some("getByRole") {
+            return;
+        }
+        let Some(role) = call.arguments.first().and_then(static_argument_value) else {
+            return;
+        };
+        let Some(restriction) = last_restriction(&self.options.restricted_roles, role) else {
+            return;
+        };
+        self.report(
+            ROLES_RULE,
+            restriction,
+            call.span,
+            DiagnosticSubject::Role(role),
+        );
+    }
+
+    fn check_restricted_matchers(&mut self, call: &CallExpression<'_>) {
+        let Some(member) = member_from_expression(&call.callee) else {
+            return;
+        };
+        let Some(chain) = matcher_chain(member, &self.expect_names) else {
+            return;
+        };
+
+        for restriction in &self.options.restricted_matchers {
+            let links = restriction
+                .value
+                .split('.')
+                .filter(|link| !link.is_empty())
+                .collect::<SmallVec<[&str; 4]>>();
+            if links.is_empty() || links.len() > chain.len() {
+                continue;
+            }
+            let Some(start) = chain.windows(links.len()).position(|window| {
+                window
+                    .iter()
+                    .map(|link| link.name)
+                    .eq(links.iter().copied())
+            }) else {
+                continue;
+            };
+            let matched = &chain[start..start + links.len()];
+            let span = Span::new(matched[0].span.start, matched[matched.len() - 1].span.end);
+            self.report(
+                MATCHERS_RULE,
+                restriction,
+                span,
+                DiagnosticSubject::Restriction(restriction.value.as_str()),
+            );
+        }
+    }
+
+    fn report(
+        &mut self,
+        rule_name: &'static str,
+        restriction: &Restriction,
+        span: Span,
+        subject: DiagnosticSubject<'_>,
+    ) {
+        let custom_message = restriction
+            .message
+            .as_ref()
+            .filter(|message| !message.is_empty());
+        let mut data = DiagnosticData {
+            message: custom_message.cloned().unwrap_or_default(),
+            ..DiagnosticData::default()
+        };
+        match subject {
+            DiagnosticSubject::Method(method) => {
+                data.method = Some(CompactString::from(method));
+            }
+            DiagnosticSubject::Restriction(value) => {
+                data.restriction = Some(CompactString::from(value));
+            }
+            DiagnosticSubject::Role(role) => {
+                data.role = Some(CompactString::from(role));
+            }
+        }
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id: if custom_message.is_some() {
+                "restrictedWithMessage"
+            } else {
+                "restricted"
+            },
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+enum DiagnosticSubject<'a> {
+    Method(&'a str),
+    Restriction(&'a str),
+    Role(&'a str),
+}
+
+#[derive(Clone, Copy)]
+struct ChainLink<'a> {
+    name: &'a str,
+    span: Span,
+}
+
+fn matcher_chain<'ast>(
+    member: &'ast MemberExpression<'ast>,
+    expect_names: &[CompactString],
+) -> Option<SmallVec<[ChainLink<'ast>; 8]>> {
+    let mut reversed = SmallVec::<[ChainLink<'ast>; 8]>::new();
+    let mut current = member;
+    loop {
+        reversed.push(member_link(current)?);
+        match current.object().get_inner_expression() {
+            Expression::CallExpression(call) => {
+                if is_expect_call(call, expect_names) {
+                    break;
+                }
+                current = member_from_expression(&call.callee)?;
+            }
+            expression => {
+                current = member_from_expression(expression)?;
+            }
+        }
+    }
+    reversed.reverse();
+    Some(reversed)
+}
+
+fn is_expect_call(call: &CallExpression<'_>, expect_names: &[CompactString]) -> bool {
+    match call.callee.get_inner_expression() {
+        Expression::Identifier(identifier) => contains_name(expect_names, identifier.name.as_str()),
+        member @ match_member_expression!(Expression) => {
+            let member = member.to_member_expression();
+            matches!(member.static_property_name(), Some("poll" | "soft"))
+                && matches!(
+                    member.object().get_inner_expression(),
+                    Expression::Identifier(identifier)
+                        if contains_name(expect_names, identifier.name.as_str())
+                )
+        }
+        _ => false,
+    }
+}
+
+fn member_link<'ast>(member: &'ast MemberExpression<'ast>) -> Option<ChainLink<'ast>> {
+    match member {
+        MemberExpression::StaticMemberExpression(member) => Some(ChainLink {
+            name: member.property.name.as_str(),
+            span: member.property.span,
+        }),
+        MemberExpression::ComputedMemberExpression(member) => {
+            let expression = member.expression.get_inner_expression();
+            Some(ChainLink {
+                name: static_expression_value(expression)?,
+                span: expression.span(),
+            })
+        }
+        MemberExpression::PrivateFieldExpression(_) => None,
+    }
+}
+
+fn member_from_expression<'ast>(
+    expression: &'ast Expression<'ast>,
+) -> Option<&'ast MemberExpression<'ast>> {
+    match expression.get_inner_expression() {
+        member @ match_member_expression!(Expression) => Some(member.to_member_expression()),
+        _ => None,
+    }
+}
+
+fn static_argument_value<'ast>(argument: &'ast Argument<'ast>) -> Option<&'ast str> {
+    static_expression_value(argument.as_expression()?.get_inner_expression())
+}
+
+fn static_expression_value<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
+    match expression {
+        Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+        Expression::TemplateLiteral(template) if template.expressions.is_empty() => template
+            .quasis
+            .first()
+            .and_then(|quasi| quasi.value.cooked.as_ref())
+            .map(|value| value.as_str()),
+        _ => None,
+    }
+}
+
+fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn last_restriction<'a>(restrictions: &'a [Restriction], value: &str) -> Option<&'a Restriction> {
+    restrictions
+        .iter()
+        .rev()
+        .find(|restriction| restriction.value == value)
+}
+
+fn contains_name(names: &[CompactString], value: &str) -> bool {
+    names.iter().any(|name| name == value)
+}
+
+fn push_unique(names: &mut SmallVec<[CompactString; 8]>, value: &str) {
+    if !contains_name(names, value) {
+        names.push(CompactString::from(value));
+    }
+}

--- a/crates/playwright/src/scanner.rs
+++ b/crates/playwright/src/scanner.rs
@@ -4,7 +4,7 @@ use oxc_span::Span;
 use oxlint_plugins_carton::SmallVec;
 use regex::Regex;
 
-use crate::types::{Diagnostic, LineIndex};
+use crate::types::{Diagnostic, DiagnosticData, LineIndex};
 
 pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,
@@ -67,15 +67,6 @@ impl<'a> Scanner<'a> {
         self.check_regex("no-nth-methods", r#"\.(first|last|nth)\s*\("#);
         self.check_regex("no-page-pause", r#"page\.pause\s*\("#);
         self.check_regex("no-raw-locators", r#"page\.locator\s*\(\s*['"][^'"]+['"]"#);
-        self.check_regex(
-            "no-restricted-locators",
-            r#"\.getByText\s*\(\s*['"]Forbidden['"]"#,
-        );
-        self.check_regex("no-restricted-matchers", r#"\.toBeTruthy\s*\("#);
-        self.check_regex(
-            "no-restricted-roles",
-            r#"\.getByRole\s*\(\s*['"]button['"]"#,
-        );
         self.check_regex("no-skipped-test", r#"\btest\.skip\s*\("#);
         self.check_regex("no-slowed-test", r#"\btest\.slow\s*\("#);
         self.check_regex("no-standalone-expect", r#"(?m)^\s*expect\s*\("#);
@@ -220,6 +211,7 @@ impl<'a> Scanner<'a> {
         self.diagnostics.push(Diagnostic {
             rule_name,
             message_id: "unexpected",
+            data: DiagnosticData::default(),
             loc: self.line_index.loc_for_span(self.source_text, span),
         });
     }

--- a/crates/playwright/src/tests.rs
+++ b/crates/playwright/src/tests.rs
@@ -1,6 +1,9 @@
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
 
-use crate::{RULE_NAMES, implemented_playwright_rule_names, scan_playwright};
+use crate::{
+    PlaywrightOptions, RULE_NAMES, Restriction, implemented_playwright_rule_names, scan_playwright,
+    scan_playwright_with_options,
+};
 
 const REPRESENTATIVE_SOURCE: &str = r#"
 test("one", async ({ page }) => { await expect(page).toBeTruthy(); });
@@ -81,13 +84,144 @@ fn exposes_all_rule_names() {
 
 #[test]
 fn scans_representative_rules() {
-    let diagnostics = scan_playwright(REPRESENTATIVE_SOURCE, "fixture.spec.ts");
+    let diagnostics = scan_playwright_with_options(
+        REPRESENTATIVE_SOURCE,
+        "fixture.spec.ts",
+        &representative_options(),
+    );
     let mut actual: SmallVec<[&str; 64]> = diagnostics
         .iter()
         .map(|diagnostic| diagnostic.rule_name)
         .collect();
     let mut expected: SmallVec<[&str; 64]> = RULE_NAMES.into_iter().collect();
     actual.sort_unstable();
+    actual.dedup();
     expected.sort_unstable();
     assert_eq!(actual, expected);
+}
+
+#[test]
+fn restricted_rules_honor_lists_custom_messages_and_exact_utf16_ranges() {
+    let source = concat!(
+        "const café = page.getByText(\"Submit\");\n",
+        "expect(café).not.toBeTruthy();\n",
+        "page.getByRole(`progressbar`, { name: \"Loading\" });\n",
+    );
+    let options = PlaywrightOptions {
+        restricted_locators: [restriction("getByText", None)].into_iter().collect(),
+        restricted_matchers: [restriction(
+            "not.toBeTruthy",
+            Some("Prefer a positive assertion"),
+        )]
+        .into_iter()
+        .collect(),
+        restricted_roles: [restriction(
+            "progressbar",
+            Some("Assert the loaded content"),
+        )]
+        .into_iter()
+        .collect(),
+        expect_aliases: Default::default(),
+    };
+
+    let diagnostics = scan_playwright_with_options(source, "fixture.ts", &options);
+    let restricted = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.rule_name.starts_with("no-restricted-"))
+        .collect::<SmallVec<[_; 4]>>();
+
+    assert_eq!(restricted.len(), 3);
+    assert_eq!(restricted[0].rule_name, "no-restricted-locators");
+    assert_eq!(restricted[0].message_id, "restricted");
+    assert_eq!(restricted[0].data.method.as_deref(), Some("getByText"));
+    assert_eq!(restricted[0].loc.start_column, 13);
+    assert_eq!(restricted[0].loc.end_column, 37);
+
+    assert_eq!(restricted[1].rule_name, "no-restricted-matchers");
+    assert_eq!(restricted[1].message_id, "restrictedWithMessage");
+    assert_eq!(restricted[1].data.message, "Prefer a positive assertion");
+    assert_eq!(restricted[1].loc.start_column, 13);
+    assert_eq!(restricted[1].loc.end_column, 27);
+
+    assert_eq!(restricted[2].rule_name, "no-restricted-roles");
+    assert_eq!(restricted[2].message_id, "restrictedWithMessage");
+    assert_eq!(restricted[2].data.role.as_deref(), Some("progressbar"));
+    assert_eq!(restricted[2].loc.start_column, 0);
+    assert_eq!(restricted[2].loc.end_column, 50);
+}
+
+#[test]
+fn restricted_rules_support_computed_names_aliases_and_last_duplicate_wins() {
+    let source = concat!(
+        "page[\"getByTestId\"](\"button\");\n",
+        "assuming(value)[`not`][\"toBe\"]();\n",
+        "page[`getByRole`](role);\n",
+        "import { expect as assuming } from \"@playwright/test\";\n",
+    );
+    let options = PlaywrightOptions {
+        restricted_locators: [
+            restriction("getByTestId", Some("old")),
+            restriction("getByTestId", Some("Use a role")),
+        ]
+        .into_iter()
+        .collect(),
+        restricted_matchers: [
+            restriction("not", None),
+            restriction("not.toBe", Some("Use a positive matcher")),
+        ]
+        .into_iter()
+        .collect(),
+        restricted_roles: [restriction("button", None)].into_iter().collect(),
+        expect_aliases: Default::default(),
+    };
+
+    let diagnostics = scan_playwright_with_options(source, "fixture.ts", &options);
+    let restricted = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.rule_name.starts_with("no-restricted-"))
+        .collect::<SmallVec<[_; 4]>>();
+
+    assert_eq!(restricted.len(), 3);
+    assert_eq!(restricted[0].data.message, "Use a role");
+    assert_eq!(restricted[1].data.restriction.as_deref(), Some("not"));
+    assert_eq!(restricted[2].data.restriction.as_deref(), Some("not.toBe"));
+    assert!(
+        restricted
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "no-restricted-roles")
+    );
+}
+
+#[test]
+fn restricted_rules_are_inert_without_options_and_on_parse_errors() {
+    let source = concat!(
+        "page.getByText(\"Forbidden\");\n",
+        "expect(value).toBeTruthy();\n",
+        "page.getByRole(\"button\");\n",
+    );
+    assert!(
+        scan_playwright(source, "fixture.ts")
+            .iter()
+            .all(|diagnostic| !diagnostic.rule_name.starts_with("no-restricted-"))
+    );
+    assert!(
+        scan_playwright_with_options("page.getByText(", "fixture.ts", &representative_options(),)
+            .is_empty()
+    );
+}
+
+fn representative_options() -> PlaywrightOptions {
+    PlaywrightOptions {
+        restricted_locators: [restriction("getByText", None)].into_iter().collect(),
+        restricted_matchers: [restriction("toBeTruthy", None)].into_iter().collect(),
+        restricted_roles: [restriction("button", None)].into_iter().collect(),
+        expect_aliases: Default::default(),
+    }
+}
+
+fn restriction(value: &str, message: Option<&str>) -> Restriction {
+    Restriction {
+        value: CompactString::from(value),
+        message: message.map(CompactString::from),
+    }
 }

--- a/crates/playwright/src/types.rs
+++ b/crates/playwright/src/types.rs
@@ -1,7 +1,21 @@
 //! Diagnostic types and line indexing for the playwright port.
 
 use oxc_span::Span;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Restriction {
+    pub value: CompactString,
+    pub message: Option<CompactString>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PlaywrightOptions {
+    pub restricted_locators: SmallVec<[Restriction; 8]>,
+    pub restricted_matchers: SmallVec<[Restriction; 8]>,
+    pub restricted_roles: SmallVec<[Restriction; 8]>,
+    pub expect_aliases: SmallVec<[CompactString; 4]>,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiagnosticLoc {
@@ -15,7 +29,16 @@ pub struct DiagnosticLoc {
 pub struct Diagnostic {
     pub rule_name: &'static str,
     pub message_id: &'static str,
+    pub data: DiagnosticData,
     pub loc: DiagnosticLoc,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiagnosticData {
+    pub message: CompactString,
+    pub method: Option<CompactString>,
+    pub restriction: Option<CompactString>,
+    pub role: Option<CompactString>,
 }
 
 pub(crate) struct LineIndex {

--- a/npm/playwright/Cargo.toml
+++ b/npm/playwright/Cargo.toml
@@ -15,6 +15,7 @@ name = "oxlint_plugin_playwright"
 [dependencies]
 napi.workspace = true
 napi-derive.workspace = true
+oxlint-plugins-carton.workspace = true
 oxlint-plugins-playwright.workspace = true
 
 [build-dependencies]

--- a/npm/playwright/README.md
+++ b/npm/playwright/README.md
@@ -4,3 +4,57 @@ Rust-backed Oxlint plugin port of `eslint-plugin-playwright` v2.10.4.
 
 This package exposes the `playwright` plugin, recommended configs, and a native
 API for scanning Playwright test source through the Rust implementation.
+
+## Restricted rule options
+
+The option-bearing `no-restricted-locators`, `no-restricted-matchers`, and
+`no-restricted-roles` rules follow the pinned v2.10.4 contract. Locator and role
+lists accept either strings or objects with an optional custom message, while
+matcher restrictions use a matcher-chain-to-message map:
+
+```jsonc
+{
+  "rules": {
+    "playwright/no-restricted-locators": [
+      "error",
+      [
+        "getByTestId",
+        {
+          "type": "getByTitle",
+          "message": "Prefer accessible locators",
+        },
+      ],
+    ],
+    "playwright/no-restricted-matchers": [
+      "error",
+      {
+        "not.toBeTruthy": "Prefer a positive matcher",
+      },
+    ],
+    "playwright/no-restricted-roles": [
+      "error",
+      [
+        "progressbar",
+        {
+          "role": "alert",
+          "message": "Assert on specific content",
+        },
+      ],
+    ],
+  },
+}
+```
+
+The direct API accepts the same option values:
+
+```js
+const { scanPlaywright } = require('@oxlint-plugins/oxlint-plugin-playwright/api');
+
+scanPlaywright('page.getByTestId("submit")', 'fixture.spec.ts', {
+  noRestrictedLocators: ['getByTestId'],
+});
+```
+
+Static dot, string-computed, and template-computed member names are supported.
+Matcher modifiers and chains are checked against Playwright `expect`, configured
+global aliases, and named `expect` import aliases.

--- a/npm/playwright/api.d.ts
+++ b/npm/playwright/api.d.ts
@@ -8,8 +8,39 @@ export type PlaywrightDiagnosticLoc = {
 export type PlaywrightDiagnostic = {
   ruleName: string;
   messageId: string;
+  data: {
+    message: string;
+    method?: string;
+    restriction?: string;
+    role?: string;
+  };
   loc: PlaywrightDiagnosticLoc;
 };
 
+export type PlaywrightRestrictedLocator =
+  | string
+  | {
+      type: string;
+      message?: string;
+    };
+
+export type PlaywrightRestrictedRole =
+  | string
+  | {
+      role: string;
+      message?: string;
+    };
+
+export type PlaywrightScanOptions = {
+  noRestrictedLocators?: PlaywrightRestrictedLocator[];
+  noRestrictedMatchers?: Record<string, string | null>;
+  noRestrictedRoles?: PlaywrightRestrictedRole[];
+  expectAliases?: string[];
+};
+
 export function implementedPlaywrightRuleNames(): string[];
-export function scanPlaywright(sourceText: string, filename?: string): PlaywrightDiagnostic[];
+export function scanPlaywright(
+  sourceText: string,
+  filename?: string,
+  options?: PlaywrightScanOptions,
+): PlaywrightDiagnostic[];

--- a/npm/playwright/api.js
+++ b/npm/playwright/api.js
@@ -6,15 +6,61 @@ function implementedPlaywrightRuleNames() {
   return native.implementedPlaywrightRuleNames();
 }
 
-function scanPlaywright(sourceText, filename = 'file.spec.ts') {
+function scanPlaywright(sourceText, filename = 'file.spec.ts', options = {}) {
   if (typeof sourceText !== 'string') {
     throw new TypeError('sourceText must be a string.');
   }
   if (typeof filename !== 'string') {
     throw new TypeError('filename must be a string.');
   }
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('options must be an object.');
+  }
 
-  return native.scanPlaywright(sourceText, filename);
+  return native.scanPlaywright(sourceText, filename, {
+    expectAliases: stringList(options.expectAliases),
+    restrictedLocators: listRestrictions(options.noRestrictedLocators, 'type'),
+    restrictedMatchers: matcherRestrictions(options.noRestrictedMatchers),
+    restrictedRoles: listRestrictions(options.noRestrictedRoles, 'role'),
+  });
+}
+
+function listRestrictions(values, key) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.flatMap((value) => {
+    if (typeof value === 'string') {
+      return [{ value }];
+    }
+    if (!value || typeof value !== 'object' || typeof value[key] !== 'string') {
+      return [];
+    }
+    return [
+      {
+        value: value[key],
+        ...(typeof value.message === 'string' ? { message: value.message } : {}),
+      },
+    ];
+  });
+}
+
+function matcherRestrictions(values) {
+  if (!values || typeof values !== 'object' || Array.isArray(values)) {
+    return [];
+  }
+  return Object.entries(values).flatMap(([value, message]) =>
+    message === null || typeof message === 'string'
+      ? [{ value, ...(message === null ? {} : { message }) }]
+      : [],
+  );
+}
+
+function stringList(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.filter((value) => typeof value === 'string');
 }
 
 module.exports = {

--- a/npm/playwright/index.js
+++ b/npm/playwright/index.js
@@ -11,7 +11,7 @@ const PLUGIN_NAME = 'playwright';
 const DOCS_BASE = 'https://github.com/mskelton/eslint-plugin-playwright/blob/main/docs/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedPlaywrightRuleNames());
-const optionRequiredRules = new Set([
+const restrictedRules = new Set([
   'no-restricted-locators',
   'no-restricted-matchers',
   'no-restricted-roles',
@@ -133,24 +133,22 @@ function createLegacyRecommendedConfig() {
 }
 
 function createPlaywrightRule(ruleName) {
+  const restrictedMeta = restrictedRuleMeta(ruleName);
   return {
     meta: {
       type: ruleType(ruleName),
       docs: {
-        description: `enforce playwright ${ruleName.replaceAll('-', ' ')}`,
+        description:
+          restrictedMeta?.description ?? `enforce playwright ${ruleName.replaceAll('-', ' ')}`,
         category: 'Best Practices',
         recommended: recommendedRuleConfig[`playwright/${ruleName}`] !== undefined,
         url: `${DOCS_BASE}/${ruleName}.md`,
       },
       fixable: fixableRule(ruleName) ? 'code' : undefined,
-      messages: {
+      messages: restrictedMeta?.messages ?? {
         unexpected: 'Unexpected Playwright pattern.',
       },
-      // The core does not honor upstream option values (it has no options
-      // struct). Declare no schema so configured options surface as an error
-      // rather than being silently dropped. The `no-restricted-*` rules need
-      // real options support to function; tracked for implementation.
-      schema: [],
+      schema: restrictedMeta?.schema ?? [],
     },
     createOnce(context) {
       return {
@@ -182,32 +180,39 @@ function fixableRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
-  if (optionRequiredRules.has(ruleName) && !hasConfiguredOptions(context.options)) {
-    return [];
-  }
-
-  return diagnosticsForContext(context).filter((diagnostic) => diagnostic.ruleName === ruleName);
+  const options = restrictedRules.has(ruleName)
+    ? restrictedScanOptions(context, ruleName)
+    : undefined;
+  return diagnosticsForContext(context, options).filter(
+    (diagnostic) => diagnostic.ruleName === ruleName,
+  );
 }
 
-function diagnosticsForContext(context) {
+function diagnosticsForContext(context, options) {
   const sourceCode = context.sourceCode || {};
   const sourceText = sourceTextForContext(context);
   const filename = typeof context.filename === 'string' ? context.filename : 'file.spec.ts';
+  const optionsKey = JSON.stringify(options ?? null);
   let cached = diagnosticsCache.get(sourceCode);
 
-  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
-    return cached.diagnostics;
+  if (!cached || cached.sourceText !== sourceText || cached.filename !== filename) {
+    cached = { sourceText, filename, diagnosticsByOptions: new Map() };
+    diagnosticsCache.set(sourceCode, cached);
+  }
+  const existing = cached.diagnosticsByOptions.get(optionsKey);
+  if (existing) {
+    return existing;
   }
 
-  const diagnostics = scanPlaywright(sourceText, filename);
-  cached = { sourceText, filename, diagnostics };
-  diagnosticsCache.set(sourceCode, cached);
+  const diagnostics = scanPlaywright(sourceText, filename, options);
+  cached.diagnosticsByOptions.set(optionsKey, diagnostics);
   return diagnostics;
 }
 
 function reportDiagnostic(context, diagnostic) {
   context.report({
     messageId: diagnostic.messageId,
+    data: diagnostic.data,
     loc: {
       start: {
         line: diagnostic.loc.startLine,
@@ -232,14 +237,76 @@ function sourceTextForContext(context) {
   return '';
 }
 
-function hasConfiguredOptions(options) {
-  return (
-    Array.isArray(options) &&
-    options.some((option) => {
-      if (Array.isArray(option)) return option.length > 0;
-      return option && typeof option === 'object' && Object.keys(option).length > 0;
-    })
-  );
+function restrictedScanOptions(context, ruleName) {
+  const options = Array.isArray(context.options) ? context.options : [];
+  const expectAliases = context.settings?.playwright?.globalAliases?.expect;
+  return {
+    ...(ruleName === 'no-restricted-locators' ? { noRestrictedLocators: options[0] } : {}),
+    ...(ruleName === 'no-restricted-matchers' ? { noRestrictedMatchers: options[0] } : {}),
+    ...(ruleName === 'no-restricted-roles' ? { noRestrictedRoles: options[0] } : {}),
+    ...(Array.isArray(expectAliases) ? { expectAliases } : {}),
+  };
+}
+
+function restrictedRuleMeta(ruleName) {
+  switch (ruleName) {
+    case 'no-restricted-locators':
+      return {
+        description: 'Disallows the usage of specific locator methods',
+        messages: {
+          restricted: 'Usage of `{{method}}` is disallowed',
+          restrictedWithMessage: '{{message}}',
+        },
+        schema: [restrictedListSchema('type')],
+      };
+    case 'no-restricted-matchers':
+      return {
+        description: 'Disallow specific matchers & modifiers',
+        messages: {
+          restricted: 'Use of `{{restriction}}` is disallowed',
+          restrictedWithMessage: '{{message}}',
+        },
+        schema: [
+          {
+            additionalProperties: {
+              type: ['string', 'null'],
+            },
+            type: 'object',
+          },
+        ],
+      };
+    case 'no-restricted-roles':
+      return {
+        description: 'Disallows the usage of specific roles in getByRole()',
+        messages: {
+          restricted: 'Usage of role `{{role}}` in getByRole() is disallowed',
+          restrictedWithMessage: '{{message}}',
+        },
+        schema: [restrictedListSchema('role')],
+      };
+    default:
+      return null;
+  }
+}
+
+function restrictedListSchema(requiredProperty) {
+  return {
+    items: {
+      oneOf: [
+        { type: 'string' },
+        {
+          additionalProperties: false,
+          properties: {
+            message: { type: 'string' },
+            [requiredProperty]: { type: 'string' },
+          },
+          required: [requiredProperty],
+          type: 'object',
+        },
+      ],
+    },
+    type: 'array',
+  };
 }
 
 module.exports = plugin;

--- a/npm/playwright/src/lib.rs
+++ b/npm/playwright/src/lib.rs
@@ -1,6 +1,9 @@
 //! NAPI boundary for the playwright oxlint plugin.
 
-pub use napi_abi::{Diagnostic, DiagnosticLoc, implemented_playwright_rule_names, scan_playwright};
+pub use napi_abi::{
+    Diagnostic, DiagnosticData, DiagnosticLoc, PlaywrightRestriction, PlaywrightScanOptions,
+    implemented_playwright_rule_names, scan_playwright,
+};
 
 #[allow(
     clippy::disallowed_macros,
@@ -9,7 +12,24 @@ pub use napi_abi::{Diagnostic, DiagnosticLoc, implemented_playwright_rule_names,
 )]
 mod napi_abi {
     use napi_derive::napi;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
     use oxlint_plugins_playwright as core;
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct PlaywrightRestriction {
+        pub value: String,
+        pub message: Option<String>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct PlaywrightScanOptions {
+        pub restricted_locators: Option<Vec<PlaywrightRestriction>>,
+        pub restricted_matchers: Option<Vec<PlaywrightRestriction>>,
+        pub restricted_roles: Option<Vec<PlaywrightRestriction>>,
+        pub expect_aliases: Option<Vec<String>>,
+    }
 
     #[napi(object)]
     #[derive(Clone, Debug)]
@@ -25,7 +45,17 @@ mod napi_abi {
     pub struct Diagnostic {
         pub rule_name: String,
         pub message_id: String,
+        pub data: DiagnosticData,
         pub loc: DiagnosticLoc,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticData {
+        pub message: String,
+        pub method: Option<String>,
+        pub restriction: Option<String>,
+        pub role: Option<String>,
     }
 
     #[napi]
@@ -37,18 +67,53 @@ mod napi_abi {
     }
 
     #[napi]
-    pub fn scan_playwright(source_text: String, filename: String) -> Vec<Diagnostic> {
-        core::scan_playwright(&source_text, &filename)
+    pub fn scan_playwright(
+        source_text: String,
+        filename: String,
+        options: Option<PlaywrightScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::PlaywrightOptions {
+            restricted_locators: compact_restrictions(options.restricted_locators),
+            restricted_matchers: compact_restrictions(options.restricted_matchers),
+            restricted_roles: compact_restrictions(options.restricted_roles),
+            expect_aliases: options
+                .expect_aliases
+                .unwrap_or_default()
+                .into_iter()
+                .map(CompactString::from)
+                .collect(),
+        };
+        core::scan_playwright_with_options(&source_text, &filename, &core_options)
             .into_iter()
             .map(|diagnostic| Diagnostic {
                 rule_name: diagnostic.rule_name.to_owned(),
                 message_id: diagnostic.message_id.to_owned(),
+                data: DiagnosticData {
+                    message: diagnostic.data.message.into_string(),
+                    method: diagnostic.data.method.map(CompactString::into_string),
+                    restriction: diagnostic.data.restriction.map(CompactString::into_string),
+                    role: diagnostic.data.role.map(CompactString::into_string),
+                },
                 loc: DiagnosticLoc {
                     start_line: diagnostic.loc.start_line,
                     start_column: diagnostic.loc.start_column,
                     end_line: diagnostic.loc.end_line,
                     end_column: diagnostic.loc.end_column,
                 },
+            })
+            .collect()
+    }
+
+    fn compact_restrictions(
+        restrictions: Option<Vec<PlaywrightRestriction>>,
+    ) -> SmallVec<[core::Restriction; 8]> {
+        restrictions
+            .unwrap_or_default()
+            .into_iter()
+            .map(|restriction| core::Restriction {
+                value: CompactString::from(restriction.value),
+                message: restriction.message.map(CompactString::from),
             })
             .collect()
     }

--- a/npm/playwright/test/api.test.mjs
+++ b/npm/playwright/test/api.test.mjs
@@ -136,9 +136,13 @@ describe('playwright native API', () => {
   });
 
   it('scans representative Playwright patterns for every rule', () => {
-    const diagnostics = scanPlaywright(representativeSource, 'fixture.spec.ts');
+    const diagnostics = scanPlaywright(representativeSource, 'fixture.spec.ts', {
+      noRestrictedLocators: ['getByText'],
+      noRestrictedMatchers: { toBeTruthy: null },
+      noRestrictedRoles: ['button'],
+    });
 
-    expect(diagnostics.map((diagnostic) => diagnostic.ruleName).sort()).toEqual(
+    expect([...new Set(diagnostics.map((diagnostic) => diagnostic.ruleName))].sort()).toEqual(
       [...expectedRuleNames].sort(),
     );
   });

--- a/npm/playwright/test/fixtures/restricted-v2.10.4.json
+++ b/npm/playwright/test/fixtures/restricted-v2.10.4.json
@@ -1,0 +1,1471 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-playwright",
+    "version": "2.10.4",
+    "sourceCommit": "894c0ec261763bb1e073b276c70bbf88b4ebad39",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-playwright-restricted-tests.ts",
+    "sourceFiles": [
+      "src/rules/no-restricted-locators.ts",
+      "src/rules/no-restricted-locators.test.ts",
+      "src/rules/no-restricted-matchers.ts",
+      "src/rules/no-restricted-matchers.test.ts",
+      "src/rules/no-restricted-roles.ts",
+      "src/rules/no-restricted-roles.test.ts"
+    ],
+    "sourceHashes": {
+      "src/rules/no-restricted-locators.ts": "af178bba1c720c60192ca10a31c0d9cb15a1ab49c4c54294db109365923f1784",
+      "src/rules/no-restricted-locators.test.ts": "eacd9eaa6593b840467d2be6a0ed926b67402dbc98acdeeca19a0ae6018b28cc",
+      "src/rules/no-restricted-matchers.ts": "8160ced6694d28062ae621287a959178813a3924c28d21787404bd83838df6ef",
+      "src/rules/no-restricted-matchers.test.ts": "951c1eb5c95d666f69f2339a6da21e4a9b63f50749028307bc65210342f471bf",
+      "src/rules/no-restricted-roles.ts": "b5fc1ad9d033620282e65950b012d7324d8eab60ba51df441111f07fce042afb",
+      "src/rules/no-restricted-roles.test.ts": "f91987b72b3432cb56a4f74032d1bf7ad1e98669b5ab9f2095cf3e1133d65abb"
+    },
+    "inventory": {
+      "suites": [
+        {
+          "rule": "no-restricted-locators",
+          "valid": 12,
+          "invalid": 15,
+          "diagnostics": 17
+        },
+        {
+          "rule": "no-restricted-matchers",
+          "valid": 20,
+          "invalid": 13,
+          "diagnostics": 13
+        },
+        {
+          "rule": "no-restricted-roles",
+          "valid": 16,
+          "invalid": 18,
+          "diagnostics": 20
+        }
+      ],
+      "valid": 48,
+      "invalid": 46,
+      "diagnostics": 50
+    }
+  },
+  "suites": [
+    {
+      "rule": "no-restricted-locators",
+      "valid": [
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"button\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByTitle(\"tooltip\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"button\") })",
+          "options": [[]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"button\") })",
+          "options": [["getByTitle"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByTitle(\"tooltip\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"button\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByText(\"Submit\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByLabel(\"Email\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.locator(\".btn\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.click() })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { const section = page.getByRole(\"section\"); section.getByRole(\"button\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { const button = page.getByRole(\"button\", { name: \"common button\" }); page.locator(button) })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"button\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 59
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await this.page.getByTestId(\"button\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 64
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page[\"getByTestId\"](\"button\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page[`getByTestId`](\"button\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await frame.getByTestId(\"button\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 60
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"btn\"); await page.getByTitle(\"tip\") })",
+          "options": [["getByTestId", "getByTitle"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 56
+              }
+            },
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTitle"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 64,
+                "endLine": 1,
+                "endColumn": 86
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"button\") })",
+          "options": [
+            [
+              {
+                "type": "getByTestId"
+              }
+            ]
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 59
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"button\") })",
+          "options": [
+            [
+              {
+                "message": "Prefer getByRole or getByLabel instead",
+                "type": "getByTestId"
+              }
+            ]
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Prefer getByRole or getByLabel instead",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 59
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"btn\"); await page.getByTitle(\"tip\") })",
+          "options": [
+            [
+              "getByTestId",
+              {
+                "message": "Prefer getByRole or getByLabel instead",
+                "type": "getByTitle"
+              }
+            ]
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 56
+              }
+            },
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Prefer getByRole or getByLabel instead",
+                "method": "getByTitle"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 64,
+                "endLine": 1,
+                "endColumn": 86
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByAltText(\"logo\") })",
+          "options": [["getByAltText"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByAltText"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 58
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByPlaceholder(\"Email\") })",
+          "options": [["getByPlaceholder"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByPlaceholder"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 63
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByLabel(\"Email\") })",
+          "options": [["getByLabel"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByLabel"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 57
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"button\") })",
+          "options": [["getByRole"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByRole"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 57
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByText(\"Submit\") })",
+          "options": [["getByText"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByText"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 57
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { page.getByRole(\"section\").getByTestId(\"btn\") })",
+          "options": [["getByTestId"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "method": "getByTestId"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 27,
+                "endLine": 1,
+                "endColumn": 71
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rule": "no-restricted-matchers",
+      "valid": [
+        {
+          "code": "expect(a)",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).toBe()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).not.toContain()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).toHaveText()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).toThrow()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect.soft(a)",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect.soft(a).toHaveText()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect.poll(() => true).toThrow()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect[\"soft\"](a).toHaveText()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect[`poll`](() => true).toThrow()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).toBe(b)",
+          "options": [
+            {
+              "not.toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect.soft(a).toBe(b)",
+          "options": [
+            {
+              "not.toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect.poll(() => true).toBe(b)",
+          "options": [
+            {
+              "not.toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect[\"soft\"](a)[\"toBe\"](b)",
+          "options": [
+            {
+              "not.toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect[`poll`](() => true)[`toBe`](b)",
+          "options": [
+            {
+              "not.toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).toHaveKnot(b)",
+          "options": [
+            {
+              "not": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "expect(a).nothing(b)",
+          "options": [
+            {
+              "not": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "assert(a).nothing(b)",
+          "options": [
+            {
+              "not": null
+            }
+          ],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "expect": ["assert"]
+              }
+            }
+          },
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom(\"foo\", () => {\n  expect(a).toHaveText();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "import { expect as assuming } from '@playwright/test';\nassuming(something).toBe(something);",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        }
+      ],
+      "invalid": [
+        {
+          "code": "expect(a).toBe(b)",
+          "options": [
+            {
+              "toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 14
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect.soft(a).toBe(b)",
+          "options": [
+            {
+              "toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 15,
+                "endLine": 1,
+                "endColumn": 19
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect[\"poll\"](() => a)[\"toBe\"](b)",
+          "options": [
+            {
+              "toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 24,
+                "endLine": 1,
+                "endColumn": 30
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect(a).not.toBe()",
+          "options": [
+            {
+              "not": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "not"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 13
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect(a).not.toBeTruthy()",
+          "options": [
+            {
+              "not.toBeTruthy": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "not.toBeTruthy"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 24
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect[`soft`](a)[`not`][\"toBe\"]()",
+          "options": [
+            {
+              "not": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "not"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 18,
+                "endLine": 1,
+                "endColumn": 23
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect.poll(() => true).not.toBeTruthy()",
+          "options": [
+            {
+              "not.toBeTruthy": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "not.toBeTruthy"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 24,
+                "endLine": 1,
+                "endColumn": 38
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect(a).toBe(b)",
+          "options": [
+            {
+              "toBe": "Prefer `toStrictEqual` instead"
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Prefer `toStrictEqual` instead",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 14
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect(foo).not.toHaveText('bar')",
+          "options": [
+            {
+              "not.toHaveText": "Use not.toContainText instead"
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Use not.toContainText instead",
+                "restriction": "not.toHaveText"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 12,
+                "endLine": 1,
+                "endColumn": 26
+              }
+            }
+          ]
+        },
+        {
+          "code": "assert(a).toBe(b)",
+          "options": [
+            {
+              "toBe": null
+            }
+          ],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "expect": ["assert"]
+              }
+            }
+          },
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 14
+              }
+            }
+          ]
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom(\"foo\", () => {\n  expect(a).toBe(b);\n});",
+          "options": [
+            {
+              "toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 3,
+                "startColumn": 12,
+                "endLine": 3,
+                "endColumn": 16
+              }
+            }
+          ]
+        },
+        {
+          "code": "import { expect as assuming } from '@playwright/test';\nassuming(a).toBe(b);",
+          "options": [
+            {
+              "toBe": null
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "restriction": "toBe"
+              },
+              "loc": {
+                "startLine": 2,
+                "startColumn": 12,
+                "endLine": 2,
+                "endColumn": 16
+              }
+            }
+          ]
+        },
+        {
+          "code": "expect(a).resolves.toBe(b)",
+          "options": [
+            {
+              "resolves.toBe": "Use a different approach"
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Use a different approach",
+                "restriction": "resolves.toBe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 23
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rule": "no-restricted-roles",
+      "valid": [
+        {
+          "code": "test('test', async () => { await page.getByRole(\"button\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\") })",
+          "options": [[]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"button\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"heading\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"link\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"textbox\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"checkbox\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByTestId(\"progressbar\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.getByText(\"Loading...\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.locator(\"[role=progressbar]\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { const section = page.getByRole(\"region\"); section.getByRole(\"button\") })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await dialog.getByRole(\"button\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await table.getByRole(\"button\", { name: \"Submit\" }) })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { await page.locator(\".foo\").getByRole(\"button\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('test', async () => { const role = \"progressbar\"; await page.getByRole(role) })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await this.page.getByRole(\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 67
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page[\"getByRole\"](\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 65
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page[`getByRole`](\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 65
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await frame.getByRole(\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 63
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\"); await page.getByRole(\"alert\") })",
+          "options": [["progressbar", "alert"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            },
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "alert"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 70,
+                "endLine": 1,
+                "endColumn": 93
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\") })",
+          "options": [
+            [
+              {
+                "role": "progressbar"
+              }
+            ]
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\") })",
+          "options": [
+            [
+              {
+                "message": "Progressbar assertions are flaky. Assert on the actual content change instead.",
+                "role": "progressbar"
+              }
+            ]
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Progressbar assertions are flaky. Assert on the actual content change instead.",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\"); await page.getByRole(\"alert\") })",
+          "options": [
+            [
+              "progressbar",
+              {
+                "message": "Prefer asserting on specific content",
+                "role": "alert"
+              }
+            ]
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 62
+              }
+            },
+            {
+              "messageId": "restrictedWithMessage",
+              "data": {
+                "message": "Prefer asserting on specific content",
+                "role": "alert"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 70,
+                "endLine": 1,
+                "endColumn": 93
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"alert\") })",
+          "options": [["alert"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "alert"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 56
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"status\") })",
+          "options": [["status"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "status"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 57
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"img\") })",
+          "options": [["img"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "img"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 54
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"progressbar\", { name: \"Loading\" }) })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 83
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { page.getByRole(`button`) })",
+          "options": [["button"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "button"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 27,
+                "endLine": 1,
+                "endColumn": 51
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await dialog.getByRole(\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 64
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await table.getByRole(\"progressbar\", { name: \"Loading\" }) })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 84
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.locator(\".foo\").getByRole(\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 78
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', async () => { await page.getByRole(\"region\").getByRole(\"progressbar\") })",
+          "options": [["progressbar"]],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "restricted",
+              "data": {
+                "message": "",
+                "role": "progressbar"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 33,
+                "endLine": 1,
+                "endColumn": 82
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/npm/playwright/test/plugin.test.mjs
+++ b/npm/playwright/test/plugin.test.mjs
@@ -141,6 +141,11 @@ const invalidCases = [
   ['valid-test-tags', 'test("@bad tag", () => {});\n'],
   ['valid-title', 'test("", () => {});\n'],
 ];
+const expectedRestrictedMessages = {
+  'no-restricted-locators': 'Usage of `{{method}}` is disallowed',
+  'no-restricted-matchers': 'Use of `{{restriction}}` is disallowed',
+  'no-restricted-roles': 'Usage of role `{{role}}` in getByRole() is disallowed',
+};
 
 function runRule(ruleName, sourceText, options = [], filename = 'fixture.spec.ts') {
   const reports = [];
@@ -194,7 +199,7 @@ describe('playwright plugin adapter', () => {
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      'Unexpected Playwright pattern.',
+      expectedRestrictedMessages[ruleName] ?? 'Unexpected Playwright pattern.',
     );
   });
 

--- a/npm/playwright/test/restricted-upstream.test.mjs
+++ b/npm/playwright/test/restricted-upstream.test.mjs
@@ -1,0 +1,302 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanPlaywright } from '../api.js';
+import plugin from '../index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = dirname(here);
+const workspaceRoot = resolve(packageRoot, '../..');
+const fixture = JSON.parse(readFileSync(join(here, 'fixtures', 'restricted-v2.10.4.json'), 'utf8'));
+const validCases = fixture.suites.flatMap((suite) =>
+  suite.valid.map((testCase, index) => ({ rule: suite.rule, index, testCase })),
+);
+const invalidCases = fixture.suites.flatMap((suite) =>
+  suite.invalid.map((testCase, index) => ({ rule: suite.rule, index, testCase })),
+);
+
+describe('eslint-plugin-playwright v2.10.4 restricted-rule replay', () => {
+  it('pins every authored suite and source hash', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-playwright',
+      version: '2.10.4',
+      sourceCommit: '894c0ec261763bb1e073b276c70bbf88b4ebad39',
+      license: 'MIT',
+      tool: 'tools/tasks/sync-playwright-restricted-tests.ts',
+      inventory: {
+        suites: [
+          {
+            rule: 'no-restricted-locators',
+            valid: 12,
+            invalid: 15,
+            diagnostics: 17,
+          },
+          {
+            rule: 'no-restricted-matchers',
+            valid: 20,
+            invalid: 13,
+            diagnostics: 13,
+          },
+          {
+            rule: 'no-restricted-roles',
+            valid: 16,
+            invalid: 18,
+            diagnostics: 20,
+          },
+        ],
+        valid: 48,
+        invalid: 46,
+        diagnostics: 50,
+      },
+    });
+    expect(fixture.__generated.sourceFiles).toHaveLength(6);
+    expect(Object.values(fixture.__generated.sourceHashes)).toHaveLength(6);
+    expect(
+      Object.values(fixture.__generated.sourceHashes).every((hash) => /^[\da-f]{64}$/u.test(hash)),
+    ).toBe(true);
+  });
+
+  it.each(validCases)('$rule accepts upstream valid case $index', ({ rule, testCase }) => {
+    expect(nativeDiagnostics(rule, testCase)).toEqual([]);
+    expect(adapterDiagnostics(rule, testCase)).toEqual([]);
+  });
+
+  it.each(invalidCases)(
+    '$rule matches upstream invalid case $index exactly',
+    ({ rule, testCase }) => {
+      expect(nativeDiagnostics(rule, testCase)).toEqual(testCase.expectedDiagnostics);
+      expect(adapterDiagnostics(rule, testCase)).toEqual(testCase.expectedDiagnostics);
+      expect(
+        adapterReports(rule, testCase).map((report) =>
+          renderMessage(plugin.rules[rule].meta.messages[report.messageId], report.data),
+        ),
+      ).toEqual(
+        testCase.expectedDiagnostics.map((diagnostic) =>
+          renderMessage(plugin.rules[rule].meta.messages[diagnostic.messageId], diagnostic.data),
+        ),
+      );
+    },
+  );
+
+  it('exposes the exact upstream messages and schemas', () => {
+    expect(plugin.rules['no-restricted-locators'].meta).toMatchObject({
+      messages: {
+        restricted: 'Usage of `{{method}}` is disallowed',
+        restrictedWithMessage: '{{message}}',
+      },
+      schema: [restrictedListSchema('type')],
+    });
+    expect(plugin.rules['no-restricted-matchers'].meta).toMatchObject({
+      messages: {
+        restricted: 'Use of `{{restriction}}` is disallowed',
+        restrictedWithMessage: '{{message}}',
+      },
+      schema: [
+        {
+          additionalProperties: { type: ['string', 'null'] },
+          type: 'object',
+        },
+      ],
+    });
+    expect(plugin.rules['no-restricted-roles'].meta).toMatchObject({
+      messages: {
+        restricted: 'Usage of role `{{role}}` in getByRole() is disallowed',
+        restrictedWithMessage: '{{message}}',
+      },
+      schema: [restrictedListSchema('role')],
+    });
+  });
+
+  it('honors lists and custom messages through a real Oxlint TSX run', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-playwright-restricted-'));
+    try {
+      const source = [
+        'import { expect as assuming } from "@playwright/test";',
+        'export const Example = () => <button>Submit</button>;',
+        'page.getByTestId("submit");',
+        'page.getByTitle("tooltip");',
+        'assuming(value).not.toBeTruthy();',
+        'page.getByRole("progressbar");',
+        'page.getByRole("alert");',
+        '',
+      ].join('\n');
+      writeFileSync(join(tempDir, 'fixture.spec.tsx'), source);
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'playwright',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'playwright/no-restricted-locators': [
+              'error',
+              [
+                'getByTestId',
+                {
+                  type: 'getByTitle',
+                  message: 'Prefer accessible locators',
+                },
+              ],
+            ],
+            'playwright/no-restricted-matchers': [
+              'error',
+              {
+                'not.toBeTruthy': 'Prefer a positive matcher',
+              },
+            ],
+            'playwright/no-restricted-roles': [
+              'error',
+              [
+                'progressbar',
+                {
+                  role: 'alert',
+                  message: 'Assert on specific content',
+                },
+              ],
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.spec.tsx'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+        'Usage of `getByTestId` is disallowed',
+        'Prefer accessible locators',
+        'Prefer a positive matcher',
+        'Usage of role `progressbar` in getByRole() is disallowed',
+        'Assert on specific content',
+      ]);
+      expect(payload.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+        'playwright(no-restricted-locators)',
+        'playwright(no-restricted-locators)',
+        'playwright(no-restricted-matchers)',
+        'playwright(no-restricted-roles)',
+        'playwright(no-restricted-roles)',
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps all restricted rules inert when their option collection is empty', () => {
+    const source = [
+      'page.getByTestId("submit");',
+      'expect(value).not.toBeTruthy();',
+      'page.getByRole("progressbar");',
+    ].join('\n');
+    for (const rule of fixture.suites.map((suite) => suite.rule)) {
+      expect(
+        scanPlaywright(source, 'fixture.spec.ts', scanOptions(rule, { options: [] })).filter(
+          (diagnostic) => diagnostic.ruleName === rule,
+        ),
+      ).toEqual([]);
+    }
+  });
+});
+
+function nativeDiagnostics(rule, testCase) {
+  return scanPlaywright(testCase.code, 'fixture.spec.ts', scanOptions(rule, testCase))
+    .filter((diagnostic) => diagnostic.ruleName === rule)
+    .map(({ messageId, data, loc }) => ({ messageId, data, loc }));
+}
+
+function adapterReports(rule, testCase) {
+  const reports = [];
+  const sourceCode = {
+    text: testCase.code,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[rule].createOnce({
+    filename: 'fixture.spec.ts',
+    options: testCase.options,
+    settings: testCase.settings ?? {},
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, testCase.code.length] });
+  return reports;
+}
+
+function adapterDiagnostics(rule, testCase) {
+  return adapterReports(rule, testCase).map(({ messageId, data, loc }) => ({
+    messageId,
+    data,
+    loc: {
+      startLine: loc.start.line,
+      startColumn: loc.start.column,
+      endLine: loc.end.line,
+      endColumn: loc.end.column,
+    },
+  }));
+}
+
+function scanOptions(rule, testCase) {
+  const options = testCase.options ?? [];
+  const expectAliases = testCase.settings?.playwright?.globalAliases?.expect;
+  return {
+    ...(rule === 'no-restricted-locators' ? { noRestrictedLocators: options[0] } : {}),
+    ...(rule === 'no-restricted-matchers' ? { noRestrictedMatchers: options[0] } : {}),
+    ...(rule === 'no-restricted-roles' ? { noRestrictedRoles: options[0] } : {}),
+    ...(Array.isArray(expectAliases) ? { expectAliases } : {}),
+  };
+}
+
+function restrictedListSchema(requiredProperty) {
+  return {
+    items: {
+      oneOf: [
+        { type: 'string' },
+        {
+          additionalProperties: false,
+          properties: {
+            message: { type: 'string' },
+            [requiredProperty]: { type: 'string' },
+          },
+          required: [requiredProperty],
+          type: 'object',
+        },
+      ],
+    },
+    type: 'array',
+  };
+}
+
+function renderMessage(template, data) {
+  return template.replace(/\{\{(\w+)\}\}/gu, (_match, key) => data[key] ?? '');
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((left, right) => left.localeCompare(right));
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+  return candidates.at(-1);
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "port:tests:postgresql": "node tools/tasks/sync-postgresql-tests.ts",
     "port:tests:postgresql-parser": "node tools/tasks/sync-postgresql-parser-tests.ts",
     "port:tests:perfectionist:sort-named-imports": "node tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
+    "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",
     "port:tests:simple-import-sort": "node tools/tasks/sync-simple-import-sort-tests.ts",

--- a/status.json
+++ b/status.json
@@ -4242,7 +4242,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-playwright/no-restricted-locators; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Option-aware Oxc AST port of eslint-plugin-playwright/no-restricted-locators v2.10.4. It honors string/object restriction lists, custom messages, duplicate last-wins semantics, dot/string/template-computed members, nested locator chains, exact UTF-16 CallExpression ranges, NAPI/direct API forwarding, and real Oxlint TSX execution. A reproducible pinned fixture replays all 12 valid and 15 invalid upstream authored cases with 17 exact ordered diagnostics."
       },
       {
         "name": "no-restricted-matchers",
@@ -4258,7 +4258,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-playwright/no-restricted-matchers; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Option-aware Oxc AST port of eslint-plugin-playwright/no-restricted-matchers v2.10.4. It honors matcher/modifier chain maps, null/default and custom messages, dot/string/template-computed members, expect.soft/poll, configured global aliases and named Playwright expect imports, exact property-chain UTF-16 ranges, NAPI/direct API forwarding, and real Oxlint TSX execution. A reproducible pinned fixture replays all 20 valid and 13 invalid upstream authored cases with 13 exact diagnostics."
       },
       {
         "name": "no-restricted-roles",
@@ -4274,7 +4274,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-playwright/no-restricted-roles; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Option-aware Oxc AST port of eslint-plugin-playwright/no-restricted-roles v2.10.4. It honors string/object role lists, custom messages, duplicate last-wins semantics, static string/template roles, dot/string/template-computed getByRole calls, nested locator chains, exact UTF-16 CallExpression ranges, NAPI/direct API forwarding, and real Oxlint TSX execution. A reproducible pinned fixture replays all 16 valid and 18 invalid upstream authored cases with 20 exact ordered diagnostics."
       },
       {
         "name": "no-skipped-test",

--- a/tools/tasks/sync-playwright-restricted-tests.ts
+++ b/tools/tasks/sync-playwright-restricted-tests.ts
@@ -1,0 +1,220 @@
+// Captures every authored eslint-plugin-playwright v2.10.4 RuleTester case for
+// the three no-restricted-* rules from the exact vendored commit.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type RawCase =
+  | string
+  | {
+      code: string;
+      errors?: RawError[];
+      options?: unknown[];
+      settings?: unknown;
+    };
+type RawError = {
+  column?: number;
+  data?: Record<string, unknown>;
+  endColumn?: number;
+  endLine?: number;
+  line?: number;
+  messageId?: string;
+};
+type CapturedSuite = {
+  invalid: RawCase[];
+  valid: RawCase[];
+};
+type Manifest = {
+  plugins: Array<{
+    baselineVersion: string;
+    id: string;
+    license: string;
+    pinnedRef?: string;
+    submodule: string;
+  }>;
+};
+
+const ROOT = process.cwd();
+const VERSION = '2.10.4';
+const PINNED_COMMIT = '894c0ec261763bb1e073b276c70bbf88b4ebad39';
+const RULES = ['no-restricted-locators', 'no-restricted-matchers', 'no-restricted-roles'] as const;
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-playwright');
+if (!plugin) {
+  throw new Error('eslint-plugin-playwright is not registered in tools/port-targets.json');
+}
+if (plugin.baselineVersion !== VERSION || plugin.pinnedRef !== `v${VERSION}`) {
+  throw new Error(
+    `Expected eslint-plugin-playwright v${VERSION}, received ` +
+      `${plugin.baselineVersion} / ${plugin.pinnedRef}`,
+  );
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(
+    `Upstream checkout not found at ${submodule}. ` +
+      `Run \`git submodule update --init ${plugin.submodule}\` first.`,
+  );
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${plugin.submodule} at ${PINNED_COMMIT}, received ${actualCommit}.`);
+}
+
+const sourceFiles = RULES.flatMap((rule) => [`src/rules/${rule}.ts`, `src/rules/${rule}.test.ts`]);
+const sourceHashes = Object.fromEntries(
+  sourceFiles.map((sourceFile) => {
+    const source = upstreamSource(sourceFile);
+    return [sourceFile, createHash('sha256').update(source).digest('hex')];
+  }),
+);
+const suites = RULES.map((rule) => {
+  const capture = captureSuite(rule, upstreamSource(`src/rules/${rule}.test.ts`));
+  return {
+    rule,
+    valid: capture.valid.map((testCase, index) =>
+      normalizeCase(testCase, false, `${rule} valid ${index}`),
+    ),
+    invalid: capture.invalid.map((testCase, index) =>
+      normalizeCase(testCase, true, `${rule} invalid ${index}`),
+    ),
+  };
+});
+const inventory = suites.map((suite) => ({
+  rule: suite.rule,
+  valid: suite.valid.length,
+  invalid: suite.invalid.length,
+  diagnostics: suite.invalid.reduce(
+    (total, testCase) => total + testCase.expectedDiagnostics.length,
+    0,
+  ),
+}));
+const fixture = {
+  __generated: {
+    source: 'eslint-plugin-playwright',
+    version: VERSION,
+    sourceCommit: PINNED_COMMIT,
+    license: plugin.license,
+    tool: 'tools/tasks/sync-playwright-restricted-tests.ts',
+    sourceFiles,
+    sourceHashes,
+    inventory: {
+      suites: inventory,
+      valid: inventory.reduce((total, entry) => total + entry.valid, 0),
+      invalid: inventory.reduce((total, entry) => total + entry.invalid, 0),
+      diagnostics: inventory.reduce((total, entry) => total + entry.diagnostics, 0),
+    },
+  },
+  suites,
+};
+
+const outputDirectory = join(ROOT, 'npm', 'playwright', 'test', 'fixtures');
+mkdirSync(outputDirectory, { recursive: true });
+const outputPath = join(outputDirectory, `restricted-v${VERSION}.json`);
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { stdio: 'ignore' });
+console.log(
+  `Captured ${fixture.__generated.inventory.valid} valid, ` +
+    `${fixture.__generated.inventory.invalid} invalid, and ` +
+    `${fixture.__generated.inventory.diagnostics} exact diagnostics in ${outputPath}.`,
+);
+
+function captureSuite(rule: string, source: string): CapturedSuite {
+  const test = (input: string): string => `test('test', async () => { ${input} })`;
+  const executable = source.replace(/^import .*$/gmu, '');
+  const sandbox: {
+    captured?: CapturedSuite;
+    dedent: typeof dedent;
+    rule: object;
+    runRuleTester: (
+      capturedRule: string,
+      capturedRuleModule: unknown,
+      suite: CapturedSuite,
+    ) => void;
+    test: typeof test;
+  } = {
+    dedent,
+    rule: {},
+    runRuleTester(capturedRule, _capturedRuleModule, suite) {
+      if (capturedRule !== rule) {
+        throw new Error(`Expected ${rule}, captured ${capturedRule}.`);
+      }
+      sandbox.captured = suite;
+    },
+    test,
+  };
+  runInNewContext(`"use strict";\n${executable}`, sandbox);
+  if (!sandbox.captured) {
+    throw new Error(`Failed to capture ${rule}.`);
+  }
+  return sandbox.captured;
+}
+
+function normalizeCase(testCase: RawCase, invalid: boolean, label: string) {
+  const normalized = typeof testCase === 'string' ? { code: testCase } : testCase;
+  if (typeof normalized.code !== 'string') {
+    throw new Error(`${label} is missing source code.`);
+  }
+  const errors = invalid ? normalized.errors : [];
+  if (invalid && (!Array.isArray(errors) || errors.length === 0)) {
+    throw new Error(`${label} is missing expected errors.`);
+  }
+  return {
+    code: normalized.code,
+    options: normalized.options ?? [],
+    settings: normalized.settings ?? null,
+    expectedDiagnostics: (errors ?? []).map((error, index) =>
+      normalizeError(error, `${label} error ${index}`),
+    ),
+  };
+}
+
+function normalizeError(error: RawError, label: string) {
+  if (
+    typeof error.messageId !== 'string' ||
+    typeof error.column !== 'number' ||
+    typeof error.endColumn !== 'number'
+  ) {
+    throw new Error(`${label} is missing its exact diagnostic contract.`);
+  }
+  const line = error.line ?? 1;
+  return {
+    messageId: error.messageId,
+    data: error.data ?? {},
+    loc: {
+      startLine: line,
+      startColumn: error.column - 1,
+      endLine: error.endLine ?? line,
+      endColumn: error.endColumn - 1,
+    },
+  };
+}
+
+function upstreamSource(sourceFile: string): string {
+  return execFileSync('git', ['-C', submodule, 'show', `${PINNED_COMMIT}:${sourceFile}`], {
+    encoding: 'utf8',
+  });
+}
+
+function dedent(strings: TemplateStringsArray | string, ...values: unknown[]): string {
+  const value =
+    typeof strings === 'string' ? strings : String.raw({ raw: [...strings.raw] }, ...values);
+  const lines = value
+    .replace(/^\n/u, '')
+    .replace(/\n\s*$/u, '')
+    .split('\n');
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^\s*/u)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join('\n');
+}


### PR DESCRIPTION
## Summary
- implement configured values for `no-restricted-locators`, `no-restricted-matchers`, and `no-restricted-roles` using the Oxc AST
- support string/object restrictions, custom/default messages, duplicate last-wins behavior, computed/static/template access, matcher chains, settings aliases, and named import aliases
- remove the old hardcoded detections so empty options are inert and expose exact upstream schemas/messages through NAPI, direct API, plugin, real Oxlint, README, and status

## Tests
- deterministic pinned eslint-plugin-playwright v2.10.4 fixture: all 94 authored cases (48 valid, 46 invalid), 50 exact diagnostics through both the native API and plugin
- targeted Playwright JS: 162 passed
- targeted Playwright Rust: 5 passed
- full `pnpm verify`: 105 JS files, 16,109 passed and 1,159 skipped; workspace Rust/doc tests, Clippy, benches, security, licenses, status, and publish-ready package checks passed
- fixture regeneration is deterministic across repeated runs

This is the restricted-rule slice of #420. Remaining Playwright option families stay in separate small follow-up PRs. React and JSX plugins are intentionally out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->