### PR TITLE
feat(astro): port template expression rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This is unofficial community work. It is not an official Oxlint project, and bui
 
 <!-- This section is generated from `status.json` by `tools/tasks/generate-readme-coverage.ts`. Do not edit by hand; run `pnpm run docs:readme`. -->
 
-**26** ESLint plugins are being ported · **822 / 1001** rules implemented (**82%**).
+**26** ESLint plugins are being ported · **826 / 1001** rules implemented (**83%**).
 
 | Plugin                                                     | Upstream                                                                                                               | Implemented | Total | Coverage |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- | ----- | -------- |
 | [`angular-eslint`](npm/angular-eslint)                     | [`@angular-eslint/eslint-plugin`](https://github.com/angular-eslint/angular-eslint)                                    | 48          | 48    | 100%     |
 | [`angular-eslint-template`](npm/angular-eslint-template)   | [`@angular-eslint/eslint-plugin-template`](https://github.com/angular-eslint/angular-eslint)                           | 0           | 39    | 0%       |
-| [`astro`](npm/astro)                                       | [`eslint-plugin-astro`](https://github.com/ota-meshi/eslint-plugin-astro)                                              | 3           | 20    | 15%      |
+| [`astro`](npm/astro)                                       | [`eslint-plugin-astro`](https://github.com/ota-meshi/eslint-plugin-astro)                                              | 7           | 20    | 35%      |
 | [`cypress`](npm/cypress)                                   | [`eslint-plugin-cypress`](https://github.com/cypress-io/eslint-plugin-cypress)                                         | 13          | 13    | 100%     |
 | [`e18e`](npm/e18e)                                         | [`@e18e/eslint-plugin`](https://github.com/e18e/eslint-plugin)                                                         | 25          | 27    | 93%      |
 | [`eslint-comments`](npm/eslint-comments)                   | [`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) | 9           | 9     | 100%     |
@@ -56,11 +56,11 @@ This is unofficial community work. It is not an official Oxlint project, and bui
 
 </details>
 <details>
-<summary><code>astro</code> — 3/20 implemented</summary>
+<summary><code>astro</code> — 7/20 implemented</summary>
 
-**Implemented (3):** `no-deprecated-astro-canonicalurl`, `no-deprecated-astro-fetchcontent`, `no-deprecated-getentrybyslug`
+**Implemented (7):** `no-deprecated-astro-canonicalurl`, `no-deprecated-astro-fetchcontent`, `no-deprecated-astro-resolve`, `no-deprecated-getentrybyslug`, `no-set-html-directive`, `no-set-text-directive`, `prefer-class-list-directive`
 
-**Not implemented (17):** `missing-client-only-directive-value`, `no-conflict-set-directives`, `no-deprecated-astro-resolve`, `no-exports-from-components`, `no-omitted-end-tags`, `no-prerender-export-outside-pages`, `no-set-html-directive`, `no-set-text-directive`, `no-unsafe-inline-scripts`, `no-unused-css-selector`, `no-unused-define-vars-in-style`, `prefer-class-list-directive`, `prefer-object-class-list`, `prefer-split-class-list`, `semi`, `sort-attributes`, `valid-compile`
+**Not implemented (13):** `missing-client-only-directive-value`, `no-conflict-set-directives`, `no-exports-from-components`, `no-omitted-end-tags`, `no-prerender-export-outside-pages`, `no-unsafe-inline-scripts`, `no-unused-css-selector`, `no-unused-define-vars-in-style`, `prefer-object-class-list`, `prefer-split-class-list`, `semi`, `sort-attributes`, `valid-compile`
 
 </details>
 <details>

--- a/crates/astro/src/lib.rs
+++ b/crates/astro/src/lib.rs
@@ -12,10 +12,14 @@ use oxc_semantic::SemanticBuilder;
 use oxc_span::{GetSpan, SourceType, Span};
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
-pub const RULE_NAMES: [&str; 3] = [
+pub const RULE_NAMES: [&str; 7] = [
     "no-deprecated-astro-canonicalurl",
     "no-deprecated-astro-fetchcontent",
+    "no-deprecated-astro-resolve",
     "no-deprecated-getentrybyslug",
+    "no-set-html-directive",
+    "no-set-text-directive",
+    "prefer-class-list-directive",
 ];
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -40,19 +44,23 @@ pub struct DiagnosticLoc {
     pub end_column: u32,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DiagnosticFix {
     /// UTF-8 byte offset into the original `.astro` source.
     pub start: u32,
     /// UTF-8 byte offset into the original `.astro` source.
     pub end: u32,
-    pub replacement: &'static str,
+    pub replacement: CompactString,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Diagnostic {
     pub rule_name: &'static str,
     pub message_id: &'static str,
+    /// UTF-8 byte offset into the original source.
+    pub start: u32,
+    /// UTF-8 byte offset into the original source.
+    pub end: u32,
     pub loc: DiagnosticLoc,
     pub fix: Option<DiagnosticFix>,
 }
@@ -61,13 +69,11 @@ pub fn implemented_astro_rule_names() -> &'static [&'static str] {
     &RULE_NAMES
 }
 
-/// Scans the first Astro frontmatter block.
+/// Scans Astro frontmatter and the template body.
 ///
-/// Direct callers can pass raw `.astro` source; Oxlint's JavaScript-plugin path
-/// passes its extracted frontmatter through [`AstroOptions::frontmatter_only`].
-/// This core deliberately parses only that TypeScript segment with Oxc.
-/// Template rules remain out of scope until a separate expression segmenter is
-/// added.
+/// Frontmatter and segmented template expressions are parsed with Oxc. The
+/// surrounding Astro markup is handled by a conservative attribute/element
+/// segmenter instead of being treated as JavaScript.
 pub fn scan_astro(
     source_text: &str,
     filename: &str,
@@ -80,47 +86,85 @@ pub fn scan_astro(
         Frontmatter {
             source: source_text,
             offset: 0,
+            body_offset: source_text.len(),
         }
     } else {
-        let Some(frontmatter) = frontmatter(source_text) else {
-            return SmallVec::new();
-        };
-        frontmatter
+        match frontmatter(source_text) {
+            Some(frontmatter) => frontmatter,
+            None if starts_with_frontmatter_delimiter(source_text) => return SmallVec::new(),
+            None => Frontmatter {
+                source: "",
+                offset: 0,
+                body_offset: 0,
+            },
+        }
     };
-
-    let allocator = Allocator::default();
-    let parser_return = Parser::new(
-        &allocator,
-        frontmatter.source,
-        SourceType::ts().with_module(true),
-    )
-    .parse();
-    if !parser_return.errors.is_empty() {
-        return SmallVec::new();
-    }
-    let semantic_return = SemanticBuilder::new().build(&parser_return.program);
-    if !semantic_return.errors.is_empty() {
-        return SmallVec::new();
-    }
 
     let line_index = LineIndex::new(source_text);
-    let mut scanner = Scanner {
+    let mut diagnostics = SmallVec::new();
+    let Some(global_astro_shadowed) = scan_script(
+        frontmatter.source,
+        frontmatter.offset,
         source_text,
-        source_offset: frontmatter.offset,
         options,
-        line_index: &line_index,
-        scoping: semantic_return.semantic.scoping(),
-        diagnostics: SmallVec::new(),
+        &line_index,
+        &mut diagnostics,
+        false,
+    ) else {
+        return SmallVec::new();
     };
-    scanner.visit_program(&parser_return.program);
-    scanner.diagnostics.sort_by(|left, right| {
+    if !options.frontmatter_only {
+        scan_template(
+            source_text,
+            frontmatter.body_offset,
+            options,
+            &line_index,
+            &mut diagnostics,
+            global_astro_shadowed,
+        );
+    }
+    diagnostics.sort_by(|left, right| {
         left.loc
             .start_line
             .cmp(&right.loc.start_line)
             .then(left.loc.start_column.cmp(&right.loc.start_column))
             .then(left.rule_name.cmp(right.rule_name))
     });
-    scanner.diagnostics
+    diagnostics
+}
+
+fn scan_script(
+    script: &str,
+    source_offset: u32,
+    source_text: &str,
+    options: &AstroOptions,
+    line_index: &LineIndex,
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+    inherited_astro_shadow: bool,
+) -> Option<bool> {
+    let allocator = Allocator::default();
+    let parser_return = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+    if !parser_return.errors.is_empty() {
+        return None;
+    }
+    let semantic_return = SemanticBuilder::new().build(&parser_return.program);
+    if !semantic_return.errors.is_empty() {
+        return None;
+    }
+    let scoping = semantic_return.semantic.scoping();
+    let global_astro_shadowed =
+        inherited_astro_shadow || scoping.get_root_binding("Astro".into()).is_some();
+    let mut scanner = Scanner {
+        source_text,
+        source_offset,
+        options,
+        line_index,
+        scoping,
+        global_astro_shadowed: inherited_astro_shadow,
+        diagnostics,
+    };
+    scanner.visit_program(&parser_return.program);
+    Some(global_astro_shadowed)
 }
 
 fn has_astro_extension(filename: &str) -> bool {
@@ -129,10 +173,18 @@ fn has_astro_extension(filename: &str) -> bool {
         .is_some_and(|(_, extension)| extension.eq_ignore_ascii_case("astro"))
 }
 
+fn starts_with_frontmatter_delimiter(source: &str) -> bool {
+    let bom_len = usize::from(source.starts_with('\u{feff}')) * '\u{feff}'.len_utf8();
+    read_line(source, bom_len).is_some_and(|line| {
+        line.text.trim_end_matches([' ', '\t']) == "---" && line.next > line.start
+    })
+}
+
 #[derive(Clone, Copy)]
 struct Frontmatter<'a> {
     source: &'a str,
     offset: u32,
+    body_offset: usize,
 }
 
 fn frontmatter(source: &str) -> Option<Frontmatter<'_>> {
@@ -150,6 +202,7 @@ fn frontmatter(source: &str) -> Option<Frontmatter<'_>> {
             return Some(Frontmatter {
                 source: &source[content_start..line.start],
                 offset: u32::try_from(content_start).ok()?,
+                body_offset: line.next,
             });
         }
         if line.next == cursor || line.next == source.len() {
@@ -197,17 +250,21 @@ fn read_line(source: &str, start: usize) -> Option<Line<'_>> {
     })
 }
 
-struct Scanner<'s> {
+struct Scanner<'s, 'd> {
     source_text: &'s str,
     source_offset: u32,
     options: &'s AstroOptions,
     line_index: &'s LineIndex,
     scoping: &'s Scoping,
-    diagnostics: SmallVec<[Diagnostic; 8]>,
+    global_astro_shadowed: bool,
+    diagnostics: &'d mut SmallVec<[Diagnostic; 8]>,
 }
 
-impl Scanner<'_> {
+impl Scanner<'_, '_> {
     fn is_global_astro(&self, expression: &Expression<'_>) -> bool {
+        if self.global_astro_shadowed {
+            return false;
+        }
         let Expression::Identifier(identifier) = expression.get_inner_expression() else {
             return false;
         };
@@ -229,6 +286,8 @@ impl Scanner<'_> {
         self.diagnostics.push(Diagnostic {
             rule_name,
             message_id: "deprecated",
+            start: span.start,
+            end: span.end,
             loc: self.line_index.loc_for_span(self.source_text, span),
             fix,
         });
@@ -252,16 +311,19 @@ impl Scanner<'_> {
                 let fix = property_span.map(|span| DiagnosticFix {
                     start: span.start.saturating_add(self.source_offset),
                     end: span.end.saturating_add(self.source_offset),
-                    replacement: "glob",
+                    replacement: CompactString::new("glob"),
                 });
                 self.report("no-deprecated-astro-fetchcontent", span, fix);
+            }
+            "resolve" => {
+                self.report("no-deprecated-astro-resolve", span, None);
             }
             _ => {}
         }
     }
 }
 
-impl<'a> Visit<'a> for Scanner<'_> {
+impl<'a> Visit<'a> for Scanner<'_, '_> {
     fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
         self.check_member(
             &member.object,
@@ -299,6 +361,555 @@ impl<'a> Visit<'a> for Scanner<'_> {
         }
         walk::walk_import_declaration(self, declaration);
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttributeKind {
+    Normal,
+    Shorthand,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttributeValueKind {
+    Expression,
+    Template,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AttributeValue {
+    span: Span,
+    kind: AttributeValueKind,
+}
+
+#[derive(Clone, Debug)]
+struct TemplateAttribute<'a> {
+    name: &'a str,
+    name_span: Span,
+    span: Span,
+    kind: AttributeKind,
+    value: Option<AttributeValue>,
+}
+
+#[derive(Clone, Debug)]
+struct TemplateElement<'a> {
+    name: &'a str,
+    opening_span: Span,
+    attributes: SmallVec<[TemplateAttribute<'a>; 8]>,
+    self_closing: bool,
+    closing_span: Option<Span>,
+    children_span: Option<Span>,
+}
+
+fn scan_template(
+    source: &str,
+    body_offset: usize,
+    options: &AstroOptions,
+    line_index: &LineIndex,
+    diagnostics: &mut SmallVec<[Diagnostic; 8]>,
+    global_astro_shadowed: bool,
+) {
+    let mut cursor = body_offset;
+    let mut elements: SmallVec<[TemplateElement<'_>; 16]> = SmallVec::new();
+    let mut stack: SmallVec<[usize; 16]> = SmallVec::new();
+    let mut expressions: SmallVec<[Span; 16]> = SmallVec::new();
+
+    while cursor < source.len() {
+        if source[cursor..].starts_with("<!--") {
+            cursor = source[cursor + 4..]
+                .find("-->")
+                .map_or(source.len(), |relative| cursor + 4 + relative + 3);
+            continue;
+        }
+        if source.as_bytes()[cursor] == b'{'
+            && let Some(end) = balanced_brace_end(source, cursor)
+        {
+            if end > cursor + 2 {
+                expressions.push(span_from_usize(cursor + 1, end - 1));
+            }
+            cursor = end;
+            continue;
+        }
+        if source.as_bytes()[cursor] == b'<' {
+            if source[cursor..].starts_with("</") {
+                if let Some((name, closing_span, end)) = parse_closing_tag(source, cursor) {
+                    if let Some(position) = stack
+                        .iter()
+                        .rposition(|index| elements[*index].name == name)
+                    {
+                        let element_index = stack.remove(position);
+                        stack.truncate(position);
+                        let opening_end = elements[element_index].opening_span.end;
+                        elements[element_index].closing_span = Some(closing_span);
+                        elements[element_index].children_span =
+                            Some(Span::new(opening_end, closing_span.start));
+                    }
+                    cursor = end;
+                    continue;
+                }
+            } else if let Some((element, end, attribute_expressions)) =
+                parse_opening_tag(source, cursor)
+            {
+                expressions.extend(attribute_expressions);
+                let self_closing = element.self_closing;
+                elements.push(element);
+                if !self_closing {
+                    stack.push(elements.len() - 1);
+                }
+                cursor = end;
+                continue;
+            }
+        }
+        cursor = next_char_boundary(source, cursor);
+    }
+
+    for expression_span in expressions {
+        let start = expression_span.start as usize;
+        let end = expression_span.end as usize;
+        if start >= end || end > source.len() {
+            continue;
+        }
+        let _ = scan_script(
+            &source[start..end],
+            expression_span.start,
+            source,
+            options,
+            line_index,
+            diagnostics,
+            global_astro_shadowed,
+        );
+    }
+
+    let mut reporter = TemplateReporter {
+        source,
+        options,
+        line_index,
+        diagnostics,
+    };
+    for element in &elements {
+        let set_text_count = element
+            .attributes
+            .iter()
+            .filter(|attribute| attribute.name == "set:text")
+            .count();
+        for attribute in &element.attributes {
+            match attribute.name {
+                "set:html" => reporter.report(
+                    "no-set-html-directive",
+                    "unexpected",
+                    attribute.name_span,
+                    None,
+                ),
+                "set:text" => {
+                    let fix = (set_text_count == 1)
+                        .then(|| set_text_fix(source, element, attribute))
+                        .flatten();
+                    reporter.report(
+                        "no-set-text-directive",
+                        "disallow",
+                        attribute.name_span,
+                        fix,
+                    );
+                }
+                "class"
+                    if matches!(
+                        attribute.value,
+                        Some(AttributeValue {
+                            kind: AttributeValueKind::Expression | AttributeValueKind::Template,
+                            ..
+                        })
+                    ) || attribute.kind == AttributeKind::Shorthand =>
+                {
+                    let (start, end, replacement) = if attribute.kind == AttributeKind::Shorthand {
+                        (
+                            attribute.span.start,
+                            attribute.span.start,
+                            CompactString::new("class:list="),
+                        )
+                    } else {
+                        (
+                            attribute.name_span.end,
+                            attribute.name_span.end,
+                            CompactString::new(":list"),
+                        )
+                    };
+                    reporter.report(
+                        "prefer-class-list-directive",
+                        "unexpected",
+                        attribute.name_span,
+                        Some(DiagnosticFix {
+                            start,
+                            end,
+                            replacement,
+                        }),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+struct TemplateReporter<'a, 'd> {
+    source: &'a str,
+    options: &'a AstroOptions,
+    line_index: &'a LineIndex,
+    diagnostics: &'d mut SmallVec<[Diagnostic; 8]>,
+}
+
+impl TemplateReporter<'_, '_> {
+    fn report(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        span: Span,
+        fix: Option<DiagnosticFix>,
+    ) {
+        if !self.options.has_rule(rule_name) {
+            return;
+        }
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            start: span.start,
+            end: span.end,
+            loc: self.line_index.loc_for_span(self.source, span),
+            fix,
+        });
+    }
+}
+
+fn set_text_fix(
+    source: &str,
+    element: &TemplateElement<'_>,
+    attribute: &TemplateAttribute<'_>,
+) -> Option<DiagnosticFix> {
+    let value = attribute.value?;
+    let value_text = &source[value.span.start as usize..value.span.end as usize];
+    let mut rendered_value = CompactString::new("");
+    if value.kind == AttributeValueKind::Template {
+        rendered_value.push('{');
+        rendered_value.push_str(value_text);
+        rendered_value.push('}');
+    } else {
+        rendered_value.push_str(value_text);
+    }
+
+    let opening_start = element.opening_span.start as usize;
+    let opening_end = element.opening_span.end as usize;
+    let attribute_start = attribute.span.start as usize;
+    let attribute_end = attribute.span.end as usize;
+    let mut replacement = CompactString::new("");
+    replacement.push_str(&source[opening_start..attribute_start]);
+    replacement.push_str(&source[attribute_end..opening_end]);
+
+    let replacement_end = if element.self_closing {
+        if !replacement.ends_with("/>") {
+            return None;
+        }
+        replacement.remove(replacement.len() - 2);
+        replacement.push_str(&rendered_value);
+        replacement.push_str("</");
+        replacement.push_str(element.name);
+        replacement.push('>');
+        element.opening_span.end
+    } else {
+        let children = element.children_span?;
+        if !source[children.start as usize..children.end as usize]
+            .trim()
+            .is_empty()
+        {
+            return None;
+        }
+        let closing = element.closing_span?;
+        replacement.push_str(&rendered_value);
+        replacement.push_str(&source[closing.start as usize..closing.end as usize]);
+        closing.end
+    };
+
+    Some(DiagnosticFix {
+        start: element.opening_span.start,
+        end: replacement_end,
+        replacement,
+    })
+}
+
+fn parse_opening_tag<'a>(
+    source: &'a str,
+    start: usize,
+) -> Option<(TemplateElement<'a>, usize, SmallVec<[Span; 4]>)> {
+    if !source[start..].starts_with('<')
+        || source[start..].starts_with("</")
+        || source[start..].starts_with("<!")
+        || source[start..].starts_with("<?")
+        || source[start..].starts_with("<>")
+    {
+        return None;
+    }
+    let mut cursor = start + 1;
+    let name_start = cursor;
+    while cursor < source.len() && is_tag_name_byte(source.as_bytes()[cursor]) {
+        cursor += 1;
+    }
+    if cursor == name_start {
+        return None;
+    }
+    let name = &source[name_start..cursor];
+    let mut attributes = SmallVec::new();
+    let mut expressions = SmallVec::new();
+
+    loop {
+        cursor = skip_ascii_whitespace(source, cursor);
+        if cursor >= source.len() {
+            return None;
+        }
+        if source[cursor..].starts_with("/>") {
+            let end = cursor + 2;
+            return Some((
+                TemplateElement {
+                    name,
+                    opening_span: span_from_usize(start, end),
+                    attributes,
+                    self_closing: true,
+                    closing_span: None,
+                    children_span: None,
+                },
+                end,
+                expressions,
+            ));
+        }
+        if source.as_bytes()[cursor] == b'>' {
+            let end = cursor + 1;
+            return Some((
+                TemplateElement {
+                    name,
+                    opening_span: span_from_usize(start, end),
+                    attributes,
+                    self_closing: false,
+                    closing_span: None,
+                    children_span: None,
+                },
+                end,
+                expressions,
+            ));
+        }
+
+        let attribute_start = cursor;
+        if source.as_bytes()[cursor] == b'{' {
+            let end = balanced_brace_end(source, cursor)?;
+            let inner = source[cursor + 1..end - 1].trim();
+            if is_identifier_name(inner) {
+                let relative = source[cursor + 1..end - 1].find(inner)?;
+                let name_start = cursor + 1 + relative;
+                attributes.push(TemplateAttribute {
+                    name: inner,
+                    name_span: span_from_usize(name_start, name_start + inner.len()),
+                    span: span_from_usize(attribute_start, end),
+                    kind: AttributeKind::Shorthand,
+                    value: Some(AttributeValue {
+                        span: span_from_usize(cursor + 1, end - 1),
+                        kind: AttributeValueKind::Expression,
+                    }),
+                });
+                expressions.push(span_from_usize(cursor + 1, end - 1));
+            }
+            cursor = end;
+            continue;
+        }
+
+        let name_start = cursor;
+        while cursor < source.len() && is_attribute_name_byte(source.as_bytes()[cursor]) {
+            cursor += 1;
+        }
+        if cursor == name_start {
+            cursor = next_char_boundary(source, cursor);
+            continue;
+        }
+        let attribute_name = &source[name_start..cursor];
+        let name_span = span_from_usize(name_start, cursor);
+        cursor = skip_ascii_whitespace(source, cursor);
+        let mut value = None;
+        if cursor < source.len() && source.as_bytes()[cursor] == b'=' {
+            cursor = skip_ascii_whitespace(source, cursor + 1);
+            let value_start = cursor;
+            if cursor >= source.len() {
+                return None;
+            }
+            match source.as_bytes()[cursor] {
+                b'{' => {
+                    cursor = balanced_brace_end(source, cursor)?;
+                    value = Some(AttributeValue {
+                        span: span_from_usize(value_start, cursor),
+                        kind: AttributeValueKind::Expression,
+                    });
+                    expressions.push(span_from_usize(value_start + 1, cursor - 1));
+                }
+                b'`' => {
+                    cursor = quoted_end(source, cursor, b'`')?;
+                    value = Some(AttributeValue {
+                        span: span_from_usize(value_start, cursor),
+                        kind: AttributeValueKind::Template,
+                    });
+                    collect_template_interpolations(source, value_start, cursor, &mut expressions);
+                }
+                b'\'' | b'"' => {
+                    let quote = source.as_bytes()[cursor];
+                    cursor = quoted_end(source, cursor, quote)?;
+                    value = Some(AttributeValue {
+                        span: span_from_usize(value_start, cursor),
+                        kind: AttributeValueKind::Other,
+                    });
+                }
+                _ => {
+                    while cursor < source.len()
+                        && !source.as_bytes()[cursor].is_ascii_whitespace()
+                        && !matches!(source.as_bytes()[cursor], b'>' | b'/')
+                    {
+                        cursor += 1;
+                    }
+                    value = Some(AttributeValue {
+                        span: span_from_usize(value_start, cursor),
+                        kind: AttributeValueKind::Other,
+                    });
+                }
+            }
+        }
+        attributes.push(TemplateAttribute {
+            name: attribute_name,
+            name_span,
+            span: span_from_usize(attribute_start, cursor),
+            kind: AttributeKind::Normal,
+            value,
+        });
+    }
+}
+
+fn parse_closing_tag(source: &str, start: usize) -> Option<(&str, Span, usize)> {
+    let mut cursor = start + 2;
+    let name_start = cursor;
+    while cursor < source.len() && is_tag_name_byte(source.as_bytes()[cursor]) {
+        cursor += 1;
+    }
+    if cursor == name_start {
+        return None;
+    }
+    let name = &source[name_start..cursor];
+    cursor = skip_ascii_whitespace(source, cursor);
+    if cursor >= source.len() || source.as_bytes()[cursor] != b'>' {
+        return None;
+    }
+    let end = cursor + 1;
+    Some((name, span_from_usize(start, end), end))
+}
+
+fn collect_template_interpolations(
+    source: &str,
+    start: usize,
+    end: usize,
+    expressions: &mut SmallVec<[Span; 4]>,
+) {
+    let mut cursor = start + 1;
+    while cursor + 1 < end {
+        if source[cursor..].starts_with("${")
+            && let Some(expression_end) = balanced_brace_end(source, cursor + 1)
+        {
+            expressions.push(span_from_usize(cursor + 2, expression_end - 1));
+            cursor = expression_end;
+            continue;
+        }
+        cursor = next_char_boundary(source, cursor);
+    }
+}
+
+fn balanced_brace_end(source: &str, start: usize) -> Option<usize> {
+    if source.as_bytes().get(start) != Some(&b'{') {
+        return None;
+    }
+    let mut cursor = start + 1;
+    let mut depth = 1_u32;
+    while cursor < source.len() {
+        if source[cursor..].starts_with("//") {
+            cursor = source[cursor + 2..]
+                .find(['\n', '\r', '\u{2028}', '\u{2029}'])
+                .map_or(source.len(), |relative| cursor + 2 + relative);
+            continue;
+        }
+        if source[cursor..].starts_with("/*") {
+            cursor = source[cursor + 2..]
+                .find("*/")
+                .map_or(source.len(), |relative| cursor + 2 + relative + 2);
+            continue;
+        }
+        match source.as_bytes()[cursor] {
+            b'\'' | b'"' | b'`' => {
+                cursor = quoted_end(source, cursor, source.as_bytes()[cursor])?;
+            }
+            b'{' => {
+                depth += 1;
+                cursor += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                cursor += 1;
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            _ => cursor = next_char_boundary(source, cursor),
+        }
+    }
+    None
+}
+
+fn quoted_end(source: &str, start: usize, quote: u8) -> Option<usize> {
+    let mut cursor = start + 1;
+    while cursor < source.len() {
+        match source.as_bytes()[cursor] {
+            b'\\' => {
+                cursor += 1;
+                if cursor < source.len() {
+                    cursor = next_char_boundary(source, cursor);
+                }
+            }
+            byte if byte == quote => return Some(cursor + 1),
+            _ => cursor = next_char_boundary(source, cursor),
+        }
+    }
+    None
+}
+
+fn skip_ascii_whitespace(source: &str, mut cursor: usize) -> usize {
+    while cursor < source.len() && source.as_bytes()[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn next_char_boundary(source: &str, cursor: usize) -> usize {
+    cursor + source[cursor..].chars().next().map_or(1, char::len_utf8)
+}
+
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b':' | b'$' | b'.' | b'-')
+}
+
+fn is_attribute_name_byte(byte: u8) -> bool {
+    !byte.is_ascii_whitespace() && !matches!(byte, b'=' | b'>' | b'/' | b'{' | b'}')
+}
+
+fn is_identifier_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}
+
+fn span_from_usize(start: usize, end: usize) -> Span {
+    Span::new(
+        u32::try_from(start).unwrap_or(u32::MAX),
+        u32::try_from(end).unwrap_or(u32::MAX),
+    )
 }
 
 fn shifted_span(span: Span, offset: u32) -> Span {

--- a/crates/astro/src/tests.rs
+++ b/crates/astro/src/tests.rs
@@ -27,6 +27,14 @@ fn names(diagnostics: &[Diagnostic]) -> SmallVec<[&str; 8]> {
         .collect()
 }
 
+fn apply_fix(source: &str, diagnostic: &Diagnostic) -> CompactString {
+    let fix = diagnostic.fix.as_ref().expect("diagnostic fix");
+    let mut output = CompactString::new(&source[..fix.start as usize]);
+    output.push_str(&fix.replacement);
+    output.push_str(&source[fix.end as usize..]);
+    output
+}
+
 #[test]
 fn exposes_the_slice_rule_names() {
     assert_eq!(
@@ -34,7 +42,11 @@ fn exposes_the_slice_rule_names() {
         [
             "no-deprecated-astro-canonicalurl",
             "no-deprecated-astro-fetchcontent",
+            "no-deprecated-astro-resolve",
             "no-deprecated-getentrybyslug",
+            "no-set-html-directive",
+            "no-set-text-directive",
+            "prefer-class-list-directive",
         ]
     );
 }
@@ -91,7 +103,7 @@ fn replays_upstream_fetchcontent_invalid_fixture_and_fix() {
         Some(DiagnosticFix {
             start: property as u32,
             end: (property + "fetchContent".len()) as u32,
-            replacement: "glob",
+            replacement: "glob".into(),
         })
     );
 }
@@ -126,6 +138,244 @@ fn replays_upstream_getentrybyslug_invalid_fixture() {
 #[test]
 fn replays_upstream_getentry_valid_fixture() {
     assert!(scan("---\n/* ✓ GOOD */\nimport { getEntry } from \"astro:content\"\n---").is_empty());
+}
+
+#[test]
+fn replays_upstream_resolve_template_fixture() {
+    let source = "---\nconst { animal } = Astro.props;\n---\n\n{/* ✗ BAD */}\n<img src={Astro.resolve(`../images/${animal}.png`)} />";
+    let diagnostics = scan_rule(source, "no-deprecated-astro-resolve");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "deprecated");
+    assert_eq!(diagnostics[0].loc.start_line, 6);
+    assert_eq!(diagnostics[0].loc.start_column, 10);
+}
+
+#[test]
+fn accepts_upstream_resolve_replacement() {
+    assert!(
+        scan_rule(
+            "---\nconst { animal } = Astro.props;\n---\n\n{/* ✓ GOOD */}\n<img src={await import(`../images/${animal}.png`)} />",
+            "no-deprecated-astro-resolve",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn frontmatter_astro_binding_shadows_template_references() {
+    assert!(
+        scan_rule(
+            "---\nconst Astro = { resolve() {} }\n---\n<div>{Astro.resolve(\"local\")}</div>",
+            "no-deprecated-astro-resolve",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn reports_set_html_names_for_expression_and_template_attributes() {
+    let diagnostics = scan_rule(
+        "<p set:html={html}></p>\n<p set:html=`<strong>${html}</strong>`></p>",
+        "no-set-html-directive",
+    );
+    assert_eq!(diagnostics.len(), 2);
+    assert!(diagnostics.iter().all(|diagnostic| {
+        diagnostic.message_id == "unexpected" && diagnostic.loc.start_column == 3
+    }));
+}
+
+#[test]
+fn replays_set_text_normal_and_self_closing_fixes() {
+    let normal = "---\nlet string = `text`\n---\n\n<p set:text={string}></p>\n";
+    let normal_diagnostic = scan_rule(normal, "no-set-text-directive");
+    assert_eq!(
+        apply_fix(normal, &normal_diagnostic[0]),
+        "---\nlet string = `text`\n---\n\n<p >{string}</p>\n"
+    );
+
+    let self_closing = "---\nlet string = `text`\n---\n\n<p set:text={string} />\n";
+    let self_closing_diagnostic = scan_rule(self_closing, "no-set-text-directive");
+    assert_eq!(
+        apply_fix(self_closing, &self_closing_diagnostic[0]),
+        "---\nlet string = `text`\n---\n\n<p  >{string}</p>\n"
+    );
+}
+
+#[test]
+fn replays_set_text_template_attribute_fix() {
+    let source = "<p set:text=`text`></p>\n";
+    let diagnostics = scan_rule(source, "no-set-text-directive");
+    assert_eq!(apply_fix(source, &diagnostics[0]), "<p >{`text`}</p>\n");
+}
+
+#[test]
+fn set_text_reports_without_fix_for_boolean_void_or_nonempty_children() {
+    for source in [
+        "<p set:text ></p>",
+        "<input set:text={text}>",
+        "<div set:text={text}>child</div>",
+        "<div set:text={text}><!-- comment --></div>",
+    ] {
+        let diagnostics = scan_rule(source, "no-set-text-directive");
+        assert_eq!(diagnostics.len(), 1, "{source}");
+        assert!(diagnostics[0].fix.is_none(), "{source}");
+    }
+}
+
+#[test]
+fn set_text_whitespace_body_fix_is_idempotent() {
+    let source = "<div set:text={text}>\n  \n</div>";
+    let diagnostics = scan_rule(source, "no-set-text-directive");
+    let fixed = apply_fix(source, &diagnostics[0]);
+    assert_eq!(fixed, "<div >{text}</div>");
+    assert!(scan_rule(&fixed, "no-set-text-directive").is_empty());
+}
+
+#[test]
+fn replays_prefer_class_list_expression_and_template_fixes() {
+    for (source, expected) in [
+        ("<div class={foo}></div>", "<div class:list={foo}></div>"),
+        (
+            "<div class=`${foo}`></div>",
+            "<div class:list=`${foo}`></div>",
+        ),
+        ("<div class=`foo`></div>", "<div class:list=`foo`></div>"),
+        ("<div {class}></div>", "<div class:list={class}></div>"),
+    ] {
+        let diagnostics = scan_rule(source, "prefer-class-list-directive");
+        assert_eq!(diagnostics.len(), 1, "{source}");
+        let fixed = apply_fix(source, &diagnostics[0]);
+        assert_eq!(fixed, expected, "{source}");
+        assert!(
+            scan_rule(&fixed, "prefer-class-list-directive").is_empty(),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn prefer_class_list_ignores_static_and_existing_directive_attributes() {
+    assert!(
+        scan_rule(
+            "<div class=\"foo\" class:list={foo}></div>",
+            "prefer-class-list-directive",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn template_expression_segmenter_handles_nested_braces_and_template_literals() {
+    let source = "<div>{condition ? { image: Astro.resolve(`./${name}.png`) } : null}</div>";
+    let diagnostics = scan_rule(source, "no-deprecated-astro-resolve");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        &source[diagnostics[0].start as usize..diagnostics[0].end as usize],
+        "Astro.resolve"
+    );
+}
+
+#[test]
+fn template_expression_segmenter_ignores_comments_strings_and_plain_text() {
+    for source in [
+        "<!-- {Astro.resolve('comment')} -->",
+        "{/* Astro.resolve('comment') */}",
+        "<p>Astro.resolve('text')</p>",
+        "<p>{'Astro.resolve(\\'string\\')'}</p>",
+    ] {
+        assert!(
+            scan_rule(source, "no-deprecated-astro-resolve").is_empty(),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn template_expression_semantics_ignore_a_local_shadow() {
+    assert!(
+        scan_rule(
+            "<div>{items.map((Astro) => Astro.resolve('local'))}</div>",
+            "no-deprecated-astro-resolve",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn template_expression_reports_computed_resolve_access() {
+    let diagnostics = scan_rule(
+        "<img src={Astro['resolve']('./image.png')} />",
+        "no-deprecated-astro-resolve",
+    );
+    assert_eq!(diagnostics.len(), 1);
+}
+
+#[test]
+fn template_attribute_parser_handles_delimiters_inside_values() {
+    let diagnostics = scan_rule(
+        "<p title=\">\" data={{ nested: '>' }} set:html=`<strong>${html}</strong>`></p>",
+        "no-set-html-directive",
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].loc.start_column, 36);
+}
+
+#[test]
+fn template_locations_remain_utf16_after_non_bmp_text() {
+    let diagnostics = scan_rule(
+        "<p title=\"😀\" set:html={html}></p>",
+        "no-set-html-directive",
+    );
+    assert_eq!(diagnostics[0].loc.start_column, 14);
+}
+
+#[test]
+fn template_fixes_keep_utf8_byte_ranges_after_non_ascii_text() {
+    let source = "<p title=\"日本語\" class={klass}></p>";
+    let diagnostics = scan_rule(source, "prefer-class-list-directive");
+    let insertion = source.find("class").expect("class attribute") + "class".len();
+    assert_eq!(
+        diagnostics[0].fix.as_ref().expect("class fix").start,
+        source[..insertion].len() as u32
+    );
+    assert_eq!(
+        apply_fix(source, &diagnostics[0]),
+        "<p title=\"日本語\" class:list={klass}></p>"
+    );
+}
+
+#[test]
+fn set_text_fix_preserves_crlf_around_the_element() {
+    let source = "<section>\r\n<p set:text={text}>\r\n\t</p>\r\n</section>";
+    let diagnostics = scan_rule(source, "no-set-text-directive");
+    assert_eq!(
+        apply_fix(source, &diagnostics[0]),
+        "<section>\r\n<p >{text}</p>\r\n</section>"
+    );
+}
+
+#[test]
+fn template_diagnostics_remain_in_source_order_across_elements() {
+    let diagnostics = scan(
+        "<p set:text={text}></p>\n<div class={klass}></div>\n<section set:html={html}></section>",
+    );
+    assert_eq!(
+        names(&diagnostics).as_slice(),
+        [
+            "no-set-text-directive",
+            "prefer-class-list-directive",
+            "no-set-html-directive",
+        ]
+    );
+}
+
+#[test]
+fn malformed_template_segments_fail_closed_without_hiding_prior_elements() {
+    let diagnostics = scan_rule(
+        "<p set:html={html}></p>\n<div>{Astro.resolve({ broken: true)</div>",
+        "no-set-html-directive",
+    );
+    assert_eq!(diagnostics.len(), 1);
 }
 
 #[test]
@@ -238,16 +488,19 @@ fn keeps_native_fix_ranges_as_utf8_bytes() {
     let source = "---\nconst emoji = \"😀\"; Astro.fetchContent(\"*.md\")\n---";
     let diagnostics = scan(source);
     let property = source.find("fetchContent").expect("fixture property");
-    assert_eq!(diagnostics[0].fix.expect("fix").start, property as u32);
+    assert_eq!(
+        diagnostics[0].fix.as_ref().expect("fix").start,
+        property as u32
+    );
 }
 
 #[test]
 fn applied_fetchcontent_fix_is_idempotent() {
     let source = "---\nconst emoji = \"😀\"; Astro.fetchContent(\"*.md\")\n---";
     let first = scan(source);
-    let fix = first[0].fix.expect("first scan fix");
+    let fix = first[0].fix.as_ref().expect("first scan fix");
     let mut fixed = CompactString::new(&source[..fix.start as usize]);
-    fixed.push_str(fix.replacement);
+    fixed.push_str(&fix.replacement);
     fixed.push_str(&source[fix.end as usize..]);
     assert_eq!(
         fixed,
@@ -293,8 +546,11 @@ fn accepts_trailing_horizontal_space_on_delimiters() {
 }
 
 #[test]
-fn ignores_source_without_frontmatter() {
-    assert!(scan("<p>{Astro.canonicalURL}</p>").is_empty());
+fn scans_template_expressions_without_frontmatter() {
+    assert_eq!(
+        names(&scan("<p>{Astro.canonicalURL}</p>")).as_slice(),
+        ["no-deprecated-astro-canonicalurl"]
+    );
 }
 
 #[test]
@@ -332,7 +588,10 @@ fn extracted_frontmatter_fix_ranges_start_at_the_virtual_source() {
         },
     );
     let property = source.find("fetchContent").expect("fixture property");
-    assert_eq!(diagnostics[0].fix.expect("fix").start, property as u32);
+    assert_eq!(
+        diagnostics[0].fix.as_ref().expect("fix").start,
+        property as u32
+    );
 }
 
 #[test]
@@ -384,7 +643,7 @@ fn ignores_non_astro_extensions_case_insensitively_except_astro() {
 
 #[test]
 fn isolates_each_selected_rule() {
-    let source = "---\nimport { getEntryBySlug } from \"astro:content\"\nAstro.fetchContent(\"*.md\")\nAstro.canonicalURL\n---";
+    let source = "---\nimport { getEntryBySlug } from \"astro:content\"\nAstro.fetchContent(\"*.md\")\nAstro.canonicalURL\n---\n<div set:html={html} set:text={text} class={klass}>{Astro.resolve(\"asset\")}</div>";
     for rule_name in implemented_astro_rule_names() {
         assert_eq!(
             names(&scan_rule(source, rule_name)).as_slice(),

--- a/docs/port-targets/eslint-plugin-astro.md
+++ b/docs/port-targets/eslint-plugin-astro.md
@@ -11,7 +11,7 @@
 | Oxlint native support | none — port target |
 | Rules to port | 20 |
 
-> Lints .astro files via astro-eslint-parser. Frontmatter-only rules can be ported by segmenting raw .astro source and parsing TypeScript with Oxc; full template parity still depends on Astro-aware parsing. React rules are outside this target because Oxc covers React separately.
+> Lints .astro files via astro-eslint-parser. Frontmatter and conservatively segmented template expressions, attributes, and element bodies can be parsed with Oxc-backed Rust logic; full template parity still depends on Astro-aware parsing. React rules are outside this target because Oxc covers React separately.
 
 ## Rules
 

--- a/npm/astro/README.md
+++ b/npm/astro/README.md
@@ -2,12 +2,20 @@
 
 Rust-backed Oxlint plugin port of selected `eslint-plugin-astro` rules.
 
-This first slice implements three deprecated-API rules by extracting Astro
-frontmatter and parsing it as TypeScript with Oxc:
+The Rust core parses frontmatter with Oxc and conservatively segments template
+expressions, attributes, and element bodies:
 
 - `no-deprecated-astro-canonicalurl`
 - `no-deprecated-astro-fetchcontent`
+- `no-deprecated-astro-resolve`
 - `no-deprecated-getentrybyslug`
+- `no-set-html-directive`
+- `no-set-text-directive`
+- `prefer-class-list-directive`
 
-Template expressions are intentionally not scanned in this slice. React rules
-are outside the Astro port's scope because Oxc handles React rules separately.
+Oxlint 1.68 exposes `.astro` JavaScript plugins through a virtual frontmatter
+source. Physical template-body diagnostics are mapped back to their real
+locations; body fixes remain available through the direct API but are omitted
+from the Oxlint adapter because Oxlint rejects edits outside that virtual
+source. React rules are outside the Astro port's scope because Oxc handles
+React rules separately.

--- a/npm/astro/api.d.ts
+++ b/npm/astro/api.d.ts
@@ -1,7 +1,11 @@
 export type AstroRuleName =
   | 'no-deprecated-astro-canonicalurl'
   | 'no-deprecated-astro-fetchcontent'
-  | 'no-deprecated-getentrybyslug';
+  | 'no-deprecated-astro-resolve'
+  | 'no-deprecated-getentrybyslug'
+  | 'no-set-html-directive'
+  | 'no-set-text-directive'
+  | 'prefer-class-list-directive';
 
 export type AstroDiagnosticLoc = {
   startLine: number;
@@ -20,7 +24,11 @@ export type AstroDiagnosticFix = {
 
 export type AstroDiagnostic = {
   ruleName: AstroRuleName;
-  messageId: 'deprecated';
+  messageId: 'deprecated' | 'disallow' | 'unexpected';
+  /** UTF-8 byte offset into the original source. */
+  start: number;
+  /** UTF-8 byte offset into the original source. */
+  end: number;
   loc: AstroDiagnosticLoc;
   fix?: AstroDiagnosticFix | null;
 };

--- a/npm/astro/index.js
+++ b/npm/astro/index.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { readFileSync } = require('node:fs');
+
 // Oxlint plugin port of eslint-plugin-astro (MIT).
-// The Rust core segments and parses Astro frontmatter with Oxc. React rules
-// are intentionally outside this package's scope.
+// The Rust core parses frontmatter with Oxc and conservatively segments
+// template expressions, attributes, and element bodies. React rules are
+// intentionally outside this package's scope.
 
 const { eslintCompatPlugin } = require('@oxlint/plugins');
 const { implementedAstroRuleNames, scanAstro } = require('./api.js');
@@ -14,7 +17,21 @@ const diagnosticsCache = new WeakMap();
 const descriptions = Object.freeze({
   'no-deprecated-astro-canonicalurl': 'disallow using deprecated `Astro.canonicalURL`',
   'no-deprecated-astro-fetchcontent': 'disallow using deprecated `Astro.fetchContent()`',
+  'no-deprecated-astro-resolve': 'disallow using deprecated `Astro.resolve()`',
   'no-deprecated-getentrybyslug': 'disallow using deprecated `getEntryBySlug()`',
+  'no-set-html-directive': 'disallow use of `set:html` to prevent XSS attacks',
+  'no-set-text-directive': 'disallow use of `set:text`',
+  'prefer-class-list-directive':
+    'require `class:list` directives instead of `class` with expressions',
+});
+const categories = Object.freeze({
+  'no-deprecated-astro-canonicalurl': 'Possible Errors',
+  'no-deprecated-astro-fetchcontent': 'Possible Errors',
+  'no-deprecated-astro-resolve': 'Possible Errors',
+  'no-deprecated-getentrybyslug': 'Possible Errors',
+  'no-set-html-directive': 'Security Vulnerability',
+  'no-set-text-directive': 'Best Practices',
+  'prefer-class-list-directive': 'Stylistic Issues',
 });
 
 const messages = Object.freeze({
@@ -24,18 +41,38 @@ const messages = Object.freeze({
   'no-deprecated-astro-fetchcontent': {
     deprecated: "'Astro.fetchContent()' is deprecated. Use 'Astro.glob()' instead.",
   },
+  'no-deprecated-astro-resolve': {
+    deprecated: "'Astro.resolve()' is deprecated.",
+  },
   'no-deprecated-getentrybyslug': {
     deprecated: "'getEntryBySlug()' is deprecated. Use 'getEntry()' instead.",
+  },
+  'no-set-html-directive': {
+    unexpected: '`set:html` can lead to XSS attack.',
+  },
+  'no-set-text-directive': {
+    disallow: "Don't use `set:text`.",
+  },
+  'prefer-class-list-directive': {
+    unexpected: "Unexpected `class` using expression. Use 'class:list' instead.",
   },
 });
 
 const implementedRuleNames = Object.freeze(implementedAstroRuleNames());
+const recommendedRuleNames = new Set([
+  'no-deprecated-astro-canonicalurl',
+  'no-deprecated-astro-fetchcontent',
+  'no-deprecated-astro-resolve',
+  'no-deprecated-getentrybyslug',
+]);
 const rules = Object.freeze(
   Object.fromEntries(implementedRuleNames.map((ruleName) => [ruleName, createAstroRule(ruleName)])),
 );
 const recommendedRules = Object.freeze(
   Object.fromEntries(
-    implementedRuleNames.map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
+    implementedRuleNames
+      .filter((ruleName) => recommendedRuleNames.has(ruleName))
+      .map((ruleName) => [`${PLUGIN_NAME}/${ruleName}`, 'error']),
   ),
 );
 
@@ -60,18 +97,28 @@ plugin.implementedAstroRuleNames = implementedRuleNames;
 plugin.scanAstro = scanAstro;
 
 function createAstroRule(ruleName) {
+  const recommended = recommendedRuleNames.has(ruleName);
+  const suggestion = new Set([
+    'no-set-html-directive',
+    'no-set-text-directive',
+    'prefer-class-list-directive',
+  ]).has(ruleName);
   const meta = {
-    type: 'problem',
+    type: suggestion ? 'suggestion' : 'problem',
     docs: {
       description: descriptions[ruleName],
-      category: 'Possible Errors',
-      recommended: true,
+      category: categories[ruleName],
+      recommended,
       url: `${DOCS_BASE}#${ruleName}`,
     },
     messages: messages[ruleName],
     schema: [],
   };
-  if (ruleName === 'no-deprecated-astro-fetchcontent') {
+  if (
+    ruleName === 'no-deprecated-astro-fetchcontent' ||
+    ruleName === 'no-set-text-directive' ||
+    ruleName === 'prefer-class-list-directive'
+  ) {
     meta.fixable = 'code';
   }
 
@@ -98,30 +145,56 @@ function diagnosticsForRule(context, ruleName) {
         ? sourceCode.text
         : '';
   const filename = typeof context.filename === 'string' ? context.filename : 'file.astro';
-  const frontmatterOnly = !startsWithFrontmatterDelimiter(sourceText);
+  const physicalSource = readPhysicalSource(context, filename, sourceText);
+  const scanSource = physicalSource?.sourceText ?? sourceText;
+  const frontmatterOnly =
+    physicalSource === null &&
+    !startsWithFrontmatterDelimiter(sourceText) &&
+    !looksLikeAstroTemplate(sourceText);
   let byRule = diagnosticsCache.get(sourceCode);
   if (!byRule) {
     byRule = new Map();
     diagnosticsCache.set(sourceCode, byRule);
   }
   const cached = byRule.get(ruleName);
-  if (cached && cached.sourceText === sourceText && cached.filename === filename) {
+  if (
+    cached &&
+    cached.sourceText === sourceText &&
+    cached.scanSource === scanSource &&
+    cached.filename === filename
+  ) {
     return cached.diagnostics;
   }
 
-  const byteToUtf16 = createByteToUtf16Mapper(sourceText);
-  const diagnostics = scanAstro(sourceText, filename, {
+  const byteToUtf16 = createByteToUtf16Mapper(scanSource);
+  const diagnostics = scanAstro(scanSource, filename, {
     ruleNames: [ruleName],
     frontmatterOnly,
-  }).map((diagnostic) => mapDiagnosticFix(diagnostic, byteToUtf16));
-  byRule.set(ruleName, { sourceText, filename, diagnostics });
+  }).map((diagnostic) =>
+    mapDiagnosticOffsets(
+      diagnostic,
+      byteToUtf16,
+      physicalSource === null
+        ? null
+        : {
+            ...physicalSource,
+            virtualLength: sourceText.length,
+            virtualByteLength: utf8Length(sourceText),
+          },
+    ),
+  );
+  byRule.set(ruleName, { sourceText, scanSource, filename, diagnostics });
   return diagnostics;
 }
 
 function reportDiagnostic(context, diagnostic) {
   const descriptor = {
     messageId: diagnostic.messageId,
-    loc: {
+  };
+  if (diagnostic.reportRange) {
+    descriptor.node = { range: diagnostic.reportRange };
+  } else {
+    descriptor.loc = {
       start: {
         line: diagnostic.loc.startLine,
         column: diagnostic.loc.startColumn,
@@ -130,8 +203,8 @@ function reportDiagnostic(context, diagnostic) {
         line: diagnostic.loc.endLine,
         column: diagnostic.loc.endColumn,
       },
-    },
-  };
+    };
+  }
   if (diagnostic.fix) {
     descriptor.fix = (fixer) =>
       fixer.replaceTextRange(
@@ -142,18 +215,74 @@ function reportDiagnostic(context, diagnostic) {
   context.report(descriptor);
 }
 
-function mapDiagnosticFix(diagnostic, byteToUtf16) {
-  if (!diagnostic.fix) {
-    return diagnostic;
-  }
-  return {
+function mapDiagnosticOffsets(diagnostic, byteToUtf16, virtualSource) {
+  const mapped = {
     ...diagnostic,
-    fix: {
+    start: byteToUtf16(diagnostic.start),
+    end: byteToUtf16(diagnostic.end),
+  };
+  if (diagnostic.fix) {
+    mapped.fix = {
       start: byteToUtf16(diagnostic.fix.start),
       end: byteToUtf16(diagnostic.fix.end),
       replacement: diagnostic.fix.replacement,
-    },
+    };
+  }
+  if (virtualSource === null) {
+    return mapped;
+  }
+  mapped.reportRange = [
+    diagnostic.start > virtualSource.frontmatterByteOffset + virtualSource.virtualByteLength
+      ? diagnostic.start - virtualSource.frontmatterByteOffset
+      : mapped.start - virtualSource.frontmatterOffset,
+    diagnostic.end > virtualSource.frontmatterByteOffset + virtualSource.virtualByteLength
+      ? diagnostic.end - virtualSource.frontmatterByteOffset
+      : mapped.end - virtualSource.frontmatterOffset,
+  ];
+  if (mapped.fix) {
+    const start = mapped.fix.start - virtualSource.frontmatterOffset;
+    const end = mapped.fix.end - virtualSource.frontmatterOffset;
+    mapped.fix =
+      start >= 0 && end <= virtualSource.virtualLength ? { ...mapped.fix, start, end } : undefined;
+  }
+  return mapped;
+}
+
+function readPhysicalSource(context, filename, virtualSourceText) {
+  const physicalFilename =
+    typeof context.physicalFilename === 'string'
+      ? context.physicalFilename
+      : typeof context.getPhysicalFilename === 'function'
+        ? context.getPhysicalFilename()
+        : null;
+  if (!physicalFilename || !physicalFilename.toLowerCase().endsWith('.astro')) {
+    return null;
+  }
+  try {
+    const sourceText = readFileSync(physicalFilename, 'utf8');
+    if (sourceText === virtualSourceText) {
+      return null;
+    }
+    return {
+      sourceText,
+      ...frontmatterContentOffsets(sourceText),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function frontmatterContentOffsets(sourceText) {
+  const match = /^(?:\uFEFF)?---[ \t]*(?:\r\n|[\n\r\u2028\u2029])/.exec(sourceText);
+  const opening = match?.[0] ?? '';
+  return {
+    frontmatterOffset: opening.length,
+    frontmatterByteOffset: utf8Length(opening),
   };
+}
+
+function looksLikeAstroTemplate(sourceText) {
+  return /<(?:\/?[A-Za-z]|!|>)/.test(sourceText);
 }
 
 function startsWithFrontmatterDelimiter(sourceText) {
@@ -216,6 +345,14 @@ function utf8ByteLength(codePoint) {
   if (codePoint <= 0x7ff) return 2;
   if (codePoint <= 0xffff) return 3;
   return 4;
+}
+
+function utf8Length(sourceText) {
+  let length = 0;
+  for (const char of sourceText) {
+    length += utf8ByteLength(char.codePointAt(0));
+  }
+  return length;
 }
 
 function clampOffset(offset, maximum) {

--- a/npm/astro/src/lib.rs
+++ b/npm/astro/src/lib.rs
@@ -44,6 +44,8 @@ mod napi_abi {
     pub struct Diagnostic {
         pub rule_name: String,
         pub message_id: String,
+        pub start: u32,
+        pub end: u32,
         pub loc: DiagnosticLoc,
         pub fix: Option<DiagnosticFix>,
     }
@@ -72,6 +74,8 @@ mod napi_abi {
             .map(|diagnostic| Diagnostic {
                 rule_name: diagnostic.rule_name.to_owned(),
                 message_id: diagnostic.message_id.to_owned(),
+                start: diagnostic.start,
+                end: diagnostic.end,
                 loc: DiagnosticLoc {
                     start_line: diagnostic.loc.start_line,
                     start_column: diagnostic.loc.start_column,
@@ -81,7 +85,7 @@ mod napi_abi {
                 fix: diagnostic.fix.map(|fix| DiagnosticFix {
                     start: fix.start,
                     end: fix.end,
-                    replacement: fix.replacement.to_owned(),
+                    replacement: fix.replacement.as_str().to_owned(),
                 }),
             })
             .collect()

--- a/npm/astro/test/api.test.mjs
+++ b/npm/astro/test/api.test.mjs
@@ -11,11 +11,38 @@ const fixture = JSON.parse(readFileSync(join(testRoot, 'fixtures', 'astro-v3.0.1
 const expectedRuleNames = [
   'no-deprecated-astro-canonicalurl',
   'no-deprecated-astro-fetchcontent',
+  'no-deprecated-astro-resolve',
   'no-deprecated-getentrybyslug',
+  'no-set-html-directive',
+  'no-set-text-directive',
+  'prefer-class-list-directive',
 ];
+const messageIds = {
+  'no-deprecated-astro-canonicalurl': 'deprecated',
+  'no-deprecated-astro-fetchcontent': 'deprecated',
+  'no-deprecated-astro-resolve': 'deprecated',
+  'no-deprecated-getentrybyslug': 'deprecated',
+  'no-set-html-directive': 'unexpected',
+  'no-set-text-directive': 'disallow',
+  'prefer-class-list-directive': 'unexpected',
+};
+
+function applyNativeFixes(sourceText, diagnostics) {
+  return diagnostics
+    .flatMap((diagnostic) => (diagnostic.fix ? [diagnostic.fix] : []))
+    .sort((left, right) => right.start - left.start)
+    .reduce((output, fix) => {
+      const bytes = Buffer.from(output);
+      return Buffer.concat([
+        bytes.subarray(0, fix.start),
+        Buffer.from(fix.replacement),
+        bytes.subarray(fix.end),
+      ]).toString();
+    }, sourceText);
+}
 
 describe('astro native API', () => {
-  it('exposes the first eslint-plugin-astro slice', () => {
+  it('exposes both implemented eslint-plugin-astro slices', () => {
     expect(implementedAstroRuleNames()).toEqual(expectedRuleNames);
   });
 
@@ -44,11 +71,37 @@ describe('astro native API', () => {
       })),
     ).toEqual(
       testCase.errors.map((error) => ({
-        messageId: 'deprecated',
+        messageId: messageIds[ruleName],
         line: error.line,
         column: error.column,
       })),
     );
+  });
+
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.invalid
+        .filter((testCase) => testCase.output !== undefined)
+        .map((testCase) => [ruleName, testCase]),
+    ),
+  )('replays authored upstream fixed output for %s', (ruleName, testCase) => {
+    const diagnostics = scanAstro(testCase.code, testCase.filename, {
+      ruleNames: [ruleName],
+    });
+    expect(applyNativeFixes(testCase.code, diagnostics)).toBe(testCase.output);
+  });
+
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.invalid
+        .filter((testCase) => testCase.output !== undefined && testCase.output !== testCase.code)
+        .map((testCase) => [ruleName, testCase]),
+    ),
+  )('is stable after applying authored %s output once', (ruleName, testCase) => {
+    const diagnostics = scanAstro(testCase.output, testCase.filename, {
+      ruleNames: [ruleName],
+    });
+    expect(applyNativeFixes(testCase.output, diagnostics)).toBe(testCase.output);
   });
 
   it('returns native UTF-8 byte fix ranges', () => {

--- a/npm/astro/test/fixtures/astro-v3.0.1.json
+++ b/npm/astro/test/fixtures/astro-v3.0.1.json
@@ -12,9 +12,55 @@
       "tests/fixtures/rules/no-deprecated-astro-fetchcontent/invalid/test01-input.astro",
       "tests/fixtures/rules/no-deprecated-astro-fetchcontent/invalid/test01-output.astro",
       "tests/fixtures/rules/no-deprecated-astro-fetchcontent/valid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-astro-resolve/invalid/test01-errors.json",
+      "tests/fixtures/rules/no-deprecated-astro-resolve/invalid/test01-input.astro",
+      "tests/fixtures/rules/no-deprecated-astro-resolve/valid/test01-input.astro",
       "tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-errors.json",
       "tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-input.astro",
-      "tests/fixtures/rules/no-deprecated-getentrybyslug/valid/test01-input.astro"
+      "tests/fixtures/rules/no-deprecated-getentrybyslug/valid/test01-input.astro",
+      "tests/fixtures/rules/no-set-html-directive/invalid/set-html-errors.json",
+      "tests/fixtures/rules/no-set-html-directive/invalid/set-html-input.astro",
+      "tests/fixtures/rules/no-set-html-directive/invalid/template-attr-set-html-errors.json",
+      "tests/fixtures/rules/no-set-html-directive/invalid/template-attr-set-html-input.astro",
+      "tests/fixtures/rules/no-set-html-directive/valid/set-text-input.astro",
+      "tests/fixtures/rules/no-set-html-directive/valid/template-attr-set-text-input.astro",
+      "tests/fixtures/rules/no-set-html-directive/valid/text-mustash-input.astro",
+      "tests/fixtures/rules/no-set-html-directive/valid/text-mustash-with-template-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/boolean-errors.json",
+      "tests/fixtures/rules/no-set-text-directive/invalid/boolean-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/boolean-output.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/input-errors.json",
+      "tests/fixtures/rules/no-set-text-directive/invalid/input-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/input-output.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/self-closing-errors.json",
+      "tests/fixtures/rules/no-set-text-directive/invalid/self-closing-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/self-closing-output.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/set-text-errors.json",
+      "tests/fixtures/rules/no-set-text-directive/invalid/set-text-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/set-text-output.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/set-text-with-child-errors.json",
+      "tests/fixtures/rules/no-set-text-directive/invalid/set-text-with-child-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/set-text-with-child-output.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/template-attr-set-html-errors.json",
+      "tests/fixtures/rules/no-set-text-directive/invalid/template-attr-set-html-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/invalid/template-attr-set-html-output.astro",
+      "tests/fixtures/rules/no-set-text-directive/valid/set-html-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/valid/template-attr-set-html-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/valid/text-mustash-input.astro",
+      "tests/fixtures/rules/no-set-text-directive/valid/text-mustash-with-template-input.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/class-attr-errors.json",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/class-attr-input.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/class-attr-output.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/clsx-errors.json",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/clsx-input.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/clsx-output.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/template-attr-class01-errors.json",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/template-attr-class01-input.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/template-attr-class01-output.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/template-attr-class02-errors.json",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/template-attr-class02-input.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/invalid/template-attr-class02-output.astro",
+      "tests/fixtures/rules/prefer-class-list-directive/valid/class-attr-input.astro"
     ],
     "license": "MIT",
     "tool": "tools/tasks/sync-astro-tests.ts"
@@ -63,6 +109,27 @@
         }
       ]
     },
+    "no-deprecated-astro-resolve": {
+      "valid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\nconst { animal } = Astro.props;\n---\n\n{/* ✓ GOOD */}\n<img src={await import(`../images/${animal}.png`)} />\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "test01-input.astro",
+          "code": "---\nconst { animal } = Astro.props;\n---\n\n{/* ✗ BAD */}\n<img src={Astro.resolve(`../images/${animal}.png`)} />",
+          "errors": [
+            {
+              "message": "'Astro.resolve()' is deprecated.",
+              "line": 6,
+              "column": 11
+            }
+          ]
+        }
+      ]
+    },
     "no-deprecated-getentrybyslug": {
       "valid": [
         {
@@ -81,6 +148,207 @@
               "column": 10
             }
           ]
+        }
+      ]
+    },
+    "no-set-html-directive": {
+      "valid": [
+        {
+          "filename": "set-text-input.astro",
+          "code": "---\nlet string = `this string contains some <strong>HTML!!!</strong>`\n---\n\n<p set:text={string}></p>\n"
+        },
+        {
+          "filename": "template-attr-set-text-input.astro",
+          "code": "<p set:text=`this string contains some <strong>HTML!!!</strong>`></p>\n"
+        },
+        {
+          "filename": "text-mustash-input.astro",
+          "code": "---\nlet string = `this string contains some <strong>HTML!!!</strong>`\n---\n\n<p>{string}</p>\n"
+        },
+        {
+          "filename": "text-mustash-with-template-input.astro",
+          "code": "<p>{`this string contains some <strong>HTML!!!</strong>`}</p>\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "set-html-input.astro",
+          "code": "---\nlet string = `this string contains some <strong>HTML!!!</strong>`\n---\n\n<p set:html={string}></p>\n",
+          "errors": [
+            {
+              "message": "`set:html` can lead to XSS attack.",
+              "line": 5,
+              "column": 4
+            }
+          ]
+        },
+        {
+          "filename": "template-attr-set-html-input.astro",
+          "code": "<p set:html=`this string contains some <strong>HTML!!!</strong>`></p>\n",
+          "errors": [
+            {
+              "message": "`set:html` can lead to XSS attack.",
+              "line": 1,
+              "column": 4
+            }
+          ]
+        }
+      ]
+    },
+    "no-set-text-directive": {
+      "valid": [
+        {
+          "filename": "set-html-input.astro",
+          "code": "---\nlet string = `text`\n---\n\n<p set:html={string}></p>\n"
+        },
+        {
+          "filename": "template-attr-set-html-input.astro",
+          "code": "<p set:html=`text`></p>\n"
+        },
+        {
+          "filename": "text-mustash-input.astro",
+          "code": "---\nlet string = `text`\n---\n\n<p>{string}</p>\n"
+        },
+        {
+          "filename": "text-mustash-with-template-input.astro",
+          "code": "<p>{`text`}</p>\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "boolean-input.astro",
+          "code": "<p set:text ></p>\n",
+          "errors": [
+            {
+              "message": "Don't use `set:text`.",
+              "line": 1,
+              "column": 4
+            }
+          ],
+          "output": "<p set:text ></p>\n"
+        },
+        {
+          "filename": "input-input.astro",
+          "code": "---\nlet string = `text`\n---\n\n<input set:text={string}>\n",
+          "errors": [
+            {
+              "message": "Don't use `set:text`.",
+              "line": 5,
+              "column": 8
+            }
+          ],
+          "output": "---\nlet string = `text`\n---\n\n<input set:text={string}>\n"
+        },
+        {
+          "filename": "self-closing-input.astro",
+          "code": "---\nlet string = `text`\n---\n\n<p set:text={string} />\n",
+          "errors": [
+            {
+              "message": "Don't use `set:text`.",
+              "line": 5,
+              "column": 4
+            }
+          ],
+          "output": "---\nlet string = `text`\n---\n\n<p  >{string}</p>\n"
+        },
+        {
+          "filename": "set-text-input.astro",
+          "code": "---\nlet string = `text`\n---\n\n<p set:text={string}></p>\n",
+          "errors": [
+            {
+              "message": "Don't use `set:text`.",
+              "line": 5,
+              "column": 4
+            }
+          ],
+          "output": "---\nlet string = `text`\n---\n\n<p >{string}</p>\n"
+        },
+        {
+          "filename": "set-text-with-child-input.astro",
+          "code": "---\nlet string = `text`\n---\n\n<div set:text={string}>Foo</div>\n<div set:text={string}>\n</div>\n",
+          "errors": [
+            {
+              "message": "Don't use `set:text`.",
+              "line": 5,
+              "column": 6
+            },
+            {
+              "message": "Don't use `set:text`.",
+              "line": 6,
+              "column": 6
+            }
+          ],
+          "output": "---\nlet string = `text`\n---\n\n<div set:text={string}>Foo</div>\n<div >{string}</div>\n"
+        },
+        {
+          "filename": "template-attr-set-html-input.astro",
+          "code": "<p set:text=`text`></p>\n",
+          "errors": [
+            {
+              "message": "Don't use `set:text`.",
+              "line": 1,
+              "column": 4
+            }
+          ],
+          "output": "<p >{`text`}</p>\n"
+        }
+      ]
+    },
+    "prefer-class-list-directive": {
+      "valid": [
+        {
+          "filename": "class-attr-input.astro",
+          "code": "---\nconst foo = \"foo\"\n---\n\n<div class=\"foo\"></div>\n"
+        }
+      ],
+      "invalid": [
+        {
+          "filename": "class-attr-input.astro",
+          "code": "---\nconst foo = \"foo\"\n---\n\n<div class={foo}></div>\n",
+          "errors": [
+            {
+              "message": "Unexpected `class` using expression. Use 'class:list' instead.",
+              "line": 5,
+              "column": 6
+            }
+          ],
+          "output": "---\nconst foo = \"foo\"\n---\n\n<div class:list={foo}></div>\n"
+        },
+        {
+          "filename": "clsx-input.astro",
+          "code": "---\nimport clsx from \"clsx\"\nconst foo = true\n---\n\n<div class={clsx({ foo })}></div>\n",
+          "errors": [
+            {
+              "message": "Unexpected `class` using expression. Use 'class:list' instead.",
+              "line": 6,
+              "column": 6
+            }
+          ],
+          "output": "---\nimport clsx from \"clsx\"\nconst foo = true\n---\n\n<div class:list={clsx({ foo })}></div>\n"
+        },
+        {
+          "filename": "template-attr-class01-input.astro",
+          "code": "---\nconst foo = \"foo\"\n---\n\n<div class=`${foo}`></div>\n",
+          "errors": [
+            {
+              "message": "Unexpected `class` using expression. Use 'class:list' instead.",
+              "line": 5,
+              "column": 6
+            }
+          ],
+          "output": "---\nconst foo = \"foo\"\n---\n\n<div class:list=`${foo}`></div>\n"
+        },
+        {
+          "filename": "template-attr-class02-input.astro",
+          "code": "---\nconst foo = \"foo\"\n---\n\n<div class=`foo`></div>\n",
+          "errors": [
+            {
+              "message": "Unexpected `class` using expression. Use 'class:list' instead.",
+              "line": 5,
+              "column": 6
+            }
+          ],
+          "output": "---\nconst foo = \"foo\"\n---\n\n<div class:list=`foo`></div>\n"
         }
       ]
     }

--- a/npm/astro/test/plugin.test.mjs
+++ b/npm/astro/test/plugin.test.mjs
@@ -16,6 +16,16 @@ const fixture = JSON.parse(
 const expectedRuleNames = [
   'no-deprecated-astro-canonicalurl',
   'no-deprecated-astro-fetchcontent',
+  'no-deprecated-astro-resolve',
+  'no-deprecated-getentrybyslug',
+  'no-set-html-directive',
+  'no-set-text-directive',
+  'prefer-class-list-directive',
+];
+const recommendedRuleNames = [
+  'no-deprecated-astro-canonicalurl',
+  'no-deprecated-astro-fetchcontent',
+  'no-deprecated-astro-resolve',
   'no-deprecated-getentrybyslug',
 ];
 
@@ -113,22 +123,28 @@ describe('astro plugin shape', () => {
   it('enables all selected rules in recommended for Astro files', () => {
     expect(plugin.configs.recommended.files).toEqual(['**/*.astro']);
     expect(plugin.configs.recommended.rules).toEqual(
-      Object.fromEntries(expectedRuleNames.map((name) => [`astro/${name}`, 'error'])),
+      Object.fromEntries(recommendedRuleNames.map((name) => [`astro/${name}`, 'error'])),
     );
   });
 
-  it('keeps every schema empty and every rule recommended', () => {
-    for (const rule of Object.values(plugin.rules)) {
+  it('keeps every schema empty and matches upstream recommendation metadata', () => {
+    for (const [ruleName, rule] of Object.entries(plugin.rules)) {
       expect(rule.meta.schema).toEqual([]);
-      expect(rule.meta.docs.recommended).toBe(true);
-      expect(rule.meta.type).toBe('problem');
+      expect(rule.meta.docs.recommended).toBe(recommendedRuleNames.includes(ruleName));
+      expect(rule.meta.type).toBe(
+        recommendedRuleNames.includes(ruleName) ? 'problem' : 'suggestion',
+      );
     }
   });
 
-  it('marks only fetchContent as fixable', () => {
+  it('marks exactly the authored fixable rules as fixable', () => {
     expect(plugin.rules['no-deprecated-astro-fetchcontent'].meta.fixable).toBe('code');
+    expect(plugin.rules['no-set-text-directive'].meta.fixable).toBe('code');
+    expect(plugin.rules['prefer-class-list-directive'].meta.fixable).toBe('code');
     expect(plugin.rules['no-deprecated-astro-canonicalurl'].meta.fixable).toBeUndefined();
+    expect(plugin.rules['no-deprecated-astro-resolve'].meta.fixable).toBeUndefined();
     expect(plugin.rules['no-deprecated-getentrybyslug'].meta.fixable).toBeUndefined();
+    expect(plugin.rules['no-set-html-directive'].meta.fixable).toBeUndefined();
   });
 });
 
@@ -158,11 +174,14 @@ describe('authored eslint-plugin-astro v3.0.1 fixtures through the adapter', () 
     ).toEqual(testCase.errors.map((error) => ({ line: error.line, column: error.column })));
   });
 
-  it('matches the authored fetchContent output', () => {
-    const testCase = fixture.rules['no-deprecated-astro-fetchcontent'].invalid[0];
-    expect(
-      applyReports(testCase.code, runRule('no-deprecated-astro-fetchcontent', testCase.code)),
-    ).toBe(testCase.output);
+  it.each(
+    Object.entries(fixture.rules).flatMap(([ruleName, cases]) =>
+      cases.invalid
+        .filter((testCase) => testCase.output !== undefined)
+        .map((testCase) => [ruleName, testCase]),
+    ),
+  )('matches authored %s fixed output', (ruleName, testCase) => {
+    expect(applyReports(testCase.code, runRule(ruleName, testCase.code))).toBe(testCase.output);
   });
 });
 
@@ -173,18 +192,24 @@ describe('adapter regression coverage', () => {
     expect(applyReports(code, reports)).toBe('---\nconst emoji = "😀"; Astro.glob("*.md")\n---\n');
   });
 
+  it('maps template-body UTF-8 fix ranges to JavaScript UTF-16 ranges', () => {
+    const code = '<div title="日本語😀" class={klass}></div>';
+    const reports = runRule('prefer-class-list-directive', code);
+    expect(applyReports(code, reports)).toBe('<div title="日本語😀" class:list={klass}></div>');
+  });
+
   it('does not report a shadowed Astro binding', () => {
     const code = '---\nconst Astro = { canonicalURL: "local" };\nAstro.canonicalURL\n---\n';
     expect(runRule('no-deprecated-astro-canonicalurl', code)).toEqual([]);
   });
 
-  it('does not scan template expressions in the frontmatter slice', () => {
+  it('scans template expressions after the frontmatter slice', () => {
     expect(
       runRule(
         'no-deprecated-astro-canonicalurl',
         '---\nconst title = "page"\n---\n<p>{Astro.canonicalURL}</p>\n',
       ),
-    ).toEqual([]);
+    ).toHaveLength(1);
   });
 
   it('does not report malformed frontmatter', () => {
@@ -223,6 +248,40 @@ describe('astro rules through real Oxlint jsPlugins', () => {
     expect(rerun.stderr).toBe('');
     expect(rerun.diagnostics).toEqual([]);
     expect(rerun.output).toBe(result.output);
+  });
+
+  it('reports an authored template-body expression at its physical location', () => {
+    const testCase = fixture.rules['no-deprecated-astro-resolve'].invalid[0];
+    const result = runOxlint('no-deprecated-astro-resolve', testCase.code);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('astro(no-deprecated-astro-resolve)');
+    expect(result.diagnostics[0].labels[0].span.line).toBe(6);
+    expect(result.diagnostics[0].labels[0].span.column).toBe(11);
+  });
+
+  it('reports an authored template attribute after empty frontmatter', () => {
+    const testCase = fixture.rules['no-set-html-directive'].invalid.find((entry) =>
+      entry.filename.startsWith('template-attr-'),
+    );
+    const result = runOxlint('no-set-html-directive', `---\n---\n${testCase.code}`);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('astro(no-set-html-directive)');
+    expect(result.diagnostics[0].labels[0].span.line).toBe(3);
+    expect(result.diagnostics[0].labels[0].span.column).toBe(4);
+  });
+
+  it('reports a fixable body rule without returning an invalid virtual-source fix', () => {
+    const testCase = fixture.rules['prefer-class-list-directive'].invalid[0];
+    const result = runOxlint('prefer-class-list-directive', testCase.code, true);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe('astro(prefer-class-list-directive)');
+    expect(result.output).toBe(testCase.code);
   });
 
   it('keeps rule selection isolated through the CLI', () => {

--- a/playground/src/samples.ts
+++ b/playground/src/samples.ts
@@ -15,10 +15,12 @@ import { getEntryBySlug } from 'astro:content';
 
 const canonical = Astro.canonicalURL;
 const posts = await Astro.fetchContent('../pages/post/*.md');
+const active = true;
 ---
 
 <h1>{canonical.pathname}</h1>
-<p>{posts.length}</p>
+<img class={active ? 'active' : ''} src={Astro.resolve('../images/hero.png')} />
+<p set:text={posts.length}></p>
 `,
   },
   {

--- a/status.json
+++ b/status.json
@@ -1506,19 +1506,19 @@
       },
       {
         "name": "no-deprecated-astro-resolve",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-deprecated-astro-resolve."
+        "notes": "Rust/Oxc template-expression port synced to the authored eslint-plugin-astro v3.0.1 fixtures. Covers balanced expression segmentation, frontmatter shadowing, UTF-8/UTF-16 physical range normalization, NAPI/API, real Oxlint .astro body reporting, and the playground."
       },
       {
         "name": "no-deprecated-getentrybyslug",
@@ -1586,35 +1586,35 @@
       },
       {
         "name": "no-set-html-directive",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-set-html-directive."
+        "notes": "Rust template-attribute port synced to every authored eslint-plugin-astro v3.0.1 valid and invalid fixture. Covers expression, quoted, and Astro template-literal attributes, NAPI/API, real Oxlint physical body reporting, and the playground."
       },
       {
         "name": "no-set-text-directive",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule no-set-text-directive."
+        "notes": "Rust template element/body port synced to every authored eslint-plugin-astro v3.0.1 input, error, and fixed output. Covers boolean, void, self-closing, whitespace-only, nonempty-child, and template-literal cases plus adapter fix idempotence. Oxlint 1.68 rejects fixes outside its virtual frontmatter, so the CLI integration reports body diagnostics without emitting an invalid fix."
       },
       {
         "name": "no-unsafe-inline-scripts",
@@ -1666,19 +1666,19 @@
       },
       {
         "name": "prefer-class-list-directive",
-        "status": "pending",
+        "status": "ported",
         "published": false,
         "oxlintBuiltin": false,
         "typeAware": false,
-        "rustCore": false,
-        "napi": false,
+        "rustCore": true,
+        "napi": true,
         "tests": {
           "insta": false,
-          "vitest": false,
+          "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Pending port of upstream rule prefer-class-list-directive."
+        "notes": "Rust template-expression/attribute port synced to every authored eslint-plugin-astro v3.0.1 input, error, and fixed output. Covers expression, clsx, template literal, shorthand, adapter fix idempotence, real Oxlint physical body reporting, and the playground. Oxlint 1.68 body fixes are suppressed because its virtual frontmatter rejects out-of-range edits."
       },
       {
         "name": "prefer-object-class-list",

--- a/tools/port-targets.json
+++ b/tools/port-targets.json
@@ -725,7 +725,7 @@
         "exclude": ["index.ts"]
       },
       "docsUrlTemplate": "https://ota-meshi.github.io/eslint-plugin-astro/rules/{rule}/",
-      "notes": "Lints .astro files via astro-eslint-parser. Frontmatter-only rules can be ported by segmenting raw .astro source and parsing TypeScript with Oxc; full template parity still depends on Astro-aware parsing. React rules are outside this target because Oxc covers React separately."
+      "notes": "Lints .astro files via astro-eslint-parser. Frontmatter and conservatively segmented template expressions, attributes, and element bodies can be parsed with Oxc-backed Rust logic; full template parity still depends on Astro-aware parsing. React rules are outside this target because Oxc covers React separately."
     }
   ]
 }

--- a/tools/tasks/sync-astro-tests.ts
+++ b/tools/tasks/sync-astro-tests.ts
@@ -64,7 +64,11 @@ if (actualCommit !== expectedCommit) {
 const ruleNames = [
   'no-deprecated-astro-canonicalurl',
   'no-deprecated-astro-fetchcontent',
+  'no-deprecated-astro-resolve',
   'no-deprecated-getentrybyslug',
+  'no-set-html-directive',
+  'no-set-text-directive',
+  'prefer-class-list-directive',
 ] as const;
 const rules: Record<string, { valid: FixtureCase[]; invalid: FixtureCase[] }> = {};
 const sourceFiles: string[] = [];


### PR DESCRIPTION
## Summary

- port no-deprecated-astro-resolve, no-set-html-directive, no-set-text-directive, and prefer-class-list-directive from eslint-plugin-astro v3.0.1
- add conservative Astro template expression, attribute, and element-body segmentation with physical-file location mapping
- preserve exact upstream direct-API fixes and idempotence; suppress body fixes only when Oxlint exposes a shorter virtual frontmatter source
- update native API, Oxlint adapter, playground, status, package docs, and generated root coverage
- keep React, JSX, and TSX out of scope

## Tests

- pinned upstream authored fixtures: 29 cases
- Astro Rust: 64 passed
- targeted API/plugin: 114 passed
- full pnpm verify on latest main: 16,370 JS tests passed, 1,159 skipped; all workspace Rust/doc tests, Clippy, build, bench compile, security, licenses, status, README coverage, and publish-readiness passed
- real Oxlint coverage verifies physical .astro body locations and safe virtual-source fix behavior
- UTF-8/UTF-16, CRLF, malformed segments, shadowing, nested expressions, rule isolation, fix output, and idempotence regressions included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->