### PR TITLE
feat(perfectionist): support sort-named-exports options

### DIFF
--- a/crates/perfectionist/src/lib.rs
+++ b/crates/perfectionist/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod helpers;
 mod scanner;
-mod sort_named_imports;
+mod sort_named_specifiers;
 mod sort_options;
 mod types;
 
@@ -76,9 +76,6 @@ pub fn scan_perfectionist_rule(
     rule_name: &str,
     options: &serde_json::Value,
 ) -> SmallVec<[RuleDiagnostic; 8]> {
-    if rule_name != "sort-named-imports" {
-        return SmallVec::new();
-    }
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(filename)
         .unwrap_or_else(|_| SourceType::tsx())
@@ -87,10 +84,19 @@ pub fn scan_perfectionist_rule(
     if !parser_return.errors.is_empty() {
         return SmallVec::new();
     }
-    sort_named_imports::check(
-        source_text,
-        &parser_return.program.body,
-        &parser_return.program.comments,
-        options,
-    )
+    match rule_name {
+        "sort-named-imports" => sort_named_specifiers::check(
+            source_text,
+            &parser_return.program.body,
+            &parser_return.program.comments,
+            options,
+        ),
+        "sort-named-exports" => sort_named_specifiers::check_exports(
+            source_text,
+            &parser_return.program.body,
+            &parser_return.program.comments,
+            options,
+        ),
+        _ => SmallVec::new(),
+    }
 }

--- a/crates/perfectionist/src/sort_named_specifiers.rs
+++ b/crates/perfectionist/src/sort_named_specifiers.rs
@@ -1,10 +1,10 @@
 #![allow(
     clippy::disallowed_macros,
     clippy::disallowed_types,
-    reason = "serde_json option maps require String keys and configured group/import collections are user-sized rather than bounded rule state."
+    reason = "serde_json option maps require String keys and configured group/specifier collections are user-sized rather than bounded rule state."
 )]
 
-//! Configurable `sort-named-imports` slice pinned to Perfectionist v5.9.1.
+//! Shared configurable named-import/export engine pinned to Perfectionist v5.9.1.
 
 use std::cmp::Ordering;
 use std::sync::OnceLock;
@@ -12,8 +12,8 @@ use std::sync::OnceLock;
 use oxc_ast::{
     Comment, CommentKind,
     ast::{
-        ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind, ImportSpecifier,
-        ModuleExportName, Statement,
+        ExportNamedDeclaration, ExportSpecifier, ImportDeclaration, ImportDeclarationSpecifier,
+        ImportOrExportKind, ImportSpecifier, ModuleExportName, Statement,
     },
 };
 use oxc_span::Span;
@@ -24,11 +24,33 @@ use serde_json::{Map, Value};
 use crate::sort_options::SortOptions;
 use crate::types::{LineIndex, RuleDiagnostic, RuleDiagnosticData, RuleDiagnosticFix};
 
-const RULE: &str = "sort-named-imports";
-const ORDER_MESSAGE_ID: &str = "unexpectedNamedImportsOrder";
-const GROUP_ORDER_MESSAGE_ID: &str = "unexpectedNamedImportsGroupOrder";
-const EXTRA_SPACING_MESSAGE_ID: &str = "extraSpacingBetweenNamedImports";
-const MISSED_SPACING_MESSAGE_ID: &str = "missedSpacingBetweenNamedImports";
+#[derive(Clone, Copy)]
+struct RuleContract {
+    rule: &'static str,
+    selector: &'static str,
+    order_message_id: &'static str,
+    group_order_message_id: &'static str,
+    extra_spacing_message_id: &'static str,
+    missed_spacing_message_id: &'static str,
+}
+
+const IMPORT_CONTRACT: RuleContract = RuleContract {
+    rule: "sort-named-imports",
+    selector: "import",
+    order_message_id: "unexpectedNamedImportsOrder",
+    group_order_message_id: "unexpectedNamedImportsGroupOrder",
+    extra_spacing_message_id: "extraSpacingBetweenNamedImports",
+    missed_spacing_message_id: "missedSpacingBetweenNamedImports",
+};
+
+const EXPORT_CONTRACT: RuleContract = RuleContract {
+    rule: "sort-named-exports",
+    selector: "export",
+    order_message_id: "unexpectedNamedExportsOrder",
+    group_order_message_id: "unexpectedNamedExportsGroupOrder",
+    extra_spacing_message_id: "extraSpacingBetweenNamedExports",
+    missed_spacing_message_id: "missedSpacingBetweenNamedExports",
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Newlines {
@@ -74,7 +96,7 @@ struct RuleOptions {
     newlines_inside: Newlines,
 }
 
-struct NamedImport<'a> {
+struct NamedSpecifier<'a> {
     span: Span,
     name: CompactString,
     source: &'a str,
@@ -115,9 +137,9 @@ pub(crate) fn check(
             continue;
         }
 
-        let selected = select_options(raw_options, declaration, &named_specifiers);
+        let selected = select_import_options(raw_options, declaration, &named_specifiers);
         let options = RuleOptions::from_object(selected);
-        let mut imports: SmallVec<[NamedImport<'_>; 8]> = named_specifiers
+        let mut specifiers: SmallVec<[NamedSpecifier<'_>; 8]> = named_specifiers
             .iter()
             .enumerate()
             .filter_map(|(index, specifier)| {
@@ -131,75 +153,159 @@ pub(crate) fn check(
                     specifier,
                     boundary,
                     &options,
+                    IMPORT_CONTRACT,
                 )
             })
             .collect();
-        if imports.len() < 2 {
+        if specifiers.len() < 2 {
             continue;
         }
 
-        assign_partitions(source_text, comments, &options, &mut imports);
-        let sorted_indices = sort_imports(&options, &imports);
-        let mut sorted_positions = vec![0; imports.len()];
-        for (position, &original_index) in sorted_indices.iter().enumerate() {
-            sorted_positions[original_index] = position;
-        }
-
-        let mut pending: SmallVec<[(&'static str, usize, Option<usize>); 8]> = SmallVec::new();
-        for right_index in 1..imports.len() {
-            let left_index = right_index - 1;
-            let left = &imports[left_index];
-            let right = &imports[right_index];
-
-            if sorted_positions[left_index] > sorted_positions[right_index] {
-                let message_id = if left.group_index == right.group_index {
-                    ORDER_MESSAGE_ID
-                } else {
-                    GROUP_ORDER_MESSAGE_ID
-                };
-                pending.push((message_id, right_index, Some(left_index)));
-            }
-
-            if left.partition_id == right.partition_id
-                && left.group_index <= right.group_index
-                && let Newlines::Count(expected) = newlines_between(&options, left, right)
-            {
-                let actual = empty_lines_between(source_text, left.source_end, right.source_start);
-                if actual < expected {
-                    pending.push((MISSED_SPACING_MESSAGE_ID, right_index, Some(left_index)));
-                } else if actual > expected {
-                    pending.push((EXTRA_SPACING_MESSAGE_ID, right_index, Some(left_index)));
-                }
-            }
-        }
-        if pending.is_empty() {
-            continue;
-        }
-
-        let Some(fix) = build_fix(source_text, &options, &imports, &sorted_indices) else {
-            continue;
-        };
-        for (message_id, right_index, left_index) in pending {
-            let right = &imports[right_index];
-            let left = left_index.map(|index| &imports[index]);
-            let is_group_error = message_id == GROUP_ORDER_MESSAGE_ID;
-            diagnostics.push(RuleDiagnostic {
-                rule_name: RULE,
-                message_id,
-                data: RuleDiagnosticData {
-                    left: left.map_or_else(|| CompactString::new(""), |node| node.name.clone()),
-                    right: right.name.clone(),
-                    left_group: is_group_error.then(|| {
-                        left.map_or_else(|| CompactString::new(""), |node| node.group.clone())
-                    }),
-                    right_group: is_group_error.then(|| right.group.clone()),
-                },
-                loc: lines.loc_for_span(source_text, right.span),
-                fix: fix.clone(),
-            });
-        }
+        check_specifiers(
+            source_text,
+            comments,
+            &options,
+            &mut specifiers,
+            IMPORT_CONTRACT,
+            &lines,
+            &mut diagnostics,
+        );
     }
     diagnostics
+}
+
+pub(crate) fn check_exports(
+    source_text: &str,
+    body: &[Statement<'_>],
+    comments: &[Comment],
+    raw_options: &Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    let lines = LineIndex::new(source_text);
+    let mut diagnostics = SmallVec::new();
+
+    for statement in body {
+        let Statement::ExportNamedDeclaration(declaration) = statement else {
+            continue;
+        };
+        if declaration.specifiers.len() < 2 {
+            continue;
+        }
+        let named_specifiers: SmallVec<[&ExportSpecifier<'_>; 8]> =
+            declaration.specifiers.iter().collect();
+        let selected = select_export_options(raw_options, declaration, &named_specifiers);
+        let options = RuleOptions::from_object(selected);
+        let mut specifiers: SmallVec<[NamedSpecifier<'_>; 8]> = named_specifiers
+            .iter()
+            .enumerate()
+            .filter_map(|(index, specifier)| {
+                let boundary = named_specifiers
+                    .get(index + 1)
+                    .map_or(declaration.span.end, |next| next.span.start);
+                named_export(
+                    source_text,
+                    comments,
+                    declaration,
+                    specifier,
+                    boundary,
+                    &options,
+                    EXPORT_CONTRACT,
+                )
+            })
+            .collect();
+        if specifiers.len() < 2 {
+            continue;
+        }
+
+        check_specifiers(
+            source_text,
+            comments,
+            &options,
+            &mut specifiers,
+            EXPORT_CONTRACT,
+            &lines,
+            &mut diagnostics,
+        );
+    }
+    diagnostics
+}
+
+fn check_specifiers(
+    source_text: &str,
+    comments: &[Comment],
+    options: &RuleOptions,
+    specifiers: &mut [NamedSpecifier<'_>],
+    contract: RuleContract,
+    lines: &LineIndex,
+    diagnostics: &mut SmallVec<[RuleDiagnostic; 8]>,
+) {
+    assign_partitions(source_text, comments, options, specifiers);
+    let sorted_indices = sort_specifiers(options, specifiers);
+    let mut sorted_positions = vec![0; specifiers.len()];
+    for (position, &original_index) in sorted_indices.iter().enumerate() {
+        sorted_positions[original_index] = position;
+    }
+
+    let mut pending: SmallVec<[(&'static str, usize, Option<usize>); 8]> = SmallVec::new();
+    for right_index in 1..specifiers.len() {
+        let left_index = right_index - 1;
+        let left = &specifiers[left_index];
+        let right = &specifiers[right_index];
+
+        if sorted_positions[left_index] > sorted_positions[right_index] {
+            let message_id = if left.group_index == right.group_index {
+                contract.order_message_id
+            } else {
+                contract.group_order_message_id
+            };
+            pending.push((message_id, right_index, Some(left_index)));
+        }
+
+        if left.partition_id == right.partition_id
+            && left.group_index <= right.group_index
+            && let Newlines::Count(expected) = newlines_between(options, left, right)
+        {
+            let actual = empty_lines_between(source_text, left.source_end, right.source_start);
+            if actual < expected {
+                pending.push((
+                    contract.missed_spacing_message_id,
+                    right_index,
+                    Some(left_index),
+                ));
+            } else if actual > expected {
+                pending.push((
+                    contract.extra_spacing_message_id,
+                    right_index,
+                    Some(left_index),
+                ));
+            }
+        }
+    }
+    if pending.is_empty() {
+        return;
+    }
+
+    let Some(fix) = build_fix(source_text, options, specifiers, &sorted_indices) else {
+        return;
+    };
+    for (message_id, right_index, left_index) in pending {
+        let right = &specifiers[right_index];
+        let left = left_index.map(|index| &specifiers[index]);
+        let is_group_error = message_id == contract.group_order_message_id;
+        diagnostics.push(RuleDiagnostic {
+            rule_name: contract.rule,
+            message_id,
+            data: RuleDiagnosticData {
+                left: left.map_or_else(|| CompactString::new(""), |node| node.name.clone()),
+                right: right.name.clone(),
+                left_group: is_group_error.then(|| {
+                    left.map_or_else(|| CompactString::new(""), |node| node.group.clone())
+                }),
+                right_group: is_group_error.then(|| right.group.clone()),
+            },
+            loc: lines.loc_for_span(source_text, right.span),
+            fix: fix.clone(),
+        });
+    }
 }
 
 impl RuleOptions {
@@ -285,7 +391,7 @@ impl RuleOptions {
     }
 }
 
-fn select_options(
+fn select_import_options(
     raw_options: &Value,
     declaration: &ImportDeclaration<'_>,
     specifiers: &[&ImportSpecifier<'_>],
@@ -324,6 +430,45 @@ fn select_options(
     Map::new()
 }
 
+fn select_export_options(
+    raw_options: &Value,
+    declaration: &ExportNamedDeclaration<'_>,
+    specifiers: &[&ExportSpecifier<'_>],
+) -> Map<String, Value> {
+    let candidates: Vec<&Map<String, Value>> = match raw_options {
+        Value::Array(values) => values.iter().filter_map(Value::as_object).collect(),
+        Value::Object(object) => vec![object],
+        _ => Vec::new(),
+    };
+    for candidate in candidates {
+        let Some(condition) = candidate
+            .get("useConfigurationIf")
+            .and_then(Value::as_object)
+        else {
+            return candidate.clone();
+        };
+        let ignore_alias = candidate
+            .get("ignoreAlias")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if let Some(pattern) = condition.get("allNamesMatchPattern")
+            && !specifiers.iter().all(|specifier| {
+                let name = export_name(specifier, ignore_alias);
+                matches_regex(name.as_str(), pattern)
+            })
+        {
+            continue;
+        }
+        if let Some(selector) = condition.get("matchesAstSelector").and_then(Value::as_str)
+            && !matches_export_selector(selector, declaration)
+        {
+            continue;
+        }
+        return candidate.clone();
+    }
+    Map::new()
+}
+
 fn matches_import_selector(selector: &str, declaration: &ImportDeclaration<'_>) -> bool {
     let selector = selector.trim();
     if matches!(
@@ -344,6 +489,36 @@ fn matches_import_selector(selector: &str, declaration: &ImportDeclaration<'_>) 
                 let expected = expected.trim().trim_matches(['\'', '"']);
                 if matches!(field.trim(), "source.value" | "source.raw") {
                     return declaration.source.value.as_str() == expected;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn matches_export_selector(selector: &str, declaration: &ExportNamedDeclaration<'_>) -> bool {
+    let selector = selector.trim();
+    if matches!(
+        selector,
+        "ExportNamedDeclaration"
+            | "* > ExportNamedDeclaration"
+            | "Program > ExportNamedDeclaration"
+            | "Program ExportNamedDeclaration"
+    ) {
+        return true;
+    }
+    if let Some(attribute) = selector
+        .strip_prefix("ExportNamedDeclaration[")
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        for operator in ["=", "=="] {
+            if let Some((field, expected)) = attribute.split_once(operator) {
+                let expected = expected.trim().trim_matches(['\'', '"']);
+                if matches!(field.trim(), "source.value" | "source.raw") {
+                    return declaration
+                        .source
+                        .as_ref()
+                        .is_some_and(|source| source.value.as_str() == expected);
                 }
             }
         }
@@ -437,8 +612,10 @@ fn named_import<'a>(
     specifier: &ImportSpecifier<'_>,
     boundary: u32,
     options: &RuleOptions,
-) -> Option<NamedImport<'a>> {
-    let source_start = movable_leading_comment_start(source_text, comments, specifier, options);
+    contract: RuleContract,
+) -> Option<NamedSpecifier<'a>> {
+    let source_start =
+        movable_leading_comment_start(source_text, comments, specifier.span, options);
     let source_end = comments
         .iter()
         .filter(|comment| {
@@ -462,9 +639,58 @@ fn named_import<'a>(
     } else {
         "value"
     };
-    let group = compute_group(options, name.as_str(), modifier);
+    let group = compute_group(options, name.as_str(), modifier, contract.selector);
     let group_index = options.group_index(group.as_str());
-    Some(NamedImport {
+    Some(NamedSpecifier {
+        span: specifier.span,
+        name,
+        source,
+        source_start,
+        source_end,
+        size: node_source.encode_utf16().count(),
+        group,
+        group_index,
+        partition_id: 0,
+    })
+}
+
+fn named_export<'a>(
+    source_text: &'a str,
+    comments: &[Comment],
+    declaration: &ExportNamedDeclaration<'_>,
+    specifier: &ExportSpecifier<'_>,
+    boundary: u32,
+    options: &RuleOptions,
+    contract: RuleContract,
+) -> Option<NamedSpecifier<'a>> {
+    let source_start =
+        movable_leading_comment_start(source_text, comments, specifier.span, options);
+    let source_end = comments
+        .iter()
+        .filter(|comment| {
+            comment.span.start >= specifier.span.end
+                && comment.span.end <= boundary
+                && is_same_line(source_text, specifier.span.end, comment.span.start)
+        })
+        .map(|comment| comment.span.end)
+        .max()
+        .unwrap_or(specifier.span.end);
+    let source =
+        source_text.get(usize::try_from(source_start).ok()?..usize::try_from(source_end).ok()?)?;
+    let node_source = source_text.get(
+        usize::try_from(specifier.span.start).ok()?..usize::try_from(specifier.span.end).ok()?,
+    )?;
+    let name = export_name(specifier, options.sort.ignore_alias);
+    let modifier = if declaration.export_kind == ImportOrExportKind::Type
+        || specifier.export_kind == ImportOrExportKind::Type
+    {
+        "type"
+    } else {
+        "value"
+    };
+    let group = compute_group(options, name.as_str(), modifier, contract.selector);
+    let group_index = options.group_index(group.as_str());
+    Some(NamedSpecifier {
         span: specifier.span,
         name,
         source,
@@ -480,17 +706,17 @@ fn named_import<'a>(
 fn movable_leading_comment_start(
     source_text: &str,
     comments: &[Comment],
-    specifier: &ImportSpecifier<'_>,
+    specifier_span: Span,
     options: &RuleOptions,
 ) -> u32 {
     let mut leading: SmallVec<[&Comment; 4]> = comments
         .iter()
         .filter(|comment| {
-            comment.attached_to == specifier.span.start && comment.span.end <= specifier.span.start
+            comment.attached_to == specifier_span.start && comment.span.end <= specifier_span.start
         })
         .collect();
     leading.sort_by_key(|comment| comment.span.start);
-    let mut start = specifier.span.start;
+    let mut start = specifier_span.start;
     for comment in leading.into_iter().rev() {
         if is_partition_comment(source_text, comment, &options.partition_by_comment)
             || empty_lines_between(source_text, comment.span.end, start) > 0
@@ -502,7 +728,12 @@ fn movable_leading_comment_start(
     start
 }
 
-fn compute_group(options: &RuleOptions, name: &str, modifier: &str) -> CompactString {
+fn compute_group(
+    options: &RuleOptions,
+    name: &str,
+    modifier: &str,
+    selector: &str,
+) -> CompactString {
     let configured: SmallVec<[&str; 8]> = options.group_names().collect();
     for custom in &options.custom_groups {
         if !configured
@@ -514,12 +745,12 @@ fn compute_group(options: &RuleOptions, name: &str, modifier: &str) -> CompactSt
         if custom
             .matches
             .iter()
-            .any(|matcher| custom_match(matcher, name, modifier))
+            .any(|matcher| custom_match(matcher, name, modifier, selector))
         {
             return custom.group_name.clone();
         }
     }
-    for predefined in [format!("{modifier}-import"), "import".to_owned()] {
+    for predefined in [format!("{modifier}-{selector}"), selector.to_owned()] {
         if configured
             .iter()
             .any(|configured_name| *configured_name == predefined)
@@ -530,11 +761,11 @@ fn compute_group(options: &RuleOptions, name: &str, modifier: &str) -> CompactSt
     CompactString::new("unknown")
 }
 
-fn custom_match(matcher: &CustomMatch, name: &str, modifier: &str) -> bool {
+fn custom_match(matcher: &CustomMatch, name: &str, modifier: &str, selector: &str) -> bool {
     if matcher
         .selector
         .as_ref()
-        .is_some_and(|selector| selector.as_str() != "import")
+        .is_some_and(|candidate| candidate.as_str() != selector)
     {
         return false;
     }
@@ -556,45 +787,45 @@ fn assign_partitions(
     source_text: &str,
     comments: &[Comment],
     options: &RuleOptions,
-    imports: &mut [NamedImport<'_>],
+    specifiers: &mut [NamedSpecifier<'_>],
 ) {
     let mut partition_id = 1;
-    for index in 0..imports.len() {
+    for index in 0..specifiers.len() {
         if index > 0 {
             let has_partition_comment = comments.iter().any(|comment| {
-                comment.attached_to == imports[index].span.start
-                    && comment.span.end <= imports[index].span.start
+                comment.attached_to == specifiers[index].span.start
+                    && comment.span.end <= specifiers[index].span.start
                     && is_partition_comment(source_text, comment, &options.partition_by_comment)
             });
             let has_partition_newline = options.partition_by_new_line
                 && empty_lines_between(
                     source_text,
-                    imports[index - 1].source_end,
-                    imports[index].source_start,
+                    specifiers[index - 1].source_end,
+                    specifiers[index].source_start,
                 ) > 0;
             if has_partition_comment || has_partition_newline {
                 partition_id += 1;
             }
         }
-        imports[index].partition_id = partition_id;
+        specifiers[index].partition_id = partition_id;
     }
 }
 
-fn sort_imports(options: &RuleOptions, imports: &[NamedImport<'_>]) -> Vec<usize> {
-    let mut sorted = Vec::with_capacity(imports.len());
+fn sort_specifiers(options: &RuleOptions, specifiers: &[NamedSpecifier<'_>]) -> Vec<usize> {
+    let mut sorted = Vec::with_capacity(specifiers.len());
     let mut start = 0;
-    while start < imports.len() {
-        let partition = imports[start].partition_id;
+    while start < specifiers.len() {
+        let partition = specifiers[start].partition_id;
         let mut end = start + 1;
-        while end < imports.len() && imports[end].partition_id == partition {
+        while end < specifiers.len() && specifiers[end].partition_id == partition {
             end += 1;
         }
         let mut partition_indices: Vec<usize> = (start..end).collect();
         partition_indices.sort_by(|&left, &right| {
-            imports[left]
+            specifiers[left]
                 .group_index
-                .cmp(&imports[right].group_index)
-                .then_with(|| compare_in_group(options, &imports[left], &imports[right]))
+                .cmp(&specifiers[right].group_index)
+                .then_with(|| compare_in_group(options, &specifiers[left], &specifiers[right]))
                 .then_with(|| left.cmp(&right))
         });
         sorted.extend(partition_indices);
@@ -605,8 +836,8 @@ fn sort_imports(options: &RuleOptions, imports: &[NamedImport<'_>]) -> Vec<usize
 
 fn compare_in_group(
     options: &RuleOptions,
-    left: &NamedImport<'_>,
-    right: &NamedImport<'_>,
+    left: &NamedSpecifier<'_>,
+    right: &NamedSpecifier<'_>,
 ) -> Ordering {
     let (sort, raw) = options.sort_options_for_group(left.group_index);
     let object = raw.as_object();
@@ -646,8 +877,8 @@ fn compare_in_group(
 
 fn fallback_compare(
     options: &RuleOptions,
-    left: &NamedImport<'_>,
-    right: &NamedImport<'_>,
+    left: &NamedSpecifier<'_>,
+    right: &NamedSpecifier<'_>,
     raw: Option<&Map<String, Value>>,
 ) -> Ordering {
     let Some(fallback) = raw
@@ -677,8 +908,8 @@ fn fallback_compare(
 
 fn subgroup_compare(
     options: &RuleOptions,
-    left: &NamedImport<'_>,
-    right: &NamedImport<'_>,
+    left: &NamedSpecifier<'_>,
+    right: &NamedSpecifier<'_>,
     raw: Option<&Map<String, Value>>,
 ) -> Ordering {
     let Some(GroupEntry::Group { names, .. }) = options.groups.get(left.group_index) else {
@@ -704,8 +935,8 @@ fn subgroup_compare(
 
 fn newlines_between(
     options: &RuleOptions,
-    left: &NamedImport<'_>,
-    right: &NamedImport<'_>,
+    left: &NamedSpecifier<'_>,
+    right: &NamedSpecifier<'_>,
 ) -> Newlines {
     if left.group_index == right.group_index {
         if let Some(custom) = options
@@ -774,36 +1005,36 @@ fn newlines_between(
 fn build_fix(
     source_text: &str,
     options: &RuleOptions,
-    imports: &[NamedImport<'_>],
+    specifiers: &[NamedSpecifier<'_>],
     sorted_indices: &[usize],
 ) -> Option<RuleDiagnosticFix> {
     let mut replacement = CompactString::new("");
-    let mut desired_source_starts = Vec::with_capacity(imports.len());
-    let mut desired_source_ends = Vec::with_capacity(imports.len());
+    let mut desired_source_starts = Vec::with_capacity(specifiers.len());
+    let mut desired_source_ends = Vec::with_capacity(specifiers.len());
     let mut changed_start: Option<u32> = None;
     let mut changed_end: Option<u32> = None;
-    for position in 0..imports.len() {
+    for position in 0..specifiers.len() {
         desired_source_starts.push(replacement.len());
-        replacement.push_str(imports[*sorted_indices.get(position)?].source);
+        replacement.push_str(specifiers[*sorted_indices.get(position)?].source);
         desired_source_ends.push(replacement.len());
         if sorted_indices[position] != position {
             changed_start = Some(
-                changed_start.map_or(imports[position].source_start, |start| {
-                    start.min(imports[position].source_start)
+                changed_start.map_or(specifiers[position].source_start, |start| {
+                    start.min(specifiers[position].source_start)
                 }),
             );
-            changed_end = Some(changed_end.map_or(imports[position].source_end, |end| {
-                end.max(imports[position].source_end)
+            changed_end = Some(changed_end.map_or(specifiers[position].source_end, |end| {
+                end.max(specifiers[position].source_end)
             }));
         }
-        if position + 1 == imports.len() {
+        if position + 1 == specifiers.len() {
             continue;
         }
-        let separator_start = usize::try_from(imports[position].source_end).ok()?;
-        let separator_end = usize::try_from(imports[position + 1].source_start).ok()?;
+        let separator_start = usize::try_from(specifiers[position].source_end).ok()?;
+        let separator_end = usize::try_from(specifiers[position + 1].source_start).ok()?;
         let separator = source_text.get(separator_start..separator_end)?;
-        let sorted_left = &imports[*sorted_indices.get(position)?];
-        let sorted_right = &imports[*sorted_indices.get(position + 1)?];
+        let sorted_left = &specifiers[*sorted_indices.get(position)?];
+        let sorted_right = &specifiers[*sorted_indices.get(position + 1)?];
         let desired_separator = if sorted_left.partition_id == sorted_right.partition_id
             && sorted_left.group_index <= sorted_right.group_index
             && let Newlines::Count(expected) = newlines_between(options, sorted_left, sorted_right)
@@ -813,20 +1044,22 @@ fn build_fix(
                 expected,
                 is_same_line(
                     source_text,
-                    imports[position].span.end,
-                    imports[position + 1].span.start,
+                    specifiers[position].span.end,
+                    specifiers[position + 1].span.start,
                 ),
             )
         } else {
             CompactString::from(separator)
         };
         if desired_separator.as_str() != separator {
-            changed_start = Some(changed_start.map_or(imports[position].span.end, |start| {
-                start.min(imports[position].span.end)
-            }));
+            changed_start = Some(
+                changed_start.map_or(specifiers[position].span.end, |start| {
+                    start.min(specifiers[position].span.end)
+                }),
+            );
             changed_end = Some(
-                changed_end.map_or(imports[position + 1].source_start, |end| {
-                    end.max(imports[position + 1].source_start)
+                changed_end.map_or(specifiers[position + 1].source_start, |end| {
+                    end.max(specifiers[position + 1].source_start)
                 }),
             );
         }
@@ -836,13 +1069,13 @@ fn build_fix(
     let changed_end = changed_end?;
     let replacement_start = desired_offset_for_boundary(
         changed_start,
-        imports,
+        specifiers,
         &desired_source_starts,
         &desired_source_ends,
     )?;
     let replacement_end = desired_offset_for_boundary(
         changed_end,
-        imports,
+        specifiers,
         &desired_source_starts,
         &desired_source_ends,
     )?;
@@ -859,23 +1092,24 @@ fn build_fix(
 
 fn desired_offset_for_boundary(
     boundary: u32,
-    imports: &[NamedImport<'_>],
+    specifiers: &[NamedSpecifier<'_>],
     desired_source_starts: &[usize],
     desired_source_ends: &[usize],
 ) -> Option<usize> {
-    for (index, import) in imports.iter().enumerate() {
-        if boundary == import.source_start {
+    for (index, specifier) in specifiers.iter().enumerate() {
+        if boundary == specifier.source_start {
             return desired_source_starts.get(index).copied();
         }
-        if boundary == import.source_end {
+        if boundary == specifier.source_end {
             return desired_source_ends.get(index).copied();
         }
-        if boundary == import.span.end {
-            let offset = usize::try_from(import.span.end.checked_sub(import.source_start)?).ok()?;
+        if boundary == specifier.span.end {
+            let offset =
+                usize::try_from(specifier.span.end.checked_sub(specifier.source_start)?).ok()?;
             return desired_source_starts.get(index)?.checked_add(offset);
         }
     }
-    let first_start = imports.first()?.source_start;
+    let first_start = specifiers.first()?.source_start;
     usize::try_from(boundary.checked_sub(first_start)?).ok()
 }
 
@@ -946,6 +1180,14 @@ fn import_name(specifier: &ImportSpecifier<'_>, ignore_alias: bool) -> CompactSt
         module_export_name(&specifier.imported)
     } else {
         CompactString::from(specifier.local.name.as_str())
+    }
+}
+
+fn export_name(specifier: &ExportSpecifier<'_>, ignore_alias: bool) -> CompactString {
+    if ignore_alias {
+        module_export_name(&specifier.local)
+    } else {
+        module_export_name(&specifier.exported)
     }
 }
 

--- a/crates/perfectionist/src/tests.rs
+++ b/crates/perfectionist/src/tests.rs
@@ -61,6 +61,10 @@ fn configured(source: &str, options: serde_json::Value) -> SmallVec<[RuleDiagnos
     scan_perfectionist_rule(source, "fixture.ts", "sort-named-imports", &options)
 }
 
+fn configured_exports(source: &str, options: serde_json::Value) -> SmallVec<[RuleDiagnostic; 8]> {
+    scan_perfectionist_rule(source, "fixture.ts", "sort-named-exports", &options)
+}
+
 #[test]
 fn sorts_predefined_type_and_value_groups() {
     let diagnostics = configured(
@@ -262,4 +266,150 @@ fn keeps_utf16_offsets_for_unicode_group_fixes() {
     assert_eq!(diagnostics[0].fix.start, 15);
     assert_eq!(diagnostics[0].fix.end, 26);
     assert_eq!(diagnostics[0].fix.replacement, "api, 你好, 世界");
+}
+
+#[test]
+fn sorts_named_exports_by_exported_alias_and_original_name() {
+    let by_alias = configured_exports("export { a as C, b as B, c as A } from 'pkg';", json!([]));
+    assert_eq!(by_alias.len(), 2);
+    assert_eq!(by_alias[0].data.left, "C");
+    assert_eq!(by_alias[0].data.right, "B");
+    assert_eq!(by_alias[0].fix.replacement, "c as A, b as B, a as C");
+
+    let by_original = configured_exports(
+        "export { c as A, b as B, a as C } from 'pkg';",
+        json!([{ "ignoreAlias": true }]),
+    );
+    assert_eq!(by_original.len(), 2);
+    assert_eq!(by_original[0].data.left, "c");
+    assert_eq!(by_original[0].data.right, "b");
+    assert_eq!(by_original[0].fix.replacement, "a as C, b as B, c as A");
+}
+
+#[test]
+fn sorts_named_export_predefined_and_custom_groups() {
+    let diagnostics = configured_exports(
+        "export { value, type ApiType, type Other } from 'pkg';",
+        json!([{
+            "customGroups": [{
+                "groupName": "api",
+                "modifiers": ["type"],
+                "selector": "export",
+                "elementNamePattern": "^Api"
+            }],
+            "groups": ["api", "type-export", "unknown"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].message_id,
+        "unexpectedNamedExportsGroupOrder"
+    );
+    assert_eq!(diagnostics[0].data.right, "ApiType");
+    assert_eq!(diagnostics[0].data.right_group.as_deref(), Some("api"));
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "type ApiType, type Other, value"
+    );
+}
+
+#[test]
+fn applies_named_export_partition_and_newline_policies() {
+    let diagnostics = configured_exports(
+        "export {\n  D,\n  A,\n\n  C,\n  // Part\n  B,\n  A2,\n} from 'pkg';",
+        json!([{
+            "partitionByNewLine": true,
+            "partitionByComment": "^Part",
+            "newlinesInside": 0
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].data.left, "D");
+    assert_eq!(diagnostics[0].data.right, "A");
+    assert_eq!(diagnostics[1].data.left, "B");
+    assert_eq!(diagnostics[1].data.right, "A2");
+}
+
+#[test]
+fn selects_named_export_conditional_configuration() {
+    let diagnostics = configured_exports(
+        "export { b, g, r } from 'pkg';",
+        json!([
+            {
+                "type": "unsorted",
+                "useConfigurationIf": { "allNamesMatchPattern": "^foo" }
+            },
+            {
+                "customGroups": [
+                    { "groupName": "r", "elementNamePattern": "^r$" },
+                    { "groupName": "g", "elementNamePattern": "^g$" },
+                    { "groupName": "b", "elementNamePattern": "^b$" }
+                ],
+                "groups": ["r", "g", "b"],
+                "useConfigurationIf": {
+                    "matchesAstSelector": "ExportNamedDeclaration",
+                    "allNamesMatchPattern": "^[rgb]$"
+                }
+            }
+        ]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.message_id == "unexpectedNamedExportsGroupOrder")
+    );
+    assert_eq!(diagnostics[0].fix.replacement, "r, g, b");
+}
+
+#[test]
+fn keeps_utf16_offsets_for_unicode_named_export_fixes() {
+    let source = "'😀';\nexport { 世界, 你好, api } from '模块';";
+    let diagnostics = configured_exports(
+        source,
+        json!([{
+            "locales": "zh-CN",
+            "customGroups": [{ "groupName": "api", "elementNamePattern": "^api$" }],
+            "groups": ["api", "unknown"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].fix.start, 15);
+    assert_eq!(diagnostics[0].fix.end, 26);
+    assert_eq!(diagnostics[0].fix.replacement, "api, 你好, 世界");
+}
+
+#[test]
+fn named_export_rule_selection_and_malformed_sources_fail_closed() {
+    assert!(
+        scan_perfectionist_rule(
+            "export { b, a };",
+            "fixture.ts",
+            "sort-named-imports",
+            &json!([])
+        )
+        .is_empty()
+    );
+    assert!(
+        scan_perfectionist_rule(
+            "export { b,",
+            "fixture.ts",
+            "sort-named-exports",
+            &json!([])
+        )
+        .is_empty()
+    );
+    assert!(
+        scan_perfectionist_rule(
+            "export { a };",
+            "fixture.ts",
+            "sort-named-exports",
+            &json!([])
+        )
+        .is_empty()
+    );
 }

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -15,6 +15,7 @@ const PLUGIN_NAME = 'perfectionist';
 const DOCS_BASE = 'https://perfectionist.dev/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedPerfectionistRuleNames());
+const configuredRuleNames = new Set(['sort-named-exports', 'sort-named-imports']);
 const recommendedRuleNames = Object.freeze(
   implementedRuleNames.filter((ruleName) => ruleName !== 'sort-arrays'),
 );
@@ -72,7 +73,7 @@ function recommendedRules(options) {
   return Object.fromEntries(
     recommendedRuleNames.map((ruleName) => [
       `${PLUGIN_NAME}/${ruleName}`,
-      ruleName === 'sort-named-imports' ? ['error', options] : 'error',
+      configuredRuleNames.has(ruleName) ? ['error', options] : 'error',
     ]),
   );
 }
@@ -88,8 +89,8 @@ function createPerfectionistRule(ruleName) {
         url: `${DOCS_BASE}/${ruleName}`,
       },
       fixable: 'code',
-      messages:
-        ruleName === 'sort-named-imports'
+      messages: configuredRuleNames.has(ruleName)
+        ? ruleName === 'sort-named-imports'
           ? {
               unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
               unexpectedNamedImportsGroupOrder:
@@ -99,8 +100,16 @@ function createPerfectionistRule(ruleName) {
                 'Missed spacing between "{{left}}" and "{{right}}".',
             }
           : {
-              unexpected: 'Expected sorted order.',
-            },
+              unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+              unexpectedNamedExportsGroupOrder:
+                'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+              extraSpacingBetweenNamedExports: 'Extra spacing between "{{left}}" and "{{right}}".',
+              missedSpacingBetweenNamedExports:
+                'Missed spacing between "{{left}}" and "{{right}}".',
+            }
+        : {
+            unexpected: 'Expected sorted order.',
+          },
       schema: schemaForRule(ruleName),
     },
     createOnce(context) {
@@ -116,7 +125,7 @@ function createPerfectionistRule(ruleName) {
 }
 
 function diagnosticsForRule(context, ruleName) {
-  if (ruleName === 'sort-named-imports') {
+  if (configuredRuleNames.has(ruleName)) {
     return configuredDiagnosticsForRule(context, ruleName);
   }
   return diagnosticsForContext(context).filter((diagnostic) => diagnostic.ruleName === ruleName);
@@ -191,9 +200,10 @@ function reportDiagnostic(context, diagnostic) {
 }
 
 function schemaForRule(ruleName) {
-  if (ruleName !== 'sort-named-imports') {
+  if (!configuredRuleNames.has(ruleName)) {
     return [];
   }
+  const selector = ruleName === 'sort-named-imports' ? 'import' : 'export';
   const sortType = {
     type: 'string',
     enum: ['subgroup-order', 'alphabetical', 'natural', 'line-length', 'custom', 'unsorted'],
@@ -257,7 +267,7 @@ function schemaForRule(ruleName) {
       type: 'array',
       items: { type: 'string', enum: ['value', 'type'] },
     },
-    selector: { type: 'string', enum: ['import'] },
+    selector: { type: 'string', enum: [selector] },
   };
   const groups = {
     type: 'array',

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -117,6 +117,35 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact named-export data and UTF-16 fix offsets', () => {
+    const source = `'😀';\r\nexport { item2, item10 } from "pkg";\r\n`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-named-exports', [
+      { type: 'natural', order: 'desc' },
+    ]);
+    const start = source.indexOf('item2');
+    const end = source.indexOf('item10') + 'item10'.length;
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-named-exports',
+      messageId: 'unexpectedNamedExportsOrder',
+      data: {
+        left: 'item2',
+        right: 'item10',
+      },
+      loc: {
+        startLine: 2,
+        startColumn: 16,
+        endLine: 2,
+        endColumn: 22,
+      },
+      fix: {
+        start,
+        end,
+        replacement: 'item10, item2',
+      },
+    });
+  });
+
   it('returns exact group-order data and a comment-preserving fix', () => {
     const source = `import {
   // value docs
@@ -150,12 +179,57 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact named-export group data and a comment-preserving fix', () => {
+    const source = `export {
+  // value docs
+  value,
+  // type docs
+  type Type,
+} from "pkg";
+`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-named-exports', [
+      { groups: ['type-export', 'unknown'] },
+    ]);
+
+    expect(diagnostic).toMatchObject({
+      ruleName: 'sort-named-exports',
+      messageId: 'unexpectedNamedExportsGroupOrder',
+      data: {
+        left: 'value',
+        right: 'Type',
+        leftGroup: 'unknown',
+        rightGroup: 'type-export',
+      },
+      loc: {
+        startLine: 5,
+        startColumn: 2,
+        endLine: 5,
+        endColumn: 11,
+      },
+      fix: {
+        replacement: '// type docs\n  type Type,\n  // value docs\n  value',
+      },
+    });
+  });
+
   it('isolates configured scanning to its implemented rule', () => {
     expect(
       scanPerfectionistRule('import { b, a } from "pkg";', 'fixture.ts', 'sort-objects', [
         { order: 'desc' },
       ]),
     ).toEqual([]);
+    expect(
+      scanPerfectionistRule('export { b, a };', 'fixture.ts', 'sort-named-imports', []),
+    ).toEqual([]);
+    expect(
+      scanPerfectionistRule('import { b, a } from "pkg";', 'fixture.ts', 'sort-named-exports', []),
+    ).toEqual([]);
+  });
+
+  it('fails closed for malformed named-export syntax', () => {
+    expect(scanPerfectionistRule('export { b,', 'fixture.ts', 'sort-named-exports', [])).toEqual(
+      [],
+    );
   });
 
   it('validates public API scalar arguments', () => {

--- a/npm/perfectionist/test/fixtures/sort-named-exports-options-v5.9.1.json
+++ b/npm/perfectionist/test/fixtures/sort-named-exports-options-v5.9.1.json
@@ -1,0 +1,3152 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-perfectionist",
+    "version": "5.9.1",
+    "sourceCommit": "b35e8e4caf0c8d350cf386e504241f21827dd60b",
+    "sourceHashes": {
+      "rules/sort-named-exports.ts": "8fab71ff2def798b8c5d96d6871125bae80a67e7de6e76ecf15475863b61655e",
+      "rules/sort-named-exports/sort-named-export.ts": "a6016b975724ee115a23467044096934c8b059076ba5e15bc691d920763a7b4d",
+      "test/rules/sort-named-exports.test.ts": "af2674f97668787725ea7971db7c847e517865218eda4bb24c1e99584f53ec4c"
+    },
+    "license": "MIT",
+    "eslintVersion": "9.39.2",
+    "typescriptEslintParserVersion": "8.60.0",
+    "capturePolicy": "Authored named-specifier matrix replayed for export scalar comparators, groups, custom groups, partitions, newline policies, and conditional configuration.",
+    "authoredCases": "npm/perfectionist/test/fixtures/sort-named-imports-options-v5.9.1.json inputs",
+    "tool": "tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
+    "inventory": {
+      "valid": 30,
+      "invalid": 65,
+      "diagnostics": 95,
+      "total": 95
+    }
+  },
+  "cases": [
+    {
+      "name": "default alphabetical order",
+      "code": "export { AAA, BB, C } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "default alphabetical inversion",
+      "code": "export { BB, AAA, C } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"AAA\" to come before \"BB\".",
+          "data": {
+            "right": "AAA",
+            "left": "BB"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 14,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "AAA, BB"
+          }
+        }
+      ],
+      "output": "export { AAA, BB, C } from 'module'"
+    },
+    {
+      "name": "default complete reversal",
+      "code": "export { C, BB, AAA } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"BB\" to come before \"C\".",
+          "data": {
+            "right": "BB",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 15
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "AAA, BB, C"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"AAA\" to come before \"BB\".",
+          "data": {
+            "right": "AAA",
+            "left": "BB"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "AAA, BB, C"
+          }
+        }
+      ],
+      "output": "export { AAA, BB, C } from 'module'"
+    },
+    {
+      "name": "multiline alphabetical order",
+      "code": "export {\n  AAAA,\n  BBB,\n  CC,\n  D,\n} from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "multiline alphabetical inversion",
+      "code": "export {\n  AAAA,\n  CC,\n  BBB,\n  D,\n} from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"BBB\" to come before \"CC\".",
+          "data": {
+            "right": "BBB",
+            "left": "CC"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [19, 28],
+            "text": "BBB,\n  CC"
+          }
+        }
+      ],
+      "output": "export {\n  AAAA,\n  BBB,\n  CC,\n  D,\n} from 'module'"
+    },
+    {
+      "name": "default ignores default export",
+      "code": "export { A, B } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "default sorts by local alias",
+      "code": "export { c as A, b as B, a as C } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "default local alias inversion",
+      "code": "export { a as C, b as B, c as A } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "c as A, b as B, a as C"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 26,
+            "endLine": 1,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "c as A, b as B, a as C"
+          }
+        }
+      ],
+      "output": "export { c as A, b as B, a as C } from 'module'"
+    },
+    {
+      "name": "ignoreAlias original names",
+      "code": "export { A as C, B as B, C as A } from 'module'",
+      "options": [
+        {
+          "ignoreAlias": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "ignoreAlias inversion",
+      "code": "export { C as A, B as B, A as C } from 'module'",
+      "options": [
+        {
+          "ignoreAlias": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "A as C, B as B, C as A"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 26,
+            "endLine": 1,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [9, 31],
+            "text": "A as C, B as B, C as A"
+          }
+        }
+      ],
+      "output": "export { A as C, B as B, C as A } from 'module'"
+    },
+    {
+      "name": "ignoreCase stable equivalent aliases",
+      "code": "export { b as a, a as A } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "case-sensitive lowercase before uppercase",
+      "code": "export { b as a, a as A } from 'module'",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "case-sensitive inversion",
+      "code": "export { a as A, b as a } from 'module'",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"a\" to come before \"A\".",
+          "data": {
+            "right": "a",
+            "left": "A"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 23],
+            "text": "b as a, a as A"
+          }
+        }
+      ],
+      "output": "export { b as a, a as A } from 'module'"
+    },
+    {
+      "name": "alphabetical descending",
+      "code": "export { C, BB, AAA } from 'module'",
+      "options": [
+        {
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "alphabetical descending inversion",
+      "code": "export { AAA, BB, C } from 'module'",
+      "options": [
+        {
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"BB\" to come before \"AAA\".",
+          "data": {
+            "right": "BB",
+            "left": "AAA"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 15,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "C, BB, AAA"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"C\" to come before \"BB\".",
+          "data": {
+            "right": "C",
+            "left": "BB"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 19,
+            "endLine": 1,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "C, BB, AAA"
+          }
+        }
+      ],
+      "output": "export { C, BB, AAA } from 'module'"
+    },
+    {
+      "name": "natural numeric order",
+      "code": "export { item1, item2, item10 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "natural numeric inversion",
+      "code": "export { item10, item2, item1 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"item2\" to come before \"item10\".",
+          "data": {
+            "right": "item2",
+            "left": "item10"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item1, item2, item10"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"item1\" to come before \"item2\".",
+          "data": {
+            "right": "item1",
+            "left": "item2"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 25,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item1, item2, item10"
+          }
+        }
+      ],
+      "output": "export { item1, item2, item10 } from 'module'"
+    },
+    {
+      "name": "natural leading zero order",
+      "code": "export { item01, item1, item2 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "natural leading zero inversion",
+      "code": "export { item2, item1, item01 } from 'module'",
+      "options": [
+        {
+          "type": "natural"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"item1\" to come before \"item2\".",
+          "data": {
+            "right": "item1",
+            "left": "item2"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item01, item1, item2"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"item01\" to come before \"item1\".",
+          "data": {
+            "right": "item01",
+            "left": "item1"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item01, item1, item2"
+          }
+        }
+      ],
+      "output": "export { item01, item1, item2 } from 'module'"
+    },
+    {
+      "name": "natural descending inversion",
+      "code": "export { item1, item2, item10 } from 'module'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"item2\" to come before \"item1\".",
+          "data": {
+            "right": "item2",
+            "left": "item1"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item10, item2, item1"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"item10\" to come before \"item2\".",
+          "data": {
+            "right": "item10",
+            "left": "item2"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [9, 29],
+            "text": "item10, item2, item1"
+          }
+        }
+      ],
+      "output": "export { item10, item2, item1 } from 'module'"
+    },
+    {
+      "name": "line length descending",
+      "code": "export { AAA, BB, C } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "line length descending inversion",
+      "code": "export { C, AAA, BB } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"AAA\" to come before \"C\".",
+          "data": {
+            "right": "AAA",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 16
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "AAA, BB, C"
+          }
+        }
+      ],
+      "output": "export { AAA, BB, C } from 'module'"
+    },
+    {
+      "name": "line length ascending",
+      "code": "export { C, BB, AAA } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "line length counts alias source",
+      "code": "export { long as A, B } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"B\" to come before \"A\".",
+          "data": {
+            "right": "B",
+            "left": "A"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 21,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 21],
+            "text": "B, long as A"
+          }
+        }
+      ],
+      "output": "export { B, long as A } from 'module'"
+    },
+    {
+      "name": "custom reverse alphabet",
+      "code": "export { c, b, a } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "cba"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "custom reverse alphabet inversion",
+      "code": "export { a, b, c } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "cba"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "c, b, a"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"c\" to come before \"b\".",
+          "data": {
+            "right": "c",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "c, b, a"
+          }
+        }
+      ],
+      "output": "export { c, b, a } from 'module'"
+    },
+    {
+      "name": "custom unknown characters remain stable",
+      "code": "export { x, y, z } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "abc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "custom unknown characters compare length",
+      "code": "export { xx, y, zzz } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "abc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"y\" to come before \"xx\".",
+          "data": {
+            "right": "y",
+            "left": "xx"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 14,
+            "endLine": 1,
+            "endColumn": 15
+          },
+          "fix": {
+            "range": [9, 14],
+            "text": "y, xx"
+          }
+        }
+      ],
+      "output": "export { y, xx, zzz } from 'module'"
+    },
+    {
+      "name": "custom descending inversion",
+      "code": "export { c, b, a } from 'module'",
+      "options": [
+        {
+          "type": "custom",
+          "alphabet": "abc",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "unsorted preserves arbitrary order",
+      "code": "export { c, a, b } from 'module'",
+      "options": [
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "unsorted ignores configured fallback",
+      "code": "export { c, a, b } from 'module'",
+      "options": [
+        {
+          "type": "unsorted",
+          "fallbackSort": {
+            "type": "alphabetical"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "special characters keep identifier punctuation",
+      "code": "export { _a, $a, a } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "special characters trim",
+      "code": "export { _a, b, _c } from 'module'",
+      "options": [
+        {
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "special characters trim inversion",
+      "code": "export { _b, a, _c } from 'module'",
+      "options": [
+        {
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"a\" to come before \"_b\".",
+          "data": {
+            "right": "a",
+            "left": "_b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 14,
+            "endLine": 1,
+            "endColumn": 15
+          },
+          "fix": {
+            "range": [9, 14],
+            "text": "a, _b"
+          }
+        }
+      ],
+      "output": "export { a, _b, _c } from 'module'"
+    },
+    {
+      "name": "special characters remove stable equality",
+      "code": "export { ab, a_b } from 'module'",
+      "options": [
+        {
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "Chinese locale order",
+      "code": "export { 你好, 世界, a, A, b, B } from 'module'",
+      "options": [
+        {
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "Chinese locale inversion",
+      "code": "export { b, B, a, A, 世界, 你好 } from 'module'",
+      "options": [
+        {
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"a\" to come before \"B\".",
+          "data": {
+            "right": "a",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "你好, 世界, a, A, b, B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"世界\" to come before \"A\".",
+          "data": {
+            "right": "世界",
+            "left": "A"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 22,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "你好, 世界, a, A, b, B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"你好\" to come before \"世界\".",
+          "data": {
+            "right": "你好",
+            "left": "世界"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 26,
+            "endLine": 1,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "你好, 世界, a, A, b, B"
+          }
+        }
+      ],
+      "output": "export { 你好, 世界, a, A, b, B } from 'module'"
+    },
+    {
+      "name": "locale preference array",
+      "code": "export { 你好, 世界, a, A, b, B } from 'module'",
+      "options": [
+        {
+          "locales": ["zh-CN", "en-US"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "Swedish locale inversion",
+      "code": "export { ä, å, z, a } from 'module'",
+      "options": [
+        {
+          "locales": "sv"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"å\" to come before \"ä\".",
+          "data": {
+            "right": "å",
+            "left": "ä"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "a, z, å, ä"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"z\" to come before \"å\".",
+          "data": {
+            "right": "z",
+            "left": "å"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "a, z, å, ä"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"a\" to come before \"z\".",
+          "data": {
+            "right": "a",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 19,
+            "endLine": 1,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [9, 19],
+            "text": "a, z, å, ä"
+          }
+        }
+      ],
+      "output": "export { a, z, å, ä } from 'module'"
+    },
+    {
+      "name": "fallback resolves case-insensitive tie",
+      "code": "export { bb as a, a as A } from 'module'",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "line-length",
+            "order": "asc"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"a\".",
+          "data": {
+            "right": "A",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 19,
+            "endLine": 1,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [9, 24],
+            "text": "a as A, bb as a"
+          }
+        }
+      ],
+      "output": "export { a as A, bb as a } from 'module'"
+    },
+    {
+      "name": "fallback descending resolves line-length tie",
+      "code": "export { c, a, b } from 'module'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc",
+          "fallbackSort": {
+            "type": "alphabetical",
+            "order": "desc"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 16],
+            "text": "b, a"
+          }
+        }
+      ],
+      "output": "export { c, b, a } from 'module'"
+    },
+    {
+      "name": "type-only export",
+      "code": "export type { A, B } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "type specifier inversion",
+      "code": "export { type B, type A } from 'module'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 23],
+            "text": "type A, type B"
+          }
+        }
+      ],
+      "output": "export { type A, type B } from 'module'"
+    },
+    {
+      "name": "arbitrary string export inversion",
+      "code": "export { \"B\" as b, \"A\" as a } from 'module'",
+      "options": [
+        {
+          "ignoreAlias": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 20,
+            "endLine": 1,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "\"A\" as a, \"B\" as b"
+          }
+        }
+      ],
+      "output": "export { \"A\" as a, \"B\" as b } from 'module'"
+    },
+    {
+      "name": "multiple declarations",
+      "code": "export { B, A } from 'one';\nexport { D, C } from 'two';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 13],
+            "text": "A, B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"C\" to come before \"D\".",
+          "data": {
+            "right": "C",
+            "left": "D"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 13,
+            "endLine": 2,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [37, 41],
+            "text": "C, D"
+          }
+        }
+      ],
+      "output": "export { A, B } from 'one';\nexport { C, D } from 'two';"
+    },
+    {
+      "name": "CRLF multiline inversion",
+      "code": "export {\r\n  B,\r\n  A,\r\n} from 'module';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 19],
+            "text": "A,\r\n  B"
+          }
+        }
+      ],
+      "output": "export {\r\n  A,\r\n  B,\r\n} from 'module';"
+    },
+    {
+      "name": "UTF-16 prefix keeps fix offsets",
+      "code": "'😀';\nexport { B, A } from 'module';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 13,
+            "endLine": 2,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [15, 19],
+            "text": "A, B"
+          }
+        }
+      ],
+      "output": "'😀';\nexport { A, B } from 'module';"
+    },
+    {
+      "name": "inline trailing comma inversion",
+      "code": "export { B, A, } from 'module';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 13],
+            "text": "A, B"
+          }
+        }
+      ],
+      "output": "export { A, B, } from 'module';"
+    },
+    {
+      "name": "multiline without trailing comma",
+      "code": "export {\n  B,\n  A\n} from 'module';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 17],
+            "text": "A,\n  B"
+          }
+        }
+      ],
+      "output": "export {\n  A,\n  B\n} from 'module';"
+    },
+    {
+      "name": "leading comments move with exports",
+      "code": "export {\n  // B docs\n  B,\n  // A docs\n  A,\n} from 'module';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 41],
+            "text": "// A docs\n  A,\n  // B docs\n  B"
+          }
+        }
+      ],
+      "output": "export {\n  // A docs\n  A,\n  // B docs\n  B,\n} from 'module';"
+    },
+    {
+      "name": "trailing comments stay attached to slots",
+      "code": "export {\n  B, // first\n  A, // second\n} from 'module';",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 37],
+            "text": "A, // second\n  B, // first"
+          }
+        }
+      ],
+      "output": "export {\n  A, // second\n  B, // first\n} from 'module';"
+    },
+    {
+      "name": "predefined type group before unknown",
+      "code": "export {\n  value,\n  type Type,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-export", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"Type\" (type-export) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-export",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [11, 29],
+            "text": "type Type,\n  value"
+          }
+        }
+      ],
+      "output": "export {\n  type Type,\n  value,\n} from 'module';"
+    },
+    {
+      "name": "predefined unknown before type group",
+      "code": "export {\n  type Type,\n  value,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["unknown", "type-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"value\" (unknown) to come before \"Type\" (type-export).",
+          "data": {
+            "right": "value",
+            "rightGroup": "unknown",
+            "left": "Type",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 29],
+            "text": "value,\n  type Type"
+          }
+        }
+      ],
+      "output": "export {\n  value,\n  type Type,\n} from 'module';"
+    },
+    {
+      "name": "declaration type exports use type group",
+      "code": "export type {\n  B,\n  A,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-export", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [16, 22],
+            "text": "A,\n  B"
+          }
+        }
+      ],
+      "output": "export type {\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "custom element pattern orders matching group first",
+      "code": "export { zebra, alpha, apiClient } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api"
+            }
+          ],
+          "groups": ["api", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"zebra\".",
+          "data": {
+            "right": "alpha",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "apiClient, alpha, zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"apiClient\" (api) to come before \"alpha\" (unknown).",
+          "data": {
+            "right": "apiClient",
+            "rightGroup": "api",
+            "left": "alpha",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "apiClient, alpha, zebra"
+          }
+        }
+      ],
+      "output": "export { apiClient, alpha, zebra } from 'module';"
+    },
+    {
+      "name": "custom regex flags and alias name",
+      "code": "export { zed, source as APIClient } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": {
+                "pattern": "^api",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["api", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"APIClient\" (api) to come before \"zed\" (unknown).",
+          "data": {
+            "right": "APIClient",
+            "rightGroup": "api",
+            "left": "zed",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 15,
+            "endLine": 1,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [9, 33],
+            "text": "source as APIClient, zed"
+          }
+        }
+      ],
+      "output": "export { source as APIClient, zed } from 'module';"
+    },
+    {
+      "name": "custom regex pattern array",
+      "code": "export { zebra, beta, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "letters",
+              "elementNamePattern": ["^alpha$", "^beta$"]
+            }
+          ],
+          "groups": ["letters", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"beta\" (letters) to come before \"zebra\" (unknown).",
+          "data": {
+            "right": "beta",
+            "rightGroup": "letters",
+            "left": "zebra",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "alpha, beta, zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 23,
+            "endLine": 1,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [9, 27],
+            "text": "alpha, beta, zebra"
+          }
+        }
+      ],
+      "output": "export { alpha, beta, zebra } from 'module';"
+    },
+    {
+      "name": "custom type modifier",
+      "code": "export { value, type Zebra, type Alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "types",
+              "modifiers": ["type"]
+            }
+          ],
+          "groups": ["types", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"Zebra\" (types) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Zebra",
+            "rightGroup": "types",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [9, 38],
+            "text": "type Alpha, type Zebra, value"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"Alpha\" to come before \"Zebra\".",
+          "data": {
+            "right": "Alpha",
+            "left": "Zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 29,
+            "endLine": 1,
+            "endColumn": 39
+          },
+          "fix": {
+            "range": [9, 38],
+            "text": "type Alpha, type Zebra, value"
+          }
+        }
+      ],
+      "output": "export { type Alpha, type Zebra, value } from 'module';"
+    },
+    {
+      "name": "custom value modifier",
+      "code": "export { type Type, zebra, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "values",
+              "modifiers": ["value"]
+            }
+          ],
+          "groups": ["values", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"zebra\" (values) to come before \"Type\" (unknown).",
+          "data": {
+            "right": "zebra",
+            "rightGroup": "values",
+            "left": "Type",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 21,
+            "endLine": 1,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, zebra, type Type"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"zebra\".",
+          "data": {
+            "right": "alpha",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 28,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, zebra, type Type"
+          }
+        }
+      ],
+      "output": "export { alpha, zebra, type Type } from 'module';"
+    },
+    {
+      "name": "custom selector export",
+      "code": "export { zebra, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "imports",
+              "selector": "export"
+            }
+          ],
+          "groups": ["imports", "unknown"],
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "custom anyOf match",
+      "code": "export { type other, type FooType, fooValue } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "foo",
+              "anyOf": [
+                {
+                  "modifiers": ["type"],
+                  "elementNamePattern": "Foo"
+                },
+                {
+                  "elementNamePattern": "^foo"
+                }
+              ]
+            }
+          ],
+          "groups": ["foo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"FooType\" (foo) to come before \"other\" (unknown).",
+          "data": {
+            "right": "FooType",
+            "rightGroup": "foo",
+            "left": "other",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 22,
+            "endLine": 1,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [9, 43],
+            "text": "type FooType, fooValue, type other"
+          }
+        }
+      ],
+      "output": "export { type FooType, fooValue, type other } from 'module';"
+    },
+    {
+      "name": "custom groups ignore names absent from groups",
+      "code": "export { zebra, apiClient, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api"
+            }
+          ],
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"apiClient\" to come before \"zebra\".",
+          "data": {
+            "right": "apiClient",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, apiClient, zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"apiClient\".",
+          "data": {
+            "right": "alpha",
+            "left": "apiClient"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 28,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "alpha, apiClient, zebra"
+          }
+        }
+      ],
+      "output": "export { alpha, apiClient, zebra } from 'module';"
+    },
+    {
+      "name": "custom group line length override",
+      "code": "export { type a, type bb, type cccc, value } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "types",
+              "modifiers": ["type"],
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["types", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [9, 35],
+            "text": "type cccc, type bb, type a"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"cccc\" to come before \"bb\".",
+          "data": {
+            "right": "cccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 27,
+            "endLine": 1,
+            "endColumn": 36
+          },
+          "fix": {
+            "range": [9, 35],
+            "text": "type cccc, type bb, type a"
+          }
+        }
+      ],
+      "output": "export { type cccc, type bb, type a, value } from 'module';"
+    },
+    {
+      "name": "custom group unsorted preserves member order",
+      "code": "export { value, type Zebra, type Alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "types",
+              "modifiers": ["type"],
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["types", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"Zebra\" (types) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Zebra",
+            "rightGroup": "types",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [9, 38],
+            "text": "type Zebra, type Alpha, value"
+          }
+        }
+      ],
+      "output": "export { type Zebra, type Alpha, value } from 'module';"
+    },
+    {
+      "name": "group object alphabetical descending override",
+      "code": "export { alpha, beta } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "groups": [
+            {
+              "group": "unknown",
+              "type": "alphabetical",
+              "order": "desc"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"beta\" to come before \"alpha\".",
+          "data": {
+            "right": "beta",
+            "left": "alpha"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "beta, alpha"
+          }
+        }
+      ],
+      "output": "export { beta, alpha } from 'module';"
+    },
+    {
+      "name": "subgroup declaration order fallback",
+      "code": "export { beta, alpha } from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "a",
+              "elementNamePattern": "^alpha$"
+            },
+            {
+              "groupName": "b",
+              "elementNamePattern": "^beta$"
+            }
+          ],
+          "groups": [["a", "b"], "unknown"],
+          "fallbackSort": {
+            "type": "subgroup-order"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "alpha, beta"
+          }
+        }
+      ],
+      "output": "export { alpha, beta } from 'module';"
+    },
+    {
+      "name": "partition by newline sorts sections independently",
+      "code": "export {\n  D,\n  A,\n\n  C,\n\n  E,\n  B,\n} from 'module';",
+      "options": [
+        {
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"D\".",
+          "data": {
+            "right": "A",
+            "left": "D"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 34],
+            "text": "A,\n  D,\n\n  C,\n\n  B,\n  E"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"B\" to come before \"E\".",
+          "data": {
+            "right": "B",
+            "left": "E"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 34],
+            "text": "A,\n  D,\n\n  C,\n\n  B,\n  E"
+          }
+        }
+      ],
+      "output": "export {\n  A,\n  D,\n\n  C,\n\n  B,\n  E,\n} from 'module';"
+    },
+    {
+      "name": "partition by any comment",
+      "code": "export {\n  B,\n  // section\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "partition by string comment",
+      "code": "export {\n  C,\n  // Part: one\n  B,\n  // note\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [31, 47],
+            "text": "// note\n  A,\n  B"
+          }
+        }
+      ],
+      "output": "export {\n  C,\n  // Part: one\n  // note\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "partition by comment pattern array",
+      "code": "export {\n  D,\n  /* Section */\n  C,\n  // Part: one\n  B,\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": ["Section", "^Part"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [52, 58],
+            "text": "A,\n  B"
+          }
+        }
+      ],
+      "output": "export {\n  D,\n  /* Section */\n  C,\n  // Part: one\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "partition by line comments only",
+      "code": "export {\n  C,\n  /* block */\n  B,\n  // line\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 31],
+            "text": "/* block */\n  B,\n  C"
+          }
+        }
+      ],
+      "output": "export {\n  /* block */\n  B,\n  C,\n  // line\n  A,\n} from 'module';"
+    },
+    {
+      "name": "partition by block comments only",
+      "code": "export {\n  C,\n  // line\n  B,\n  /* block */\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"B\" to come before \"C\".",
+          "data": {
+            "right": "B",
+            "left": "C"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 27],
+            "text": "// line\n  B,\n  C"
+          }
+        }
+      ],
+      "output": "export {\n  // line\n  B,\n  C,\n  /* block */\n  A,\n} from 'module';"
+    },
+    {
+      "name": "partition line and block patterns",
+      "code": "export {\n  D,\n  // LINE A\n  C,\n  /* BLOCK B */\n  B,\n  A,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": {
+            "line": {
+              "pattern": "^ LINE",
+              "flags": "i"
+            },
+            "block": ["BLOCK"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"C\" to come before \"D\".",
+          "data": {
+            "right": "C",
+            "left": "D"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 55],
+            "text": "// LINE A\n  C,\n  D,\n  /* BLOCK B */\n  A,\n  B"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [11, 55],
+            "text": "// LINE A\n  C,\n  D,\n  /* BLOCK B */\n  A,\n  B"
+          }
+        }
+      ],
+      "output": "export {\n  // LINE A\n  C,\n  D,\n  /* BLOCK B */\n  A,\n  B,\n} from 'module';"
+    },
+    {
+      "name": "partition preserves comments with group ordering",
+      "code": "export {\n  // Part: A\n  value,\n  type Type,\n  // Part: B\n  Zebra,\n  Alpha,\n} from 'module';",
+      "options": [
+        {
+          "partitionByComment": "^Part",
+          "groups": ["type-export", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"Type\" (type-export) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-export",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [24, 73],
+            "text": "type Type,\n  value,\n  // Part: B\n  Alpha,\n  Zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"Alpha\" to come before \"Zebra\".",
+          "data": {
+            "right": "Alpha",
+            "left": "Zebra"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [24, 73],
+            "text": "type Type,\n  value,\n  // Part: B\n  Alpha,\n  Zebra"
+          }
+        }
+      ],
+      "output": "export {\n  // Part: A\n  type Type,\n  value,\n  // Part: B\n  Alpha,\n  Zebra,\n} from 'module';"
+    },
+    {
+      "name": "zero newlines inside and between groups",
+      "code": "export {\n  api,\n\n  zebra,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenNamedExports",
+          "message": "Extra spacing between \"api\" and \"zebra\".",
+          "data": {
+            "left": "api",
+            "right": "zebra"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 34],
+            "text": ",\n  alpha,\n  zebra"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"zebra\".",
+          "data": {
+            "right": "alpha",
+            "left": "zebra"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 34],
+            "text": ",\n  alpha,\n  zebra"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenNamedExports",
+          "message": "Extra spacing between \"zebra\" and \"alpha\".",
+          "data": {
+            "left": "zebra",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 34],
+            "text": ",\n  alpha,\n  zebra"
+          }
+        }
+      ],
+      "output": "export {\n  api,\n  alpha,\n  zebra,\n} from 'module';"
+    },
+    {
+      "name": "one newline between groups",
+      "code": "export {\n  api,\n  alpha,\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedExports",
+          "message": "Missed spacing between \"api\" and \"alpha\".",
+          "data": {
+            "left": "api",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 18],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "export {\n  api,\n\n  alpha,\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "two newlines between groups",
+      "code": "export {\n  api,\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedExports",
+          "message": "Missed spacing between \"api\" and \"alpha\".",
+          "data": {
+            "left": "api",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [14, 18],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "export {\n  api,\n\n\n  alpha,\n} from 'module';"
+    },
+    {
+      "name": "zero newlines inside group",
+      "code": "export {\n  beta,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenNamedExports",
+          "message": "Extra spacing between \"beta\" and \"alpha\".",
+          "data": {
+            "left": "beta",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        }
+      ],
+      "output": "export {\n  alpha,\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "one newline inside custom group",
+      "code": "export {\n  alpha,\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "letters",
+              "elementNamePattern": ".*",
+              "newlinesInside": 1
+            }
+          ],
+          "groups": ["letters"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedExports",
+          "message": "Missed spacing between \"alpha\" and \"beta\".",
+          "data": {
+            "left": "alpha",
+            "right": "beta"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [16, 20],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "export {\n  alpha,\n\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "group object newlinesInside override",
+      "code": "export {\n  alpha,\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "groups": [
+            {
+              "group": "unknown",
+              "newlinesInside": 1
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenNamedExports",
+          "message": "Missed spacing between \"alpha\" and \"beta\".",
+          "data": {
+            "left": "alpha",
+            "right": "beta"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [16, 20],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "export {\n  alpha,\n\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "inline newlinesBetween override",
+      "code": "export {\n  alpha,\n\n  beta,\n  charlie,\n} from 'module';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "a",
+              "elementNamePattern": "^alpha$"
+            },
+            {
+              "groupName": "b",
+              "elementNamePattern": "^beta$"
+            },
+            {
+              "groupName": "c",
+              "elementNamePattern": "^charlie$"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenNamedExports",
+          "message": "Extra spacing between \"alpha\" and \"beta\".",
+          "data": {
+            "left": "alpha",
+            "right": "beta"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [16, 29],
+            "text": ",\n  beta,\n\n  "
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenNamedExports",
+          "message": "Missed spacing between \"beta\" and \"charlie\".",
+          "data": {
+            "left": "beta",
+            "right": "charlie"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [16, 29],
+            "text": ",\n  beta,\n\n  "
+          }
+        }
+      ],
+      "output": "export {\n  alpha,\n  beta,\n\n  charlie,\n} from 'module';"
+    },
+    {
+      "name": "newlines ignore preserves spacing",
+      "code": "export {\n  alpha,\n\n\n  beta,\n} from 'module';",
+      "options": [
+        {
+          "newlinesInside": "ignore",
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "partition newline suppresses spacing diagnostic",
+      "code": "export {\n  beta,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "spacing and ordering diagnostics combine",
+      "code": "export {\n  beta,\n\n  alpha,\n} from 'module';",
+      "options": [
+        {
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenNamedExports",
+          "message": "Extra spacing between \"beta\" and \"alpha\".",
+          "data": {
+            "left": "beta",
+            "right": "alpha"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 25],
+            "text": "alpha,\n  beta"
+          }
+        }
+      ],
+      "output": "export {\n  alpha,\n  beta,\n} from 'module';"
+    },
+    {
+      "name": "conditional names picks first matching option",
+      "code": "export { b, g, r } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^foo"
+          }
+        },
+        {
+          "customGroups": [
+            {
+              "groupName": "r",
+              "elementNamePattern": "^r$"
+            },
+            {
+              "groupName": "g",
+              "elementNamePattern": "^g$"
+            },
+            {
+              "groupName": "b",
+              "elementNamePattern": "^b$"
+            }
+          ],
+          "groups": ["r", "g", "b"],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "r, g, b"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [9, 16],
+            "text": "r, g, b"
+          }
+        }
+      ],
+      "output": "export { r, g, b } from 'module';"
+    },
+    {
+      "name": "conditional names regex object and alias",
+      "code": "export { first as B, second as A } from 'module';",
+      "options": [
+        {
+          "ignoreAlias": false,
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "^[ab]$",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"A\" to come before \"B\".",
+          "data": {
+            "right": "A",
+            "left": "B"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 22,
+            "endLine": 1,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [9, 32],
+            "text": "second as A, first as B"
+          }
+        }
+      ],
+      "output": "export { second as A, first as B } from 'module';"
+    },
+    {
+      "name": "conditional names ignore alias",
+      "code": "export { b as y, a as z } from 'module';",
+      "options": [
+        {
+          "ignoreAlias": true,
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[ab]$"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 18,
+            "endLine": 1,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [9, 23],
+            "text": "a as z, b as y"
+          }
+        }
+      ],
+      "output": "export { a as z, b as y } from 'module';"
+    },
+    {
+      "name": "conditional export selector match",
+      "code": "export { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ExportNamedDeclaration"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "conditional export selector child match",
+      "code": "export { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ExportNamedDeclaration"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "conditional nonmatching selector falls through",
+      "code": "export { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "VariableDeclaration"
+          }
+        },
+        {
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "alpha, beta"
+          }
+        }
+      ],
+      "output": "export { alpha, beta } from 'module';"
+    },
+    {
+      "name": "conditional selector and names both required",
+      "code": "export { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ExportNamedDeclaration",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "name": "no conditional match uses defaults",
+      "code": "export { beta, alpha } from 'module';",
+      "options": [
+        {
+          "type": "unsorted",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^never$"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 16,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [9, 20],
+            "text": "alpha, beta"
+          }
+        }
+      ],
+      "output": "export { alpha, beta } from 'module';"
+    },
+    {
+      "name": "unicode custom group and utf16 prefix",
+      "code": "'😀';\nexport { 世界, 你好, api } from '模块';",
+      "options": [
+        {
+          "locales": "zh-CN",
+          "customGroups": [
+            {
+              "groupName": "api",
+              "elementNamePattern": "^api$"
+            }
+          ],
+          "groups": ["api", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"你好\" to come before \"世界\".",
+          "data": {
+            "right": "你好",
+            "left": "世界"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 14,
+            "endLine": 2,
+            "endColumn": 16
+          },
+          "fix": {
+            "range": [15, 26],
+            "text": "api, 你好, 世界"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"api\" (api) to come before \"你好\" (unknown).",
+          "data": {
+            "right": "api",
+            "rightGroup": "api",
+            "left": "你好",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 18,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [15, 26],
+            "text": "api, 你好, 世界"
+          }
+        }
+      ],
+      "output": "'😀';\nexport { api, 你好, 世界 } from '模块';"
+    },
+    {
+      "name": "comments move with group members",
+      "code": "export {\n  // value docs\n  value,\n  // type docs\n  type Type,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-export", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"Type\" (type-export) to come before \"value\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-export",
+            "left": "value",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [11, 60],
+            "text": "// type docs\n  type Type,\n  // value docs\n  value"
+          }
+        }
+      ],
+      "output": "export {\n  // type docs\n  type Type,\n  // value docs\n  value,\n} from 'module';"
+    },
+    {
+      "name": "inline comment survives group movement and spacing",
+      "code": "export {\n  beta,\n  alpha, // alpha docs\n  type Type,\n} from 'module';",
+      "options": [
+        {
+          "groups": ["type-export", "unknown"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedNamedExportsOrder",
+          "message": "Expected \"alpha\" to come before \"beta\".",
+          "data": {
+            "right": "alpha",
+            "left": "beta"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [11, 51],
+            "text": "type Type,\n\n  alpha, // alpha docs\n  beta"
+          }
+        },
+        {
+          "messageId": "unexpectedNamedExportsGroupOrder",
+          "message": "Expected \"Type\" (type-export) to come before \"alpha\" (unknown).",
+          "data": {
+            "right": "Type",
+            "rightGroup": "type-export",
+            "left": "alpha",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [11, 51],
+            "text": "type Type,\n\n  alpha, // alpha docs\n  beta"
+          }
+        }
+      ],
+      "output": "export {\n  type Type,\n\n  alpha, // alpha docs\n  beta,\n} from 'module';"
+    }
+  ]
+}

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -120,14 +120,17 @@ describe('perfectionist plugin adapter', () => {
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      ruleName === 'sort-named-imports'
+      ['sort-named-exports', 'sort-named-imports'].includes(ruleName)
         ? 'Expected "{{right}}" to come before "{{left}}".'
         : 'Expected sorted order.',
     );
   });
 
-  it('declares the complete implemented option schema', () => {
-    const schema = plugin.rules['sort-named-imports'].meta.schema;
+  it.each([
+    ['sort-named-imports', 'import'],
+    ['sort-named-exports', 'export'],
+  ])('declares the complete implemented option schema for %s', (ruleName, selector) => {
+    const schema = plugin.rules[ruleName].meta.schema;
 
     expect(schema).toHaveLength(1);
     expect(Object.keys(schema[0].properties).sort()).toEqual([
@@ -169,6 +172,9 @@ describe('perfectionist plugin adapter', () => {
       type: 'array',
       items: { oneOf: expect.any(Array) },
     });
+    expect(schema[0].properties.customGroups.items.oneOf[0].properties.selector.enum).toEqual([
+      selector,
+    ]);
     expect(schema[0].properties.partitionByComment.oneOf).toHaveLength(5);
     expect(schema[0].properties.useConfigurationIf).toMatchObject({
       minProperties: 1,
@@ -177,10 +183,14 @@ describe('perfectionist plugin adapter', () => {
     expect(plugin.rules['sort-imports'].meta.schema).toEqual([]);
   });
 
-  it('threads recommended comparator options only into sort-named-imports', () => {
+  it('threads recommended comparator options into both named-specifier rules', () => {
     const rules = plugin.configs['recommended-natural'].rules;
 
     expect(rules['perfectionist/sort-named-imports']).toEqual([
+      'error',
+      { type: 'natural', order: 'asc' },
+    ]);
+    expect(rules['perfectionist/sort-named-exports']).toEqual([
       'error',
       { type: 'natural', order: 'asc' },
     ]);
@@ -295,6 +305,68 @@ describe('perfectionist plugin adapter', () => {
       expect(fixed.stderr).toBe('');
       expect(readFileSync(fixturePath, 'utf8')).toBe(
         'import {\n  type Type,\n\n  value,\n} from "pkg";\n',
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads named-export options and fixes through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-named-exports-'));
+    try {
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(fixturePath, 'export { value, type Type } from "pkg";\n');
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'perfectionist',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'perfectionist/sort-named-exports': [
+              'error',
+              {
+                groups: ['type-export', 'unknown'],
+                newlinesBetween: 1,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(1);
+      expect(payload.diagnostics[0]).toMatchObject({
+        code: 'perfectionist(sort-named-exports)',
+        message: 'Expected "Type" (type-export) to come before "value" (unknown).',
+      });
+
+      const fixed = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe(
+        'export { type Type, \n\nvalue } from "pkg";\n',
       );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/npm/perfectionist/test/sort-named-exports-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-named-exports-options-upstream.test.mjs
@@ -1,0 +1,151 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/sort-named-exports-options-v5.9.1.json', import.meta.url),
+    'utf8',
+  ),
+);
+const rule = plugin.rules['sort-named-exports'];
+
+describe('perfectionist/sort-named-exports v5.9.1 option parity', () => {
+  it('pins the reviewed upstream source and exact fixture inventory', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-perfectionist',
+      version: '5.9.1',
+      sourceCommit: 'b35e8e4caf0c8d350cf386e504241f21827dd60b',
+      sourceHashes: {
+        'rules/sort-named-exports.ts':
+          '8fab71ff2def798b8c5d96d6871125bae80a67e7de6e76ecf15475863b61655e',
+        'rules/sort-named-exports/sort-named-export.ts':
+          'a6016b975724ee115a23467044096934c8b059076ba5e15bc691d920763a7b4d',
+        'test/rules/sort-named-exports.test.ts':
+          'af2674f97668787725ea7971db7c847e517865218eda4bb24c1e99584f53ec4c',
+      },
+      inventory: {
+        valid: 30,
+        invalid: 65,
+        diagnostics: 95,
+        total: 95,
+      },
+    });
+    expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
+    expect(
+      fixture.cases.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+    ).toBe(fixture.__generated.inventory.diagnostics);
+  });
+
+  for (const [index, testCase] of fixture.cases.entries()) {
+    it(`replays case ${index + 1}/${fixture.cases.length}: ${testCase.name}`, () => {
+      const reports = runRule(testCase.code, testCase.options, testCase.filename);
+      expect(
+        reports.map((report) => exactDiagnostic(report)),
+        testCase.name,
+      ).toEqual(testCase.expectedDiagnostics);
+
+      if (testCase.output === null) {
+        expect(reports, testCase.name).toEqual([]);
+        return;
+      }
+
+      const convergence = applyIteratively(testCase.code, testCase.options, testCase.filename);
+      expect(convergence.output, testCase.name).toBe(testCase.output);
+      expect(convergence.remainingReports, testCase.name).toEqual([]);
+      expect(convergence.passes, testCase.name).toBeGreaterThanOrEqual(1);
+      expect(convergence.passes, testCase.name).toBeLessThanOrEqual(8);
+    });
+  }
+});
+
+function runRule(sourceText, options, filename) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    options,
+    sourceCode,
+    filename,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function exactDiagnostic(report) {
+  const replacement = report.fix?.({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return {
+    messageId: report.messageId,
+    message: Object.entries(report.data).reduce(
+      (message, [key, value]) => message.replace(`{{${key}}}`, value),
+      rule.meta.messages[report.messageId],
+    ),
+    data: report.data,
+    loc: {
+      startLine: report.loc.start.line,
+      startColumn: report.loc.start.column + 1,
+      endLine: report.loc.end.line,
+      endColumn: report.loc.end.column + 1,
+    },
+    fix: replacement ?? null,
+  };
+}
+
+function applyIteratively(sourceText, options, filename) {
+  let output = sourceText;
+  let passes = 0;
+  for (; passes < 8; passes += 1) {
+    const reports = runRule(output, options, filename);
+    const next = applyFixPass(output, reports);
+    if (next === null) {
+      return { output, passes, remainingReports: reports };
+    }
+    output = next;
+  }
+  throw new Error(`Fixes did not converge for ${JSON.stringify(sourceText)}`);
+}
+
+function applyFixPass(sourceText, reports) {
+  const fixes = reports
+    .flatMap((report) => {
+      const fix = report.fix?.({
+        replaceTextRange(range, text) {
+          return { range, text };
+        },
+      });
+      return fix ? [fix] : [];
+    })
+    .sort((left, right) => left.range[0] - right.range[0] || left.range[1] - right.range[1]);
+  if (fixes.length === 0) {
+    return null;
+  }
+
+  const accepted = [];
+  let lastEnd = -1;
+  for (const fix of fixes) {
+    if (fix.range[0] < lastEnd) {
+      continue;
+    }
+    accepted.push(fix);
+    lastEnd = fix.range[1];
+  }
+
+  let output = sourceText;
+  for (const fix of accepted.toReversed()) {
+    output = output.slice(0, fix.range[0]) + fix.text + output.slice(fix.range[1]);
+  }
+  return output;
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "port:tests:postgresql": "node tools/tasks/sync-postgresql-tests.ts",
     "port:tests:postgresql-parser": "node tools/tasks/sync-postgresql-parser-tests.ts",
     "port:tests:perfectionist:sort-named-imports": "node tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
+    "port:tests:perfectionist:sort-named-exports": "node tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",

--- a/tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts
@@ -1,0 +1,308 @@
+// Captures the authored named-specifier option matrix against
+// eslint-plugin-perfectionist/sort-named-exports v5.9.1. The exact upstream
+// commit and source hashes prevent silent fixture drift.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+type TestCase = {
+  name: string;
+  code: string;
+  options?: Array<Record<string, unknown>>;
+  filename?: string;
+};
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type AuthoredFixture = {
+  __generated: {
+    version: string;
+    sourceCommit: string;
+  };
+  cases: TestCase[];
+};
+
+const ROOT = process.cwd();
+const RULE = 'sort-named-exports';
+const PINNED_COMMIT = 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
+const ESLINT_VERSION = '9.39.2';
+const TYPESCRIPT_ESLINT_VERSION = '8.60.0';
+const SOURCE_HASHES = {
+  'rules/sort-named-exports.ts': '8fab71ff2def798b8c5d96d6871125bae80a67e7de6e76ecf15475863b61655e',
+  'rules/sort-named-exports/sort-named-export.ts':
+    'a6016b975724ee115a23467044096934c8b059076ba5e15bc691d920763a7b4d',
+  'test/rules/sort-named-exports.test.ts':
+    'af2674f97668787725ea7971db7c847e517865218eda4bb24c1e99584f53ec4c',
+} as const;
+
+const authoredFixture = JSON.parse(
+  readFileSync(
+    join(
+      ROOT,
+      'npm',
+      'perfectionist',
+      'test',
+      'fixtures',
+      'sort-named-imports-options-v5.9.1.json',
+    ),
+    'utf8',
+  ),
+) as AuthoredFixture;
+if (
+  authoredFixture.__generated.version !== '5.9.1' ||
+  authoredFixture.__generated.sourceCommit !== PINNED_COMMIT
+) {
+  throw new Error('Named-import authored matrix is not pinned to Perfectionist v5.9.1.');
+}
+
+const cases = authoredFixture.cases.map(toNamedExportCase);
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-perfectionist');
+if (!plugin) {
+  throw new Error('eslint-plugin-perfectionist is not registered in tools/port-targets.json');
+}
+if (plugin.baselineVersion !== '5.9.1' || plugin.pinnedRef !== 'v5.9.1') {
+  throw new Error(
+    `Expected perfectionist v5.9.1 manifest pin, received ${plugin.baselineVersion} / ${plugin.pinnedRef}`,
+  );
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Upstream checkout not found: ${plugin.submodule}`);
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}`);
+}
+for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
+  const actualHash = createHash('sha256')
+    .update(readFileSync(join(submodule, sourceFile)))
+    .digest('hex');
+  if (actualHash !== expectedHash) {
+    throw new Error(`Expected ${sourceFile} hash ${expectedHash}, received ${actualHash}`);
+  }
+}
+
+const runnerDirectory = mkdtempSync(join(tmpdir(), 'perfectionist-named-exports-'));
+try {
+  writeFileSync(
+    join(runnerDirectory, 'package.json'),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@typescript-eslint/parser': TYPESCRIPT_ESLINT_VERSION,
+          eslint: ESLINT_VERSION,
+          'eslint-plugin-perfectionist': plugin.baselineVersion,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(join(runnerDirectory, 'cases.json'), `${JSON.stringify(cases)}\n`);
+  writeFileSync(join(runnerDirectory, 'runner.mjs'), runnerSource());
+  execFileSync(
+    'pnpm',
+    ['install', '--dir', runnerDirectory, '--ignore-workspace', '--lockfile=false', '--silent'],
+    { stdio: 'inherit' },
+  );
+  execFileSync('node', [join(runnerDirectory, 'runner.mjs')], { stdio: 'inherit' });
+  const captured = JSON.parse(
+    readFileSync(join(runnerDirectory, 'captured.json'), 'utf8'),
+  ) as Array<{ expectedDiagnostics: unknown[] }>;
+  const valid = captured.filter((testCase) => testCase.expectedDiagnostics.length === 0).length;
+  const invalid = captured.length - valid;
+  const diagnostics = captured.reduce(
+    (total, testCase) => total + testCase.expectedDiagnostics.length,
+    0,
+  );
+  const fixture = {
+    __generated: {
+      source: plugin.npm,
+      version: plugin.baselineVersion,
+      sourceCommit: PINNED_COMMIT,
+      sourceHashes: SOURCE_HASHES,
+      license: plugin.license,
+      eslintVersion: ESLINT_VERSION,
+      typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
+      capturePolicy:
+        'Authored named-specifier matrix replayed for export scalar comparators, groups, custom groups, partitions, newline policies, and conditional configuration.',
+      authoredCases:
+        'npm/perfectionist/test/fixtures/sort-named-imports-options-v5.9.1.json inputs',
+      tool: 'tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts',
+      inventory: {
+        valid,
+        invalid,
+        diagnostics,
+        total: captured.length,
+      },
+    },
+    cases: captured,
+  };
+  const fixturesDirectory = join(ROOT, 'npm', 'perfectionist', 'test', 'fixtures');
+  mkdirSync(fixturesDirectory, { recursive: true });
+  const fixturePath = join(fixturesDirectory, `${RULE}-options-v${plugin.baselineVersion}.json`);
+  writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  execFileSync('pnpm', ['exec', 'vp', 'fmt', fixturePath], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  console.log(
+    `Captured ${RULE} v${plugin.baselineVersion}: ${valid} valid, ${invalid} invalid, ${diagnostics} diagnostics.`,
+  );
+} finally {
+  rmSync(runnerDirectory, { recursive: true, force: true });
+}
+
+function toNamedExportCase(testCase: TestCase): TestCase {
+  let code = testCase.code.replaceAll('import ', 'export ');
+  code = code.replace(/export Default,\s*(?=\{)/gu, 'export ');
+  return {
+    name: testCase.name.replaceAll('import', 'export'),
+    code,
+    options: transformOptions(testCase.options ?? []) as Array<Record<string, unknown>>,
+    filename: 'fixture.ts',
+  };
+}
+
+function transformOptions(value: unknown, key?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => transformOptions(entry, key));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        transformOptions(entryValue, entryKey),
+      ]),
+    );
+  }
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value === 'type-import') {
+    return 'type-export';
+  }
+  if (value === 'value-import') {
+    return 'value-export';
+  }
+  if (key === 'selector' && value === 'import') {
+    return 'export';
+  }
+  if (key === 'matchesAstSelector') {
+    return value.replaceAll('ImportDeclaration', 'ExportNamedDeclaration');
+  }
+  return value;
+}
+
+function runnerSource(): string {
+  return `
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import perfectionistModule from 'eslint-plugin-perfectionist';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const cases = JSON.parse(readFileSync(join(here, 'cases.json'), 'utf8'));
+const perfectionist = perfectionistModule.default ?? perfectionistModule;
+const linter = new Linter();
+
+function configFor(testCase) {
+  return [{
+    files: ['**/*.{js,ts}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: { perfectionist },
+    rules: {
+      'perfectionist/${RULE}': ['error', ...(testCase.options ?? [])],
+    },
+  }];
+}
+
+const captured = cases.map(testCase => {
+  const filename = testCase.filename ?? 'fixture.ts';
+  const config = configFor(testCase);
+  const diagnostics = linter.verify(testCase.code, config, { filename });
+  const unexpected = diagnostics.filter(problem => problem.ruleId !== 'perfectionist/${RULE}');
+  if (unexpected.length > 0) {
+    throw new Error(
+      testCase.name + ' produced non-rule diagnostics: ' + JSON.stringify(unexpected),
+    );
+  }
+  const fixed = linter.verifyAndFix(testCase.code, config, { filename });
+  return {
+    ...testCase,
+    options: testCase.options ?? [],
+    filename,
+    expectedDiagnostics: diagnostics.map(problem => ({
+      messageId: problem.messageId,
+      message: problem.message,
+      data: dataFromMessage(problem.message),
+      loc: {
+        startLine: problem.line,
+        startColumn: problem.column,
+        endLine: problem.endLine,
+        endColumn: problem.endColumn,
+      },
+      fix: problem.fix
+        ? {
+            range: problem.fix.range,
+            text: problem.fix.text,
+          }
+        : null,
+    })),
+    output: fixed.fixed ? fixed.output : null,
+  };
+});
+
+writeFileSync(join(here, 'captured.json'), JSON.stringify(captured));
+
+function dataFromMessage(message) {
+  const match = /^Expected "(.+)" to come before "(.+)"\\.$/u.exec(message);
+  if (match) {
+    return { right: match[1], left: match[2] };
+  }
+  const groupMatch = /^Expected "(.+)" \\((.+)\\) to come before "(.+)" \\((.+)\\)\\.$/u.exec(message);
+  if (groupMatch) {
+    return {
+      right: groupMatch[1],
+      rightGroup: groupMatch[2],
+      left: groupMatch[3],
+      leftGroup: groupMatch[4],
+    };
+  }
+  const spacingMatch = /^(?:Extra|Missed) spacing between "(.+)" and "(.+)"\\.$/u.exec(message);
+  if (spacingMatch) {
+    return { left: spacingMatch[1], right: spacingMatch[2] };
+  }
+  return {};
+}
+`;
+}


### PR DESCRIPTION
## Summary
- port the full Perfectionist v5.9.1 sort-named-exports option family
- share the named import/export comparator, groups, custom groups, partitions, newline policies, and conditional configuration engine
- expose exact schemas, messages, data, fixes, UTF-16 ranges, direct adapter behavior, and real Oxlint integration
- add a hash-pinned deterministic upstream capture fixture

## Validation
- 95 pinned upstream-captured cases and 95 exact diagnostics
- 232 targeted JavaScript tests passed
- 27 Perfectionist Rust tests passed
- full pnpm verify passed twice on the final tree
- 16,225 JavaScript tests passed, 1,159 skipped
- full Rust workspace tests, Clippy, typecheck, lint, bench compile, security, license, status, and package dry-run passed

React, JSX, and TSX are intentionally outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->