### PR TITLE
feat(angular-eslint): support class suffix options

### DIFF
--- a/crates/angular_eslint/src/class_suffix.rs
+++ b/crates/angular_eslint/src/class_suffix.rs
@@ -1,0 +1,350 @@
+use oxc_ast::ast::{
+    Class, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey, TSTypeName,
+};
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::scanner::Scanner;
+use crate::types::{Diagnostic, DiagnosticDatum};
+
+const COMPONENT_CLASS_SUFFIX: &str = "component-class-suffix";
+const DIRECTIVE_CLASS_SUFFIX: &str = "directive-class-suffix";
+const VALIDATOR_SUFFIX: &str = "Validator";
+
+impl Scanner<'_> {
+    pub(crate) fn check_class_suffix_decorators(&mut self, class: &Class<'_>) {
+        for decorator in &class.decorators {
+            let Expression::CallExpression(call) = decorator.expression.get_inner_expression()
+            else {
+                continue;
+            };
+            let Expression::Identifier(callee) = call.callee.get_inner_expression() else {
+                continue;
+            };
+            match callee.name.as_str() {
+                "Component" if self.options.is_enabled(COMPONENT_CLASS_SUFFIX) => {
+                    let suffixes = configured_suffixes(&self.options.options, "Component");
+                    self.check_class_suffix(
+                        class,
+                        COMPONENT_CLASS_SUFFIX,
+                        "componentClassSuffix",
+                        suffixes,
+                    );
+                }
+                "Directive"
+                    if self.options.is_enabled(DIRECTIVE_CLASS_SUFFIX)
+                        && call
+                            .arguments
+                            .first()
+                            .and_then(|argument| argument.as_expression())
+                            .is_some_and(|expression| {
+                                let Expression::ObjectExpression(metadata) =
+                                    expression.get_inner_expression()
+                                else {
+                                    return false;
+                                };
+                                has_selector_property(metadata)
+                            }) =>
+                {
+                    let mut suffixes = configured_suffixes(&self.options.options, "Directive");
+                    if implements_validator(class) {
+                        suffixes.push(CompactString::from(VALIDATOR_SUFFIX));
+                    }
+                    self.check_class_suffix(
+                        class,
+                        DIRECTIVE_CLASS_SUFFIX,
+                        "directiveClassSuffix",
+                        suffixes,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn check_class_suffix(
+        &mut self,
+        class: &Class<'_>,
+        rule_name: &'static str,
+        message_id: &'static str,
+        suffixes: SmallVec<[CompactString; 4]>,
+    ) {
+        let class_name = class.id.as_ref().map(|identifier| identifier.name.as_str());
+        if class_name.is_some_and(|name| {
+            suffixes
+                .iter()
+                .any(|suffix| name.ends_with(suffix.as_str()))
+        }) {
+            return;
+        }
+        let span = class
+            .id
+            .as_ref()
+            .map_or(class.span, |identifier| identifier.span);
+        let mut data = SmallVec::new();
+        data.push(DiagnosticDatum {
+            key: CompactString::from("suffixes"),
+            value: human_readable_suffixes(&suffixes),
+        });
+        self.report_class_suffix(rule_name, message_id, data, span);
+    }
+
+    fn report_class_suffix(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        data: SmallVec<[DiagnosticDatum; 2]>,
+        span: Span,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+fn configured_suffixes(options: &Value, default_suffix: &str) -> SmallVec<[CompactString; 4]> {
+    let configured = options
+        .as_array()
+        .and_then(|options| options.first())
+        .and_then(Value::as_object)
+        .and_then(|option| option.get("suffixes"))
+        .and_then(Value::as_array);
+    match configured {
+        Some(suffixes) => suffixes
+            .iter()
+            .filter_map(Value::as_str)
+            .map(CompactString::from)
+            .collect(),
+        None => {
+            let mut suffixes = SmallVec::new();
+            suffixes.push(CompactString::from(default_suffix));
+            suffixes
+        }
+    }
+}
+
+fn has_selector_property(metadata: &ObjectExpression<'_>) -> bool {
+    metadata.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return false;
+        };
+        property_name(&property.key) == Some("selector")
+    })
+}
+
+fn property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
+fn implements_validator(class: &Class<'_>) -> bool {
+    class.implements.iter().any(|implementation| {
+        type_name(&implementation.expression).is_some_and(|name| name.ends_with(VALIDATOR_SUFFIX))
+    })
+}
+
+fn type_name<'a>(name: &'a TSTypeName<'a>) -> Option<&'a str> {
+    match name {
+        TSTypeName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        TSTypeName::QualifiedName(qualified) => Some(qualified.right.name.as_str()),
+        TSTypeName::ThisExpression(_) => None,
+    }
+}
+
+fn human_readable_suffixes(suffixes: &[CompactString]) -> CompactString {
+    let mut output = CompactString::new("");
+    for (index, suffix) in suffixes.iter().enumerate() {
+        if index > 0 {
+            if index + 1 == suffixes.len() {
+                output.push_str(" or ");
+            } else {
+                output.push_str(", ");
+            }
+        }
+        output.push('"');
+        output.push_str(suffix);
+        output.push('"');
+    }
+    output
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "Pinned upstream option cases use serde_json::json and Vec-shaped assertions to mirror the JavaScript ABI exactly."
+)]
+mod tests {
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use serde_json::{Value, json};
+
+    use super::{COMPONENT_CLASS_SUFFIX, DIRECTIVE_CLASS_SUFFIX};
+    use crate::{Diagnostic, ScanOptions, scan_angular_eslint_with_options};
+
+    // Pinned from angular-eslint v22.0.0, commit
+    // 7ee4556badebf8c140ffdefdd0b07b02820d5e96.
+    fn scan(rule_name: &str, source: &str, options: Value) -> Vec<Diagnostic> {
+        let mut rule_names = SmallVec::new();
+        rule_names.push(CompactString::from(rule_name));
+        scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names,
+                options,
+            },
+        )
+        .into_vec()
+    }
+
+    #[test]
+    fn ports_the_upstream_component_class_suffix_cases() {
+        let valid = [
+            "@Component({ selector: 'sg-foo-bar' }) class TestComponent {}",
+            "@Directive({ selector: '[myHighlight]' }) class TestDirective {}",
+            "@Pipe({ name: 'sg-test-pipe' }) class TestPipe {}",
+            "@Injectable() class TestService {}",
+            "class TestEmpty {}",
+        ];
+        for source in valid {
+            assert!(scan(COMPONENT_CLASS_SUFFIX, source, Value::Null).is_empty());
+        }
+        for (source, option) in [
+            (
+                "@Component({ selector: 'sgBarFoo' }) class TestPage {}",
+                json!([{"suffixes":["Page"]}]),
+            ),
+            (
+                "@Component({ selector: 'sgBarFoo' }) class TestView {}",
+                json!([{"suffixes":["Page","View"]}]),
+            ),
+        ] {
+            assert!(scan(COMPONENT_CLASS_SUFFIX, source, option).is_empty());
+        }
+
+        let invalid = [
+            (
+                "@Component({ selector: 'sg-foo-bar' }) class Test {}",
+                Value::Null,
+                "\"Component\"",
+            ),
+            (
+                "@Component({ selector: 'sgBarFoo' }) class TestPage {}",
+                json!([{"suffixes":["Component","View"]}]),
+                "\"Component\" or \"View\"",
+            ),
+            (
+                "@Component({ selector: 'sgBarFoo' }) class TestPage {}",
+                json!([{"suffixes":["Component"]}]),
+                "\"Component\"",
+            ),
+            (
+                "@Component({ selector: 'sgBarFoo' }) class TestDirective {}",
+                json!([{"suffixes":["Page"]}]),
+                "\"Page\"",
+            ),
+        ];
+        for (source, option, suffixes) in invalid {
+            let diagnostics = scan(COMPONENT_CLASS_SUFFIX, source, option);
+            assert_eq!(diagnostics.len(), 1, "{source}");
+            assert_eq!(diagnostics[0].message_id, "componentClassSuffix");
+            assert_eq!(diagnostics[0].data[0].key, "suffixes");
+            assert_eq!(diagnostics[0].data[0].value, suffixes);
+        }
+    }
+
+    #[test]
+    fn ports_the_upstream_directive_class_suffix_cases() {
+        let valid = [
+            "@Directive({ selector: 'sgBarFoo' }) class TestDirective {}",
+            "@Directive({ selector: 'sgBarFoo' }) class TestValidator implements Validator {}",
+            "@Directive({ selector: 'sgBarFoo' }) class TestValidator implements AsyncValidator {}",
+            "@Directive class Test {}",
+            "@Directive() class Test {}",
+            "@Component({ selector: 'sg-bar-foo' }) class TestComponent {}",
+            "@Pipe({ name: 'sgPipe' }) class TestPipe {}",
+            "@Injectable() class TestService {}",
+            "class TestEmpty {}",
+        ];
+        for source in valid {
+            assert!(scan(DIRECTIVE_CLASS_SUFFIX, source, Value::Null).is_empty());
+        }
+        for (source, option) in [
+            (
+                "@Directive({ selector: 'sgBarFoo' }) class TestDir {}",
+                json!([{"suffixes":["Dir"]}]),
+            ),
+            (
+                "@Directive({ selector: 'sgBarFoo' }) class TestView {}",
+                json!([{"suffixes":["Page","View"]}]),
+            ),
+        ] {
+            assert!(scan(DIRECTIVE_CLASS_SUFFIX, source, option).is_empty());
+        }
+
+        let invalid = [
+            (
+                "@Directive({ selector: 'sg-foo-bar' }) class Test {}",
+                Value::Null,
+                "\"Directive\"",
+            ),
+            (
+                "@Directive({ selector: 'sg-foo-bar' }) class TestDirectivePage implements AsyncValidator {}",
+                Value::Null,
+                "\"Directive\" or \"Validator\"",
+            ),
+            (
+                "@Directive({ selector: 'sgBarFoo' }) class TestPageDirective {}",
+                json!([{"suffixes":["Page"]}]),
+                "\"Page\"",
+            ),
+        ];
+        for (source, option, suffixes) in invalid {
+            let diagnostics = scan(DIRECTIVE_CLASS_SUFFIX, source, option);
+            assert_eq!(diagnostics.len(), 1, "{source}");
+            assert_eq!(diagnostics[0].message_id, "directiveClassSuffix");
+            assert_eq!(diagnostics[0].data[0].key, "suffixes");
+            assert_eq!(diagnostics[0].data[0].value, suffixes);
+        }
+    }
+
+    #[test]
+    fn covers_multiple_classes_rule_selection_utf16_and_edge_options() {
+        let source = concat!(
+            "const emoji = '😀';\n",
+            "@Component({}) class First {}\n",
+            "@Component({}) class SecondPage {}\n",
+            "@Directive({ selector: dynamicSelector }) class ThirdValidator implements forms.AsyncValidator {}\n",
+            "@Directive({ other: true }) class Ignored {}\n",
+        );
+        let component_diagnostics = scan(
+            COMPONENT_CLASS_SUFFIX,
+            source,
+            json!([{"suffixes":["Page"]}]),
+        );
+        assert_eq!(component_diagnostics.len(), 1);
+        assert_eq!(component_diagnostics[0].loc.start_line, 2);
+        assert_eq!(component_diagnostics[0].loc.start_column, 21);
+        assert_eq!(component_diagnostics[0].loc.end_column, 26);
+
+        let directive_diagnostics = scan(DIRECTIVE_CLASS_SUFFIX, source, Value::Null);
+        assert!(directive_diagnostics.is_empty());
+        assert!(scan(COMPONENT_CLASS_SUFFIX, source, json!([{"suffixes":[]}])).len() == 2);
+        assert!(scan(COMPONENT_CLASS_SUFFIX, "class 😀 {}", Value::Null).is_empty());
+        assert!(
+            scan(
+                DIRECTIVE_CLASS_SUFFIX,
+                "@Directive({ selector: 'x' }) class Wrong {}",
+                json!([{"suffixes":["Wrong"]}]),
+            )
+            .is_empty()
+        );
+    }
+}

--- a/crates/angular_eslint/src/lib.rs
+++ b/crates/angular_eslint/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = "Rust implementation of @angular-eslint/eslint-plugin rule logic."]
 
+mod class_suffix;
 mod scanner;
 mod selector;
 mod types;

--- a/crates/angular_eslint/src/scanner.rs
+++ b/crates/angular_eslint/src/scanner.rs
@@ -18,7 +18,6 @@ pub(crate) struct Scanner<'a> {
 
 impl<'a> Scanner<'a> {
     pub(crate) fn scan(&mut self, program: &Program<'a>) {
-        self.check_class_suffix("component-class-suffix", "@Component", "Component");
         self.check_regex(
             "component-max-inline-declarations",
             r#"(?s)template\s*:\s*`[^`]*\n[^`]*\n[^`]*`"#,
@@ -36,7 +35,6 @@ impl<'a> Scanner<'a> {
             "contextual-lifecycle",
             r#"class\s+\w+\s*\{[^}]*\bngOnInit\s*\("#,
         );
-        self.check_class_suffix("directive-class-suffix", "@Directive", "Directive");
         self.check_regex(
             "no-async-lifecycle-method",
             r#"async\s+ng(OnInit|OnDestroy|AfterViewInit|OnChanges)\s*\("#,
@@ -148,33 +146,6 @@ impl<'a> Scanner<'a> {
                 rule_name,
                 Span::new(index as u32, (index + needle.len()) as u32),
             );
-        }
-    }
-
-    fn check_class_suffix(&mut self, rule_name: &'static str, decorator: &str, suffix: &str) {
-        if !self.options.is_enabled(rule_name) {
-            return;
-        }
-        if self.has_reported(rule_name) {
-            return;
-        }
-        let Some(decorator_index) = self.source_text.find(decorator) else {
-            return;
-        };
-        let Some(class_offset) = self.source_text[decorator_index..].find("class ") else {
-            return;
-        };
-        let class_index = decorator_index + class_offset;
-        let name_start = class_index + "class ".len();
-        let name_end = self.source_text[name_start..]
-            .find(|ch: char| !ch.is_alphanumeric() && ch != '_')
-            .map_or(self.source_text.len(), |offset| name_start + offset);
-        if name_end <= name_start {
-            return;
-        }
-        let class_name = &self.source_text[name_start..name_end];
-        if !class_name.ends_with(suffix) {
-            self.report(rule_name, Span::new(name_start as u32, name_end as u32));
         }
     }
 

--- a/crates/angular_eslint/src/selector.rs
+++ b/crates/angular_eslint/src/selector.rs
@@ -72,6 +72,7 @@ struct ParsedSelector {
 
 impl Visit<'_> for Scanner<'_> {
     fn visit_class(&mut self, class: &Class<'_>) {
+        self.check_class_suffix_decorators(class);
         self.check_selector_decorators(class);
         walk::walk_class(self, class);
     }

--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -13,6 +13,32 @@ const DOCS_BASE =
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedAngularEslintRuleNames());
 const selectorRuleNames = new Set(['component-selector', 'directive-selector']);
+const classSuffixRuleNames = new Set(['component-class-suffix', 'directive-class-suffix']);
+const optionAwareRuleNames = new Set([...selectorRuleNames, ...classSuffixRuleNames]);
+
+const classSuffixSchema = [
+  {
+    type: 'object',
+    properties: {
+      suffixes: {
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+    additionalProperties: false,
+  },
+];
+
+const classSuffixMessages = {
+  'component-class-suffix': {
+    componentClassSuffix:
+      'Component class names should end with one of these suffixes: {{suffixes}}',
+  },
+  'directive-class-suffix': {
+    directiveClassSuffix:
+      'Directive class names should end with one of these suffixes: {{suffixes}}',
+  },
+};
 
 const selectorConfigSchema = {
   type: 'object',
@@ -124,6 +150,7 @@ plugin.scanAngularEslint = scanAngularEslint;
 
 function createAngularEslintRule(ruleName) {
   const isSelectorRule = selectorRuleNames.has(ruleName);
+  const isClassSuffixRule = classSuffixRuleNames.has(ruleName);
   return {
     meta: {
       type: problemRules.has(ruleName) ? 'problem' : 'suggestion',
@@ -135,10 +162,12 @@ function createAngularEslintRule(ruleName) {
       },
       messages: isSelectorRule
         ? selectorMessages[ruleName]
-        : {
-            unexpected: 'Unexpected Angular pattern.',
-          },
-      schema: isSelectorRule ? selectorSchema : [],
+        : isClassSuffixRule
+          ? classSuffixMessages[ruleName]
+          : {
+              unexpected: 'Unexpected Angular pattern.',
+            },
+      schema: isSelectorRule ? selectorSchema : isClassSuffixRule ? classSuffixSchema : [],
     },
     createOnce(context) {
       return {
@@ -153,7 +182,7 @@ function createAngularEslintRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
-  if (selectorRuleNames.has(ruleName)) {
+  if (optionAwareRuleNames.has(ruleName)) {
     const sourceText = sourceTextForContext(context);
     const filename = typeof context.filename === 'string' ? context.filename : 'file.ts';
     return scanAngularEslint(sourceText, filename, {

--- a/npm/angular-eslint/test/api.test.mjs
+++ b/npm/angular-eslint/test/api.test.mjs
@@ -188,6 +188,64 @@ describe('angular-eslint native API', () => {
     ).toEqual([]);
   });
 
+  it.each([
+    ['component-class-suffix', '@Component({}) class TestPage {}', [{ suffixes: ['Page'] }], []],
+    [
+      'component-class-suffix',
+      '@Component({}) class TestPage {}',
+      [{ suffixes: ['Component', 'View'] }],
+      [
+        {
+          messageId: 'componentClassSuffix',
+          data: [{ key: 'suffixes', value: '"Component" or "View"' }],
+        },
+      ],
+    ],
+    ['component-class-suffix', '@Component({}) class TestComponent {}', [], []],
+    [
+      'component-class-suffix',
+      '@Component({}) class TestComponent {}',
+      [{ suffixes: [] }],
+      [
+        {
+          messageId: 'componentClassSuffix',
+          data: [{ key: 'suffixes', value: '' }],
+        },
+      ],
+    ],
+    [
+      'directive-class-suffix',
+      '@Directive({ selector: "[x]" }) class TestDir {}',
+      [{ suffixes: ['Dir'] }],
+      [],
+    ],
+    [
+      'directive-class-suffix',
+      '@Directive({ selector: "[x]" }) class TestDirectivePage implements AsyncValidator {}',
+      [],
+      [
+        {
+          messageId: 'directiveClassSuffix',
+          data: [{ key: 'suffixes', value: '"Directive" or "Validator"' }],
+        },
+      ],
+    ],
+    [
+      'directive-class-suffix',
+      '@Directive({ selector: "[x]" }) class TestValidator implements forms.AsyncValidator {}',
+      [],
+      [],
+    ],
+    ['directive-class-suffix', '@Directive() class Test {}', [{ suffixes: [] }], []],
+  ])('honors %s suffix options through the native API', (ruleName, source, options, expected) => {
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: [ruleName],
+        options,
+      }),
+    ).toMatchObject(expected);
+  });
+
   it('returns LSP-shaped locations', () => {
     const [diagnostic] = scanAngularEslint(
       '@Component({ selector: "app-x" }) class App {}\n',
@@ -196,7 +254,8 @@ describe('angular-eslint native API', () => {
 
     expect(diagnostic).toMatchObject({
       ruleName: 'component-class-suffix',
-      messageId: 'unexpected',
+      messageId: 'componentClassSuffix',
+      data: [{ key: 'suffixes', value: '"Component"' }],
       loc: {
         startLine: 1,
         endLine: 1,

--- a/npm/angular-eslint/test/plugin.test.mjs
+++ b/npm/angular-eslint/test/plugin.test.mjs
@@ -176,9 +176,59 @@ describe('angular-eslint plugin adapter', () => {
     const reports = runRule(ruleName, code);
 
     expect(reports).toHaveLength(1);
+    const expectedMessages = {
+      'component-class-suffix':
+        'Component class names should end with one of these suffixes: {{suffixes}}',
+      'directive-class-suffix':
+        'Directive class names should end with one of these suffixes: {{suffixes}}',
+    };
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      'Unexpected Angular pattern.',
+      expectedMessages[ruleName] || 'Unexpected Angular pattern.',
     );
+  });
+
+  it('exposes complete class-suffix schemas and messages', () => {
+    for (const ruleName of ['component-class-suffix', 'directive-class-suffix']) {
+      const { meta } = plugin.rules[ruleName];
+      expect(meta.schema).toEqual([
+        {
+          type: 'object',
+          properties: {
+            suffixes: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+          additionalProperties: false,
+        },
+      ]);
+      expect(Object.values(meta.messages)).toEqual([expect.stringContaining('{{suffixes}}')]);
+    }
+  });
+
+  it.each([
+    ['component-class-suffix', '@Component({}) class TestPage {}', [{ suffixes: ['Page'] }], []],
+    [
+      'component-class-suffix',
+      '@Component({}) class TestPage {}',
+      [{ suffixes: ['Component', 'View'] }],
+      [{ messageId: 'componentClassSuffix', data: { suffixes: '"Component" or "View"' } }],
+    ],
+    [
+      'directive-class-suffix',
+      '@Directive({ selector: "[x]" }) class TestDir {}',
+      [{ suffixes: ['Dir'] }],
+      [],
+    ],
+    [
+      'directive-class-suffix',
+      '@Directive({ selector: "[x]" }) class TestDirectivePage implements AsyncValidator {}',
+      [],
+      [{ messageId: 'directiveClassSuffix', data: { suffixes: '"Directive" or "Validator"' } }],
+    ],
+    ['directive-class-suffix', '@Directive() class Wrong {}', [{ suffixes: [] }], []],
+  ])('honors configured %s suffixes through createOnce', (ruleName, code, options, expected) => {
+    expect(runRule(ruleName, code, options)).toMatchObject(expected);
   });
 
   it('exposes the complete selector schemas and messages', () => {
@@ -348,7 +398,55 @@ describe('angular-eslint plugin adapter', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toBe('');
       expect(payload.diagnostics).toHaveLength(1);
-      expect(payload.diagnostics[0].message).toBe('Unexpected Angular pattern.');
+      expect(payload.diagnostics[0].message).toBe(
+        'Component class names should end with one of these suffixes: "Component"',
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors class-suffix options through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-class-suffix-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.ts'),
+        '@Component({ selector: "app-x" }) class AppComponent {}\n' +
+          '@Component({ selector: "app-y" }) class SettingsPage {}\n',
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: '@angular-eslint',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            '@angular-eslint/component-class-suffix': ['error', { suffixes: ['Page', 'View'] }],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toMatchObject([
+        {
+          code: '@angular-eslint(component-class-suffix)',
+          message: 'Component class names should end with one of these suffixes: "Page" or "View"',
+        },
+      ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- replace the first-match class-suffix regexes with Oxc decorator/class AST handling for `component-class-suffix` and `directive-class-suffix`
- honor custom `suffixes`, upstream defaults, empty lists, multiple decorated classes, and the Directive `Validator`/`AsyncValidator` exception
- expose exact upstream schemas, message IDs, message data, UTF-16 locations, direct API behavior, plugin behavior, real Oxlint integration, and playground diagnostics

## Tests
- pinned angular-eslint v22.0.0 authored component/directive cases plus multiple-class, qualified-validator, dynamic-selector, empty-suffix, rule-selection, malformed-input, and UTF-16 coverage
- targeted Angular JS: 90 passed
- targeted Angular Rust: 8 passed
- full `pnpm verify`: 104 JS files, 15,980 passed and 1,159 skipped; workspace Rust/doc tests, Clippy, benches, security, licenses, status, and publish-ready package checks passed
- post-rebase NAPI rebuild, 90 JS tests, 8 Rust tests, and targeted Clippy passed

This is the class-suffix slice of #419. Remaining Angular option families stay in separate small follow-up PRs. React and JSX plugins are intentionally out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->