### PR TITLE
feat(perfectionist): support sort-exports options

### DIFF
--- a/crates/perfectionist/src/lib.rs
+++ b/crates/perfectionist/src/lib.rs
@@ -97,6 +97,12 @@ pub fn scan_perfectionist_rule(
             &parser_return.program.comments,
             options,
         ),
+        "sort-exports" => sort_named_specifiers::check_sort_exports(
+            source_text,
+            &parser_return.program.body,
+            &parser_return.program.comments,
+            options,
+        ),
         _ => SmallVec::new(),
     }
 }

--- a/crates/perfectionist/src/sort_named_specifiers.rs
+++ b/crates/perfectionist/src/sort_named_specifiers.rs
@@ -12,8 +12,9 @@ use std::sync::OnceLock;
 use oxc_ast::{
     Comment, CommentKind,
     ast::{
-        ExportNamedDeclaration, ExportSpecifier, ImportDeclaration, ImportDeclarationSpecifier,
-        ImportOrExportKind, ImportSpecifier, ModuleExportName, Statement,
+        ExportAllDeclaration, ExportNamedDeclaration, ExportSpecifier, ImportDeclaration,
+        ImportDeclarationSpecifier, ImportOrExportKind, ImportSpecifier, ModuleExportName,
+        Statement,
     },
 };
 use oxc_span::Span;
@@ -32,6 +33,7 @@ struct RuleContract {
     group_order_message_id: &'static str,
     extra_spacing_message_id: &'static str,
     missed_spacing_message_id: &'static str,
+    missed_comment_above_message_id: Option<&'static str>,
 }
 
 const IMPORT_CONTRACT: RuleContract = RuleContract {
@@ -41,6 +43,7 @@ const IMPORT_CONTRACT: RuleContract = RuleContract {
     group_order_message_id: "unexpectedNamedImportsGroupOrder",
     extra_spacing_message_id: "extraSpacingBetweenNamedImports",
     missed_spacing_message_id: "missedSpacingBetweenNamedImports",
+    missed_comment_above_message_id: None,
 };
 
 const EXPORT_CONTRACT: RuleContract = RuleContract {
@@ -50,6 +53,17 @@ const EXPORT_CONTRACT: RuleContract = RuleContract {
     group_order_message_id: "unexpectedNamedExportsGroupOrder",
     extra_spacing_message_id: "extraSpacingBetweenNamedExports",
     missed_spacing_message_id: "missedSpacingBetweenNamedExports",
+    missed_comment_above_message_id: None,
+};
+
+const SORT_EXPORTS_CONTRACT: RuleContract = RuleContract {
+    rule: "sort-exports",
+    selector: "export",
+    order_message_id: "unexpectedExportsOrder",
+    group_order_message_id: "unexpectedExportsGroupOrder",
+    extra_spacing_message_id: "extraSpacingBetweenExports",
+    missed_spacing_message_id: "missedSpacingBetweenExports",
+    missed_comment_above_message_id: Some("missedCommentAboveExport"),
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -65,6 +79,7 @@ enum GroupEntry {
         names: SmallVec<[CompactString; 2]>,
         overrides: Option<Map<String, Value>>,
         newlines_inside: Option<Newlines>,
+        comment_above: Option<CompactString>,
     },
     Newlines(Newlines),
 }
@@ -96,7 +111,7 @@ struct RuleOptions {
     newlines_inside: Newlines,
 }
 
-struct NamedSpecifier<'a> {
+pub(crate) struct SortableNode<'a> {
     span: Span,
     name: CompactString,
     source: &'a str,
@@ -106,6 +121,53 @@ struct NamedSpecifier<'a> {
     group: CompactString,
     group_index: usize,
     partition_id: usize,
+    is_disabled: bool,
+    add_safety_semicolon_when_inline: bool,
+}
+
+struct PendingDiagnostic {
+    message_id: &'static str,
+    right_index: usize,
+    left_index: Option<usize>,
+    missed_comment_above: Option<CompactString>,
+}
+
+enum ExportDeclarationRef<'a> {
+    Named(&'a ExportNamedDeclaration<'a>),
+    All(&'a ExportAllDeclaration<'a>),
+}
+
+impl ExportDeclarationRef<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Named(declaration) => declaration.span,
+            Self::All(declaration) => declaration.span,
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            Self::Named(declaration) => declaration
+                .source
+                .as_ref()
+                .map_or("", |source| source.value.as_str()),
+            Self::All(declaration) => declaration.source.value.as_str(),
+        }
+    }
+
+    fn export_kind(&self) -> ImportOrExportKind {
+        match self {
+            Self::Named(declaration) => declaration.export_kind,
+            Self::All(declaration) => declaration.export_kind,
+        }
+    }
+
+    fn export_type(&self) -> &'static str {
+        match self {
+            Self::Named(_) => "named",
+            Self::All(_) => "wildcard",
+        }
+    }
 }
 
 pub(crate) fn check(
@@ -139,7 +201,7 @@ pub(crate) fn check(
 
         let selected = select_import_options(raw_options, declaration, &named_specifiers);
         let options = RuleOptions::from_object(selected);
-        let mut specifiers: SmallVec<[NamedSpecifier<'_>; 8]> = named_specifiers
+        let mut specifiers: SmallVec<[SortableNode<'_>; 8]> = named_specifiers
             .iter()
             .enumerate()
             .filter_map(|(index, specifier)| {
@@ -194,7 +256,7 @@ pub(crate) fn check_exports(
             declaration.specifiers.iter().collect();
         let selected = select_export_options(raw_options, declaration, &named_specifiers);
         let options = RuleOptions::from_object(selected);
-        let mut specifiers: SmallVec<[NamedSpecifier<'_>; 8]> = named_specifiers
+        let mut specifiers: SmallVec<[SortableNode<'_>; 8]> = named_specifiers
             .iter()
             .enumerate()
             .filter_map(|(index, specifier)| {
@@ -229,35 +291,174 @@ pub(crate) fn check_exports(
     diagnostics
 }
 
+pub(crate) fn check_sort_exports(
+    source_text: &str,
+    body: &[Statement<'_>],
+    comments: &[Comment],
+    raw_options: &Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    let selected = match raw_options {
+        Value::Array(values) => values
+            .first()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default(),
+        Value::Object(object) => object.clone(),
+        _ => Map::new(),
+    };
+    let options = RuleOptions::from_object(selected);
+    let declarations: SmallVec<[ExportDeclarationRef<'_>; 16]> = body
+        .iter()
+        .filter_map(|statement| match statement {
+            Statement::ExportNamedDeclaration(declaration) if declaration.source.is_some() => {
+                Some(ExportDeclarationRef::Named(declaration))
+            }
+            Statement::ExportAllDeclaration(declaration) => {
+                Some(ExportDeclarationRef::All(declaration))
+            }
+            _ => None,
+        })
+        .collect();
+    if declarations.is_empty() {
+        return SmallVec::new();
+    }
+
+    let mut nodes: SmallVec<[SortableNode<'_>; 16]> = declarations
+        .iter()
+        .enumerate()
+        .filter_map(|(index, declaration)| {
+            let span = declaration.span();
+            let boundary = declarations
+                .get(index + 1)
+                .map_or(source_text.len() as u32, |next| next.span().start);
+            let source_start = movable_leading_comment_start(source_text, comments, span, &options);
+            let source_end = comments
+                .iter()
+                .filter(|comment| {
+                    comment.span.start >= span.end
+                        && comment.span.end <= boundary
+                        && is_same_line(source_text, span.end, comment.span.start)
+                })
+                .map(|comment| comment.span.end)
+                .max()
+                .unwrap_or(span.end);
+            let source = source_text
+                .get(usize::try_from(source_start).ok()?..usize::try_from(source_end).ok()?)?;
+            let node_source = source_text
+                .get(usize::try_from(span.start).ok()?..usize::try_from(span.end).ok()?)?;
+            let kind = if declaration.export_kind() == ImportOrExportKind::Type {
+                "type"
+            } else {
+                "value"
+            };
+            let line_count = if node_source
+                .chars()
+                .any(|character| matches!(character, '\n' | '\r' | '\u{2028}' | '\u{2029}'))
+            {
+                "multiline"
+            } else {
+                "singleline"
+            };
+            let modifiers = [kind, declaration.export_type(), line_count];
+            let name = CompactString::from(declaration.name());
+            let group = compute_group(
+                &options,
+                name.as_str(),
+                &modifiers,
+                SORT_EXPORTS_CONTRACT.selector,
+            );
+            let group_index = options.group_index(group.as_str());
+            Some(SortableNode {
+                span,
+                name,
+                source,
+                source_start,
+                source_end,
+                size: node_source
+                    .strip_suffix(';')
+                    .unwrap_or(node_source)
+                    .encode_utf16()
+                    .count(),
+                group,
+                group_index,
+                partition_id: 0,
+                is_disabled: is_export_disabled(source_text, comments, span),
+                add_safety_semicolon_when_inline: true,
+            })
+        })
+        .collect();
+    if nodes.is_empty() {
+        return SmallVec::new();
+    }
+
+    let lines = LineIndex::new(source_text);
+    let mut diagnostics = SmallVec::new();
+    check_specifiers(
+        source_text,
+        comments,
+        &options,
+        &mut nodes,
+        SORT_EXPORTS_CONTRACT,
+        &lines,
+        &mut diagnostics,
+    );
+    diagnostics
+}
+
 fn check_specifiers(
     source_text: &str,
     comments: &[Comment],
     options: &RuleOptions,
-    specifiers: &mut [NamedSpecifier<'_>],
+    specifiers: &mut [SortableNode<'_>],
     contract: RuleContract,
     lines: &LineIndex,
     diagnostics: &mut SmallVec<[RuleDiagnostic; 8]>,
 ) {
     assign_partitions(source_text, comments, options, specifiers);
-    let sorted_indices = sort_specifiers(options, specifiers);
+    let sorted_indices = sort_specifiers(options, specifiers, false);
+    let fix_indices = sort_specifiers(options, specifiers, true);
     let mut sorted_positions = vec![0; specifiers.len()];
     for (position, &original_index) in sorted_indices.iter().enumerate() {
         sorted_positions[original_index] = position;
     }
 
-    let mut pending: SmallVec<[(&'static str, usize, Option<usize>); 8]> = SmallVec::new();
+    let mut pending: SmallVec<[PendingDiagnostic; 8]> = SmallVec::new();
+    if let Some(message_id) = contract.missed_comment_above_message_id
+        && !specifiers[0].is_disabled
+        && let Some(comment) =
+            missing_comment_above(source_text, comments, options, None, &specifiers[0])
+    {
+        pending.push(PendingDiagnostic {
+            message_id,
+            right_index: 0,
+            left_index: None,
+            missed_comment_above: Some(comment),
+        });
+    }
     for right_index in 1..specifiers.len() {
         let left_index = right_index - 1;
         let left = &specifiers[left_index];
         let right = &specifiers[right_index];
 
-        if sorted_positions[left_index] > sorted_positions[right_index] {
+        let right_fix_position = fix_indices
+            .iter()
+            .position(|index| *index == right_index)
+            .unwrap_or(right_index);
+        if !right.is_disabled
+            && (sorted_positions[left_index] > sorted_positions[right_index]
+                || (left.is_disabled && sorted_positions[left_index] >= right_fix_position))
+        {
             let message_id = if left.group_index == right.group_index {
                 contract.order_message_id
             } else {
                 contract.group_order_message_id
             };
-            pending.push((message_id, right_index, Some(left_index)));
+            pending.push(PendingDiagnostic {
+                message_id,
+                right_index,
+                left_index: Some(left_index),
+                missed_comment_above: None,
+            });
         }
 
         if left.partition_id == right.partition_id
@@ -266,28 +467,55 @@ fn check_specifiers(
         {
             let actual = empty_lines_between(source_text, left.source_end, right.source_start);
             if actual < expected {
-                pending.push((
-                    contract.missed_spacing_message_id,
+                pending.push(PendingDiagnostic {
+                    message_id: contract.missed_spacing_message_id,
                     right_index,
-                    Some(left_index),
-                ));
+                    left_index: Some(left_index),
+                    missed_comment_above: None,
+                });
             } else if actual > expected {
-                pending.push((
-                    contract.extra_spacing_message_id,
+                pending.push(PendingDiagnostic {
+                    message_id: contract.extra_spacing_message_id,
                     right_index,
-                    Some(left_index),
-                ));
+                    left_index: Some(left_index),
+                    missed_comment_above: None,
+                });
             }
+        }
+        if let Some(message_id) = contract.missed_comment_above_message_id
+            && !right.is_disabled
+            && let Some(comment) = missing_comment_above(
+                source_text,
+                comments,
+                options,
+                Some(left.group_index),
+                right,
+            )
+        {
+            pending.push(PendingDiagnostic {
+                message_id,
+                right_index,
+                left_index: Some(left_index),
+                missed_comment_above: Some(comment),
+            });
         }
     }
     if pending.is_empty() {
         return;
     }
 
-    let Some(fix) = build_fix(source_text, options, specifiers, &sorted_indices) else {
+    let fix = build_fix(source_text, options, specifiers, &fix_indices)
+        .or_else(|| build_comment_fix(source_text, comments, options, specifiers, &fix_indices));
+    let Some(fix) = fix else {
         return;
     };
-    for (message_id, right_index, left_index) in pending {
+    for pending in pending {
+        let PendingDiagnostic {
+            message_id,
+            right_index,
+            left_index,
+            missed_comment_above,
+        } = pending;
         let right = &specifiers[right_index];
         let left = left_index.map(|index| &specifiers[index]);
         let is_group_error = message_id == contract.group_order_message_id;
@@ -295,12 +523,17 @@ fn check_specifiers(
             rule_name: contract.rule,
             message_id,
             data: RuleDiagnosticData {
-                left: left.map_or_else(|| CompactString::new(""), |node| node.name.clone()),
+                left: if missed_comment_above.is_some() {
+                    CompactString::new("")
+                } else {
+                    left.map_or_else(|| CompactString::new(""), |node| node.name.clone())
+                },
                 right: right.name.clone(),
                 left_group: is_group_error.then(|| {
                     left.map_or_else(|| CompactString::new(""), |node| node.group.clone())
                 }),
                 right_group: is_group_error.then(|| right.group.clone()),
+                missed_comment_above,
             },
             loc: lines.loc_for_span(source_text, right.span),
             fix: fix.clone(),
@@ -532,6 +765,7 @@ fn parse_group(value: &Value) -> Option<GroupEntry> {
             names: SmallVec::from_vec(vec![CompactString::from(name.as_str())]),
             overrides: None,
             newlines_inside: None,
+            comment_above: None,
         }),
         Value::Array(names) => Some(GroupEntry::Group {
             names: names
@@ -541,6 +775,7 @@ fn parse_group(value: &Value) -> Option<GroupEntry> {
                 .collect(),
             overrides: None,
             newlines_inside: None,
+            comment_above: None,
         }),
         Value::Object(object) if object.contains_key("group") => {
             let names = match object.get("group") {
@@ -558,6 +793,10 @@ fn parse_group(value: &Value) -> Option<GroupEntry> {
                 names,
                 overrides: Some(object.clone()),
                 newlines_inside: object.get("newlinesInside").map(parse_newlines),
+                comment_above: object
+                    .get("commentAbove")
+                    .and_then(Value::as_str)
+                    .map(CompactString::from),
             })
         }
         Value::Object(object) => object
@@ -613,7 +852,7 @@ fn named_import<'a>(
     boundary: u32,
     options: &RuleOptions,
     contract: RuleContract,
-) -> Option<NamedSpecifier<'a>> {
+) -> Option<SortableNode<'a>> {
     let source_start =
         movable_leading_comment_start(source_text, comments, specifier.span, options);
     let source_end = comments
@@ -639,9 +878,9 @@ fn named_import<'a>(
     } else {
         "value"
     };
-    let group = compute_group(options, name.as_str(), modifier, contract.selector);
+    let group = compute_group(options, name.as_str(), &[modifier], contract.selector);
     let group_index = options.group_index(group.as_str());
-    Some(NamedSpecifier {
+    Some(SortableNode {
         span: specifier.span,
         name,
         source,
@@ -651,6 +890,8 @@ fn named_import<'a>(
         group,
         group_index,
         partition_id: 0,
+        is_disabled: false,
+        add_safety_semicolon_when_inline: false,
     })
 }
 
@@ -662,7 +903,7 @@ fn named_export<'a>(
     boundary: u32,
     options: &RuleOptions,
     contract: RuleContract,
-) -> Option<NamedSpecifier<'a>> {
+) -> Option<SortableNode<'a>> {
     let source_start =
         movable_leading_comment_start(source_text, comments, specifier.span, options);
     let source_end = comments
@@ -688,9 +929,9 @@ fn named_export<'a>(
     } else {
         "value"
     };
-    let group = compute_group(options, name.as_str(), modifier, contract.selector);
+    let group = compute_group(options, name.as_str(), &[modifier], contract.selector);
     let group_index = options.group_index(group.as_str());
-    Some(NamedSpecifier {
+    Some(SortableNode {
         span: specifier.span,
         name,
         source,
@@ -700,6 +941,8 @@ fn named_export<'a>(
         group,
         group_index,
         partition_id: 0,
+        is_disabled: false,
+        add_safety_semicolon_when_inline: false,
     })
 }
 
@@ -719,6 +962,7 @@ fn movable_leading_comment_start(
     let mut start = specifier_span.start;
     for comment in leading.into_iter().rev() {
         if is_partition_comment(source_text, comment, &options.partition_by_comment)
+            || is_eslint_block_directive(source_text, comment)
             || empty_lines_between(source_text, comment.span.end, start) > 0
         {
             break;
@@ -728,10 +972,94 @@ fn movable_leading_comment_start(
     start
 }
 
+fn is_export_disabled(source_text: &str, comments: &[Comment], span: Span) -> bool {
+    let node_line = line_number_at(source_text, span.start);
+    let mut block_disabled = false;
+    let mut ordered_comments: SmallVec<[&Comment; 16]> = comments.iter().collect();
+    ordered_comments.sort_by_key(|comment| comment.span.start);
+    for comment in ordered_comments {
+        let content = comment_content(source_text, comment);
+        if comment.span.end <= span.start {
+            if let Some(rules) = content
+                .strip_prefix("eslint-disable ")
+                .or_else(|| (content == "eslint-disable").then_some(""))
+            {
+                if eslint_directive_applies(rules) {
+                    block_disabled = true;
+                }
+            } else if let Some(rules) = content
+                .strip_prefix("eslint-enable ")
+                .or_else(|| (content == "eslint-enable").then_some(""))
+                && eslint_directive_applies(rules)
+            {
+                block_disabled = false;
+            }
+        }
+        let comment_line = line_number_at(source_text, comment.span.start);
+        if let Some(rules) = content.strip_prefix("eslint-disable-next-line")
+            && comment_line + 1 == node_line
+            && eslint_directive_applies(rules)
+        {
+            return true;
+        }
+        if let Some(rules) = content.strip_prefix("eslint-disable-line")
+            && comment_line == node_line
+            && eslint_directive_applies(rules)
+        {
+            return true;
+        }
+    }
+    block_disabled
+}
+
+fn is_eslint_block_directive(source_text: &str, comment: &Comment) -> bool {
+    let content = comment_content(source_text, comment);
+    content.starts_with("eslint-disable") || content.starts_with("eslint-enable")
+}
+
+fn comment_content<'a>(source_text: &'a str, comment: &Comment) -> &'a str {
+    let content_span = comment.content_span();
+    source_text
+        .get(
+            usize::try_from(content_span.start).unwrap_or(0)
+                ..usize::try_from(content_span.end).unwrap_or(0),
+        )
+        .unwrap_or("")
+        .trim()
+}
+
+fn eslint_directive_applies(rules: &str) -> bool {
+    let rules = rules.trim().trim_start_matches(|character: char| {
+        character == ':' || character == '-' || character.is_whitespace()
+    });
+    rules.is_empty()
+        || rules.split(',').any(|rule| {
+            let rule = rule.split_whitespace().next().unwrap_or("");
+            matches!(
+                rule,
+                "sort-exports"
+                    | "perfectionist/sort-exports"
+                    | "rule-to-test/sort-exports"
+                    | "@perfectionist/sort-exports"
+            )
+        })
+}
+
+fn line_number_at(source_text: &str, offset: u32) -> u32 {
+    let offset = usize::try_from(offset)
+        .unwrap_or(source_text.len())
+        .min(source_text.len());
+    source_text[..offset]
+        .bytes()
+        .filter(|byte| *byte == b'\n')
+        .count() as u32
+        + 1
+}
+
 fn compute_group(
     options: &RuleOptions,
     name: &str,
-    modifier: &str,
+    modifiers: &[&str],
     selector: &str,
 ) -> CompactString {
     let configured: SmallVec<[&str; 8]> = options.group_names().collect();
@@ -745,23 +1073,22 @@ fn compute_group(
         if custom
             .matches
             .iter()
-            .any(|matcher| custom_match(matcher, name, modifier, selector))
+            .any(|matcher| custom_match(matcher, name, modifiers, selector))
         {
             return custom.group_name.clone();
         }
     }
-    for predefined in [format!("{modifier}-{selector}"), selector.to_owned()] {
-        if configured
-            .iter()
-            .any(|configured_name| *configured_name == predefined)
-        {
+    let mut predefined = predefined_groups(modifiers, selector);
+    predefined.push(selector.to_owned());
+    for predefined in predefined {
+        if configured.contains(&predefined.as_str()) {
             return CompactString::from(predefined);
         }
     }
     CompactString::new("unknown")
 }
 
-fn custom_match(matcher: &CustomMatch, name: &str, modifier: &str, selector: &str) -> bool {
+fn custom_match(matcher: &CustomMatch, name: &str, modifiers: &[&str], selector: &str) -> bool {
     if matcher
         .selector
         .as_ref()
@@ -773,7 +1100,7 @@ fn custom_match(matcher: &CustomMatch, name: &str, modifier: &str, selector: &st
         && !matcher
             .modifiers
             .iter()
-            .all(|candidate| candidate.as_str() == modifier)
+            .all(|candidate| modifiers.contains(&candidate.as_str()))
     {
         return false;
     }
@@ -783,11 +1110,65 @@ fn custom_match(matcher: &CustomMatch, name: &str, modifier: &str, selector: &st
         .is_none_or(|pattern| matches_regex(name, pattern))
 }
 
+fn predefined_groups(modifiers: &[&str], selector: &str) -> Vec<String> {
+    let mut groups = Vec::new();
+    for size in (1..=modifiers.len()).rev() {
+        let mut combination = Vec::with_capacity(size);
+        collect_modifier_combinations(modifiers, selector, size, 0, &mut combination, &mut groups);
+    }
+    groups
+}
+
+fn collect_modifier_combinations(
+    modifiers: &[&str],
+    selector: &str,
+    size: usize,
+    start: usize,
+    combination: &mut Vec<usize>,
+    groups: &mut Vec<String>,
+) {
+    if combination.len() == size {
+        let mut permutation = combination.clone();
+        collect_modifier_permutations(modifiers, selector, &mut permutation, 0, groups);
+        return;
+    }
+    for index in start..modifiers.len() {
+        combination.push(index);
+        collect_modifier_combinations(modifiers, selector, size, index + 1, combination, groups);
+        combination.pop();
+    }
+}
+
+fn collect_modifier_permutations(
+    modifiers: &[&str],
+    selector: &str,
+    permutation: &mut [usize],
+    first: usize,
+    groups: &mut Vec<String>,
+) {
+    if first == permutation.len() {
+        let mut group = permutation
+            .iter()
+            .map(|index| modifiers[*index])
+            .collect::<Vec<_>>()
+            .join("-");
+        group.push('-');
+        group.push_str(selector);
+        groups.push(group);
+        return;
+    }
+    for index in first..permutation.len() {
+        permutation.swap(first, index);
+        collect_modifier_permutations(modifiers, selector, permutation, first + 1, groups);
+        permutation.swap(first, index);
+    }
+}
+
 fn assign_partitions(
     source_text: &str,
     comments: &[Comment],
     options: &RuleOptions,
-    specifiers: &mut [NamedSpecifier<'_>],
+    specifiers: &mut [SortableNode<'_>],
 ) {
     let mut partition_id = 1;
     for index in 0..specifiers.len() {
@@ -811,7 +1192,11 @@ fn assign_partitions(
     }
 }
 
-fn sort_specifiers(options: &RuleOptions, specifiers: &[NamedSpecifier<'_>]) -> Vec<usize> {
+fn sort_specifiers(
+    options: &RuleOptions,
+    specifiers: &[SortableNode<'_>],
+    keep_disabled_in_place: bool,
+) -> Vec<usize> {
     let mut sorted = Vec::with_capacity(specifiers.len());
     let mut start = 0;
     while start < specifiers.len() {
@@ -820,7 +1205,16 @@ fn sort_specifiers(options: &RuleOptions, specifiers: &[NamedSpecifier<'_>]) -> 
         while end < specifiers.len() && specifiers[end].partition_id == partition {
             end += 1;
         }
-        let mut partition_indices: Vec<usize> = (start..end).collect();
+        let disabled_indices: Vec<usize> = if keep_disabled_in_place {
+            (start..end)
+                .filter(|index| specifiers[*index].is_disabled)
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let mut partition_indices: Vec<usize> = (start..end)
+            .filter(|index| !keep_disabled_in_place || !specifiers[*index].is_disabled)
+            .collect();
         partition_indices.sort_by(|&left, &right| {
             specifiers[left]
                 .group_index
@@ -828,6 +1222,9 @@ fn sort_specifiers(options: &RuleOptions, specifiers: &[NamedSpecifier<'_>]) -> 
                 .then_with(|| compare_in_group(options, &specifiers[left], &specifiers[right]))
                 .then_with(|| left.cmp(&right))
         });
+        for disabled_index in disabled_indices {
+            partition_indices.insert(disabled_index - start, disabled_index);
+        }
         sorted.extend(partition_indices);
         start = end;
     }
@@ -836,8 +1233,8 @@ fn sort_specifiers(options: &RuleOptions, specifiers: &[NamedSpecifier<'_>]) -> 
 
 fn compare_in_group(
     options: &RuleOptions,
-    left: &NamedSpecifier<'_>,
-    right: &NamedSpecifier<'_>,
+    left: &SortableNode<'_>,
+    right: &SortableNode<'_>,
 ) -> Ordering {
     let (sort, raw) = options.sort_options_for_group(left.group_index);
     let object = raw.as_object();
@@ -877,8 +1274,8 @@ fn compare_in_group(
 
 fn fallback_compare(
     options: &RuleOptions,
-    left: &NamedSpecifier<'_>,
-    right: &NamedSpecifier<'_>,
+    left: &SortableNode<'_>,
+    right: &SortableNode<'_>,
     raw: Option<&Map<String, Value>>,
 ) -> Ordering {
     let Some(fallback) = raw
@@ -908,8 +1305,8 @@ fn fallback_compare(
 
 fn subgroup_compare(
     options: &RuleOptions,
-    left: &NamedSpecifier<'_>,
-    right: &NamedSpecifier<'_>,
+    left: &SortableNode<'_>,
+    right: &SortableNode<'_>,
     raw: Option<&Map<String, Value>>,
 ) -> Ordering {
     let Some(GroupEntry::Group { names, .. }) = options.groups.get(left.group_index) else {
@@ -935,8 +1332,8 @@ fn subgroup_compare(
 
 fn newlines_between(
     options: &RuleOptions,
-    left: &NamedSpecifier<'_>,
-    right: &NamedSpecifier<'_>,
+    left: &SortableNode<'_>,
+    right: &SortableNode<'_>,
 ) -> Newlines {
     if left.group_index == right.group_index {
         if let Some(custom) = options
@@ -1002,10 +1399,204 @@ fn newlines_between(
     options.newlines_between
 }
 
+fn missing_comment_above(
+    source_text: &str,
+    comments: &[Comment],
+    options: &RuleOptions,
+    left_group_index: Option<usize>,
+    right: &SortableNode<'_>,
+) -> Option<CompactString> {
+    if left_group_index.is_some_and(|left| left >= right.group_index) {
+        return None;
+    }
+    let Some(GroupEntry::Group {
+        comment_above: Some(expected),
+        ..
+    }) = options.groups.get(right.group_index)
+    else {
+        return None;
+    };
+    let expected_lowercase = expected.trim().to_lowercase();
+    let exists = comments.iter().any(|comment| {
+        comment.attached_to == right.span.start
+            && comment.span.end <= right.span.start
+            && comment_content(source_text, comment)
+                .to_lowercase()
+                .contains(&expected_lowercase)
+    });
+    (!exists).then(|| expected.clone())
+}
+
+struct CommentEdit {
+    start: u32,
+    end: u32,
+    replacement: CompactString,
+}
+
+fn build_comment_fix(
+    source_text: &str,
+    comments: &[Comment],
+    options: &RuleOptions,
+    nodes: &[SortableNode<'_>],
+    sorted_indices: &[usize],
+) -> Option<RuleDiagnosticFix> {
+    let configured_comments: SmallVec<[&str; 8]> = options
+        .groups
+        .iter()
+        .filter_map(|entry| match entry {
+            GroupEntry::Group {
+                comment_above: Some(comment),
+                ..
+            } => Some(comment.as_str()),
+            _ => None,
+        })
+        .collect();
+    let mut edits: Vec<CommentEdit> = Vec::new();
+
+    for position in 0..sorted_indices.len() {
+        let node = &nodes[*sorted_indices.get(position)?];
+        let left_group_index = position
+            .checked_sub(1)
+            .and_then(|left| sorted_indices.get(left))
+            .map(|index| nodes[*index].group_index);
+        let expected = if left_group_index.is_some_and(|left| left >= node.group_index) {
+            None
+        } else {
+            options
+                .groups
+                .get(node.group_index)
+                .and_then(|entry| match entry {
+                    GroupEntry::Group { comment_above, .. } => comment_above.as_ref(),
+                    GroupEntry::Newlines(_) => None,
+                })
+        };
+        let mut attached: SmallVec<[&Comment; 8]> = comments
+            .iter()
+            .filter(|comment| {
+                comment.attached_to == node.span.start && comment.span.end <= node.span.start
+            })
+            .collect();
+        attached.sort_by_key(|comment| comment.span.start);
+        let mut leading: SmallVec<[&Comment; 8]> = SmallVec::new();
+        let mut cursor = node.span.start;
+        for comment in attached.into_iter().rev() {
+            if empty_lines_between(source_text, comment.span.end, cursor) > 0 {
+                break;
+            }
+            leading.push(comment);
+            cursor = comment.span.start;
+        }
+        leading.reverse();
+        let expected_exists = expected.is_some_and(|expected| {
+            let expected = expected.trim().to_lowercase();
+            leading.iter().any(|comment| {
+                comment_content(source_text, comment)
+                    .to_lowercase()
+                    .contains(&expected)
+            })
+        });
+        let mismatched_auto: SmallVec<[&Comment; 4]> = leading
+            .iter()
+            .copied()
+            .filter(|comment| {
+                let content = comment_content(source_text, comment);
+                comment.kind == CommentKind::Line
+                    && configured_comments.contains(&content.trim_start_matches('/').trim())
+                    && expected.is_none_or(|expected| content.trim() != expected.as_str())
+            })
+            .collect();
+
+        if let Some(expected) = expected.filter(|_| !expected_exists) {
+            let insertion = leading
+                .first()
+                .map_or(node.span.start, |comment| comment.span.start);
+            let replacement_comment = if left_group_index.is_none() {
+                mismatched_auto.first().copied()
+            } else {
+                mismatched_auto
+                    .first()
+                    .copied()
+                    .filter(|comment| comment.span.start == insertion)
+            };
+            if let Some(comment) = replacement_comment {
+                edits.push(CommentEdit {
+                    start: comment.span.start,
+                    end: next_comment_or_node_start(&leading, comment, node.span.start),
+                    replacement: CompactString::from(format!("// {expected}\n")),
+                });
+                for comment in mismatched_auto
+                    .iter()
+                    .copied()
+                    .filter(|candidate| candidate.span.start != comment.span.start)
+                {
+                    edits.push(CommentEdit {
+                        start: comment.span.start,
+                        end: next_comment_or_node_start(&leading, comment, node.span.start),
+                        replacement: CompactString::new(""),
+                    });
+                }
+            } else {
+                edits.push(CommentEdit {
+                    start: insertion,
+                    end: insertion,
+                    replacement: CompactString::from(format!("// {expected}\n")),
+                });
+                for comment in mismatched_auto {
+                    edits.push(CommentEdit {
+                        start: comment.span.start,
+                        end: next_comment_or_node_start(&leading, comment, node.span.start),
+                        replacement: CompactString::new(""),
+                    });
+                }
+            }
+        } else {
+            for comment in mismatched_auto {
+                edits.push(CommentEdit {
+                    start: comment.span.start,
+                    end: next_comment_or_node_start(&leading, comment, node.span.start),
+                    replacement: CompactString::new(""),
+                });
+            }
+        }
+    }
+    if edits.is_empty() {
+        return None;
+    }
+    edits.sort_by_key(|edit| (edit.start, edit.end));
+    let start = edits.first()?.start;
+    let end = edits.iter().map(|edit| edit.end).max()?;
+    let mut replacement = CompactString::new("");
+    let mut cursor = start;
+    for edit in edits {
+        if edit.start < cursor {
+            continue;
+        }
+        replacement.push_str(
+            source_text.get(usize::try_from(cursor).ok()?..usize::try_from(edit.start).ok()?)?,
+        );
+        replacement.push_str(edit.replacement.as_str());
+        cursor = edit.end;
+    }
+    replacement
+        .push_str(source_text.get(usize::try_from(cursor).ok()?..usize::try_from(end).ok()?)?);
+    Some(RuleDiagnosticFix {
+        start: LineIndex::utf16_offset(source_text, start),
+        end: LineIndex::utf16_offset(source_text, end),
+        replacement,
+    })
+}
+
+fn next_comment_or_node_start(leading: &[&Comment], comment: &Comment, node_start: u32) -> u32 {
+    leading
+        .iter()
+        .find(|candidate| candidate.span.start > comment.span.start)
+        .map_or(node_start, |candidate| candidate.span.start)
+}
+
 fn build_fix(
     source_text: &str,
     options: &RuleOptions,
-    specifiers: &[NamedSpecifier<'_>],
+    specifiers: &[SortableNode<'_>],
     sorted_indices: &[usize],
 ) -> Option<RuleDiagnosticFix> {
     let mut replacement = CompactString::new("");
@@ -1015,7 +1606,28 @@ fn build_fix(
     let mut changed_end: Option<u32> = None;
     for position in 0..specifiers.len() {
         desired_source_starts.push(replacement.len());
-        replacement.push_str(specifiers[*sorted_indices.get(position)?].source);
+        let sorted = &specifiers[*sorted_indices.get(position)?];
+        replacement.push_str(sorted.source);
+        if position + 1 < specifiers.len()
+            && sorted.add_safety_semicolon_when_inline
+            && is_same_line(
+                source_text,
+                specifiers[position].span.end,
+                specifiers[position + 1].span.start,
+            )
+            && !node_ends_with_safe_character(source_text, sorted)
+        {
+            let between = source_text.get(
+                usize::try_from(specifiers[position].span.end).ok()?
+                    ..usize::try_from(specifiers[position + 1].span.start).ok()?,
+            )?;
+            if !between.trim_start().starts_with([';', ',']) {
+                let insertion = replacement
+                    .len()
+                    .checked_sub(usize::try_from(sorted.source_end - sorted.span.end).ok()?)?;
+                replacement.insert(insertion, ';');
+            }
+        }
         desired_source_ends.push(replacement.len());
         if sorted_indices[position] != position {
             changed_start = Some(
@@ -1035,8 +1647,17 @@ fn build_fix(
         let separator = source_text.get(separator_start..separator_end)?;
         let sorted_left = &specifiers[*sorted_indices.get(position)?];
         let sorted_right = &specifiers[*sorted_indices.get(position + 1)?];
-        let desired_separator = if sorted_left.partition_id == sorted_right.partition_id
-            && sorted_left.group_index <= sorted_right.group_index
+        let checks_original_groups = specifiers
+            .iter()
+            .any(|specifier| specifier.add_safety_semicolon_when_inline);
+        let groups_allow_spacing = if checks_original_groups {
+            specifiers[position].partition_id == specifiers[position + 1].partition_id
+                && specifiers[position].group_index <= specifiers[position + 1].group_index
+        } else {
+            sorted_left.partition_id == sorted_right.partition_id
+                && sorted_left.group_index <= sorted_right.group_index
+        };
+        let desired_separator = if groups_allow_spacing
             && let Newlines::Count(expected) = newlines_between(options, sorted_left, sorted_right)
         {
             normalize_separator(
@@ -1090,9 +1711,21 @@ fn build_fix(
     })
 }
 
+fn node_ends_with_safe_character(source_text: &str, node: &SortableNode<'_>) -> bool {
+    let Ok(start) = usize::try_from(node.span.start) else {
+        return false;
+    };
+    let Ok(end) = usize::try_from(node.span.end) else {
+        return false;
+    };
+    source_text
+        .get(start..end)
+        .is_some_and(|source| source.trim_end().ends_with([';', ',']))
+}
+
 fn desired_offset_for_boundary(
     boundary: u32,
-    specifiers: &[NamedSpecifier<'_>],
+    specifiers: &[SortableNode<'_>],
     desired_source_starts: &[usize],
     desired_source_ends: &[usize],
 ) -> Option<usize> {

--- a/crates/perfectionist/src/sort_options.rs
+++ b/crates/perfectionist/src/sort_options.rs
@@ -175,7 +175,14 @@ impl SortOptions {
             SortType::Natural => {
                 let left = self.normalize(left_name);
                 let right = self.normalize(right_name);
-                natural_compare(left.as_str(), right.as_str())
+                if left.is_ascii() && right.is_ascii() {
+                    natural_compare(left.as_str(), right.as_str())
+                } else {
+                    self.collator.as_ref().map_or_else(
+                        || left.cmp(&right),
+                        |collator| collator.compare(left.as_str(), right.as_str()),
+                    )
+                }
             }
             SortType::LineLength => left_size.cmp(&right_size),
             SortType::Custom => {

--- a/crates/perfectionist/src/tests.rs
+++ b/crates/perfectionist/src/tests.rs
@@ -65,6 +65,13 @@ fn configured_exports(source: &str, options: serde_json::Value) -> SmallVec<[Rul
     scan_perfectionist_rule(source, "fixture.ts", "sort-named-exports", &options)
 }
 
+fn configured_export_declarations(
+    source: &str,
+    options: serde_json::Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    scan_perfectionist_rule(source, "fixture.ts", "sort-exports", &options)
+}
+
 #[test]
 fn sorts_predefined_type_and_value_groups() {
     let diagnostics = configured(
@@ -411,5 +418,192 @@ fn named_export_rule_selection_and_malformed_sources_fail_closed() {
             &json!([])
         )
         .is_empty()
+    );
+}
+
+#[test]
+fn sorts_export_declarations_and_preserves_trailing_comments() {
+    let source = "export * from 'z'; // z docs\nexport { a } from 'a'; // a docs\n";
+    let diagnostics = configured_export_declarations(source, json!([]));
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedExportsOrder");
+    assert_eq!(diagnostics[0].data.left, "z");
+    assert_eq!(diagnostics[0].data.right, "a");
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "export { a } from 'a'; // a docs\nexport * from 'z'; // z docs"
+    );
+}
+
+#[test]
+fn sorts_export_declarations_by_all_predefined_modifiers() {
+    let diagnostics = configured_export_declarations(
+        "export type {\n  A,\n} from 'types';\nexport * from 'runtime';\n",
+        json!([{
+            "groups": [
+                "value-wildcard-singleline-export",
+                "type-named-multiline-export"
+            ]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedExportsGroupOrder");
+    assert_eq!(
+        diagnostics[0].data.left_group.as_deref(),
+        Some("type-named-multiline-export")
+    );
+    assert_eq!(
+        diagnostics[0].data.right_group.as_deref(),
+        Some("value-wildcard-singleline-export")
+    );
+}
+
+#[test]
+fn matches_export_custom_groups_by_multiple_modifiers_and_any_of() {
+    let diagnostics = configured_export_declarations(
+        "export { a } from 'other';\nexport * from 'api-runtime';\n",
+        json!([{
+            "customGroups": [{
+                "groupName": "api-wildcard",
+                "anyOf": [
+                    {
+                        "elementNamePattern": "^api",
+                        "modifiers": ["value", "wildcard", "singleline"],
+                        "selector": "export"
+                    },
+                    { "elementNamePattern": "^never" }
+                ]
+            }],
+            "groups": ["api-wildcard", "unknown"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedExportsGroupOrder");
+    assert_eq!(
+        diagnostics[0].data.right_group.as_deref(),
+        Some("api-wildcard")
+    );
+}
+
+#[test]
+fn keeps_disabled_export_declarations_in_place() {
+    let diagnostics = configured_export_declarations(
+        "export { c } from './c'\nexport { b } from './b'\n// eslint-disable-next-line\nexport { a } from './a'",
+        json!([{}]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].data.left, "./c");
+    assert_eq!(diagnostics[0].data.right, "./b");
+    assert_eq!(diagnostics[0].fix.start, 0);
+    assert_eq!(diagnostics[0].fix.end, 47);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "export { b } from './b'\nexport { c } from './c'"
+    );
+}
+
+#[test]
+fn reports_and_fixes_missing_export_group_comments() {
+    let diagnostics = configured_export_declarations(
+        "export type { a } from './a';\n\nexport { b } from './b';",
+        json!([{
+            "groups": [
+                { "commentAbove": "Types", "group": "type-export" },
+                { "commentAbove": "Values", "group": "unknown" }
+            ]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.message_id == "missedCommentAboveExport")
+    );
+    assert_eq!(
+        diagnostics[0].data.missed_comment_above.as_deref(),
+        Some("Types")
+    );
+    assert_eq!(
+        diagnostics[1].data.missed_comment_above.as_deref(),
+        Some("Values")
+    );
+    assert_eq!(diagnostics[0].fix, diagnostics[1].fix);
+    assert_eq!(diagnostics[0].fix.start, 0);
+    assert_eq!(diagnostics[0].fix.end, 31);
+}
+
+#[test]
+fn keeps_utf16_offsets_for_unicode_export_declaration_fixes() {
+    let source = "'😀';\nexport { 世界 } from '世界';\nexport { api } from 'api';";
+    let diagnostics = configured_export_declarations(
+        source,
+        json!([{
+            "customGroups": [{ "groupName": "api", "elementNamePattern": "^api$" }],
+            "groups": ["api", "unknown"],
+            "locales": "zh-CN"
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].fix.start, 6);
+    assert_eq!(diagnostics[0].fix.end, 57);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "export { api } from 'api';\nexport { 世界 } from '世界';"
+    );
+}
+
+#[test]
+fn export_declaration_rule_ignores_local_exports_and_other_rules() {
+    assert!(
+        configured_export_declarations(
+            "export const z = 1;\nexport function a() {}\nexport { z, a };",
+            json!([])
+        )
+        .is_empty()
+    );
+    assert!(
+        scan_perfectionist_rule(
+            "export { z } from 'z';\nexport { a } from 'a';",
+            "fixture.ts",
+            "sort-named-exports",
+            &json!([])
+        )
+        .is_empty()
+    );
+    assert!(
+        scan_perfectionist_rule(
+            "export { z } from 'z';\nexport { a } from 'a';",
+            "fixture.ts",
+            "sort-named-imports",
+            &json!([])
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn export_declaration_rule_fails_closed_for_malformed_sources_and_options() {
+    assert!(configured_export_declarations("export { a } from", json!([])).is_empty());
+    assert!(
+        configured_export_declarations(
+            "export { b } from 'b';\nexport { a } from 'a';",
+            json!("not-an-option-object")
+        )
+        .len()
+            == 1
+    );
+    assert!(
+        configured_export_declarations(
+            "export { b } from 'b';\nexport { a } from 'a';",
+            json!([{ "type": "not-a-sort", "groups": [null, 1, false] }])
+        )
+        .len()
+            == 1
     );
 }

--- a/crates/perfectionist/src/types.rs
+++ b/crates/perfectionist/src/types.rs
@@ -24,6 +24,7 @@ pub struct RuleDiagnosticData {
     pub right: CompactString,
     pub left_group: Option<CompactString>,
     pub right_group: Option<CompactString>,
+    pub missed_comment_above: Option<CompactString>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -15,7 +15,7 @@ const PLUGIN_NAME = 'perfectionist';
 const DOCS_BASE = 'https://perfectionist.dev/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedPerfectionistRuleNames());
-const configuredRuleNames = new Set(['sort-named-exports', 'sort-named-imports']);
+const configuredRuleNames = new Set(['sort-exports', 'sort-named-exports', 'sort-named-imports']);
 const recommendedRuleNames = Object.freeze(
   implementedRuleNames.filter((ruleName) => ruleName !== 'sort-arrays'),
 );
@@ -99,14 +99,25 @@ function createPerfectionistRule(ruleName) {
               missedSpacingBetweenNamedImports:
                 'Missed spacing between "{{left}}" and "{{right}}".',
             }
-          : {
-              unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-              unexpectedNamedExportsGroupOrder:
-                'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-              extraSpacingBetweenNamedExports: 'Extra spacing between "{{left}}" and "{{right}}".',
-              missedSpacingBetweenNamedExports:
-                'Missed spacing between "{{left}}" and "{{right}}".',
-            }
+          : ruleName === 'sort-named-exports'
+            ? {
+                unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                unexpectedNamedExportsGroupOrder:
+                  'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                extraSpacingBetweenNamedExports:
+                  'Extra spacing between "{{left}}" and "{{right}}".',
+                missedSpacingBetweenNamedExports:
+                  'Missed spacing between "{{left}}" and "{{right}}".',
+              }
+            : {
+                unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                unexpectedExportsGroupOrder:
+                  'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                extraSpacingBetweenExports: 'Extra spacing between "{{left}}" and "{{right}}".',
+                missedSpacingBetweenExports: 'Missed spacing between "{{left}}" and "{{right}}".',
+                missedCommentAboveExport:
+                  'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
+              }
         : {
             unexpected: 'Expected sorted order.',
           },
@@ -135,7 +146,17 @@ function configuredDiagnosticsForRule(context, ruleName) {
   const sourceCode = context.sourceCode || {};
   const sourceText = sourceTextForContext(context);
   const filename = typeof context.filename === 'string' ? context.filename : 'file.tsx';
-  const options = Array.isArray(context.options) ? context.options : [];
+  let options = Array.isArray(context.options) ? context.options : [];
+  if (ruleName === 'sort-exports') {
+    const settings = context.settings?.perfectionist;
+    if (settings && typeof settings === 'object' && !Array.isArray(settings)) {
+      const configured =
+        options[0] && typeof options[0] === 'object' && !Array.isArray(options[0])
+          ? options[0]
+          : {};
+      options = [{ ...settings, ...configured }];
+    }
+  }
   const key = JSON.stringify({ filename, options, ruleName, sourceText });
   let cache = diagnosticsCache.get(sourceCode);
 
@@ -204,6 +225,7 @@ function schemaForRule(ruleName) {
     return [];
   }
   const selector = ruleName === 'sort-named-imports' ? 'import' : 'export';
+  const sortsExportDeclarations = ruleName === 'sort-exports';
   const sortType = {
     type: 'string',
     enum: ['subgroup-order', 'alphabetical', 'natural', 'line-length', 'custom', 'unsorted'],
@@ -265,7 +287,12 @@ function schemaForRule(ruleName) {
     elementNamePattern: regex,
     modifiers: {
       type: 'array',
-      items: { type: 'string', enum: ['value', 'type'] },
+      items: {
+        type: 'string',
+        enum: sortsExportDeclarations
+          ? ['value', 'type', 'named', 'wildcard', 'singleline', 'multiline']
+          : ['value', 'type'],
+      },
     },
     selector: { type: 'string', enum: [selector] },
   };
@@ -384,22 +411,26 @@ function schemaForRule(ruleName) {
         },
         alphabet: { type: 'string' },
         fallbackSort,
-        ignoreAlias: { type: 'boolean' },
+        ...(sortsExportDeclarations ? {} : { ignoreAlias: { type: 'boolean' } }),
         groups,
         customGroups,
         partitionByComment,
         partitionByNewLine: { type: 'boolean' },
         newlinesBetween: newlines,
         newlinesInside,
-        useConfigurationIf: {
-          type: 'object',
-          properties: {
-            allNamesMatchPattern: regex,
-            matchesAstSelector: { type: 'string' },
-          },
-          minProperties: 1,
-          additionalProperties: false,
-        },
+        ...(sortsExportDeclarations
+          ? {}
+          : {
+              useConfigurationIf: {
+                type: 'object',
+                properties: {
+                  allNamesMatchPattern: regex,
+                  matchesAstSelector: { type: 'string' },
+                },
+                minProperties: 1,
+                additionalProperties: false,
+              },
+            }),
       },
       additionalProperties: false,
     },

--- a/npm/perfectionist/src/lib.rs
+++ b/npm/perfectionist/src/lib.rs
@@ -38,10 +38,11 @@ mod napi_abi {
     #[napi(object)]
     #[derive(Clone, Debug)]
     pub struct DiagnosticData {
-        pub left: String,
+        pub left: Option<String>,
         pub right: String,
         pub left_group: Option<String>,
         pub right_group: Option<String>,
+        pub missed_comment_above: Option<String>,
     }
 
     #[napi(object)]
@@ -99,10 +100,18 @@ mod napi_abi {
                         end_column: diagnostic.loc.end_column,
                     },
                     data: Some(DiagnosticData {
-                        left: diagnostic.data.left.into_string(),
+                        left: diagnostic
+                            .data
+                            .missed_comment_above
+                            .is_none()
+                            .then(|| diagnostic.data.left.into_string()),
                         right: diagnostic.data.right.into_string(),
                         left_group: diagnostic.data.left_group.map(|value| value.into_string()),
                         right_group: diagnostic.data.right_group.map(|value| value.into_string()),
+                        missed_comment_above: diagnostic
+                            .data
+                            .missed_comment_above
+                            .map(|value| value.into_string()),
                     }),
                     fix: Some(DiagnosticFix {
                         start: diagnostic.fix.start,

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -146,6 +146,68 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact export-declaration groups, CRLF locations, and UTF-16 fixes', () => {
+    const source = `'😀';\r\nexport { 世界 } from '世界';\r\nexport { api } from 'api';\r\n`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-exports', [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        locales: 'zh-CN',
+      },
+    ]);
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-exports',
+      messageId: 'unexpectedExportsGroupOrder',
+      data: {
+        left: '世界',
+        right: 'api',
+        leftGroup: 'unknown',
+        rightGroup: 'api',
+      },
+      loc: {
+        startLine: 3,
+        startColumn: 0,
+        endLine: 3,
+        endColumn: 26,
+      },
+      fix: {
+        start: 7,
+        end: 59,
+        replacement: `export { api } from 'api';\r\nexport { 世界 } from '世界';`,
+      },
+    });
+  });
+
+  it('returns exact missing-comment data without unrelated placeholders', () => {
+    const [diagnostic] = scanPerfectionistRule(
+      `export type { value } from './types';`,
+      'fixture.ts',
+      'sort-exports',
+      [{ groups: [{ group: 'type-export', commentAbove: 'Types' }] }],
+    );
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-exports',
+      messageId: 'missedCommentAboveExport',
+      data: {
+        right: './types',
+        missedCommentAbove: 'Types',
+      },
+      loc: {
+        startLine: 1,
+        startColumn: 0,
+        endLine: 1,
+        endColumn: 37,
+      },
+      fix: {
+        start: 0,
+        end: 0,
+        replacement: '// Types\n',
+      },
+    });
+  });
+
   it('returns exact group-order data and a comment-preserving fix', () => {
     const source = `import {
   // value docs
@@ -224,12 +286,37 @@ describe('perfectionist native API', () => {
     expect(
       scanPerfectionistRule('import { b, a } from "pkg";', 'fixture.ts', 'sort-named-exports', []),
     ).toEqual([]);
+    expect(
+      scanPerfectionistRule('export { b, a } from "pkg";', 'fixture.ts', 'sort-exports', []),
+    ).toEqual([]);
+    expect(
+      scanPerfectionistRule(
+        'export { z } from "z";\nexport { a } from "a";',
+        'fixture.ts',
+        'sort-named-exports',
+        [],
+      ),
+    ).toEqual([]);
   });
 
   it('fails closed for malformed named-export syntax', () => {
     expect(scanPerfectionistRule('export { b,', 'fixture.ts', 'sort-named-exports', [])).toEqual(
       [],
     );
+  });
+
+  it('fails closed for malformed export-declaration syntax and malformed options', () => {
+    expect(scanPerfectionistRule('export { a } from', 'fixture.ts', 'sort-exports', [])).toEqual(
+      [],
+    );
+    expect(
+      scanPerfectionistRule(
+        'export { b } from "b";\nexport { a } from "a";',
+        'fixture.ts',
+        'sort-exports',
+        [{ type: 'not-a-sort', groups: [null, false, 1] }],
+      ),
+    ).toHaveLength(1);
   });
 
   it('validates public API scalar arguments', () => {

--- a/npm/perfectionist/test/fixtures/sort-exports-options-v5.9.1.json
+++ b/npm/perfectionist/test/fixtures/sort-exports-options-v5.9.1.json
@@ -1,0 +1,8170 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-perfectionist",
+    "version": "5.9.1",
+    "sourceCommit": "b35e8e4caf0c8d350cf386e504241f21827dd60b",
+    "sourceHashes": {
+      "rules/sort-exports.ts": "dd6ee1cd385e1f8cca77357a781f5bd82176d67d7e33695ca177624095077baf",
+      "rules/sort-exports/types.ts": "5f09e2870357909e40e8a33acce0bf2fb796350246e970f77432e2a3c8a309df",
+      "test/rules/sort-exports.test.ts": "1590b05abda2fa82c9e9579514b04f3c03137c26834711fb94fce6af399d85e4"
+    },
+    "license": "MIT",
+    "eslintVersion": "9.39.2",
+    "typescriptEslintParserVersion": "8.60.0",
+    "capturePolicy": "Every authored valid and invalid sort-exports case is executed, then replayed against the published v5.9.1 rule for exact diagnostics and fixes.",
+    "authoredCases": "upstream/eslint-plugin-perfectionist/test/rules/sort-exports.test.ts",
+    "tool": "sync-perfectionist-sort-exports-options-tests.ts",
+    "inventory": {
+      "valid": 70,
+      "invalid": 133,
+      "diagnostics": 184,
+      "total": 203
+    }
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > oxlint > supports oxlint > valid",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > oxlint > supports oxlint > invalid",
+      "code": "export { b } from 'b'\nexport { a } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 43],
+            "text": "export { a } from 'a'\nexport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > sorts exports",
+      "code": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sorts exports",
+      "code": "export { b1, b2 } from 'b'\nexport { a1 } from 'a'\nexport { d1, d2 } from 'd'\nexport { c1, c2, c3 } from 'c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+          }
+        }
+      ],
+      "output": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > sorts all-exports",
+      "code": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sorts all-exports",
+      "code": "export * as b from './b'\nexport { a1 } from './a'\nexport { c1, c2 } from './c'\nexport * from 'e'\nexport { d } from './d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./d\" to come before \"e\".",
+          "data": {
+            "right": "./d",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'"
+          }
+        }
+      ],
+      "output": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > works with export aliases",
+      "code": "export { a1 as aX } from './a'\nexport { default as b } from './b'\nexport { c1, c2 } from './c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > works with export aliases",
+      "code": "export { a1 as aX } from './a'\nexport { c1, c2 } from './c'\nexport { default as b } from './b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 35
+          },
+          "fix": {
+            "range": [31, 94],
+            "text": "export { default as b } from './b'\nexport { c1, c2 } from './c'"
+          }
+        }
+      ],
+      "output": "export { a1 as aX } from './a'\nexport { default as b } from './b'\nexport { c1, c2 } from './c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows to use new line as partition",
+      "code": "export * from \"./organisms\";\nexport * from \"./atoms\";\nexport * from \"./shared\";\n\nexport { AnotherNamed } from './second-folder';\nexport { Named } from './folder';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./atoms\" to come before \"./organisms\".",
+          "data": {
+            "right": "./atoms",
+            "left": "./organisms"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 162],
+            "text": "export * from \"./atoms\";\nexport * from \"./organisms\";\nexport * from \"./shared\";\n\nexport { Named } from './folder';\nexport { AnotherNamed } from './second-folder';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./folder\" to come before \"./second-folder\".",
+          "data": {
+            "right": "./folder",
+            "left": "./second-folder"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 162],
+            "text": "export * from \"./atoms\";\nexport * from \"./organisms\";\nexport * from \"./shared\";\n\nexport { Named } from './folder';\nexport { AnotherNamed } from './second-folder';"
+          }
+        }
+      ],
+      "output": "export * from \"./atoms\";\nexport * from \"./organisms\";\nexport * from \"./shared\";\n\nexport { Named } from './folder';\nexport { AnotherNamed } from './second-folder';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows to use partition comments",
+      "code": "// Part: A\nexport * from './cc';\nexport * from './d';\n// Not partition comment\nexport * from './bbb';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\nexport * from './gg';\n// Not partition comment\nexport * from './fff';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bbb\" to come before \"./d\".",
+          "data": {
+            "right": "./bbb",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [11, 238],
+            "text": "// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./fff\" to come before \"./gg\".",
+          "data": {
+            "right": "./fff",
+            "left": "./gg"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [11, 238],
+            "text": "// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+          }
+        }
+      ],
+      "output": "// Part: A\n// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to use all comments as parts",
+      "code": "// Comment\nexport * from './bb';\n// Other comment\nexport * from './a';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows to use multiple partition comments",
+      "code": "/* Partition Comment */\n// Part: A\nexport * from './d'\n// Part: B\nexport * from './aaa'\nexport * from './c'\nexport * from './bb'\n/* Other */\nexport * from './e'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [88, 128],
+            "text": "export * from './bb'\nexport * from './c'"
+          }
+        }
+      ],
+      "output": "/* Partition Comment */\n// Part: A\nexport * from './d'\n// Part: B\nexport * from './aaa'\nexport * from './bb'\nexport * from './c'\n/* Other */\nexport * from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to use regex for partition comments",
+      "code": "export * from './e'\nexport * from './f'\n// I am a partition comment because I don't have f o o\nexport * from './a'\nexport * from './b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > ignores line comments when using block comment partitions",
+      "code": "export * from './b'\n// Comment\nexport * from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "// Comment\nexport * from './a'\nexport * from './b'"
+          }
+        }
+      ],
+      "output": "// Comment\nexport * from './a'\nexport * from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to use block comments as partition boundaries",
+      "code": "export * from './b'\n/* Comment */\nexport * from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to use multiple block comment patterns for partitions",
+      "code": "export * from './c'\n/* b */\nexport * from './b'\n/* a */\nexport * from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to use regex patterns for block comment partitions",
+      "code": "export * from './b'\n/* I am a partition comment because I don't have f o o */\nexport * from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to trim special characters",
+      "code": "export { a } from '_a'\nexport { b } from 'b'\nexport { c } from '_c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to remove special characters",
+      "code": "export { ab } from 'ab'\nexport { ac } from 'a_c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > allows to use locale",
+      "code": "export { 你好 } from '你好'\nexport { 世界 } from '世界'\nexport { a } from 'a'\nexport { A } from 'A'\nexport { b } from 'b'\nexport { B } from 'B'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sorts inline elements correctly",
+      "code": "export { b } from \"b\"; export { a } from \"a\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 45
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "export { a } from \"a\"; export { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "export { a } from \"a\"; export { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sorts inline elements with semicolons correctly",
+      "code": "export { b } from \"b\"; export { a } from \"a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 46
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "export { a } from \"a\"; export { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "export { a } from \"a\"; export { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows to use predefined groups",
+      "code": "export type { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["value-export", "type-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (value-export) to come before \"a\" (type-export).",
+          "data": {
+            "right": "b",
+            "rightGroup": "value-export",
+            "left": "a",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "export { b } from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows to use predefined groups",
+      "code": "export { a } from 'a';\nexport * from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["wildcard-export", "named-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (wildcard-export) to come before \"a\" (named-export).",
+          "data": {
+            "right": "b",
+            "rightGroup": "wildcard-export",
+            "left": "a",
+            "leftGroup": "named-export"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 41],
+            "text": "export * from 'b';\nexport { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export * from 'b';\nexport { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows to use predefined groups",
+      "code": "export {\n  a\n} from 'a';\nexport * from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["singleline-export", "multiline-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (singleline-export) to come before \"a\" (multiline-export).",
+          "data": {
+            "right": "b",
+            "rightGroup": "singleline-export",
+            "left": "a",
+            "leftGroup": "multiline-export"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 43],
+            "text": "export * from 'b';\nexport {\n  a\n} from 'a';"
+          }
+        }
+      ],
+      "output": "export * from 'b';\nexport {\n  a\n} from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > prioritizes export kind over export type",
+      "code": "export type { a } from 'a';\nexport * as b from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["value-export", "unknown", "wildcard-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (value-export) to come before \"a\" (unknown).",
+          "data": {
+            "right": "b",
+            "rightGroup": "value-export",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "export * as b from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export * as b from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > prioritizes export type over line count",
+      "code": "export * from 'a';\nexport {\n  b\n} from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["named-export", "unknown", "multiline-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (named-export) to come before \"a\" (unknown).",
+          "data": {
+            "right": "b",
+            "rightGroup": "named-export",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [0, 43],
+            "text": "export {\n  b\n} from 'b';\nexport * from 'a';"
+          }
+        }
+      ],
+      "output": "export {\n  b\n} from 'b';\nexport * from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > allows overriding options in groups",
+      "code": "export { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "groups": [
+            {
+              "type": "alphabetical",
+              "newlinesInside": 1,
+              "group": "unknown",
+              "order": "desc"
+            }
+          ],
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "export { b } from 'b';\n\nexport { a } from 'a';"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "export { b } from 'b';\n\nexport { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\n\nexport { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > filters on modifier",
+      "code": "export type { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "valueExports",
+              "modifiers": ["value"]
+            }
+          ],
+          "groups": ["valueExports", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (valueExports) to come before \"a\" (unknown).",
+          "data": {
+            "right": "b",
+            "rightGroup": "valueExports",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "export { b } from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > filters on elementNamePattern - string pattern",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > filters on elementNamePattern - array pattern",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > filters on elementNamePattern - case-insensitive regex",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > filters on elementNamePattern - regex in array",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > handles complex regex in elementNamePattern",
+      "code": "export { iHaveFooInMyName } from 'iHaveFooInMyName';\nexport { meTooIHaveFoo } from 'meTooIHaveFoo';\nexport { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sort custom groups by overriding type and order",
+      "code": "export { a } from 'a';\nexport { bb } from 'bb';\nexport { ccc } from 'ccc';\nexport { dddd } from 'dddd';\nexport type { m } from 'm';\nexport { eee } from 'eee';\nexport { ff } from 'ff';\nexport { g } from 'g';\nexport type { o } from 'o';\nexport type { p } from 'p';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedValuesByLineLength",
+              "modifiers": ["value"],
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedValuesByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"eee\" (reversedValuesByLineLength) to come before \"m\" (unknown).",
+          "data": {
+            "right": "eee",
+            "rightGroup": "reversedValuesByLineLength",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        }
+      ],
+      "output": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';\nexport type { o } from 'o';\nexport type { p } from 'p';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sort custom groups by overriding fallbackSort",
+      "code": "export { fooZar } from 'fooZar';\nexport { fooBar } from 'fooBar';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "export { fooBar } from 'fooBar';\nexport { fooZar } from 'fooZar';"
+          }
+        }
+      ],
+      "output": "export { fooBar } from 'fooBar';\nexport { fooZar } from 'fooZar';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > does not sort custom groups with unsorted type",
+      "code": "export { b } from 'b';\nexport { a } from 'a';\nexport { d } from 'd';\nexport { e } from 'e';\nexport type { m } from 'm';\nexport { c } from 'c';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "unsortedValues",
+              "modifiers": ["value"],
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedValues", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"c\" (unsortedValues) to come before \"m\" (unknown).",
+          "data": {
+            "right": "c",
+            "rightGroup": "unsortedValues",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [92, 142],
+            "text": "export { c } from 'c';\nexport type { m } from 'm';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport { a } from 'a';\nexport { d } from 'd';\nexport { e } from 'e';\nexport { c } from 'c';\nexport type { m } from 'm';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > sort custom group blocks",
+      "code": "export { a } from 'a';\nexport { cFoo } from 'cFoo';\nexport type { foo } from 'foo';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo|Foo",
+                  "modifiers": ["value"]
+                },
+                {
+                  "elementNamePattern": "foo|Foo",
+                  "modifiers": ["type"]
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"cFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "cFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 83],
+            "text": "export { cFoo } from 'cFoo';\nexport type { foo } from 'foo';\nexport { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { cFoo } from 'cFoo';\nexport type { foo } from 'foo';\nexport { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > removes newlines between and inside groups by default when \"newlinesBetween\" is 0",
+      "code": "  export { a } from 'a'\n\n\n export { y } from 'y'\nexport { z } from 'z'\n\n    export { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+          }
+        }
+      ],
+      "output": "  export { a } from 'a'\n export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > removes newlines inside groups when newlinesInside is 0",
+      "code": "  export { a } from 'a'\n\n\n export { y } from 'y'\nexport { z } from 'z'\n\n    export { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [27, 97],
+            "text": "export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [27, 97],
+            "text": "export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+          }
+        }
+      ],
+      "output": "  export { a } from 'a'\n\n\n export { b } from 'b'\nexport { y } from 'y'\n    export { z } from 'z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > removes newlines between groups when newlinesBetween is 0",
+      "code": "  export { a } from 'a'\n\n\n export { y } from 'y'\nexport { z } from 'z'\n\n    export { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n\n    export { z } from 'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n\n    export { z } from 'z'"
+          }
+        }
+      ],
+      "output": "  export { a } from 'a'\n export { b } from 'b'\nexport { y } from 'y'\n\n    export { z } from 'z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > handles newlinesBetween between consecutive groups",
+      "code": "export { a } from 'a'\nexport { b } from 'b'\n\n\nexport { c } from 'c'\n\nexport { d } from 'd'\n\n\nexport { e } from 'e'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\nexport { b } from 'b'\n\nexport { c } from 'c'\nexport { d } from 'd'\n\n\nexport { e } from 'e'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces newlines if the global option is 2 and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces newlines if the global option is 2 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces newlines if the global option is 0 and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces newlines if the global option is ignore and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces no newline if the global option is 1 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces no newline if the global option is 2 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces no newline if the global option is ignore and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > enforces no newline if the global option is 0 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > does not enforce a newline if the global option is ignore and the group option is 0",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > does not enforce a newline if the global option is ignore and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > does not enforce a newline if the global option is 0 and the group option is ignore",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > does not enforce a newline if the global option is 0 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > ignores newline fixes between different partitions when newlinesBetween is 0",
+      "code": "export { a } from 'a'\n\n// Partition comment\n\nexport { c } from 'c'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [45, 88],
+            "text": "export { b } from 'b'\nexport { c } from 'c'"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n// Partition comment\n\nexport { b } from 'b'\nexport { c } from 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > reports missing comments",
+      "code": "export type { a } from \"./a\";\n\nexport { b } from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            },
+            {
+              "commentAbove": "Other exports",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./a\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\n"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Other exports\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Other exports",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\n"
+          }
+        }
+      ],
+      "output": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\nexport { b } from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > reports missing comments for single nodes",
+      "code": "export { a } from \"a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Comment above\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 0],
+            "text": "// Comment above\n"
+          }
+        }
+      ],
+      "output": "// Comment above\nexport { a } from \"a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > ignores shebangs and comments at the top of the file",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\nexport { b } from \"./b\";\nexport { a } from \"./a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Comment above\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 85],
+            "text": "export { a } from \"./a\";\nexport { b } from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 85],
+            "text": "export { a } from \"./a\";\nexport { b } from \"./b\";"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above\nexport { a } from \"./a\";\nexport { b } from \"./b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > detects existing comments correctly with comment: //   Comment above  ",
+      "code": "export { a } from \"a\";\n\n//   Comment above  \nexport type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > detects existing comments correctly with comment: //   comment above  ",
+      "code": "export { a } from \"a\";\n\n//   comment above  \nexport type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > detects existing comments correctly with comment: /**\n * Comment above\n */",
+      "code": "           export { a } from \"a\";\n\n           /**\n* Comment above\n*/\n           export type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > alphabetical > detects existing comments correctly with comment: /**\n * Something before\n * CoMmEnT ABoVe\n * Something after\n */",
+      "code": "           export { a } from \"a\";\n\n           /**\n* Something before\n* CoMmEnT ABoVe\n* Something after\n*/\n           export type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > deletes invalid auto-added comments",
+      "code": "export type { c } from './c';\n// Value exports\nexport type { b } from './b';\n// Type exports\nexport { a } from './a';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Value exports",
+              "group": "value-export"
+            },
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./c\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./c"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 117],
+            "text": "// Type exports\nexport { a } from './a';\n// Value exports\nexport type { b } from './b';\nexport type { c } from './c';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 117],
+            "text": "// Type exports\nexport { a } from './a';\n// Value exports\nexport type { b } from './b';\nexport type { c } from './c';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"./a\" (value-export) to come before \"./b\" (type-export).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "value-export",
+            "left": "./b",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 117],
+            "text": "// Type exports\nexport { a } from './a';\n// Value exports\nexport type { b } from './b';\nexport type { c } from './c';"
+          }
+        }
+      ],
+      "output": "// Value exports\nexport { a } from './a';\n// Type exports\nexport type { b } from './b';\nexport type { c } from './c';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > alphabetical > works with other errors",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b\n// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Value exports",
+              "group": "value-export"
+            },
+            {
+              "newlinesBetween": 1
+            },
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            }
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [36, 199],
+            "text": "// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"./a\" (value-export) to come before \"./b\" (type-export).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "value-export",
+            "left": "./b",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 199],
+            "text": "// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above a\n// Value exports\nexport { a } from \"./a\"; // Comment after a\n\n// Type exports\n// Comment above b\nexport type { b } from './b'; // Comment after b"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > sorts exports",
+      "code": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sorts exports",
+      "code": "export { b1, b2 } from 'b'\nexport { a1 } from 'a'\nexport { d1, d2 } from 'd'\nexport { c1, c2, c3 } from 'c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+          }
+        }
+      ],
+      "output": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > sorts all-exports",
+      "code": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sorts all-exports",
+      "code": "export * as b from './b'\nexport { a1 } from './a'\nexport { c1, c2 } from './c'\nexport * from 'e'\nexport { d } from './d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./d\" to come before \"e\".",
+          "data": {
+            "right": "./d",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'"
+          }
+        }
+      ],
+      "output": "export { a1 } from './a'\nexport * as b from './b'\nexport { c1, c2 } from './c'\nexport { d } from './d'\nexport * from 'e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > works with export aliases",
+      "code": "export { a1 as aX } from './a'\nexport { default as b } from './b'\nexport { c1, c2 } from './c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > works with export aliases",
+      "code": "export { a1 as aX } from './a'\nexport { c1, c2 } from './c'\nexport { default as b } from './b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 35
+          },
+          "fix": {
+            "range": [31, 94],
+            "text": "export { default as b } from './b'\nexport { c1, c2 } from './c'"
+          }
+        }
+      ],
+      "output": "export { a1 as aX } from './a'\nexport { default as b } from './b'\nexport { c1, c2 } from './c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > allows to use new line as partition",
+      "code": "export * from \"./organisms\";\nexport * from \"./atoms\";\nexport * from \"./shared\";\n\nexport { AnotherNamed } from './second-folder';\nexport { Named } from './folder';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./atoms\" to come before \"./organisms\".",
+          "data": {
+            "right": "./atoms",
+            "left": "./organisms"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 162],
+            "text": "export * from \"./atoms\";\nexport * from \"./organisms\";\nexport * from \"./shared\";\n\nexport { Named } from './folder';\nexport { AnotherNamed } from './second-folder';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./folder\" to come before \"./second-folder\".",
+          "data": {
+            "right": "./folder",
+            "left": "./second-folder"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 162],
+            "text": "export * from \"./atoms\";\nexport * from \"./organisms\";\nexport * from \"./shared\";\n\nexport { Named } from './folder';\nexport { AnotherNamed } from './second-folder';"
+          }
+        }
+      ],
+      "output": "export * from \"./atoms\";\nexport * from \"./organisms\";\nexport * from \"./shared\";\n\nexport { Named } from './folder';\nexport { AnotherNamed } from './second-folder';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > allows to use partition comments",
+      "code": "// Part: A\nexport * from './cc';\nexport * from './d';\n// Not partition comment\nexport * from './bbb';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\nexport * from './gg';\n// Not partition comment\nexport * from './fff';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bbb\" to come before \"./d\".",
+          "data": {
+            "right": "./bbb",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [11, 238],
+            "text": "// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./fff\" to come before \"./gg\".",
+          "data": {
+            "right": "./fff",
+            "left": "./gg"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [11, 238],
+            "text": "// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+          }
+        }
+      ],
+      "output": "// Part: A\n// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to use all comments as parts",
+      "code": "// Comment\nexport * from './bb';\n// Other comment\nexport * from './a';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > allows to use multiple partition comments",
+      "code": "/* Partition Comment */\n// Part: A\nexport * from './d'\n// Part: B\nexport * from './aaa'\nexport * from './c'\nexport * from './bb'\n/* Other */\nexport * from './e'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [88, 128],
+            "text": "export * from './bb'\nexport * from './c'"
+          }
+        }
+      ],
+      "output": "/* Partition Comment */\n// Part: A\nexport * from './d'\n// Part: B\nexport * from './aaa'\nexport * from './bb'\nexport * from './c'\n/* Other */\nexport * from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to use regex for partition comments",
+      "code": "export * from './e'\nexport * from './f'\n// I am a partition comment because I don't have f o o\nexport * from './a'\nexport * from './b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > ignores line comments when using block comment partitions",
+      "code": "export * from './b'\n// Comment\nexport * from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "// Comment\nexport * from './a'\nexport * from './b'"
+          }
+        }
+      ],
+      "output": "// Comment\nexport * from './a'\nexport * from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to use block comments as partition boundaries",
+      "code": "export * from './b'\n/* Comment */\nexport * from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to use multiple block comment patterns for partitions",
+      "code": "export * from './c'\n/* b */\nexport * from './b'\n/* a */\nexport * from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to use regex patterns for block comment partitions",
+      "code": "export * from './b'\n/* I am a partition comment because I don't have f o o */\nexport * from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to trim special characters",
+      "code": "export { a } from '_a'\nexport { b } from 'b'\nexport { c } from '_c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to remove special characters",
+      "code": "export { ab } from 'ab'\nexport { ac } from 'a_c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > allows to use locale",
+      "code": "export { 你好 } from '你好'\nexport { 世界 } from '世界'\nexport { a } from 'a'\nexport { A } from 'A'\nexport { b } from 'b'\nexport { B } from 'B'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sorts inline elements correctly",
+      "code": "export { b } from \"b\"; export { a } from \"a\"",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 45
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "export { a } from \"a\"; export { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "export { a } from \"a\"; export { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sorts inline elements with semicolons correctly",
+      "code": "export { b } from \"b\"; export { a } from \"a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 46
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "export { a } from \"a\"; export { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "export { a } from \"a\"; export { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > allows to use predefined groups",
+      "code": "export type { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["value-export", "type-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (value-export) to come before \"a\" (type-export).",
+          "data": {
+            "right": "b",
+            "rightGroup": "value-export",
+            "left": "a",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "export { b } from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > filters on modifier",
+      "code": "export type { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "valueExports",
+              "modifiers": ["value"]
+            }
+          ],
+          "groups": ["valueExports", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (valueExports) to come before \"a\" (unknown).",
+          "data": {
+            "right": "b",
+            "rightGroup": "valueExports",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "export { b } from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > filters on elementNamePattern - string pattern",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > filters on elementNamePattern - array pattern",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > filters on elementNamePattern - case-insensitive regex",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > filters on elementNamePattern - regex in array",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > handles complex regex in elementNamePattern",
+      "code": "export { iHaveFooInMyName } from 'iHaveFooInMyName';\nexport { meTooIHaveFoo } from 'meTooIHaveFoo';\nexport { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sort custom groups by overriding type and order",
+      "code": "export { a } from 'a';\nexport { bb } from 'bb';\nexport { ccc } from 'ccc';\nexport { dddd } from 'dddd';\nexport type { m } from 'm';\nexport { eee } from 'eee';\nexport { ff } from 'ff';\nexport { g } from 'g';\nexport type { o } from 'o';\nexport type { p } from 'p';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedValuesByLineLength",
+              "modifiers": ["value"],
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedValuesByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"eee\" (reversedValuesByLineLength) to come before \"m\" (unknown).",
+          "data": {
+            "right": "eee",
+            "rightGroup": "reversedValuesByLineLength",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        }
+      ],
+      "output": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';\nexport type { o } from 'o';\nexport type { p } from 'p';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sort custom groups by overriding fallbackSort",
+      "code": "export { fooZar } from 'fooZar';\nexport { fooBar } from 'fooBar';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "export { fooBar } from 'fooBar';\nexport { fooZar } from 'fooZar';"
+          }
+        }
+      ],
+      "output": "export { fooBar } from 'fooBar';\nexport { fooZar } from 'fooZar';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > does not sort custom groups with unsorted type",
+      "code": "export { b } from 'b';\nexport { a } from 'a';\nexport { d } from 'd';\nexport { e } from 'e';\nexport type { m } from 'm';\nexport { c } from 'c';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "unsortedValues",
+              "modifiers": ["value"],
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedValues", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"c\" (unsortedValues) to come before \"m\" (unknown).",
+          "data": {
+            "right": "c",
+            "rightGroup": "unsortedValues",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [92, 142],
+            "text": "export { c } from 'c';\nexport type { m } from 'm';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport { a } from 'a';\nexport { d } from 'd';\nexport { e } from 'e';\nexport { c } from 'c';\nexport type { m } from 'm';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > sort custom group blocks",
+      "code": "export { a } from 'a';\nexport { cFoo } from 'cFoo';\nexport type { foo } from 'foo';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo|Foo",
+                  "modifiers": ["value"]
+                },
+                {
+                  "elementNamePattern": "foo|Foo",
+                  "modifiers": ["type"]
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"cFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "cFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 83],
+            "text": "export { cFoo } from 'cFoo';\nexport type { foo } from 'foo';\nexport { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { cFoo } from 'cFoo';\nexport type { foo } from 'foo';\nexport { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > removes newlines between groups when newlinesBetween is 0",
+      "code": "  export { a } from 'a'\n\n\n export { y } from 'y'\nexport { z } from 'z'\n\n    export { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n\n    export { z } from 'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [23, 97],
+            "text": "\n export { b } from 'b'\nexport { y } from 'y'\n\n    export { z } from 'z'"
+          }
+        }
+      ],
+      "output": "  export { a } from 'a'\n export { b } from 'b'\nexport { y } from 'y'\n\n    export { z } from 'z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > handles newlinesBetween between consecutive groups",
+      "code": "export { a } from 'a'\nexport { b } from 'b'\n\n\nexport { c } from 'c'\n\nexport { d } from 'd'\n\n\nexport { e } from 'e'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\nexport { b } from 'b'\n\nexport { c } from 'c'\nexport { d } from 'd'\n\n\nexport { e } from 'e'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is 2 and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is 2 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is 0 and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is ignore and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces no newline if the global option is 1 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces no newline if the global option is 2 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces no newline if the global option is ignore and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces no newline if the global option is 0 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > does not enforce a newline if the global option is ignore and the group option is 0",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > does not enforce a newline if the global option is ignore and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > does not enforce a newline if the global option is 0 and the group option is ignore",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > does not enforce a newline if the global option is 0 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is 2 and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is 2 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is 0 and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > enforces newlines if the global option is ignore and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > ignores newline fixes between different partitions when newlinesBetween is 0",
+      "code": "export { a } from 'a'\n\n// Partition comment\n\nexport { c } from 'c'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [45, 88],
+            "text": "export { b } from 'b'\nexport { c } from 'c'"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n// Partition comment\n\nexport { b } from 'b'\nexport { c } from 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > reports missing comments",
+      "code": "export type { a } from \"./a\";\n\nexport { b } from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            },
+            {
+              "commentAbove": "Other exports",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./a\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\n"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Other exports\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Other exports",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\n"
+          }
+        }
+      ],
+      "output": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\nexport { b } from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > reports missing comments for single nodes",
+      "code": "export { a } from \"a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Comment above\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 0],
+            "text": "// Comment above\n"
+          }
+        }
+      ],
+      "output": "// Comment above\nexport { a } from \"a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > ignores shebangs and comments at the top of the file",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\nexport { b } from \"./b\";\nexport { a } from \"./a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Comment above\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 85],
+            "text": "export { a } from \"./a\";\nexport { b } from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 85],
+            "text": "export { a } from \"./a\";\nexport { b } from \"./b\";"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above\nexport { a } from \"./a\";\nexport { b } from \"./b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > detects existing comments correctly with comment: //   Comment above  ",
+      "code": "export { a } from \"a\";\n\n//   Comment above  \nexport type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > detects existing comments correctly with comment: //   comment above  ",
+      "code": "export { a } from \"a\";\n\n//   comment above  \nexport type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > detects existing comments correctly with comment: /**\n * Comment above\n */",
+      "code": "           export { a } from \"a\";\n\n           /**\n* Comment above\n*/\n           export type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > natural > detects existing comments correctly with comment: /**\n * Something before\n * CoMmEnT ABoVe\n * Something after\n */",
+      "code": "           export { a } from \"a\";\n\n           /**\n* Something before\n* CoMmEnT ABoVe\n* Something after\n*/\n           export type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > deletes invalid auto-added comments",
+      "code": "export type { c } from './c';\n// Value exports\nexport type { b } from './b';\n// Type exports\nexport { a } from './a';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Value exports",
+              "group": "value-export"
+            },
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./c\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./c"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 117],
+            "text": "// Type exports\nexport { a } from './a';\n// Value exports\nexport type { b } from './b';\nexport type { c } from './c';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 117],
+            "text": "// Type exports\nexport { a } from './a';\n// Value exports\nexport type { b } from './b';\nexport type { c } from './c';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"./a\" (value-export) to come before \"./b\" (type-export).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "value-export",
+            "left": "./b",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 117],
+            "text": "// Type exports\nexport { a } from './a';\n// Value exports\nexport type { b } from './b';\nexport type { c } from './c';"
+          }
+        }
+      ],
+      "output": "// Value exports\nexport { a } from './a';\n// Type exports\nexport type { b } from './b';\nexport type { c } from './c';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > natural > works with other errors",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b\n// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Value exports",
+              "group": "value-export"
+            },
+            {
+              "newlinesBetween": 1
+            },
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            }
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [36, 199],
+            "text": "// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"./a\" (value-export) to come before \"./b\" (type-export).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "value-export",
+            "left": "./b",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 199],
+            "text": "// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above a\n// Value exports\nexport { a } from \"./a\"; // Comment after a\n\n// Type exports\n// Comment above b\nexport type { b } from './b'; // Comment after b"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > sorts exports",
+      "code": "export { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'\nexport { b1, b2 } from 'b'\nexport { a1 } from 'a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sorts exports",
+      "code": "export { b1, b2 } from 'b'\nexport { a1 } from 'a'\nexport { d1, d2 } from 'd'\nexport { c1, c2, c3 } from 'c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"d\" to come before \"a\".",
+          "data": {
+            "right": "d",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { c1, c2, c3 } from 'c'\nexport { b1, b2 } from 'b'\nexport { d1, d2 } from 'd'\nexport { a1 } from 'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { c1, c2, c3 } from 'c'\nexport { b1, b2 } from 'b'\nexport { d1, d2 } from 'd'\nexport { a1 } from 'a'"
+          }
+        }
+      ],
+      "output": "export { c1, c2, c3 } from 'c'\nexport { b1, b2 } from 'b'\nexport { d1, d2 } from 'd'\nexport { a1 } from 'a'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > sorts all-exports",
+      "code": "export { c1, c2 } from './c'\nexport { a1 } from './a'\nexport * as b from './b'\nexport { d } from './d'\nexport * from 'e'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sorts all-exports",
+      "code": "export * as b from './b'\nexport { a1 } from './a'\nexport { c1, c2 } from './c'\nexport * from 'e'\nexport { d } from './d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./c\" to come before \"./a\".",
+          "data": {
+            "right": "./c",
+            "left": "./a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "export { c1, c2 } from './c'\nexport * as b from './b'\nexport { a1 } from './a'\nexport { d } from './d'\nexport * from 'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./d\" to come before \"e\".",
+          "data": {
+            "right": "./d",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "export { c1, c2 } from './c'\nexport * as b from './b'\nexport { a1 } from './a'\nexport { d } from './d'\nexport * from 'e'"
+          }
+        }
+      ],
+      "output": "export { c1, c2 } from './c'\nexport * as b from './b'\nexport { a1 } from './a'\nexport { d } from './d'\nexport * from 'e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > works with export aliases",
+      "code": "export { default as b } from './b'\nexport { a1 as aX } from './a'\nexport { c1, c2 } from './c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > works with export aliases",
+      "code": "export { a1 as aX } from './a'\nexport { c1, c2 } from './c'\nexport { default as b } from './b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 35
+          },
+          "fix": {
+            "range": [0, 94],
+            "text": "export { default as b } from './b'\nexport { a1 as aX } from './a'\nexport { c1, c2 } from './c'"
+          }
+        }
+      ],
+      "output": "export { default as b } from './b'\nexport { a1 as aX } from './a'\nexport { c1, c2 } from './c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > allows to use new line as partition",
+      "code": "export * from \"./organisms\";\nexport * from \"./atoms\";\nexport * from \"./shared\";\n\nexport { AnotherNamed } from './second-folder';\nexport { Named } from './folder';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./shared\" to come before \"./atoms\".",
+          "data": {
+            "right": "./shared",
+            "left": "./atoms"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [29, 79],
+            "text": "export * from \"./shared\";\nexport * from \"./atoms\";"
+          }
+        }
+      ],
+      "output": "export * from \"./organisms\";\nexport * from \"./shared\";\nexport * from \"./atoms\";\n\nexport { AnotherNamed } from './second-folder';\nexport { Named } from './folder';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > allows to use partition comments",
+      "code": "// Part: A\nexport * from './cc';\nexport * from './d';\n// Not partition comment\nexport * from './bbb';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\nexport * from './gg';\n// Not partition comment\nexport * from './fff';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bbb\" to come before \"./d\".",
+          "data": {
+            "right": "./bbb",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [11, 238],
+            "text": "// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./fff\" to come before \"./gg\".",
+          "data": {
+            "right": "./fff",
+            "left": "./gg"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [11, 238],
+            "text": "// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+          }
+        }
+      ],
+      "output": "// Part: A\n// Not partition comment\nexport * from './bbb';\nexport * from './cc';\nexport * from './d';\n// Part: B\nexport * from './aaaa';\nexport * from './e';\n// Part: C\n// Not partition comment\nexport * from './fff';\nexport * from './gg';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to use all comments as parts",
+      "code": "// Comment\nexport * from './bb';\n// Other comment\nexport * from './a';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > allows to use multiple partition comments",
+      "code": "/* Partition Comment */\n// Part: A\nexport * from './d'\n// Part: B\nexport * from './aaa'\nexport * from './c'\nexport * from './bb'\n/* Other */\nexport * from './e'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [88, 128],
+            "text": "export * from './bb'\nexport * from './c'"
+          }
+        }
+      ],
+      "output": "/* Partition Comment */\n// Part: A\nexport * from './d'\n// Part: B\nexport * from './aaa'\nexport * from './bb'\nexport * from './c'\n/* Other */\nexport * from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to use regex for partition comments",
+      "code": "export * from './ee'\nexport * from './f'\n// I am a partition comment because I don't have f o o\nexport * from './aaaa'\nexport * from './bbb'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > ignores line comments when using block comment partitions",
+      "code": "export * from './b'\n// Comment\nexport * from './aa'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./aa\" to come before \"./b\".",
+          "data": {
+            "right": "./aa",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "// Comment\nexport * from './aa'\nexport * from './b'"
+          }
+        }
+      ],
+      "output": "// Comment\nexport * from './aa'\nexport * from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to use block comments as partition boundaries",
+      "code": "export * from './b'\n/* Comment */\nexport * from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to use multiple block comment patterns for partitions",
+      "code": "export * from './c'\n/* b */\nexport * from './b'\n/* a */\nexport * from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to use regex patterns for block comment partitions",
+      "code": "export * from './b'\n/* I am a partition comment because I don't have f o o */\nexport * from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to trim special characters",
+      "code": "export { a } from '_a'\nexport { c } from '_c'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to remove special characters",
+      "code": "export { ac } from 'a_c'\nexport { ab } from 'ab'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > allows to use locale",
+      "code": "export { 你好 } from '你好'\nexport { 世界 } from '世界'\nexport { a } from 'a'\nexport { A } from 'A'\nexport { b } from 'b'\nexport { B } from 'B'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sorts inline elements correctly",
+      "code": "export { b } from \"b\"; export { a } from \"aa\"",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 46
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "export { a } from \"aa\"; export { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "export { a } from \"aa\"; export { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sorts inline elements with semicolons correctly",
+      "code": "export { b } from \"b\"; export { a } from \"aa\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 47
+          },
+          "fix": {
+            "range": [0, 46],
+            "text": "export { a } from \"aa\"; export { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "export { a } from \"aa\"; export { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > allows to use predefined groups",
+      "code": "export type { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["value-export", "type-export"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (value-export) to come before \"a\" (type-export).",
+          "data": {
+            "right": "b",
+            "rightGroup": "value-export",
+            "left": "a",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "export { b } from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > filters on modifier",
+      "code": "export type { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "valueExports",
+              "modifiers": ["value"]
+            }
+          ],
+          "groups": ["valueExports", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"b\" (valueExports) to come before \"a\" (unknown).",
+          "data": {
+            "right": "b",
+            "rightGroup": "valueExports",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "export { b } from 'b';\nexport type { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport type { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > filters on elementNamePattern - string pattern",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > filters on elementNamePattern - array pattern",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > filters on elementNamePattern - case-insensitive regex",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > filters on elementNamePattern - regex in array",
+      "code": "export { a } from 'a';\nexport { b } from 'b';\nexport { helloExport } from 'helloExport';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "valuesStartingWithHello",
+              "modifiers": ["value"],
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["valuesStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"helloExport\" (valuesStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloExport",
+            "rightGroup": "valuesStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 43
+          },
+          "fix": {
+            "range": [0, 88],
+            "text": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+          }
+        }
+      ],
+      "output": "export { helloExport } from 'helloExport';\nexport { a } from 'a';\nexport { b } from 'b';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > handles complex regex in elementNamePattern",
+      "code": "export { iHaveFooInMyName } from 'iHaveFooInMyName';\nexport { meTooIHaveFoo } from 'meTooIHaveFoo';\nexport { a } from 'a';\nexport { b } from 'b';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sort custom groups by overriding type and order",
+      "code": "export { a } from 'a';\nexport { bb } from 'bb';\nexport { ccc } from 'ccc';\nexport { dddd } from 'dddd';\nexport type { m } from 'm';\nexport { eee } from 'eee';\nexport { ff } from 'ff';\nexport { g } from 'g';\nexport type { o } from 'o';\nexport type { p } from 'p';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedValuesByLineLength",
+              "modifiers": ["value"],
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedValuesByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"eee\" (reversedValuesByLineLength) to come before \"m\" (unknown).",
+          "data": {
+            "right": "eee",
+            "rightGroup": "reversedValuesByLineLength",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 206],
+            "text": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';"
+          }
+        }
+      ],
+      "output": "export { dddd } from 'dddd';\nexport { ccc } from 'ccc';\nexport { eee } from 'eee';\nexport { bb } from 'bb';\nexport { ff } from 'ff';\nexport { a } from 'a';\nexport { g } from 'g';\nexport type { m } from 'm';\nexport type { o } from 'o';\nexport type { p } from 'p';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sort custom groups by overriding fallbackSort",
+      "code": "export { fooZar } from 'fooZar';\nexport { fooBar } from 'fooBar';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "export { fooBar } from 'fooBar';\nexport { fooZar } from 'fooZar';"
+          }
+        }
+      ],
+      "output": "export { fooBar } from 'fooBar';\nexport { fooZar } from 'fooZar';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > does not sort custom groups with unsorted type",
+      "code": "export { b } from 'b';\nexport { a } from 'a';\nexport { d } from 'd';\nexport { e } from 'e';\nexport type { m } from 'm';\nexport { c } from 'c';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "unsortedValues",
+              "modifiers": ["value"],
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedValues", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"c\" (unsortedValues) to come before \"m\" (unknown).",
+          "data": {
+            "right": "c",
+            "rightGroup": "unsortedValues",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [92, 142],
+            "text": "export { c } from 'c';\nexport type { m } from 'm';"
+          }
+        }
+      ],
+      "output": "export { b } from 'b';\nexport { a } from 'a';\nexport { d } from 'd';\nexport { e } from 'e';\nexport { c } from 'c';\nexport type { m } from 'm';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > sort custom group blocks",
+      "code": "export { a } from 'a';\nexport { cFoo } from 'cFoo';\nexport type { foo } from 'foo';",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo|Foo",
+                  "modifiers": ["value"]
+                },
+                {
+                  "elementNamePattern": "foo|Foo",
+                  "modifiers": ["type"]
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"cFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "cFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 83],
+            "text": "export { cFoo } from 'cFoo';\nexport type { foo } from 'foo';\nexport { a } from 'a';"
+          }
+        }
+      ],
+      "output": "export { cFoo } from 'cFoo';\nexport type { foo } from 'foo';\nexport { a } from 'a';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > removes newlines between groups when newlinesBetween is 0",
+      "code": "  export { a } from 'a'\n\n\n export { y } from 'y'\nexport { z } from 'z'\n\n    export { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [23, 27],
+            "text": "\n "
+          }
+        }
+      ],
+      "output": "  export { a } from 'a'\n export { y } from 'y'\nexport { z } from 'z'\n\n    export { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > handles newlinesBetween between consecutive groups",
+      "code": "export { a } from 'a'\nexport { b } from 'b'\n\n\nexport { c } from 'c'\n\nexport { d } from 'd'\n\n\nexport { e } from 'e'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 69],
+            "text": "\n\nexport { b } from 'b'\n\nexport { c } from 'c'\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\nexport { b } from 'b'\n\nexport { c } from 'c'\nexport { d } from 'd'\n\n\nexport { e } from 'e'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces newlines if the global option is 2 and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces newlines if the global option is 2 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces newlines if the global option is 0 and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces newlines if the global option is ignore and the group option is 2",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\n\n\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces no newline if the global option is 1 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces no newline if the global option is 2 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces no newline if the global option is ignore and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > enforces no newline if the global option is 0 and newlinesBetween: 0 exists between all groups",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenExports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 23],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "export { a } from 'a'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > does not enforce a newline if the global option is ignore and the group option is 0",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > does not enforce a newline if the global option is ignore and the group option is 0",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > does not enforce a newline if the global option is 0 and the group option is ignore",
+      "code": "export { a } from 'a'\n\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > does not enforce a newline if the global option is 0 and the group option is ignore",
+      "code": "export { a } from 'a'\nexport { b } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > ignores newline fixes between different partitions when newlinesBetween is 0",
+      "code": "export { a } from 'aaaa'\n\n// Partition comment\n\nexport { c } from 'cc'\nexport { b } from 'bbb'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "aaaa",
+              "groupName": "aaaa"
+            }
+          ],
+          "groups": ["aaaa", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"bbb\" to come before \"cc\".",
+          "data": {
+            "right": "bbb",
+            "left": "cc"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [48, 94],
+            "text": "export { b } from 'bbb'\nexport { c } from 'cc'"
+          }
+        }
+      ],
+      "output": "export { a } from 'aaaa'\n\n// Partition comment\n\nexport { b } from 'bbb'\nexport { c } from 'cc'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > reports missing comments",
+      "code": "export type { a } from \"./a\";\n\nexport { b } from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            },
+            {
+              "commentAbove": "Other exports",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./a\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\n"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Other exports\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Other exports",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\n"
+          }
+        }
+      ],
+      "output": "// Type exports\nexport type { a } from \"./a\";\n\n// Other exports\nexport { b } from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > reports missing comments for single nodes",
+      "code": "export { a } from \"a\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Comment above\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 0],
+            "text": "// Comment above\n"
+          }
+        }
+      ],
+      "output": "// Comment above\nexport { a } from \"a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > ignores shebangs and comments at the top of the file",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\nexport { b } from \"./b\";\nexport { a } from \"./aa\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Comment above\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 86],
+            "text": "export { a } from \"./aa\";\nexport { b } from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./aa\" to come before \"./b\".",
+          "data": {
+            "right": "./aa",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [36, 86],
+            "text": "export { a } from \"./aa\";\nexport { b } from \"./b\";"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above\nexport { a } from \"./aa\";\nexport { b } from \"./b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > detects existing comments correctly with comment: //   Comment above  ",
+      "code": "export { a } from \"a\";\n\n//   Comment above  \nexport type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > detects existing comments correctly with comment: //   comment above  ",
+      "code": "export { a } from \"a\";\n\n//   comment above  \nexport type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > detects existing comments correctly with comment: /**\n * Comment above\n */",
+      "code": "           export { a } from \"a\";\n\n           /**\n* Comment above\n*/\n           export type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > line-length > detects existing comments correctly with comment: /**\n * Something before\n * CoMmEnT ABoVe\n * Something after\n */",
+      "code": "           export { a } from \"a\";\n\n           /**\n* Something before\n* CoMmEnT ABoVe\n* Something after\n*/\n           export type { b } from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "value-export",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > deletes invalid auto-added comments",
+      "code": "export type { c } from './c';\n// Value exports\nexport type { b } from './bb';\n// Type exports\nexport { a } from './aaa';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Value exports",
+              "group": "value-export"
+            },
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./c\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./c"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "// Type exports\nexport { a } from './aaa';\n// Value exports\nexport type { b } from './bb';\nexport type { c } from './c';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "// Type exports\nexport { a } from './aaa';\n// Value exports\nexport type { b } from './bb';\nexport type { c } from './c';"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"./aaa\" (value-export) to come before \"./bb\" (type-export).",
+          "data": {
+            "right": "./aaa",
+            "rightGroup": "value-export",
+            "left": "./bb",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 120],
+            "text": "// Type exports\nexport { a } from './aaa';\n// Value exports\nexport type { b } from './bb';\nexport type { c } from './c';"
+          }
+        }
+      ],
+      "output": "// Value exports\nexport { a } from './aaa';\n// Type exports\nexport type { b } from './bb';\nexport type { c } from './c';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > line-length > works with other errors",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b\n// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Value exports",
+              "group": "value-export"
+            },
+            {
+              "newlinesBetween": 1
+            },
+            {
+              "commentAbove": "Type exports",
+              "group": ["type-export"]
+            }
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveExport",
+          "message": "Missed comment \"Type exports\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Type exports",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [36, 199],
+            "text": "// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsGroupOrder",
+          "message": "Expected \"./a\" (value-export) to come before \"./b\" (type-export).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "value-export",
+            "left": "./b",
+            "leftGroup": "type-export"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [36, 199],
+            "text": "// Comment above a\n// Type exports\nexport { a } from \"./a\"; // Comment after a\n// Comment above b\n// Value exports\nexport type { b } from './b'; // Comment after b"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above a\n// Value exports\nexport { a } from \"./a\"; // Comment after a\n\n// Type exports\n// Comment above b\nexport type { b } from './b'; // Comment after b"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > custom > sorts exports",
+      "code": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > custom > sorts exports",
+      "code": "export { b1, b2 } from 'b'\nexport { a1 } from 'a'\nexport { d1, d2 } from 'd'\nexport { c1, c2, c3 } from 'c'",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 107],
+            "text": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+          }
+        }
+      ],
+      "output": "export { a1 } from 'a'\nexport { b1, b2 } from 'b'\nexport { c1, c2, c3 } from 'c'\nexport { d1, d2 } from 'd'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > subgroup-order > fallback sorts by subgroup order",
+      "code": "export { b } from 'b'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport type { a } from 'a'",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order"
+          },
+          "type": "alphabetical",
+          "groups": [["type-export", "value-export"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "export type { a } from 'a'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport { b } from 'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "export type { a } from 'a'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "export type { a } from 'a'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > subgroup-order > fallback sorts by subgroup order through overriding groups option",
+      "code": "export { b } from 'b'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport type { a } from 'a'",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order"
+          },
+          "type": "alphabetical",
+          "groups": [
+            {
+              "group": ["type-export", "value-export"],
+              "newlinesInside": 0
+            },
+            "unknown"
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "export type { a } from 'a'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport { b } from 'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "export type { a } from 'a'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "export type { a } from 'a'\nexport { a } from 'a'\nexport type { b } from 'b'\nexport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > unsorted > does not enforce sorting",
+      "code": "export * from 'b'\nexport * from 'c'\nexport * from 'a'",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > unsorted > enforces newlines between",
+      "code": "export { b } from 'b'\nexport { a } from 'a'",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "newlinesBetween": 1,
+          "groups": ["b", "a"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenExports",
+          "message": "Missed spacing between \"b\" and \"a\".",
+          "data": {
+            "left": "b",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "export { b } from 'b'\n\nexport { a } from 'a'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > sets alphabetical asc sorting as default",
+      "code": "export { a } from '~/a'\nexport { b } from '~/b'\nexport { c } from '~/c'\nexport { d } from '~/d'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > sets alphabetical asc sorting as default",
+      "code": "export { log } from './log'\nexport { log10 } from './log10'\nexport { log1p } from './log1p'\nexport { log2 } from './log2'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > sets alphabetical asc sorting as default",
+      "code": "export { a } from '~/a'\nexport { c } from '~/c'\nexport { b } from '~/b'\nexport { d } from '~/d'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"~/b\" to come before \"~/c\".",
+          "data": {
+            "right": "~/b",
+            "left": "~/c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [24, 71],
+            "text": "export { b } from '~/b'\nexport { c } from '~/c'"
+          }
+        }
+      ],
+      "output": "export { a } from '~/a'\nexport { b } from '~/b'\nexport { c } from '~/c'\nexport { d } from '~/d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > ignores exported variables or functions",
+      "code": "export let a = () => {\n  // ...\n}\n\nexport let b = () => {\n  // ...\n}\n\nexport let c = ''",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > respects the global settings configuration",
+      "code": "export { ccc } from 'module'\nexport { bb } from 'module'\nexport { a } from 'module'",
+      "options": [{}],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > respects the global settings configuration",
+      "code": "export { a } from 'module'\nexport { bb } from 'module'\nexport { ccc } from 'module'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > handles eslint-disable-next-line comments",
+      "code": "export { b } from \"./b\"\nexport { c } from \"./c\"\n// eslint-disable-next-line\nexport { a } from \"./a\"",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles eslint-disable-next-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\n// eslint-disable-next-line\nexport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\n// eslint-disable-next-line\nexport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles eslint-disable-next-line with partitionByComment",
+      "code": "export { d } from './d'\nexport { c } from './c'\n// eslint-disable-next-line\nexport { a } from './a'\nexport { b } from './b'",
+      "options": [
+        {
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./c\" to come before \"./d\".",
+          "data": {
+            "right": "./c",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 123],
+            "text": "export { b } from './b'\nexport { c } from './c'\n// eslint-disable-next-line\nexport { a } from './a'\nexport { d } from './d'"
+          }
+        },
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./a\".",
+          "data": {
+            "right": "./b",
+            "left": "./a"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 123],
+            "text": "export { b } from './b'\nexport { c } from './c'\n// eslint-disable-next-line\nexport { a } from './a'\nexport { d } from './d'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\n// eslint-disable-next-line\nexport { a } from './a'\nexport { d } from './d'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles eslint-disable-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\nexport { a } from './a' // eslint-disable-line",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\nexport { a } from './a' // eslint-disable-line"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles block eslint-disable-next-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\n/* eslint-disable-next-line */\nexport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\n/* eslint-disable-next-line */\nexport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles block eslint-disable-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\nexport { a } from './a' /* eslint-disable-line */",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\nexport { a } from './a' /* eslint-disable-line */"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles eslint-disable/enable blocks",
+      "code": "export { d } from './d'\nexport { e } from './e'\n/* eslint-disable */\nexport { c } from './c'\nexport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nexport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 178],
+            "text": "export { a } from './a'\nexport { d } from './d'\n/* eslint-disable */\nexport { c } from './c'\nexport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nexport { e } from './e'"
+          }
+        }
+      ],
+      "output": "export { a } from './a'\nexport { d } from './d'\n/* eslint-disable */\nexport { c } from './c'\nexport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nexport { e } from './e'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles rule-specific eslint-disable-next-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\n// eslint-disable-next-line rule-to-test/sort-exports\nexport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\n// eslint-disable-next-line rule-to-test/sort-exports\nexport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles rule-specific eslint-disable-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\nexport { a } from './a' // eslint-disable-line rule-to-test/sort-exports",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\nexport { a } from './a' // eslint-disable-line rule-to-test/sort-exports"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles rule-specific block eslint-disable-next-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\n/* eslint-disable-next-line rule-to-test/sort-exports */\nexport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\n/* eslint-disable-next-line rule-to-test/sort-exports */\nexport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles rule-specific block eslint-disable-line comments",
+      "code": "export { c } from './c'\nexport { b } from './b'\nexport { a } from './a' /* eslint-disable-line rule-to-test/sort-exports */",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "export { b } from './b'\nexport { c } from './c'"
+          }
+        }
+      ],
+      "output": "export { b } from './b'\nexport { c } from './c'\nexport { a } from './a' /* eslint-disable-line rule-to-test/sort-exports */"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-exports > misc > handles rule-specific eslint-disable/enable blocks",
+      "code": "export { d } from './d'\nexport { e } from './e'\n/* eslint-disable rule-to-test/sort-exports */\nexport { c } from './c'\nexport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nexport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedExportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 204],
+            "text": "export { a } from './a'\nexport { d } from './d'\n/* eslint-disable rule-to-test/sort-exports */\nexport { c } from './c'\nexport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nexport { e } from './e'"
+          }
+        }
+      ],
+      "output": "export { a } from './a'\nexport { d } from './d'\n/* eslint-disable rule-to-test/sort-exports */\nexport { c } from './c'\nexport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nexport { e } from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-exports > misc > defaults missing exportKind to value",
+      "code": "export { bar } from './bar'\nexport { foo } from './foo'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    }
+  ]
+}

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -120,10 +120,38 @@ describe('perfectionist plugin adapter', () => {
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      ['sort-named-exports', 'sort-named-imports'].includes(ruleName)
+      ['sort-exports', 'sort-named-exports', 'sort-named-imports'].includes(ruleName)
         ? 'Expected "{{right}}" to come before "{{left}}".'
         : 'Expected sorted order.',
     );
+  });
+
+  it('declares the complete sort-exports schema without named-specifier-only options', () => {
+    const schema = plugin.rules['sort-exports'].meta.schema;
+
+    expect(schema).toHaveLength(1);
+    expect(Object.keys(schema[0].properties).sort()).toEqual([
+      'alphabet',
+      'customGroups',
+      'fallbackSort',
+      'groups',
+      'ignoreCase',
+      'locales',
+      'newlinesBetween',
+      'newlinesInside',
+      'order',
+      'partitionByComment',
+      'partitionByNewLine',
+      'specialCharacters',
+      'type',
+    ]);
+    expect(
+      schema[0].properties.customGroups.items.oneOf[0].properties.modifiers.items.enum,
+    ).toEqual(['value', 'type', 'named', 'wildcard', 'singleline', 'multiline']);
+    expect(schema[0].properties.customGroups.items.oneOf[0].properties.selector.enum).toEqual([
+      'export',
+    ]);
+    expect(schema[0].additionalProperties).toBe(false);
   });
 
   it.each([
@@ -183,7 +211,7 @@ describe('perfectionist plugin adapter', () => {
     expect(plugin.rules['sort-imports'].meta.schema).toEqual([]);
   });
 
-  it('threads recommended comparator options into both named-specifier rules', () => {
+  it('threads recommended comparator options into every configured sorting rule', () => {
     const rules = plugin.configs['recommended-natural'].rules;
 
     expect(rules['perfectionist/sort-named-imports']).toEqual([
@@ -191,6 +219,10 @@ describe('perfectionist plugin adapter', () => {
       { type: 'natural', order: 'asc' },
     ]);
     expect(rules['perfectionist/sort-named-exports']).toEqual([
+      'error',
+      { type: 'natural', order: 'asc' },
+    ]);
+    expect(rules['perfectionist/sort-exports']).toEqual([
       'error',
       { type: 'natural', order: 'asc' },
     ]);
@@ -367,6 +399,78 @@ describe('perfectionist plugin adapter', () => {
       expect(fixed.stderr).toBe('');
       expect(readFileSync(fixturePath, 'utf8')).toBe(
         'export { type Type, \n\nvalue } from "pkg";\n',
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads export-declaration groups, comments, and fixes through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-exports-'));
+    try {
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(
+        fixturePath,
+        `export type { Type } from "./types";\nexport { value } from "./value";\n`,
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'perfectionist',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'perfectionist/sort-exports': [
+              'error',
+              {
+                groups: [
+                  { group: 'value-export', commentAbove: 'Values' },
+                  { group: 'type-export', commentAbove: 'Types' },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+        'Missed comment "Types" above "./types".',
+        'Expected "./value" (value-export) to come before "./types" (type-export).',
+      ]);
+
+      let fixed;
+      for (let pass = 0; pass < 4; pass += 1) {
+        fixed = spawnSync(
+          findOxlintCli(),
+          ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+          {
+            cwd: tempDir,
+            encoding: 'utf8',
+          },
+        );
+        if (fixed.status === 0) {
+          break;
+        }
+      }
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe(
+        `// Values\nexport { value } from "./value";\n// Types\nexport type { Type } from "./types";\n`,
       );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/npm/perfectionist/test/sort-exports-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-exports-options-upstream.test.mjs
@@ -1,0 +1,158 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(new URL('./fixtures/sort-exports-options-v5.9.1.json', import.meta.url), 'utf8'),
+);
+const rule = plugin.rules['sort-exports'];
+
+describe('perfectionist/sort-exports v5.9.1 option parity', () => {
+  it('pins every authored upstream case and its exact fixture inventory', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-perfectionist',
+      version: '5.9.1',
+      sourceCommit: 'b35e8e4caf0c8d350cf386e504241f21827dd60b',
+      sourceHashes: {
+        'rules/sort-exports.ts': 'dd6ee1cd385e1f8cca77357a781f5bd82176d67d7e33695ca177624095077baf',
+        'rules/sort-exports/types.ts':
+          '5f09e2870357909e40e8a33acce0bf2fb796350246e970f77432e2a3c8a309df',
+        'test/rules/sort-exports.test.ts':
+          '1590b05abda2fa82c9e9579514b04f3c03137c26834711fb94fce6af399d85e4',
+      },
+      inventory: {
+        valid: 70,
+        invalid: 133,
+        diagnostics: 184,
+        total: 203,
+      },
+    });
+    expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
+    expect(
+      fixture.cases.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+    ).toBe(fixture.__generated.inventory.diagnostics);
+  });
+
+  for (const [index, testCase] of fixture.cases.entries()) {
+    it(`replays case ${index + 1}/${fixture.cases.length}: ${testCase.name}`, () => {
+      const reports = runRule(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(
+        reports.map((report) => exactDiagnostic(report)),
+        testCase.name,
+      ).toEqual(testCase.expectedDiagnostics);
+
+      if (testCase.output === null) {
+        expect(reports, testCase.name).toEqual([]);
+        return;
+      }
+
+      const convergence = applyIteratively(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(convergence.output, testCase.name).toBe(testCase.output);
+      expect(convergence.remainingReports, testCase.name).toEqual([]);
+      expect(convergence.passes, testCase.name).toBeGreaterThanOrEqual(1);
+      expect(convergence.passes, testCase.name).toBeLessThanOrEqual(12);
+    });
+  }
+});
+
+function runRule(sourceText, options, filename, settings) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    options,
+    settings,
+    sourceCode,
+    filename,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function exactDiagnostic(report) {
+  const replacement = report.fix?.({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return {
+    messageId: report.messageId,
+    message: Object.entries(report.data).reduce(
+      (message, [key, value]) => message.replace(`{{${key}}}`, value),
+      rule.meta.messages[report.messageId],
+    ),
+    data: report.data,
+    loc: {
+      startLine: report.loc.start.line,
+      startColumn: report.loc.start.column + 1,
+      endLine: report.loc.end.line,
+      endColumn: report.loc.end.column + 1,
+    },
+    fix: replacement ?? null,
+  };
+}
+
+function applyIteratively(sourceText, options, filename, settings) {
+  let output = sourceText;
+  let passes = 0;
+  for (; passes < 12; passes += 1) {
+    const reports = runRule(output, options, filename, settings);
+    const next = applyFixPass(output, reports);
+    if (next === null) {
+      return { output, passes, remainingReports: reports };
+    }
+    output = next;
+  }
+  throw new Error(`Fixes did not converge for ${JSON.stringify(sourceText)}`);
+}
+
+function applyFixPass(sourceText, reports) {
+  const fixes = reports
+    .flatMap((report) => {
+      const fix = report.fix?.({
+        replaceTextRange(range, text) {
+          return { range, text };
+        },
+      });
+      return fix ? [fix] : [];
+    })
+    .sort((left, right) => left.range[0] - right.range[0] || left.range[1] - right.range[1]);
+  if (fixes.length === 0) {
+    return null;
+  }
+
+  const accepted = [];
+  let lastEnd = -1;
+  for (const fix of fixes) {
+    if (fix.range[0] < lastEnd) {
+      continue;
+    }
+    accepted.push(fix);
+    lastEnd = fix.range[1];
+  }
+
+  let output = sourceText;
+  for (const fix of accepted.toReversed()) {
+    output = output.slice(0, fix.range[0]) + fix.text + output.slice(fix.range[1]);
+  }
+  return output;
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "port:tests:postgresql-parser": "node tools/tasks/sync-postgresql-parser-tests.ts",
     "port:tests:perfectionist:sort-named-imports": "node tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
     "port:tests:perfectionist:sort-named-exports": "node tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
+    "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:playwright:patterns": "node tools/tasks/sync-playwright-pattern-tests.ts",
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",

--- a/tools/tasks/sync-perfectionist-sort-exports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-exports-options-tests.ts
@@ -1,0 +1,435 @@
+// Captures every authored eslint-plugin-perfectionist/sort-exports v5.9.1
+// valid and invalid case. The exact upstream commit and source hashes prevent
+// silent fixture drift.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type CapturedCase = {
+  kind: 'valid' | 'invalid';
+  name: string;
+  code: string;
+  options: Array<Record<string, unknown>>;
+  settings?: Record<string, unknown>;
+  filename: string;
+  authoredOutput?: string | null;
+};
+
+const ROOT = process.cwd();
+const RULE = 'sort-exports';
+const PINNED_COMMIT = 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
+const ESLINT_VERSION = '9.39.2';
+const TYPESCRIPT_ESLINT_VERSION = '8.60.0';
+const SOURCE_HASHES = {
+  'rules/sort-exports.ts': 'dd6ee1cd385e1f8cca77357a781f5bd82176d67d7e33695ca177624095077baf',
+  'rules/sort-exports/types.ts': '5f09e2870357909e40e8a33acce0bf2fb796350246e970f77432e2a3c8a309df',
+  'test/rules/sort-exports.test.ts':
+    '1590b05abda2fa82c9e9579514b04f3c03137c26834711fb94fce6af399d85e4',
+} as const;
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-perfectionist');
+if (!plugin) {
+  throw new Error('eslint-plugin-perfectionist is not registered in tools/port-targets.json');
+}
+if (plugin.baselineVersion !== '5.9.1' || plugin.pinnedRef !== 'v5.9.1') {
+  throw new Error(
+    `Expected perfectionist v5.9.1 manifest pin, received ${plugin.baselineVersion} / ${plugin.pinnedRef}`,
+  );
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Upstream checkout not found: ${plugin.submodule}`);
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}`);
+}
+for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
+  const actualHash = createHash('sha256')
+    .update(readFileSync(join(submodule, sourceFile)))
+    .digest('hex');
+  if (actualHash !== expectedHash) {
+    throw new Error(`Expected ${sourceFile} hash ${expectedHash}, received ${actualHash}`);
+  }
+}
+
+const runnerDirectory = mkdtempSync(join(tmpdir(), 'perfectionist-sort-exports-'));
+try {
+  const authoredSource = readFileSync(
+    join(submodule, 'test', 'rules', 'sort-exports.test.ts'),
+    'utf8',
+  ).replace(/^import .*$/gmu, '');
+  const captureSourcePath = join(runnerDirectory, 'capture.ts');
+  writeFileSync(captureSourcePath, `${capturePrelude()}\n${authoredSource}\n${captureEpilogue()}`);
+  const compiledDirectory = join(runnerDirectory, 'compiled');
+  execFileSync(
+    'pnpm',
+    [
+      'exec',
+      'vp',
+      'pack',
+      captureSourcePath,
+      '--format',
+      'esm',
+      '--out-dir',
+      compiledDirectory,
+      '--no-clean',
+      '--logLevel',
+      'error',
+    ],
+    { cwd: ROOT, stdio: 'inherit' },
+  );
+  const compiledSource = readdirSync(compiledDirectory).find((file) => /\.(?:mjs|js)$/u.test(file));
+  if (!compiledSource) {
+    throw new Error(`No compiled capture module found in ${compiledDirectory}`);
+  }
+  execFileSync('node', [join(compiledDirectory, compiledSource)], {
+    cwd: runnerDirectory,
+    stdio: 'inherit',
+  });
+  const authoredCases = JSON.parse(
+    readFileSync(join(runnerDirectory, 'authored-cases.json'), 'utf8'),
+  ) as CapturedCase[];
+
+  writeFileSync(
+    join(runnerDirectory, 'package.json'),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@typescript-eslint/parser': TYPESCRIPT_ESLINT_VERSION,
+          eslint: ESLINT_VERSION,
+          'eslint-plugin-perfectionist': plugin.baselineVersion,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(join(runnerDirectory, 'cases.json'), `${JSON.stringify(authoredCases)}\n`);
+  writeFileSync(join(runnerDirectory, 'runner.mjs'), publishedRunnerSource());
+  execFileSync(
+    'pnpm',
+    ['install', '--dir', runnerDirectory, '--ignore-workspace', '--lockfile=false', '--silent'],
+    { stdio: 'inherit' },
+  );
+  execFileSync('node', [join(runnerDirectory, 'runner.mjs')], { stdio: 'inherit' });
+  const captured = JSON.parse(
+    readFileSync(join(runnerDirectory, 'captured.json'), 'utf8'),
+  ) as Array<{ kind: 'valid' | 'invalid'; expectedDiagnostics: unknown[] }>;
+  const valid = captured.filter((testCase) => testCase.kind === 'valid').length;
+  const invalid = captured.length - valid;
+  const diagnostics = captured.reduce(
+    (total, testCase) => total + testCase.expectedDiagnostics.length,
+    0,
+  );
+  const fixture = {
+    __generated: {
+      source: plugin.npm,
+      version: plugin.baselineVersion,
+      sourceCommit: PINNED_COMMIT,
+      sourceHashes: SOURCE_HASHES,
+      license: plugin.license,
+      eslintVersion: ESLINT_VERSION,
+      typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
+      capturePolicy:
+        'Every authored valid and invalid sort-exports case is executed, then replayed against the published v5.9.1 rule for exact diagnostics and fixes.',
+      authoredCases: 'upstream/eslint-plugin-perfectionist/test/rules/sort-exports.test.ts',
+      tool: basename(import.meta.filename),
+      inventory: {
+        valid,
+        invalid,
+        diagnostics,
+        total: captured.length,
+      },
+    },
+    cases: captured,
+  };
+  const fixturesDirectory = join(ROOT, 'npm', 'perfectionist', 'test', 'fixtures');
+  mkdirSync(fixturesDirectory, { recursive: true });
+  const fixturePath = join(fixturesDirectory, `${RULE}-options-v${plugin.baselineVersion}.json`);
+  writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  execFileSync('pnpm', ['exec', 'vp', 'fmt', fixturePath], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  console.log(
+    `Captured ${RULE} v${plugin.baselineVersion}: ${valid} valid, ${invalid} invalid, ${diagnostics} diagnostics.`,
+  );
+} finally {
+  rmSync(runnerDirectory, { recursive: true, force: true });
+}
+
+function capturePrelude(): string {
+  return String.raw`
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const __capturedCases = []
+const __tasks = []
+const __describeStack = []
+let __currentTestName = ''
+const typescriptParser = {}
+const rule = { meta: { schema: {} } }
+
+function __normalizeCase(kind, input) {
+  const value = typeof input === 'string' ? { code: input } : input
+  __capturedCases.push({
+    kind,
+    name: __currentTestName,
+    code: value.code,
+    options: value.options ?? [],
+    settings: value.settings,
+    filename: 'fixture.ts',
+    authoredOutput: Object.hasOwn(value, 'output') ? value.output : undefined,
+  })
+}
+
+function createRuleTester() {
+  return {
+    valid: async input => __normalizeCase('valid', input),
+    invalid: async input => __normalizeCase('invalid', input),
+  }
+}
+
+function buildOxlintRuleTester() {
+  return {
+    run(name, suite) {
+      for (const input of suite.valid ?? []) {
+        __capturedCases.push({
+          kind: 'valid',
+          name: [...__describeStack, name, 'valid'].join(' > '),
+          code: input.code,
+          options: input.options ?? [],
+          settings: input.settings,
+          filename: 'fixture.ts',
+        })
+      }
+      for (const input of suite.invalid ?? []) {
+        __capturedCases.push({
+          kind: 'invalid',
+          name: [...__describeStack, name, 'invalid'].join(' > '),
+          code: input.code,
+          options: input.options ?? [],
+          settings: input.settings,
+          filename: 'fixture.ts',
+          authoredOutput: Object.hasOwn(input, 'output') ? input.output : undefined,
+        })
+      }
+    },
+  }
+}
+
+function describe(name, callback) {
+  __describeStack.push(name)
+  callback()
+  __describeStack.pop()
+}
+
+function it(name, callback) {
+  __tasks.push({
+    name: [...__describeStack, name].join(' > '),
+    callback,
+  })
+}
+
+it.each = rows => (name, callback) => {
+  for (const row of rows) {
+    const values = Array.isArray(row) ? row : [row]
+    let interpolation = 0
+    const expandedName = name.replaceAll('%s', () => String(values[interpolation++]))
+    __tasks.push({
+      name: [...__describeStack, expandedName].join(' > '),
+      callback: () => callback(...values),
+    })
+  }
+}
+
+function dedent(strings, ...values) {
+  const value =
+    typeof strings === 'string'
+      ? strings
+      : strings.reduce((result, string, index) => result + string + (values[index] ?? ''), '')
+  const lines = value.replace(/^\n/u, '').replace(/\n\s*$/u, '').split('\n')
+  const indentation = lines
+    .filter(line => line.trim().length > 0)
+    .reduce((minimum, line) => Math.min(minimum, line.match(/^\s*/u)[0].length), Infinity)
+  return lines.map(line => line.slice(Number.isFinite(indentation) ? indentation : 0)).join('\n')
+}
+
+const Alphabet = {
+  generateRecommendedAlphabet() {
+    return {
+      sortByLocaleCompare() {
+        return this
+      },
+      getCharacters() {
+        return '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+      },
+    }
+  },
+}
+
+async function validateRuleJsonSchema() {}
+function expect() {
+  return {
+    resolves: {
+      not: {
+        async toThrow() {},
+      },
+    },
+  }
+}
+`;
+}
+
+function captureEpilogue(): string {
+  return String.raw`
+for (const task of __tasks) {
+  __currentTestName = task.name
+  await task.callback()
+}
+writeFileSync(
+  join(process.cwd(), 'authored-cases.json'),
+  JSON.stringify(__capturedCases),
+)
+`;
+}
+
+function publishedRunnerSource(): string {
+  return `
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import perfectionistModule from 'eslint-plugin-perfectionist';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const cases = JSON.parse(readFileSync(join(here, 'cases.json'), 'utf8'));
+const perfectionist = perfectionistModule.default ?? perfectionistModule;
+const linter = new Linter();
+
+function configFor(testCase) {
+  return [{
+    files: ['**/*.{js,ts}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      'rule-to-test': {
+        rules: {
+          '${RULE}': perfectionist.rules['${RULE}'],
+        },
+      },
+    },
+    settings: testCase.settings ?? {},
+    rules: {
+      'rule-to-test/${RULE}': ['error', ...(testCase.options ?? [])],
+    },
+  }];
+}
+
+const captured = cases.map(testCase => {
+  const filename = testCase.filename ?? 'fixture.ts';
+  const config = configFor(testCase);
+  const diagnostics = linter.verify(testCase.code, config, { filename });
+  const unexpected = diagnostics.filter(problem => problem.ruleId !== 'rule-to-test/${RULE}');
+  if (unexpected.length > 0) {
+    throw new Error(
+      testCase.name + ' produced non-rule diagnostics: ' + JSON.stringify(unexpected),
+    );
+  }
+  if (testCase.kind === 'valid' && diagnostics.length > 0) {
+    throw new Error(testCase.name + ' was authored valid but published with diagnostics.');
+  }
+  const fixed = linter.verifyAndFix(testCase.code, config, { filename });
+  return {
+    kind: testCase.kind,
+    name: testCase.name,
+    code: testCase.code,
+    options: testCase.options ?? [],
+    settings: testCase.settings,
+    filename,
+    expectedDiagnostics: diagnostics.map(problem => ({
+      messageId: problem.messageId,
+      message: problem.message,
+      data: dataFromMessage(problem.message),
+      loc: {
+        startLine: problem.line,
+        startColumn: problem.column,
+        endLine: problem.endLine,
+        endColumn: problem.endColumn,
+      },
+      fix: problem.fix
+        ? {
+            range: problem.fix.range,
+            text: problem.fix.text,
+          }
+        : null,
+    })),
+    output: fixed.fixed ? fixed.output : null,
+  };
+});
+
+writeFileSync(join(here, 'captured.json'), JSON.stringify(captured));
+
+function dataFromMessage(message) {
+  const order = /^Expected "(.+)" to come before "(.+)"\\.$/u.exec(message);
+  if (order) {
+    return { right: order[1], left: order[2] };
+  }
+  const group = /^Expected "(.+)" \\((.+)\\) to come before "(.+)" \\((.+)\\)\\.$/u.exec(message);
+  if (group) {
+    return {
+      right: group[1],
+      rightGroup: group[2],
+      left: group[3],
+      leftGroup: group[4],
+    };
+  }
+  const spacing = /^(?:Extra|Missed) spacing between "(.+)" and "(.+)"\\.$/u.exec(message);
+  if (spacing) {
+    return { left: spacing[1], right: spacing[2] };
+  }
+  const comment = /^Missed comment "(.+)" above "(.+)"\\.$/u.exec(message);
+  if (comment) {
+    return { missedCommentAbove: comment[1], right: comment[2] };
+  }
+  return {};
+}
+`;
+}


### PR DESCRIPTION
## Summary

- port the full eslint-plugin-perfectionist v5.9.1 sort-exports option surface to the Rust-backed rule
- support groups, custom groups, comments, disable directives, settings, locale-aware sorting, exact diagnostics, and convergent fixes
- pin and replay all 203 authored upstream cases with 184 exact diagnostics

Contributes to #418.

## Validation

- cargo test -p oxlint-plugins-perfectionist: 35 passed
- targeted Vitest: 249 passed
- pnpm verify: 110 JS files, 16,872 passed and 1,159 skipped; all Rust, lint, typecheck, build, bench compile, audit, license, status, and publish-readiness checks passed
- React/JSX/TSX scope: 0 files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->