### PR TITLE
feat(astro): port deprecated frontmatter rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugin-astro"
+version = "0.0.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxlint-plugins-_carton",
+ "oxlint-plugins-astro",
+]
+
+[[package]]
 name = "oxlint-plugin-cypress"
 version = "0.0.0"
 dependencies = [
@@ -1344,6 +1355,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxlint-plugins-astro"
+version = "0.0.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_span",
+ "oxlint-plugins-_carton",
+]
+
+[[package]]
 name = "oxlint-plugins-cypress"
 version = "0.0.0"
 dependencies = [
@@ -1446,6 +1470,7 @@ dependencies = [
  "oxc_span",
  "oxlint-plugins-_carton",
  "oxlint-plugins-angular-eslint",
+ "oxlint-plugins-astro",
  "oxlint-plugins-cypress",
  "oxlint-plugins-e18e",
  "oxlint-plugins-eslint-comments",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/_carton",
   "crates/angular_eslint",
+  "crates/astro",
   "crates/cypress",
   "crates/e18e",
   "crates/eslint_comments",
@@ -23,6 +24,7 @@ members = [
   "crates/unocss",
   "crates/unused_imports",
   "npm/angular-eslint",
+  "npm/astro",
   "npm/cypress",
   "npm/e18e",
   "npm/eslint-comments",
@@ -74,6 +76,7 @@ oxc_span = "0.135.0"
 oxc_syntax = "0.135.0"
 oxlint-plugins-carton = { package = "oxlint-plugins-_carton", path = "crates/_carton", version = "0.0.0" }
 oxlint-plugins-angular-eslint = { path = "crates/angular_eslint", version = "0.0.0" }
+oxlint-plugins-astro = { path = "crates/astro", version = "0.0.0" }
 oxlint-plugins-cypress = { path = "crates/cypress", version = "0.0.0" }
 oxlint-plugins-e18e = { path = "crates/e18e", version = "0.0.0" }
 oxlint-plugins-eslint-comments = { path = "crates/eslint_comments", version = "0.0.0" }

--- a/crates/astro/Cargo.toml
+++ b/crates/astro/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "oxlint-plugins-astro"
+description = "Rust implementation of selected eslint-plugin-astro rules."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_ast_visit.workspace = true
+oxc_parser.workspace = true
+oxc_semantic.workspace = true
+oxc_span.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[lints]
+workspace = true

--- a/crates/astro/src/lib.rs
+++ b/crates/astro/src/lib.rs
@@ -1,0 +1,358 @@
+#![doc = "Rust implementation of selected eslint-plugin-astro rule logic."]
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    ComputedMemberExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
+    ModuleExportName, StaticMemberExpression,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_semantic::Scoping;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::{GetSpan, SourceType, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub const RULE_NAMES: [&str; 3] = [
+    "no-deprecated-astro-canonicalurl",
+    "no-deprecated-astro-fetchcontent",
+    "no-deprecated-getentrybyslug",
+];
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AstroOptions {
+    /// Empty means all implemented rules are enabled.
+    pub rule_names: SmallVec<[CompactString; 4]>,
+    /// The caller already extracted the TypeScript frontmatter segment.
+    pub frontmatter_only: bool,
+}
+
+impl AstroOptions {
+    fn has_rule(&self, name: &str) -> bool {
+        self.rule_names.is_empty() || self.rule_names.iter().any(|rule| rule == name)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticLoc {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiagnosticFix {
+    /// UTF-8 byte offset into the original `.astro` source.
+    pub start: u32,
+    /// UTF-8 byte offset into the original `.astro` source.
+    pub end: u32,
+    pub replacement: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub rule_name: &'static str,
+    pub message_id: &'static str,
+    pub loc: DiagnosticLoc,
+    pub fix: Option<DiagnosticFix>,
+}
+
+pub fn implemented_astro_rule_names() -> &'static [&'static str] {
+    &RULE_NAMES
+}
+
+/// Scans the first Astro frontmatter block.
+///
+/// Direct callers can pass raw `.astro` source; Oxlint's JavaScript-plugin path
+/// passes its extracted frontmatter through [`AstroOptions::frontmatter_only`].
+/// This core deliberately parses only that TypeScript segment with Oxc.
+/// Template rules remain out of scope until a separate expression segmenter is
+/// added.
+pub fn scan_astro(
+    source_text: &str,
+    filename: &str,
+    options: &AstroOptions,
+) -> SmallVec<[Diagnostic; 8]> {
+    if !has_astro_extension(filename) {
+        return SmallVec::new();
+    }
+    let frontmatter = if options.frontmatter_only {
+        Frontmatter {
+            source: source_text,
+            offset: 0,
+        }
+    } else {
+        let Some(frontmatter) = frontmatter(source_text) else {
+            return SmallVec::new();
+        };
+        frontmatter
+    };
+
+    let allocator = Allocator::default();
+    let parser_return = Parser::new(
+        &allocator,
+        frontmatter.source,
+        SourceType::ts().with_module(true),
+    )
+    .parse();
+    if !parser_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+    let semantic_return = SemanticBuilder::new().build(&parser_return.program);
+    if !semantic_return.errors.is_empty() {
+        return SmallVec::new();
+    }
+
+    let line_index = LineIndex::new(source_text);
+    let mut scanner = Scanner {
+        source_text,
+        source_offset: frontmatter.offset,
+        options,
+        line_index: &line_index,
+        scoping: semantic_return.semantic.scoping(),
+        diagnostics: SmallVec::new(),
+    };
+    scanner.visit_program(&parser_return.program);
+    scanner.diagnostics.sort_by(|left, right| {
+        left.loc
+            .start_line
+            .cmp(&right.loc.start_line)
+            .then(left.loc.start_column.cmp(&right.loc.start_column))
+            .then(left.rule_name.cmp(right.rule_name))
+    });
+    scanner.diagnostics
+}
+
+fn has_astro_extension(filename: &str) -> bool {
+    filename
+        .rsplit_once('.')
+        .is_some_and(|(_, extension)| extension.eq_ignore_ascii_case("astro"))
+}
+
+#[derive(Clone, Copy)]
+struct Frontmatter<'a> {
+    source: &'a str,
+    offset: u32,
+}
+
+fn frontmatter(source: &str) -> Option<Frontmatter<'_>> {
+    let bom_len = usize::from(source.starts_with('\u{feff}')) * '\u{feff}'.len_utf8();
+    let opening = read_line(source, bom_len)?;
+    if opening.text.trim_end_matches([' ', '\t']) != "---" || opening.next == source.len() {
+        return None;
+    }
+
+    let content_start = opening.next;
+    let mut cursor = content_start;
+    while cursor <= source.len() {
+        let line = read_line(source, cursor)?;
+        if line.text.trim_end_matches([' ', '\t']) == "---" {
+            return Some(Frontmatter {
+                source: &source[content_start..line.start],
+                offset: u32::try_from(content_start).ok()?,
+            });
+        }
+        if line.next == cursor || line.next == source.len() {
+            return None;
+        }
+        cursor = line.next;
+    }
+    None
+}
+
+#[derive(Clone, Copy)]
+struct Line<'a> {
+    start: usize,
+    text: &'a str,
+    next: usize,
+}
+
+fn read_line(source: &str, start: usize) -> Option<Line<'_>> {
+    if start > source.len() || !source.is_char_boundary(start) {
+        return None;
+    }
+    let tail = &source[start..];
+    for (relative, ch) in tail.char_indices() {
+        let separator_len = match ch {
+            '\n' | '\u{2028}' | '\u{2029}' => ch.len_utf8(),
+            '\r' => {
+                if tail[relative + 1..].starts_with('\n') {
+                    2
+                } else {
+                    1
+                }
+            }
+            _ => continue,
+        };
+        return Some(Line {
+            start,
+            text: &source[start..start + relative],
+            next: start + relative + separator_len,
+        });
+    }
+    Some(Line {
+        start,
+        text: tail,
+        next: source.len(),
+    })
+}
+
+struct Scanner<'s> {
+    source_text: &'s str,
+    source_offset: u32,
+    options: &'s AstroOptions,
+    line_index: &'s LineIndex,
+    scoping: &'s Scoping,
+    diagnostics: SmallVec<[Diagnostic; 8]>,
+}
+
+impl Scanner<'_> {
+    fn is_global_astro(&self, expression: &Expression<'_>) -> bool {
+        let Expression::Identifier(identifier) = expression.get_inner_expression() else {
+            return false;
+        };
+        if identifier.name != "Astro" {
+            return false;
+        }
+        let Some(reference_id) = identifier.reference_id.get() else {
+            return false;
+        };
+        let reference = self.scoping.get_reference(reference_id);
+        reference.symbol_id().is_none() && reference.is_read()
+    }
+
+    fn report(&mut self, rule_name: &'static str, span: Span, fix: Option<DiagnosticFix>) {
+        if !self.options.has_rule(rule_name) {
+            return;
+        }
+        let span = shifted_span(span, self.source_offset);
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id: "deprecated",
+            loc: self.line_index.loc_for_span(self.source_text, span),
+            fix,
+        });
+    }
+
+    fn check_member(
+        &mut self,
+        object: &Expression<'_>,
+        property: &str,
+        span: Span,
+        property_span: Option<Span>,
+    ) {
+        if !self.is_global_astro(object) {
+            return;
+        }
+        match property {
+            "canonicalURL" => {
+                self.report("no-deprecated-astro-canonicalurl", span, None);
+            }
+            "fetchContent" => {
+                let fix = property_span.map(|span| DiagnosticFix {
+                    start: span.start.saturating_add(self.source_offset),
+                    end: span.end.saturating_add(self.source_offset),
+                    replacement: "glob",
+                });
+                self.report("no-deprecated-astro-fetchcontent", span, fix);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> Visit<'a> for Scanner<'_> {
+    fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
+        self.check_member(
+            &member.object,
+            member.property.name.as_str(),
+            member.span,
+            Some(member.property.span),
+        );
+        walk::walk_static_member_expression(self, member);
+    }
+
+    fn visit_computed_member_expression(&mut self, member: &ComputedMemberExpression<'a>) {
+        if let Expression::StringLiteral(property) = member.expression.get_inner_expression() {
+            self.check_member(&member.object, property.value.as_str(), member.span, None);
+        }
+        walk::walk_computed_member_expression(self, member);
+    }
+
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'a>) {
+        if declaration.source.value == "astro:content"
+            && self.options.has_rule("no-deprecated-getentrybyslug")
+            && let Some(specifiers) = &declaration.specifiers
+        {
+            for specifier in specifiers {
+                let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                    continue;
+                };
+                if matches!(
+                    &specifier.imported,
+                    ModuleExportName::IdentifierName(identifier)
+                        if identifier.name == "getEntryBySlug"
+                ) {
+                    self.report("no-deprecated-getentrybyslug", specifier.span(), None);
+                }
+            }
+        }
+        walk::walk_import_declaration(self, declaration);
+    }
+}
+
+fn shifted_span(span: Span, offset: u32) -> Span {
+    Span::new(
+        span.start.saturating_add(offset),
+        span.end.saturating_add(offset),
+    )
+}
+
+struct LineIndex {
+    line_starts: SmallVec<[usize; 64]>,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        let mut line_starts = SmallVec::new();
+        line_starts.push(0);
+        let mut cursor = 0;
+        while cursor < source.len() {
+            let Some(line) = read_line(source, cursor) else {
+                break;
+            };
+            if line.next <= cursor || line.next == source.len() {
+                break;
+            }
+            line_starts.push(line.next);
+            cursor = line.next;
+        }
+        Self { line_starts }
+    }
+
+    fn loc_for_span(&self, source: &str, span: Span) -> DiagnosticLoc {
+        let (start_line, start_column) = self.position(source, span.start);
+        let (end_line, end_column) = self.position(source, span.end);
+        DiagnosticLoc {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    fn position(&self, source: &str, offset: u32) -> (u32, u32) {
+        let offset = (offset as usize).min(source.len());
+        let line = self.line_starts.partition_point(|start| *start <= offset);
+        let line = line.saturating_sub(1);
+        let start = self.line_starts[line];
+        let column = source[start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        ((line + 1) as u32, column as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astro/src/tests.rs
+++ b/crates/astro/src/tests.rs
@@ -1,0 +1,450 @@
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use super::{
+    AstroOptions, Diagnostic, DiagnosticFix, DiagnosticLoc, implemented_astro_rule_names,
+    scan_astro,
+};
+
+fn scan(source: &str) -> SmallVec<[Diagnostic; 8]> {
+    scan_astro(source, "fixture.astro", &AstroOptions::default())
+}
+
+fn scan_rule(source: &str, rule_name: &str) -> SmallVec<[Diagnostic; 8]> {
+    scan_astro(
+        source,
+        "fixture.astro",
+        &AstroOptions {
+            rule_names: [CompactString::from(rule_name)].into_iter().collect(),
+            frontmatter_only: false,
+        },
+    )
+}
+
+fn names(diagnostics: &[Diagnostic]) -> SmallVec<[&str; 8]> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name)
+        .collect()
+}
+
+#[test]
+fn exposes_the_slice_rule_names() {
+    assert_eq!(
+        implemented_astro_rule_names(),
+        [
+            "no-deprecated-astro-canonicalurl",
+            "no-deprecated-astro-fetchcontent",
+            "no-deprecated-getentrybyslug",
+        ]
+    );
+}
+
+#[test]
+fn replays_upstream_canonicalurl_invalid_fixture() {
+    let diagnostics = scan(
+        "---\n/* ✗ BAD */\nconst canonicalURL = Astro.canonicalURL\nconsole.log(canonicalURL)\n---",
+    );
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        ["no-deprecated-astro-canonicalurl"]
+    );
+    assert_eq!(
+        diagnostics[0].loc,
+        DiagnosticLoc {
+            start_line: 3,
+            start_column: 21,
+            end_line: 3,
+            end_column: 39,
+        }
+    );
+}
+
+#[test]
+fn replays_upstream_canonicalurl_valid_fixture() {
+    assert!(
+        scan("---\n/* ✓ GOOD */\nconst canonicalURL = new URL(Astro.url.pathname, Astro.site)\nconsole.log(canonicalURL)\n---")
+            .is_empty()
+    );
+}
+
+#[test]
+fn replays_upstream_fetchcontent_invalid_fixture_and_fix() {
+    let source =
+        "---\n/* ✗ BAD */\nconst posts = await Astro.fetchContent(\"../pages/post/*.md\")\n---";
+    let diagnostics = scan(source);
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        ["no-deprecated-astro-fetchcontent"]
+    );
+    assert_eq!(
+        diagnostics[0].loc,
+        DiagnosticLoc {
+            start_line: 3,
+            start_column: 20,
+            end_line: 3,
+            end_column: 38,
+        }
+    );
+    let property = source.find("fetchContent").expect("fixture property");
+    assert_eq!(
+        diagnostics[0].fix,
+        Some(DiagnosticFix {
+            start: property as u32,
+            end: (property + "fetchContent".len()) as u32,
+            replacement: "glob",
+        })
+    );
+}
+
+#[test]
+fn replays_upstream_fetchcontent_valid_fixture() {
+    assert!(
+        scan("---\n/* ✓ GOOD */\nconst posts = await Astro.glob(\"../pages/post/*.md\")\n---")
+            .is_empty()
+    );
+}
+
+#[test]
+fn replays_upstream_getentrybyslug_invalid_fixture() {
+    let diagnostics =
+        scan("---\n/* ✗ BAD */\nimport { getEntryBySlug } from \"astro:content\"\n---");
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        ["no-deprecated-getentrybyslug"]
+    );
+    assert_eq!(
+        diagnostics[0].loc,
+        DiagnosticLoc {
+            start_line: 3,
+            start_column: 9,
+            end_line: 3,
+            end_column: 23,
+        }
+    );
+}
+
+#[test]
+fn replays_upstream_getentry_valid_fixture() {
+    assert!(scan("---\n/* ✓ GOOD */\nimport { getEntry } from \"astro:content\"\n---").is_empty());
+}
+
+#[test]
+fn reports_all_three_rules_in_source_order() {
+    let diagnostics = scan(
+        "---\nimport { getEntryBySlug } from \"astro:content\"\nAstro.fetchContent(\"*.md\")\nAstro.canonicalURL\n---",
+    );
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        [
+            "no-deprecated-getentrybyslug",
+            "no-deprecated-astro-fetchcontent",
+            "no-deprecated-astro-canonicalurl",
+        ]
+    );
+}
+
+#[test]
+fn reports_every_global_reference() {
+    let diagnostics =
+        scan("---\nAstro.canonicalURL\nAstro.canonicalURL\nAstro.fetchContent(\"*.md\")\n---");
+    assert_eq!(diagnostics.len(), 3);
+}
+
+#[test]
+fn ignores_a_shadowing_const() {
+    assert!(
+        scan("---\nconst Astro = { canonicalURL: \"local\", fetchContent() {} }\nAstro.canonicalURL\nAstro.fetchContent()\n---")
+            .is_empty()
+    );
+}
+
+#[test]
+fn ignores_a_shadowing_import() {
+    assert!(
+        scan("---\nimport Astro from \"./astro\"\nAstro.canonicalURL\nAstro.fetchContent()\n---")
+            .is_empty()
+    );
+}
+
+#[test]
+fn ignores_a_shadowing_parameter() {
+    assert!(scan("---\nfunction render(Astro: any) { return Astro.canonicalURL }\n---").is_empty());
+}
+
+#[test]
+fn reports_global_astro_in_a_nested_scope() {
+    assert_eq!(
+        names(&scan(
+            "---\nfunction render() { return Astro.canonicalURL }\n---"
+        ))
+        .as_slice(),
+        ["no-deprecated-astro-canonicalurl"]
+    );
+}
+
+#[test]
+fn supports_computed_string_properties_without_a_fix() {
+    let diagnostics = scan("---\nAstro[\"canonicalURL\"]\nAstro['fetchContent'](\"*.md\")\n---");
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        [
+            "no-deprecated-astro-canonicalurl",
+            "no-deprecated-astro-fetchcontent",
+        ]
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.fix.is_none())
+    );
+}
+
+#[test]
+fn ignores_dynamic_computed_properties() {
+    assert!(scan("---\nconst key = \"canonicalURL\"\nAstro[key]\n---").is_empty());
+}
+
+#[test]
+fn reports_optional_static_access() {
+    assert_eq!(
+        names(&scan("---\nAstro?.fetchContent(\"*.md\")\n---")).as_slice(),
+        ["no-deprecated-astro-fetchcontent"]
+    );
+}
+
+#[test]
+fn reports_parenthesized_global_access() {
+    assert_eq!(
+        names(&scan("---\n(Astro).canonicalURL\n---")).as_slice(),
+        ["no-deprecated-astro-canonicalurl"]
+    );
+}
+
+#[test]
+fn maps_utf16_columns_after_non_bmp_text() {
+    let diagnostics = scan("---\nconst label = \"😀\"; Astro.canonicalURL\n---");
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+    assert_eq!(diagnostics[0].loc.start_column, 20);
+}
+
+#[test]
+fn maps_utf16_columns_after_cjk_text() {
+    let diagnostics = scan("---\nconst 日本語 = 1; Astro.canonicalURL\n---");
+    assert_eq!(diagnostics[0].loc.start_column, 15);
+}
+
+#[test]
+fn keeps_native_fix_ranges_as_utf8_bytes() {
+    let source = "---\nconst emoji = \"😀\"; Astro.fetchContent(\"*.md\")\n---";
+    let diagnostics = scan(source);
+    let property = source.find("fetchContent").expect("fixture property");
+    assert_eq!(diagnostics[0].fix.expect("fix").start, property as u32);
+}
+
+#[test]
+fn applied_fetchcontent_fix_is_idempotent() {
+    let source = "---\nconst emoji = \"😀\"; Astro.fetchContent(\"*.md\")\n---";
+    let first = scan(source);
+    let fix = first[0].fix.expect("first scan fix");
+    let mut fixed = CompactString::new(&source[..fix.start as usize]);
+    fixed.push_str(fix.replacement);
+    fixed.push_str(&source[fix.end as usize..]);
+    assert_eq!(
+        fixed,
+        "---\nconst emoji = \"😀\"; Astro.glob(\"*.md\")\n---"
+    );
+    assert!(scan(&fixed).is_empty());
+}
+
+#[test]
+fn accepts_a_utf8_bom() {
+    let diagnostics = scan("\u{feff}---\nAstro.canonicalURL\n---");
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+}
+
+#[test]
+fn accepts_crlf_delimiters_and_locations() {
+    let diagnostics = scan("---\r\nAstro.canonicalURL\r\n---\r\n");
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+}
+
+#[test]
+fn accepts_cr_delimiters_and_locations() {
+    let diagnostics = scan("---\rAstro.canonicalURL\r---\r");
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+}
+
+#[test]
+fn accepts_unicode_line_separators() {
+    for separator in ['\u{2028}', '\u{2029}'] {
+        let mut source = CompactString::new("---");
+        source.push(separator);
+        source.push_str("Astro.canonicalURL");
+        source.push(separator);
+        source.push_str("---");
+        let diagnostics = scan(&source);
+        assert_eq!(diagnostics[0].loc.start_line, 2);
+    }
+}
+
+#[test]
+fn accepts_trailing_horizontal_space_on_delimiters() {
+    assert_eq!(scan("--- \nAstro.canonicalURL\n---\t").len(), 1);
+}
+
+#[test]
+fn ignores_source_without_frontmatter() {
+    assert!(scan("<p>{Astro.canonicalURL}</p>").is_empty());
+}
+
+#[test]
+fn accepts_an_empty_frontmatter_block() {
+    assert!(scan("---\n---\n<p>Hello</p>").is_empty());
+}
+
+#[test]
+fn scans_an_already_extracted_frontmatter_segment_for_oxlint() {
+    let diagnostics = scan_astro(
+        "Astro.canonicalURL\n",
+        "fixture.astro",
+        &AstroOptions {
+            rule_names: SmallVec::new(),
+            frontmatter_only: true,
+        },
+    );
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        ["no-deprecated-astro-canonicalurl"]
+    );
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+    assert_eq!(diagnostics[0].loc.start_column, 0);
+}
+
+#[test]
+fn extracted_frontmatter_fix_ranges_start_at_the_virtual_source() {
+    let source = "const emoji = \"😀\"; Astro.fetchContent(\"*.md\")\n";
+    let diagnostics = scan_astro(
+        source,
+        "fixture.astro",
+        &AstroOptions {
+            rule_names: SmallVec::new(),
+            frontmatter_only: true,
+        },
+    );
+    let property = source.find("fetchContent").expect("fixture property");
+    assert_eq!(diagnostics[0].fix.expect("fix").start, property as u32);
+}
+
+#[test]
+fn reports_multiple_diagnostics_at_the_frontmatter_boundaries() {
+    let diagnostics = scan(
+        "---\nAstro.fetchContent(\"*.md\"); Astro.canonicalURL\nAstro.fetchContent(\"*.md\")\n---\n<p>template</p>",
+    );
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        [
+            "no-deprecated-astro-fetchcontent",
+            "no-deprecated-astro-canonicalurl",
+            "no-deprecated-astro-fetchcontent",
+        ]
+    );
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+    assert_eq!(diagnostics[2].loc.start_line, 3);
+}
+
+#[test]
+fn ignores_a_nonleading_delimiter() {
+    assert!(scan("\n---\nAstro.canonicalURL\n---").is_empty());
+}
+
+#[test]
+fn ignores_an_unterminated_frontmatter_block() {
+    assert!(scan("---\nAstro.canonicalURL\n").is_empty());
+}
+
+#[test]
+fn ignores_an_opening_delimiter_without_a_line_break() {
+    assert!(scan("---").is_empty());
+}
+
+#[test]
+fn ignores_malformed_typescript() {
+    assert!(scan("---\nconst = Astro.canonicalURL\n---").is_empty());
+}
+
+#[test]
+fn ignores_non_astro_extensions_case_insensitively_except_astro() {
+    let options = AstroOptions::default();
+    assert!(scan_astro("---\nAstro.canonicalURL\n---", "fixture.ts", &options).is_empty());
+    assert_eq!(
+        scan_astro("---\nAstro.canonicalURL\n---", "fixture.ASTRO", &options).len(),
+        1
+    );
+}
+
+#[test]
+fn isolates_each_selected_rule() {
+    let source = "---\nimport { getEntryBySlug } from \"astro:content\"\nAstro.fetchContent(\"*.md\")\nAstro.canonicalURL\n---";
+    for rule_name in implemented_astro_rule_names() {
+        assert_eq!(
+            names(&scan_rule(source, rule_name)).as_slice(),
+            [*rule_name]
+        );
+    }
+}
+
+#[test]
+fn unknown_rule_selection_reports_nothing() {
+    assert!(scan_rule("---\nAstro.canonicalURL\n---", "not-an-astro-rule").is_empty());
+}
+
+#[test]
+fn supports_aliased_getentrybyslug_imports() {
+    assert_eq!(
+        names(&scan(
+            "---\nimport { getEntryBySlug as legacy } from \"astro:content\"\n---"
+        ))
+        .as_slice(),
+        ["no-deprecated-getentrybyslug"]
+    );
+}
+
+#[test]
+fn reports_type_only_getentrybyslug_like_upstream() {
+    assert_eq!(
+        names(&scan(
+            "---\nimport { type getEntryBySlug } from \"astro:content\"\n---"
+        ))
+        .as_slice(),
+        ["no-deprecated-getentrybyslug"]
+    );
+}
+
+#[test]
+fn ignores_getentrybyslug_from_another_module() {
+    assert!(scan("---\nimport { getEntryBySlug } from \"./content\"\n---").is_empty());
+}
+
+#[test]
+fn ignores_default_and_namespace_imports() {
+    assert!(
+        scan("---\nimport getEntryBySlug from \"astro:content\"\nimport * as getEntryBySlug2 from \"astro:content\"\n---")
+            .is_empty()
+    );
+}
+
+#[test]
+fn ignores_string_named_imports_like_upstream() {
+    assert!(
+        scan("---\nimport { \"getEntryBySlug\" as legacy } from \"astro:content\"\n---").is_empty()
+    );
+}
+
+#[test]
+fn scans_only_the_first_frontmatter_block() {
+    let diagnostics = scan("---\nAstro.canonicalURL\n---\n---\nAstro.fetchContent(\"*.md\")\n---");
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        ["no-deprecated-astro-canonicalurl"]
+    );
+}

--- a/crates/playground_wasm/Cargo.toml
+++ b/crates/playground_wasm/Cargo.toml
@@ -25,6 +25,7 @@ oxc_allocator.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-angular-eslint.workspace = true
+oxlint-plugins-astro.workspace = true
 oxlint-plugins-carton.workspace = true
 oxlint-plugins-cypress.workspace = true
 oxlint-plugins-e18e.workspace = true

--- a/crates/playground_wasm/src/lib.rs
+++ b/crates/playground_wasm/src/lib.rs
@@ -46,7 +46,7 @@ pub fn stylistic_rule_metas() -> String {
     plugins::stylistic_rule_metas()
 }
 
-/// Returns the source language for `filename` (`javascript`, `json`, `markdown`,
+/// Returns the source language for `filename` (`astro`, `javascript`, `json`, `markdown`,
 /// or `""`), so the UI's editor and the rule scoping use one extension map.
 #[wasm_bindgen]
 pub fn language_for_filename(filename: &str) -> String {

--- a/crates/playground_wasm/src/plugins.rs
+++ b/crates/playground_wasm/src/plugins.rs
@@ -21,6 +21,7 @@ pub(super) fn push(
 }
 
 mod angular_eslint;
+mod astro;
 mod cypress;
 mod e18e;
 mod eslint_comments;
@@ -45,6 +46,7 @@ mod unused_imports;
 /// e.g., the JSON plugin never runs against a `.js` file.
 #[derive(Clone, Copy)]
 enum Language {
+    Astro,
     JavaScript,
     Json,
     Markdown,
@@ -54,6 +56,7 @@ enum Language {
 impl Language {
     fn as_str(self) -> &'static str {
         match self {
+            Self::Astro => "astro",
             Self::JavaScript => "javascript",
             Self::Json => "json",
             Self::Markdown => "markdown",
@@ -64,6 +67,7 @@ impl Language {
     /// Whether a file with the given extension should be linted by this language.
     fn matches_extension(self, ext: &str) -> bool {
         match self {
+            Self::Astro => ext == "astro",
             Self::JavaScript => matches!(
                 ext,
                 "js" | "cjs" | "mjs" | "jsx" | "ts" | "cts" | "mts" | "tsx"
@@ -83,6 +87,7 @@ type InfoFn = fn() -> PluginInfo;
 type ScanFn = fn(&str, &str, &EnabledFilter, &mut Vec<PlaygroundDiagnostic>);
 
 const REGISTRY: &[(&str, Language, InfoFn, ScanFn)] = &[
+    (astro::PLUGIN, Language::Astro, astro::info, astro::scan),
     (
         angular_eslint::PLUGIN,
         Language::JavaScript,
@@ -262,6 +267,7 @@ fn extension(filename: &str) -> &str {
 pub fn language_for_filename(filename: &str) -> &'static str {
     let ext = extension(filename).to_ascii_lowercase();
     for language in [
+        Language::Astro,
         Language::JavaScript,
         Language::Json,
         Language::Markdown,

--- a/crates/playground_wasm/src/plugins/astro.rs
+++ b/crates/playground_wasm/src/plugins/astro.rs
@@ -1,0 +1,43 @@
+//! Adapter for the `astro` plugin (port of eslint-plugin-astro).
+
+use std::collections::BTreeMap;
+
+use oxlint_plugins_astro as core;
+
+use super::EnabledFilter;
+use crate::{PlaygroundDiagnostic, PluginInfo};
+
+pub const PLUGIN: &str = "astro";
+
+pub fn info() -> PluginInfo {
+    PluginInfo {
+        plugin: PLUGIN,
+        rules: core::implemented_astro_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect(),
+    }
+}
+
+pub fn scan(
+    source_text: &str,
+    filename: &str,
+    filter: &EnabledFilter,
+    out: &mut Vec<PlaygroundDiagnostic>,
+) {
+    for diagnostic in core::scan_astro(source_text, filename, &core::AstroOptions::default()) {
+        if !filter.rule_enabled(PLUGIN, diagnostic.rule_name) {
+            continue;
+        }
+        out.push(PlaygroundDiagnostic {
+            plugin: PLUGIN,
+            rule: diagnostic.rule_name.to_owned(),
+            message_id: diagnostic.message_id.to_owned(),
+            data: BTreeMap::new(),
+            start_line: diagnostic.loc.start_line,
+            start_column: diagnostic.loc.start_column,
+            end_line: diagnostic.loc.end_line,
+            end_column: diagnostic.loc.end_column,
+        });
+    }
+}

--- a/docs/port-targets/eslint-plugin-astro.md
+++ b/docs/port-targets/eslint-plugin-astro.md
@@ -5,13 +5,13 @@
 | | |
 |---|---|
 | Upstream repo | https://github.com/ota-meshi/eslint-plugin-astro |
-| Submodule | `upstream/eslint-plugin-astro` @ `v2.1.1` |
-| Baseline npm version | `2.1.1` |
+| Submodule | `upstream/eslint-plugin-astro` @ `v3.0.1` |
+| Baseline npm version | `3.0.1` |
 | License | MIT |
 | Oxlint native support | none — port target |
 | Rules to port | 20 |
 
-> Lints .astro files via astro-eslint-parser; full parity depends on that parser (cf. eslint-plugin-svelte / eslint-plugin-vue, which are excluded, and @unocss/eslint-plugin).
+> Lints .astro files via astro-eslint-parser. Frontmatter-only rules can be ported by segmenting raw .astro source and parsing TypeScript with Oxc; full template parity still depends on Astro-aware parsing. React rules are outside this target because Oxc covers React separately.
 
 ## Rules
 

--- a/docs/port-targets/rules.json
+++ b/docs/port-targets/rules.json
@@ -5259,7 +5259,7 @@
       "id": "eslint-plugin-astro",
       "npm": "eslint-plugin-astro",
       "repo": "https://github.com/ota-meshi/eslint-plugin-astro",
-      "baselineVersion": "2.1.1",
+      "baselineVersion": "3.0.1",
       "license": "MIT",
       "ruleCount": 20,
       "rules": [

--- a/npm/astro/Cargo.toml
+++ b/npm/astro/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "oxlint-plugin-astro"
+description = "Rust-backed oxlint plugin port of selected eslint-plugin-astro rules."
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "oxlint_plugin_astro"
+
+[dependencies]
+napi.workspace = true
+napi-derive.workspace = true
+oxlint-plugins-astro.workspace = true
+oxlint-plugins-carton.workspace = true
+
+[build-dependencies]
+napi-build.workspace = true
+
+[lints.rust]
+unused_must_use = "deny"
+
+[lints.clippy]
+dbg_macro = "deny"
+disallowed_types = "warn"
+todo = "deny"
+unwrap_used = "deny"

--- a/npm/astro/LICENSE
+++ b/npm/astro/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 oxlint-plugins contributors
+Copyright (c) OTA-Meshi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/astro/README.md
+++ b/npm/astro/README.md
@@ -1,0 +1,13 @@
+# @oxlint-plugins/oxlint-plugin-astro
+
+Rust-backed Oxlint plugin port of selected `eslint-plugin-astro` rules.
+
+This first slice implements three deprecated-API rules by extracting Astro
+frontmatter and parsing it as TypeScript with Oxc:
+
+- `no-deprecated-astro-canonicalurl`
+- `no-deprecated-astro-fetchcontent`
+- `no-deprecated-getentrybyslug`
+
+Template expressions are intentionally not scanned in this slice. React rules
+are outside the Astro port's scope because Oxc handles React rules separately.

--- a/npm/astro/api.d.ts
+++ b/npm/astro/api.d.ts
@@ -1,0 +1,47 @@
+export type AstroRuleName =
+  | 'no-deprecated-astro-canonicalurl'
+  | 'no-deprecated-astro-fetchcontent'
+  | 'no-deprecated-getentrybyslug';
+
+export type AstroDiagnosticLoc = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};
+
+export type AstroDiagnosticFix = {
+  /** UTF-8 byte offset into the original source. */
+  start: number;
+  /** UTF-8 byte offset into the original source. */
+  end: number;
+  replacement: string;
+};
+
+export type AstroDiagnostic = {
+  ruleName: AstroRuleName;
+  messageId: 'deprecated';
+  loc: AstroDiagnosticLoc;
+  fix?: AstroDiagnosticFix | null;
+};
+
+export type AstroScanOptions = {
+  /** Empty or omitted means all implemented rules. */
+  ruleNames?: readonly string[];
+  /** Scan sourceText as an already extracted frontmatter segment. */
+  frontmatterOnly?: boolean;
+};
+
+export function implementedAstroRuleNames(): AstroRuleName[];
+export function scanAstro(
+  sourceText: string,
+  filename?: string,
+  options?: AstroScanOptions,
+): AstroDiagnostic[];
+
+declare const api: {
+  implementedAstroRuleNames: typeof implementedAstroRuleNames;
+  scanAstro: typeof scanAstro;
+};
+
+export default api;

--- a/npm/astro/api.js
+++ b/npm/astro/api.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const native = require('./native.js');
+
+function scanAstro(sourceText, filename = 'file.astro', options = {}) {
+  if (typeof sourceText !== 'string') {
+    throw new TypeError('sourceText must be a string.');
+  }
+  if (typeof filename !== 'string') {
+    throw new TypeError('filename must be a string.');
+  }
+  return native.scanAstro(sourceText, filename, {
+    ruleNames: normalizeStringArray(options.ruleNames),
+    frontmatterOnly: options.frontmatterOnly === true,
+  });
+}
+
+function normalizeStringArray(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+module.exports = {
+  implementedAstroRuleNames: native.implementedAstroRuleNames,
+  scanAstro,
+};
+module.exports.default = module.exports;

--- a/npm/astro/build.rs
+++ b/npm/astro/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/npm/astro/index.js
+++ b/npm/astro/index.js
@@ -1,0 +1,230 @@
+'use strict';
+
+// Oxlint plugin port of eslint-plugin-astro (MIT).
+// The Rust core segments and parses Astro frontmatter with Oxc. React rules
+// are intentionally outside this package's scope.
+
+const { eslintCompatPlugin } = require('@oxlint/plugins');
+const { implementedAstroRuleNames, scanAstro } = require('./api.js');
+
+const PLUGIN_NAME = 'astro';
+const DOCS_BASE = 'https://github.com/ubugeeei-prod/oxlint-plugins/tree/main/npm/astro';
+const diagnosticsCache = new WeakMap();
+
+const descriptions = Object.freeze({
+  'no-deprecated-astro-canonicalurl': 'disallow using deprecated `Astro.canonicalURL`',
+  'no-deprecated-astro-fetchcontent': 'disallow using deprecated `Astro.fetchContent()`',
+  'no-deprecated-getentrybyslug': 'disallow using deprecated `getEntryBySlug()`',
+});
+
+const messages = Object.freeze({
+  'no-deprecated-astro-canonicalurl': {
+    deprecated: "'Astro.canonicalURL' is deprecated. Use 'Astro.url' helper instead.",
+  },
+  'no-deprecated-astro-fetchcontent': {
+    deprecated: "'Astro.fetchContent()' is deprecated. Use 'Astro.glob()' instead.",
+  },
+  'no-deprecated-getentrybyslug': {
+    deprecated: "'getEntryBySlug()' is deprecated. Use 'getEntry()' instead.",
+  },
+});
+
+const implementedRuleNames = Object.freeze(implementedAstroRuleNames());
+const rules = Object.freeze(
+  Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, createAstroRule(ruleName)])),
+);
+const recommendedRules = Object.freeze(
+  Object.fromEntries(
+    implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
+  ),
+);
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: PLUGIN_NAME,
+    version: '0.0.0',
+  },
+  rules,
+  rulesConfig: Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, 0])),
+  configs: {
+    recommended: {
+      name: `${PLUGIN_NAME}/recommended`,
+      plugins: [PLUGIN_NAME],
+      files: ['**/*.astro'],
+      rules: { ...recommendedRules },
+    },
+  },
+});
+
+plugin.implementedAstroRuleNames = implementedRuleNames;
+plugin.scanAstro = scanAstro;
+
+function createAstroRule(ruleName) {
+  const meta = {
+    type: 'problem',
+    docs: {
+      description: descriptions[ruleName],
+      category: 'Possible Errors',
+      recommended: true,
+      url: `${DOCS_BASE}#${ruleName}`,
+    },
+    messages: messages[ruleName],
+    schema: [],
+  };
+  if (ruleName === 'no-deprecated-astro-fetchcontent') {
+    meta.fixable = 'code';
+  }
+
+  return {
+    meta,
+    createOnce(context) {
+      return {
+        Program() {
+          for (const diagnostic of diagnosticsForRule(context, ruleName)) {
+            reportDiagnostic(context, diagnostic);
+          }
+        },
+      };
+    },
+  };
+}
+
+function diagnosticsForRule(context, ruleName) {
+  const sourceCode = context.sourceCode ?? context.getSourceCode?.() ?? {};
+  const sourceText =
+    typeof sourceCode.getText === 'function'
+      ? sourceCode.getText()
+      : typeof sourceCode.text === 'string'
+        ? sourceCode.text
+        : '';
+  const filename = typeof context.filename === 'string' ? context.filename : 'file.astro';
+  const frontmatterOnly = !startsWithFrontmatterDelimiter(sourceText);
+  let byRule = diagnosticsCache.get(sourceCode);
+  if (!byRule) {
+    byRule = new Map();
+    diagnosticsCache.set(sourceCode, byRule);
+  }
+  const cached = byRule.get(ruleName);
+  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+    return cached.diagnostics;
+  }
+
+  const byteToUtf16 = createByteToUtf16Mapper(sourceText);
+  const diagnostics = scanAstro(sourceText, filename, {
+    ruleNames: [ruleName],
+    frontmatterOnly,
+  }).map((diagnostic) => mapDiagnosticFix(diagnostic, byteToUtf16));
+  byRule.set(ruleName, { sourceText, filename, diagnostics });
+  return diagnostics;
+}
+
+function reportDiagnostic(context, diagnostic) {
+  const descriptor = {
+    messageId: diagnostic.messageId,
+    loc: {
+      start: {
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn,
+      },
+      end: {
+        line: diagnostic.loc.endLine,
+        column: diagnostic.loc.endColumn,
+      },
+    },
+  };
+  if (diagnostic.fix) {
+    descriptor.fix = (fixer) =>
+      fixer.replaceTextRange(
+        [diagnostic.fix.start, diagnostic.fix.end],
+        diagnostic.fix.replacement,
+      );
+  }
+  context.report(descriptor);
+}
+
+function mapDiagnosticFix(diagnostic, byteToUtf16) {
+  if (!diagnostic.fix) {
+    return diagnostic;
+  }
+  return {
+    ...diagnostic,
+    fix: {
+      start: byteToUtf16(diagnostic.fix.start),
+      end: byteToUtf16(diagnostic.fix.end),
+      replacement: diagnostic.fix.replacement,
+    },
+  };
+}
+
+function startsWithFrontmatterDelimiter(sourceText) {
+  return /^(?:\uFEFF)?---[ \t]*(?:\r\n|[\n\r\u2028\u2029])/.test(sourceText);
+}
+
+function createByteToUtf16Mapper(sourceText) {
+  const nonAsciiSpans = [];
+  let byteOffset = 0;
+  let utf16Offset = 0;
+
+  while (utf16Offset < sourceText.length) {
+    const codePoint = sourceText.codePointAt(utf16Offset);
+    if (codePoint === undefined) {
+      break;
+    }
+    const utf16Length = codePoint > 0xffff ? 2 : 1;
+    const byteLength = utf8ByteLength(codePoint);
+    const byteEnd = byteOffset + byteLength;
+    const utf16End = utf16Offset + utf16Length;
+    if (byteLength !== utf16Length) {
+      nonAsciiSpans.push({
+        byteStart: byteOffset,
+        byteEnd,
+        utf16Start: utf16Offset,
+        deltaAfter: byteEnd - utf16End,
+      });
+    }
+    byteOffset = byteEnd;
+    utf16Offset = utf16End;
+  }
+
+  if (nonAsciiSpans.length === 0) {
+    return (offset) => clampOffset(offset, sourceText.length);
+  }
+  const totalBytes = byteOffset;
+  return (offset) => {
+    const clamped = clampOffset(offset, totalBytes);
+    let low = 0;
+    let high = nonAsciiSpans.length;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (nonAsciiSpans[mid].byteEnd <= clamped) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    const next = nonAsciiSpans[low];
+    if (next && clamped >= next.byteStart && clamped < next.byteEnd) {
+      return next.utf16Start;
+    }
+    const delta = nonAsciiSpans[low - 1]?.deltaAfter ?? 0;
+    return clampOffset(clamped - delta, sourceText.length);
+  };
+}
+
+function utf8ByteLength(codePoint) {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function clampOffset(offset, maximum) {
+  if (!Number.isFinite(offset) || offset <= 0) return 0;
+  if (offset >= maximum) return maximum;
+  return Math.trunc(offset);
+}
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.implementedAstroRuleNames = implementedRuleNames;
+module.exports.scanAstro = scanAstro;

--- a/npm/astro/package.json
+++ b/npm/astro/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@oxlint-plugins/oxlint-plugin-astro",
+  "version": "0.0.0",
+  "description": "Rust-backed Oxlint plugin port of selected eslint-plugin-astro rules.",
+  "keywords": [
+    "astro",
+    "eslint-plugin",
+    "napi-rs",
+    "oxlint",
+    "oxlint-plugin",
+    "rust"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "@ubugeeei",
+      "url": "https://github.com/ubugeeei"
+    },
+    {
+      "name": "@baseballyama",
+      "url": "https://github.com/baseballyama"
+    },
+    {
+      "name": "Blacksmith",
+      "url": "https://www.blacksmith.sh/"
+    },
+    {
+      "name": "OpenAI",
+      "url": "https://openai.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubugeeei-prod/oxlint-plugins.git",
+    "directory": "npm/astro"
+  },
+  "files": [
+    "index.js",
+    "api.js",
+    "api.d.ts",
+    "native.js",
+    "native.d.ts",
+    "*.node",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
+  "types": "api.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "require": "./api.js",
+      "default": "./api.js"
+    },
+    "./native": {
+      "types": "./native.d.ts",
+      "require": "./native.js",
+      "default": "./native.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "napi build --platform --release --js native.js --dts native.d.ts",
+    "build:debug": "napi build --platform --js native.js --dts native.d.ts",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "catalog:"
+  },
+  "napi": {
+    "binaryName": "oxlint_plugin_astro",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/npm/astro/src/lib.rs
+++ b/npm/astro/src/lib.rs
@@ -1,0 +1,93 @@
+//! NAPI boundary for the Astro oxlint plugin.
+
+pub use napi_abi::{
+    AstroScanOptions, Diagnostic, DiagnosticFix, DiagnosticLoc, implemented_astro_rule_names,
+    scan_astro,
+};
+
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "NAPI public ABI requires String/Vec/Option; values are converted before calling core rule logic."
+)]
+mod napi_abi {
+    use napi_derive::napi;
+    use oxlint_plugins_astro as core;
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+
+    #[napi(object)]
+    #[derive(Clone, Debug, Default)]
+    pub struct AstroScanOptions {
+        pub rule_names: Option<Vec<String>>,
+        pub frontmatter_only: Option<bool>,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticLoc {
+        pub start_line: u32,
+        pub start_column: u32,
+        pub end_line: u32,
+        pub end_column: u32,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct DiagnosticFix {
+        pub start: u32,
+        pub end: u32,
+        pub replacement: String,
+    }
+
+    #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct Diagnostic {
+        pub rule_name: String,
+        pub message_id: String,
+        pub loc: DiagnosticLoc,
+        pub fix: Option<DiagnosticFix>,
+    }
+
+    #[napi]
+    pub fn implemented_astro_rule_names() -> Vec<String> {
+        core::implemented_astro_rule_names()
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect()
+    }
+
+    #[napi]
+    pub fn scan_astro(
+        source_text: String,
+        filename: String,
+        options: Option<AstroScanOptions>,
+    ) -> Vec<Diagnostic> {
+        let options = options.unwrap_or_default();
+        let core_options = core::AstroOptions {
+            rule_names: compact_strings4(options.rule_names.unwrap_or_default()),
+            frontmatter_only: options.frontmatter_only.unwrap_or(false),
+        };
+        core::scan_astro(&source_text, &filename, &core_options)
+            .into_iter()
+            .map(|diagnostic| Diagnostic {
+                rule_name: diagnostic.rule_name.to_owned(),
+                message_id: diagnostic.message_id.to_owned(),
+                loc: DiagnosticLoc {
+                    start_line: diagnostic.loc.start_line,
+                    start_column: diagnostic.loc.start_column,
+                    end_line: diagnostic.loc.end_line,
+                    end_column: diagnostic.loc.end_column,
+                },
+                fix: diagnostic.fix.map(|fix| DiagnosticFix {
+                    start: fix.start,
+                    end: fix.end,
+                    replacement: fix.replacement.to_owned(),
+                }),
+            })
+            .collect()
+    }
+
+    fn compact_strings4(values: Vec<String>) -> SmallVec<[CompactString; 4]> {
+        values.into_iter().map(CompactString::from).collect()
+    }
+}

--- a/npm/astro/test/api.test.mjs
+++ b/npm/astro/test/api.test.mjs
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { implementedAstroRuleNames, scanAstro } from '../api.js';
+
+const testRoot = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(readFileSync(join(testRoot, 'fixtures', 'astro-v3.0.1.json'), 'utf8'));
+const expectedRuleNames = [
+  'no-deprecated-astro-canonicalurl',
+  'no-deprecated-astro-fetchcontent',
+  'no-deprecated-getentrybyslug',
+];
+
+describe('astro native API', () => {
+  it('exposes the first eslint-plugin-astro slice', () => {
+    expect(implementedAstroRuleNames()).toEqual(expectedRuleNames);
+  });
+
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.valid.map((testCase) => [ruleName, testCase]),
+    ),
+  )('accepts authored upstream valid fixture for %s', (ruleName, testCase) => {
+    expect(scanAstro(testCase.code, testCase.filename, { ruleNames: [ruleName] })).toEqual([]);
+  });
+
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.invalid.map((testCase) => [ruleName, testCase]),
+    ),
+  )('replays authored upstream invalid fixture for %s', (ruleName, testCase) => {
+    const diagnostics = scanAstro(testCase.code, testCase.filename, {
+      ruleNames: [ruleName],
+    });
+    expect(diagnostics).toHaveLength(testCase.errors.length);
+    expect(
+      diagnostics.map((diagnostic) => ({
+        messageId: diagnostic.messageId,
+        line: diagnostic.loc.startLine,
+        column: diagnostic.loc.startColumn + 1,
+      })),
+    ).toEqual(
+      testCase.errors.map((error) => ({
+        messageId: 'deprecated',
+        line: error.line,
+        column: error.column,
+      })),
+    );
+  });
+
+  it('returns native UTF-8 byte fix ranges', () => {
+    const source = '---\nconst emoji = "😀"; Astro.fetchContent("*.md")\n---\n';
+    const [diagnostic] = scanAstro(source);
+    const propertyStart = source.indexOf('fetchContent');
+    expect(diagnostic.fix).toEqual({
+      start: Buffer.byteLength(source.slice(0, propertyStart)),
+      end: Buffer.byteLength(source.slice(0, propertyStart + 'fetchContent'.length)),
+      replacement: 'glob',
+    });
+  });
+
+  it('is clean and stable after applying the native fix once', () => {
+    const source = '---\nconst emoji = "😀"; Astro.fetchContent("*.md")\n---\n';
+    const [diagnostic] = scanAstro(source);
+    const bytes = Buffer.from(source);
+    const fixed = Buffer.concat([
+      bytes.subarray(0, diagnostic.fix.start),
+      Buffer.from(diagnostic.fix.replacement),
+      bytes.subarray(diagnostic.fix.end),
+    ]).toString();
+    expect(fixed).toBe('---\nconst emoji = "😀"; Astro.glob("*.md")\n---\n');
+    expect(scanAstro(fixed)).toEqual([]);
+  });
+
+  it('isolates one requested rule', () => {
+    const source = '---\nimport { getEntryBySlug } from "astro:content"\nAstro.canonicalURL\n---\n';
+    expect(
+      scanAstro(source, 'fixture.astro', {
+        ruleNames: ['no-deprecated-getentrybyslug'],
+      }).map((diagnostic) => diagnostic.ruleName),
+    ).toEqual(['no-deprecated-getentrybyslug']);
+  });
+
+  it('enables every implemented rule when ruleNames is omitted', () => {
+    const source = '---\nimport { getEntryBySlug } from "astro:content"\nAstro.canonicalURL\n---\n';
+    expect(scanAstro(source).map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'no-deprecated-getentrybyslug',
+      'no-deprecated-astro-canonicalurl',
+    ]);
+  });
+
+  it('returns no diagnostics for malformed frontmatter', () => {
+    expect(scanAstro('---\nconst = Astro.canonicalURL\n---\n')).toEqual([]);
+  });
+
+  it('preserves source order for multiple boundary diagnostics', () => {
+    const diagnostics = scanAstro(
+      '---\nAstro.fetchContent("*.md"); Astro.canonicalURL\nAstro.fetchContent("*.md")\n---\n',
+    );
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      'no-deprecated-astro-fetchcontent',
+      'no-deprecated-astro-canonicalurl',
+      'no-deprecated-astro-fetchcontent',
+    ]);
+  });
+
+  it('returns no diagnostics for another extension', () => {
+    expect(scanAstro('---\nAstro.canonicalURL\n---\n', 'fixture.ts')).toEqual([]);
+  });
+
+  it('validates sourceText and filename', () => {
+    expect(() => scanAstro(null)).toThrow('sourceText must be a string');
+    expect(() => scanAstro('', null)).toThrow('filename must be a string');
+  });
+});

--- a/npm/astro/test/fixtures/astro-v3.0.1.json
+++ b/npm/astro/test/fixtures/astro-v3.0.1.json
@@ -1,0 +1,88 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-astro",
+    "version": "3.0.1",
+    "ref": "v3.0.1",
+    "commit": "d887cce6ad7d2cacfde885b29acfe080a7be6a85",
+    "sourceFiles": [
+      "tests/fixtures/rules/no-deprecated-astro-canonicalurl/invalid/test01-errors.json",
+      "tests/fixtures/rules/no-deprecated-astro-canonicalurl/invalid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-astro-canonicalurl/valid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-astro-fetchcontent/invalid/test01-errors.json",
+      "tests/fixtures/rules/no-deprecated-astro-fetchcontent/invalid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-astro-fetchcontent/invalid/test01-output.astro",
+      "tests/fixtures/rules/no-deprecated-astro-fetchcontent/valid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-errors.json",
+      "tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-getentrybyslug/valid/test01-input.astro"
+    ],
+    "license": "MIT",
+    "tool": "tools/tasks/sync-astro-tests.ts"
+  },
+  "rules": {
+    "no-deprecated-astro-canonicalurl": {
+      "valid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\n/* ✓ GOOD */\nconst canonicalURL = new URL(Astro.url.pathname, Astro.site)\nconsole.log(canonicalURL)\n---\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\n/* ✗ BAD */\nconst canonicalURL = Astro.canonicalURL\nconsole.log(canonicalURL)\n---\n",
+          "errors": [
+            {
+              "message": "'Astro.canonicalURL' is deprecated. Use 'Astro.url' helper instead.",
+              "line": 3,
+              "column": 22
+            }
+          ]
+        }
+      ]
+    },
+    "no-deprecated-astro-fetchcontent": {
+      "valid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\n/* ✓ GOOD */\nconst posts = await Astro.glob(\"../pages/post/*.md\")\n---\n\n<div>\n  {posts.slice(0, 3).map((post) => (\n    <article>\n      <h1>{post.frontmatter.title}</h1>\n      <p>{post.frontmatter.description}</p>\n      <a href={post.frontmatter.url}>Read more</a>\n    </article>\n  ))}\n</div>\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\n/* ✗ BAD */\nconst posts = await Astro.fetchContent(\"../pages/post/*.md\")\n---\n\n<div>\n  {posts.slice(0, 3).map((post) => (\n    <article>\n      <h1>{post.frontmatter.title}</h1>\n      <p>{post.frontmatter.description}</p>\n      <a href={post.frontmatter.url}>Read more</a>\n    </article>\n  ))}\n</div>\n",
+          "errors": [
+            {
+              "message": "'Astro.fetchContent()' is deprecated. Use 'Astro.glob()' instead.",
+              "line": 3,
+              "column": 21
+            }
+          ],
+          "output": "---\n/* ✗ BAD */\nconst posts = await Astro.glob(\"../pages/post/*.md\")\n---\n\n<div>\n  {posts.slice(0, 3).map((post) => (\n    <article>\n      <h1>{post.frontmatter.title}</h1>\n      <p>{post.frontmatter.description}</p>\n      <a href={post.frontmatter.url}>Read more</a>\n    </article>\n  ))}\n</div>\n"
+        }
+      ]
+    },
+    "no-deprecated-getentrybyslug": {
+      "valid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\n/* ✓ GOOD */\nimport { getEntry } from \"astro:content\"\n---\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\n/* ✗ BAD */\nimport { getEntryBySlug } from \"astro:content\"\n---\n",
+          "errors": [
+            {
+              "message": "'getEntryBySlug()' is deprecated. Use 'getEntry()' instead.",
+              "line": 3,
+              "column": 10
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/npm/astro/test/plugin.test.mjs
+++ b/npm/astro/test/plugin.test.mjs
@@ -1,0 +1,235 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+const fixture = JSON.parse(
+  readFileSync(join(packageRoot, 'test', 'fixtures', 'astro-v3.0.1.json'), 'utf8'),
+);
+const expectedRuleNames = [
+  'no-deprecated-astro-canonicalurl',
+  'no-deprecated-astro-fetchcontent',
+  'no-deprecated-getentrybyslug',
+];
+
+function runRule(ruleName, sourceText, filename = 'fixture.astro') {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function renderedMessages(ruleName, reports) {
+  return reports.map((report) => plugin.rules[ruleName].meta.messages[report.messageId]);
+}
+
+function applyReports(sourceText, reports) {
+  const edits = [];
+  for (const report of reports) {
+    report.fix?.({
+      replaceTextRange(range, replacementText) {
+        edits.push({ range, replacementText });
+      },
+    });
+  }
+  return edits
+    .sort((left, right) => right.range[0] - left.range[0])
+    .reduce(
+      (output, edit) =>
+        output.slice(0, edit.range[0]) + edit.replacementText + output.slice(edit.range[1]),
+      sourceText,
+    );
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules', '.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules', 'oxlint', 'bin', 'oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((left, right) => left.localeCompare(right));
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+  return candidates[candidates.length - 1];
+}
+
+function runOxlint(ruleName, code, fix = false) {
+  const temporary = mkdtempSync(join(tmpdir(), 'astro-plugin-'));
+  try {
+    const sourcePath = join(temporary, 'fixture.astro');
+    const configPath = join(temporary, 'oxlint.config.jsonc');
+    writeFileSync(sourcePath, code);
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        jsPlugins: [{ name: 'astro', specifier: join(packageRoot, 'index.js') }],
+        rules: { [`astro/${ruleName}`]: 'error' },
+      }),
+    );
+    const args = ['-c', configPath, '--quiet', '--format', 'json'];
+    if (fix) args.push('--fix');
+    args.push(sourcePath);
+    const result = spawnSync(findOxlintCli(), args, { encoding: 'utf8' });
+    const payload = result.stdout.trim() === '' ? { diagnostics: [] } : JSON.parse(result.stdout);
+    return {
+      diagnostics: payload.diagnostics ?? [],
+      output: readFileSync(sourcePath, 'utf8'),
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+describe('astro plugin shape', () => {
+  it('exports only the selected Astro rules', () => {
+    expect(plugin.meta?.name).toBe('astro');
+    expect(Object.keys(plugin.rules)).toEqual(expectedRuleNames);
+    expect(plugin.implementedAstroRuleNames).toEqual(expectedRuleNames);
+    expect(typeof plugin.scanAstro).toBe('function');
+  });
+
+  it('enables all selected rules in recommended for Astro files', () => {
+    expect(plugin.configs.recommended.files).toEqual(['**/*.astro']);
+    expect(plugin.configs.recommended.rules).toEqual(
+      Object.fromEntries(expectedRuleNames.map((name) => [`astro/${name}`, 'error'])),
+    );
+  });
+
+  it('keeps every schema empty and every rule recommended', () => {
+    for (const rule of Object.values(plugin.rules)) {
+      expect(rule.meta.schema).toEqual([]);
+      expect(rule.meta.docs.recommended).toBe(true);
+      expect(rule.meta.type).toBe('problem');
+    }
+  });
+
+  it('marks only fetchContent as fixable', () => {
+    expect(plugin.rules['no-deprecated-astro-fetchcontent'].meta.fixable).toBe('code');
+    expect(plugin.rules['no-deprecated-astro-canonicalurl'].meta.fixable).toBeUndefined();
+    expect(plugin.rules['no-deprecated-getentrybyslug'].meta.fixable).toBeUndefined();
+  });
+});
+
+describe('authored eslint-plugin-astro v3.0.1 fixtures through the adapter', () => {
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.valid.map((testCase) => [ruleName, testCase]),
+    ),
+  )('accepts %s valid fixture', (ruleName, testCase) => {
+    expect(runRule(ruleName, testCase.code, testCase.filename)).toEqual([]);
+  });
+
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.invalid.map((testCase) => [ruleName, testCase]),
+    ),
+  )('matches %s invalid fixture messages and locations', (ruleName, testCase) => {
+    const reports = runRule(ruleName, testCase.code, testCase.filename);
+    expect(renderedMessages(ruleName, reports)).toEqual(
+      testCase.errors.map((error) => error.message),
+    );
+    expect(
+      reports.map((report) => ({
+        line: report.loc.start.line,
+        column: report.loc.start.column + 1,
+      })),
+    ).toEqual(testCase.errors.map((error) => ({ line: error.line, column: error.column })));
+  });
+
+  it('matches the authored fetchContent output', () => {
+    const testCase = fixture.rules['no-deprecated-astro-fetchcontent'].invalid[0];
+    expect(
+      applyReports(testCase.code, runRule('no-deprecated-astro-fetchcontent', testCase.code)),
+    ).toBe(testCase.output);
+  });
+});
+
+describe('adapter regression coverage', () => {
+  it('maps native UTF-8 fix ranges to JavaScript UTF-16 ranges', () => {
+    const code = '---\nconst emoji = "😀"; Astro.fetchContent("*.md")\n---\n';
+    const reports = runRule('no-deprecated-astro-fetchcontent', code);
+    expect(applyReports(code, reports)).toBe('---\nconst emoji = "😀"; Astro.glob("*.md")\n---\n');
+  });
+
+  it('does not report a shadowed Astro binding', () => {
+    const code = '---\nconst Astro = { canonicalURL: "local" };\nAstro.canonicalURL\n---\n';
+    expect(runRule('no-deprecated-astro-canonicalurl', code)).toEqual([]);
+  });
+
+  it('does not scan template expressions in the frontmatter slice', () => {
+    expect(
+      runRule(
+        'no-deprecated-astro-canonicalurl',
+        '---\nconst title = "page"\n---\n<p>{Astro.canonicalURL}</p>\n',
+      ),
+    ).toEqual([]);
+  });
+
+  it('does not report malformed frontmatter', () => {
+    expect(
+      runRule('no-deprecated-astro-canonicalurl', '---\nconst = Astro.canonicalURL\n---\n'),
+    ).toEqual([]);
+  });
+
+  it('does not run against non-Astro filenames', () => {
+    expect(
+      runRule('no-deprecated-astro-canonicalurl', '---\nAstro.canonicalURL\n---\n', 'fixture.ts'),
+    ).toEqual([]);
+  });
+});
+
+describe('astro rules through real Oxlint jsPlugins', () => {
+  it('reports an authored .astro invalid fixture through the CLI', () => {
+    const testCase = fixture.rules['no-deprecated-getentrybyslug'].invalid[0];
+    const result = runOxlint('no-deprecated-getentrybyslug', testCase.code);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('astro(no-deprecated-getentrybyslug)');
+  });
+
+  it('fixes an authored .astro fixture through the CLI', () => {
+    const testCase = fixture.rules['no-deprecated-astro-fetchcontent'].invalid[0];
+    const result = runOxlint('no-deprecated-astro-fetchcontent', testCase.code, true);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toEqual([]);
+    expect(result.output).toBe(testCase.output);
+
+    const rerun = runOxlint('no-deprecated-astro-fetchcontent', result.output, true);
+    expect(rerun.status).toBe(0);
+    expect(rerun.stderr).toBe('');
+    expect(rerun.diagnostics).toEqual([]);
+    expect(rerun.output).toBe(result.output);
+  });
+
+  it('keeps rule selection isolated through the CLI', () => {
+    const code = '---\nAstro.fetchContent("*.md")\nAstro.canonicalURL\n---\n';
+    const result = runOxlint('no-deprecated-astro-canonicalurl', code);
+    expect(result.status).toBe(1);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('astro(no-deprecated-astro-canonicalurl)');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "port:releases": "node tools/tasks/check-upstream-releases.ts",
     "port:rules": "node tools/tasks/enumerate-port-rules.ts",
     "port:status": "node tools/tasks/sync-status-from-port-targets.ts",
+    "port:tests:astro": "node tools/tasks/sync-astro-tests.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
     "port:tests:eslint-json": "node tools/tasks/sync-eslint-json-tests.ts",
     "port:tests:eslint-markdown": "node tools/tasks/sync-eslint-markdown-tests.ts",

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -256,6 +256,7 @@ function languageExtension(name: string) {
   if (language === 'json') return json();
   if (language === 'markdown') return markdown();
   if (language === 'sql') return sql();
+  if (language === 'astro') return javascript({ jsx: true, typescript: true });
   const ext = name.includes('.') ? name.slice(name.lastIndexOf('.') + 1).toLowerCase() : '';
   return javascript({
     jsx: ext === 'jsx' || ext === 'tsx',

--- a/playground/src/samples.ts
+++ b/playground/src/samples.ts
@@ -8,6 +8,20 @@ export type Sample = {
 
 export const samples: Sample[] = [
   {
+    label: 'Astro',
+    filename: 'index.astro',
+    code: `---
+import { getEntryBySlug } from 'astro:content';
+
+const canonical = Astro.canonicalURL;
+const posts = await Astro.fetchContent('../pages/post/*.md');
+---
+
+<h1>{canonical.pathname}</h1>
+<p>{posts.length}</p>
+`,
+  },
+  {
     label: 'Security',
     filename: 'app.js',
     code: `const cp = require('child_process');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
 
   npm/angular-eslint-template: {}
 
+  npm/astro:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: 'catalog:'
+        version: 1.68.0
+
   npm/cypress:
     dependencies:
       '@oxlint/plugins':

--- a/status.json
+++ b/status.json
@@ -1426,6 +1426,343 @@
     ]
   },
   {
+    "packageName": "@oxlint-plugins/oxlint-plugin-astro",
+    "directory": "npm/astro",
+    "version": "0.0.0",
+    "published": false,
+    "publishedVersion": null,
+    "upstream": {
+      "package": "eslint-plugin-astro",
+      "version": "3.0.1",
+      "repository": "https://github.com/ota-meshi/eslint-plugin-astro",
+      "license": "MIT"
+    },
+    "status": "in-progress",
+    "typeAware": false,
+    "rules": [
+      {
+        "name": "missing-client-only-directive-value",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule missing-client-only-directive-value."
+      },
+      {
+        "name": "no-conflict-set-directives",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-conflict-set-directives."
+      },
+      {
+        "name": "no-deprecated-astro-canonicalurl",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc frontmatter port synced to the authored eslint-plugin-astro v3.0.1 fixtures. Covers global-reference shadowing, malformed input, Unicode/UTF-16 locations, rule selection, the NAPI/API adapter, real Oxlint .astro integration, and the playground."
+      },
+      {
+        "name": "no-deprecated-astro-fetchcontent",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc frontmatter port synced to the authored eslint-plugin-astro v3.0.1 input, errors, and fixed output. Covers global-reference shadowing, computed access, UTF-8 byte to UTF-16 fix mapping, malformed input, NAPI/API, real Oxlint .astro fix integration, and the playground."
+      },
+      {
+        "name": "no-deprecated-astro-resolve",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-deprecated-astro-resolve."
+      },
+      {
+        "name": "no-deprecated-getentrybyslug",
+        "status": "ported",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": true,
+        "napi": true,
+        "tests": {
+          "insta": false,
+          "vitest": true,
+          "lsp": false,
+          "oxlintIntegration": true
+        },
+        "notes": "Rust/Oxc frontmatter port synced to the authored eslint-plugin-astro v3.0.1 fixtures. Covers aliases, type-only imports, wrong sources, malformed input, rule selection, NAPI/API, real Oxlint .astro integration, and the playground."
+      },
+      {
+        "name": "no-exports-from-components",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-exports-from-components."
+      },
+      {
+        "name": "no-omitted-end-tags",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-omitted-end-tags."
+      },
+      {
+        "name": "no-prerender-export-outside-pages",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-prerender-export-outside-pages."
+      },
+      {
+        "name": "no-set-html-directive",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-set-html-directive."
+      },
+      {
+        "name": "no-set-text-directive",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-set-text-directive."
+      },
+      {
+        "name": "no-unsafe-inline-scripts",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-unsafe-inline-scripts."
+      },
+      {
+        "name": "no-unused-css-selector",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-unused-css-selector."
+      },
+      {
+        "name": "no-unused-define-vars-in-style",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule no-unused-define-vars-in-style."
+      },
+      {
+        "name": "prefer-class-list-directive",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule prefer-class-list-directive."
+      },
+      {
+        "name": "prefer-object-class-list",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule prefer-object-class-list."
+      },
+      {
+        "name": "prefer-split-class-list",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule prefer-split-class-list."
+      },
+      {
+        "name": "semi",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule semi."
+      },
+      {
+        "name": "sort-attributes",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule sort-attributes."
+      },
+      {
+        "name": "valid-compile",
+        "status": "pending",
+        "published": false,
+        "oxlintBuiltin": false,
+        "typeAware": false,
+        "rustCore": false,
+        "napi": false,
+        "tests": {
+          "insta": false,
+          "vitest": false,
+          "lsp": false,
+          "oxlintIntegration": false
+        },
+        "notes": "Pending port of upstream rule valid-compile."
+      }
+    ]
+  },
+  {
     "packageName": "@oxlint-plugins/oxlint-plugin-cypress",
     "directory": "npm/cypress",
     "version": "0.0.0",

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -104,6 +104,10 @@ const nativePackages = [
     name: '@oxlint-plugins/oxlint-plugin-sonarjs',
     binding: 'npm/sonarjs/native.js',
   },
+  {
+    name: '@oxlint-plugins/oxlint-plugin-astro',
+    binding: 'npm/astro/native.js',
+  },
 ];
 
 function lockPathFor(pkg) {

--- a/tools/port-targets.json
+++ b/tools/port-targets.json
@@ -713,8 +713,8 @@
       "repo": "https://github.com/ota-meshi/eslint-plugin-astro",
       "submodule": "upstream/eslint-plugin-astro",
       "packageSubdir": ".",
-      "baselineVersion": "2.1.1",
-      "pinnedRef": "v2.1.1",
+      "baselineVersion": "3.0.1",
+      "pinnedRef": "v3.0.1",
       "license": "MIT",
       "monorepo": false,
       "expectedRuleCount": 20,
@@ -725,7 +725,7 @@
         "exclude": ["index.ts"]
       },
       "docsUrlTemplate": "https://ota-meshi.github.io/eslint-plugin-astro/rules/{rule}/",
-      "notes": "Lints .astro files via astro-eslint-parser; full parity depends on that parser (cf. eslint-plugin-svelte / eslint-plugin-vue, which are excluded, and @unocss/eslint-plugin)."
+      "notes": "Lints .astro files via astro-eslint-parser. Frontmatter-only rules can be ported by segmenting raw .astro source and parsing TypeScript with Oxc; full template parity still depends on Astro-aware parsing. React rules are outside this target because Oxc covers React separately."
     }
   ]
 }

--- a/tools/tasks/sync-astro-tests.ts
+++ b/tools/tasks/sync-astro-tests.ts
@@ -1,0 +1,135 @@
+// Copies the authored eslint-plugin-astro fixtures for the implemented slice
+// from the pinned upstream submodule into one deterministic replay fixture.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type AuthoredError = {
+  message: string;
+  line: number;
+  column: number;
+};
+
+type FixtureCase = {
+  filename: string;
+  code: string;
+  errors?: AuthoredError[];
+  output?: string;
+};
+
+const ROOT = process.cwd();
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-astro');
+if (!plugin) {
+  throw new Error('eslint-plugin-astro is not registered in tools/port-targets.json');
+}
+
+const expectedVersion = '3.0.1';
+const expectedRef = 'v3.0.1';
+const expectedCommit = 'd887cce6ad7d2cacfde885b29acfe080a7be6a85';
+if (plugin.baselineVersion !== expectedVersion || plugin.pinnedRef !== expectedRef) {
+  throw new Error(
+    `Astro fixture sync expects ${expectedRef}; port target is ${plugin.pinnedRef ?? plugin.baselineVersion}.`,
+  );
+}
+
+const upstreamRoot = join(ROOT, plugin.submodule);
+const fixtureRoot = join(upstreamRoot, 'tests', 'fixtures', 'rules');
+if (!existsSync(fixtureRoot)) {
+  throw new Error(
+    `Astro fixture sources not found. Run: git submodule update --init ${plugin.submodule}`,
+  );
+}
+const actualCommit = execFileSync('git', ['-C', upstreamRoot, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== expectedCommit) {
+  throw new Error(`Astro submodule must be ${expectedCommit}; found ${actualCommit}.`);
+}
+
+const ruleNames = [
+  'no-deprecated-astro-canonicalurl',
+  'no-deprecated-astro-fetchcontent',
+  'no-deprecated-getentrybyslug',
+] as const;
+const rules: Record<string, { valid: FixtureCase[]; invalid: FixtureCase[] }> = {};
+const sourceFiles: string[] = [];
+
+for (const ruleName of ruleNames) {
+  rules[ruleName] = {
+    valid: readCases(ruleName, 'valid'),
+    invalid: readCases(ruleName, 'invalid'),
+  };
+}
+
+const outputDirectory = join(ROOT, 'npm', 'astro', 'test', 'fixtures');
+mkdirSync(outputDirectory, { recursive: true });
+const outputPath = join(outputDirectory, `astro-v${expectedVersion}.json`);
+const fixture = {
+  __generated: {
+    source: plugin.npm,
+    version: expectedVersion,
+    ref: expectedRef,
+    commit: expectedCommit,
+    sourceFiles: sourceFiles.sort(),
+    license: plugin.license,
+    tool: 'tools/tasks/sync-astro-tests.ts',
+  },
+  rules,
+};
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+const caseCount = Object.values(rules).reduce(
+  (count, cases) => count + cases.valid.length + cases.invalid.length,
+  0,
+);
+console.log(
+  `Synced ${caseCount} authored eslint-plugin-astro ${expectedRef} cases for ${ruleNames.length} rules.`,
+);
+
+function readCases(ruleName: string, validity: 'valid' | 'invalid'): FixtureCase[] {
+  const directory = join(fixtureRoot, ruleName, validity);
+  if (!existsSync(directory)) {
+    throw new Error(`Missing upstream fixture directory: ${directory}`);
+  }
+  return readdirSync(directory)
+    .filter((name) => name.endsWith('-input.astro'))
+    .sort()
+    .map((inputName) => {
+      const stem = inputName.slice(0, -'-input.astro'.length);
+      const inputPath = join(directory, inputName);
+      sourceFiles.push(relative(upstreamRoot, inputPath));
+      const fixtureCase: FixtureCase = {
+        filename: basename(inputName),
+        code: readFileSync(inputPath, 'utf8'),
+      };
+      if (validity === 'invalid') {
+        const errorsPath = join(directory, `${stem}-errors.json`);
+        if (!existsSync(errorsPath)) {
+          throw new Error(`Missing authored errors for ${inputPath}`);
+        }
+        sourceFiles.push(relative(upstreamRoot, errorsPath));
+        fixtureCase.errors = JSON.parse(readFileSync(errorsPath, 'utf8')) as AuthoredError[];
+        const outputPath = join(directory, `${stem}-output.astro`);
+        if (existsSync(outputPath)) {
+          sourceFiles.push(relative(upstreamRoot, outputPath));
+          fixtureCase.output = readFileSync(outputPath, 'utf8');
+        }
+      }
+      return fixtureCase;
+    });
+}

--- a/tools/tasks/sync-status-from-port-targets.ts
+++ b/tools/tasks/sync-status-from-port-targets.ts
@@ -212,7 +212,11 @@ const PACKAGE_MAP: Record<
     typeAware: true,
   },
   'postgresql-eslint-parser': { pkgName: null },
-  'eslint-plugin-astro': { pkgName: null },
+  'eslint-plugin-astro': {
+    pkgName: '@oxlint-plugins/oxlint-plugin-astro',
+    npmDir: 'npm/astro',
+    shortName: 'astro',
+  },
 };
 
 const manifest = JSON.parse(

--- a/tools/tasks/verify-package-publish-ready.ts
+++ b/tools/tasks/verify-package-publish-ready.ts
@@ -15,6 +15,11 @@ const packages: PackageToPack[] = [
     requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
   },
   {
+    name: '@oxlint-plugins/oxlint-plugin-astro',
+    dir: 'npm/astro',
+    requiredFiles: ['index.js', 'api.js', 'api.d.ts', 'native.js', 'native.d.ts'],
+  },
+  {
     name: '@oxlint-plugins/oxlint-plugin-type-aware',
     dir: 'npm/type-aware',
     requiredFiles: ['dist/index.mjs', 'dist/index.d.mts'],


### PR DESCRIPTION
## Summary
- add the native Astro plugin package and Oxc frontmatter scanner
- port no-deprecated-astro-canonicalurl, no-deprecated-astro-fetchcontent, and no-deprecated-getentrybyslug from eslint-plugin-astro v3.0.1
- wire NAPI, JS compatibility, playground, status metadata, fixture sync, and publish validation
- preserve scope-aware global Astro behavior and UTF-16 locations; include idempotent fetchContent fixes

## Validation
- full VITEST_MAX_WORKERS=1 pnpm verify
- 15,921 JavaScript tests passed, 1,159 skipped
- 44 Astro Rust tests passed
- 34 targeted Astro API/plugin tests passed after rebasing onto latest main
- full Rust workspace tests, Clippy, typecheck, lint, bench schema, security, license, status, and package dry-run passed

React is intentionally outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->