### PR TITLE
feat(playwright): support numeric threshold options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,6 +1517,7 @@ dependencies = [
 name = "oxlint-plugins-playwright"
 version = "0.0.0"
 dependencies = [
+ "compact_str",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/playground_wasm/src/plugins/playwright.rs
+++ b/crates/playground_wasm/src/plugins/playwright.rs
@@ -33,6 +33,10 @@ pub fn scan(
         if !diagnostic.data.message.is_empty() {
             data.insert("message".to_owned(), diagnostic.data.message.into_string());
         }
+        push(&mut data, "amount", diagnostic.data.amount);
+        push(&mut data, "count", diagnostic.data.count);
+        push(&mut data, "depth", diagnostic.data.depth);
+        push(&mut data, "max", diagnostic.data.max);
         push(&mut data, "method", diagnostic.data.method);
         push(&mut data, "restriction", diagnostic.data.restriction);
         push(&mut data, "role", diagnostic.data.role);
@@ -40,6 +44,7 @@ pub fn scan(
         push(&mut data, "pattern", diagnostic.data.pattern);
         push(&mut data, "tag", diagnostic.data.tag);
         push(&mut data, "word", diagnostic.data.word);
+        push(&mut data, "s", diagnostic.data.s);
         out.push(PlaygroundDiagnostic {
             plugin: PLUGIN,
             rule: diagnostic.rule_name.to_owned(),
@@ -112,5 +117,44 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, "valid-test-tags");
         assert_eq!(diagnostics[0].message_id, "invalidTagFormat");
+    }
+
+    #[test]
+    fn preserves_threshold_message_data_locations_and_rule_selection() {
+        let filter = EnabledFilter::parse(r#"{"playwright":["max-expects"]}"#);
+        let mut diagnostics = Vec::new();
+        scan(
+            concat!(
+                "const marker = \"🧪\";\n",
+                "test(\"case\", () => {\n",
+                "  expect(1).toBe(1); expect(2).toBe(2); expect(3).toBe(3);\n",
+                "  expect(4).toBe(4); expect(5).toBe(5); expect(6).toBe(6);\n",
+                "});\n",
+            ),
+            "fixture.ts",
+            &filter,
+            &mut diagnostics,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "max-expects");
+        assert_eq!(diagnostics[0].message_id, "exceededMaxAssertion");
+        assert_eq!(
+            diagnostics[0].data.get("count").map(String::as_str),
+            Some("6")
+        );
+        assert_eq!(
+            diagnostics[0].data.get("max").map(String::as_str),
+            Some("5")
+        );
+        assert_eq!(
+            (
+                diagnostics[0].start_line,
+                diagnostics[0].start_column,
+                diagnostics[0].end_line,
+                diagnostics[0].end_column,
+            ),
+            (4, 40, 4, 57)
+        );
     }
 }

--- a/crates/playwright/Cargo.toml
+++ b/crates/playwright/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 publish = false
 
 [dependencies]
+compact_str.workspace = true
 oxc_allocator.workspace = true
 oxc_ast.workspace = true
 oxc_ast_visit.workspace = true

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -3,6 +3,7 @@
 mod patterns;
 mod restricted;
 mod scanner;
+mod thresholds;
 mod types;
 
 #[cfg(test)]
@@ -16,6 +17,7 @@ use oxlint_plugins_carton::SmallVec;
 use crate::patterns::scan_pattern_rules;
 use crate::restricted::scan_restricted_rules;
 use crate::scanner::Scanner;
+use crate::thresholds::scan_threshold_rules;
 use crate::types::LineIndex;
 
 pub use crate::types::{
@@ -120,6 +122,13 @@ pub fn scan_playwright_with_options(
         &mut scanner.diagnostics,
     );
     scan_restricted_rules(
+        &parser_return.program,
+        source_text,
+        &scanner.line_index,
+        options,
+        &mut scanner.diagnostics,
+    );
+    scan_threshold_rules(
         &parser_return.program,
         source_text,
         &scanner.line_index,

--- a/crates/playwright/src/scanner.rs
+++ b/crates/playwright/src/scanner.rs
@@ -22,13 +22,6 @@ impl<'a> Scanner<'a> {
         if self.source_text.contains("test(") && !self.source_text.contains("expect(") {
             self.report_at_first("expect-expect", "test(");
         }
-        if self.source_text.matches("expect(").count() > 2 {
-            self.report_at_first("max-expects", "expect(");
-        }
-        self.check_regex(
-            "max-nested-describe",
-            r#"(?s)test\.describe\s*\(.*?\{.*test\.describe\s*\("#,
-        );
         self.check_regex(
             "missing-playwright-await",
             r#"(?m)(^|[^\w.])page\.(click|dblclick|fill|goto|locator|press|selectOption|setInputFiles|tap|type|uncheck|waitForLoadState)\s*\("#,
@@ -143,10 +136,6 @@ impl<'a> Scanner<'a> {
         self.check_regex("require-tags", r#"test\s*\(\s*['"][^@'"]+['"]"#);
         self.check_regex("require-to-pass-timeout", r#"\.toPass\s*\(\s*\)"#);
         self.check_regex("require-to-throw-message", r#"\.toThrow\s*\(\s*\)"#);
-        self.check_regex(
-            "require-top-level-describe",
-            r#"(?m)^\s*test\s*\(\s*['"][^'"]+['"]"#,
-        );
         self.check_regex(
             "valid-describe-callback",
             r#"test\.describe\s*\(\s*['"][^'"]+['"]\s*\)"#,

--- a/crates/playwright/src/tests.rs
+++ b/crates/playwright/src/tests.rs
@@ -12,7 +12,7 @@ test("two", async ({ page }) => { await page.click("button"); });
 test("without assertions", async ({ page }) => { await page.click("button"); });
 test("x", async ({ page }) => { await page.click("button"); });
 test("many", () => { expect(a).toBe(1); expect(b).toBe(2); expect(c).toBe(3); });
-test.describe("outer", () => { test.describe("inner", () => {}); });
+test.describe("1", () => { test.describe("2", () => { test.describe("3", () => { test.describe("4", () => { test.describe("5", () => { test.describe("6", () => {}); }); }); }); }); });
 page.click("button");
 // test("commented", () => {});
 test("conditional expect", () => { if (ready) { expect(value).toBe(1); } });
@@ -376,6 +376,224 @@ fn pattern_rules_resolve_every_test_alias_form_and_ignore_malformed_input() {
             .all(|diagnostic| diagnostic.message_id == "duplicatePrefix")
     );
     assert!(scan_playwright_with_options("test(\"", "fixture.spec.ts", &options).is_empty());
+}
+
+#[test]
+fn max_expects_reports_every_excess_assertion_with_exact_data_and_locations() {
+    let source = concat!(
+        "test(\"case\", () => {\n",
+        "  expect(1).toBe(1);\n",
+        "  expect.soft(2).toBe(2);\n",
+        "  expect(3).toBe(3);\n",
+        "});\n",
+    );
+    let options = PlaywrightOptions {
+        max_expects: 1,
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = threshold_diagnostics(source, &options, "max-expects");
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].message_id, "exceededMaxAssertion");
+    assert_eq!(diagnostics[0].data.count.as_deref(), Some("2"));
+    assert_eq!(diagnostics[0].data.max.as_deref(), Some("1"));
+    assert_eq!(
+        diagnostics[0].loc,
+        crate::DiagnosticLoc {
+            start_line: 3,
+            start_column: 2,
+            end_line: 3,
+            end_column: 24,
+        }
+    );
+    assert_eq!(diagnostics[1].data.count.as_deref(), Some("3"));
+    assert_eq!(diagnostics[1].loc.start_line, 4);
+    assert_eq!(diagnostics[1].loc.start_column, 2);
+    assert_eq!(diagnostics[1].loc.end_column, 19);
+}
+
+#[test]
+fn max_expects_matches_test_and_non_test_function_reset_boundaries() {
+    let source = concat!(
+        "test(\"first\", () => {\n",
+        "  test.step(\"one\", () => { expect(1).toBe(1); });\n",
+        "  test.step(\"two\", () => { expect(2).toBe(2); });\n",
+        "});\n",
+        "test(\"second\", () => { expect(3).toBe(3); expect(4).toBe(4); });\n",
+        "const helper = () => { expect(5).toBe(5); expect(6).toBe(6); };\n",
+    );
+    let options = PlaywrightOptions {
+        max_expects: 1,
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = threshold_diagnostics(source, &options, "max-expects");
+
+    assert_eq!(diagnostics.len(), 3);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.data.count.as_deref())
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[Some("2"), Some("2"), Some("2")]
+    );
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.loc.start_line)
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[3, 5, 6]
+    );
+}
+
+#[test]
+fn max_nested_describe_tracks_real_ast_nesting_computed_names_and_siblings() {
+    let source = concat!(
+        "test.describe(\"outer\", () => {\n",
+        "  test[\"describe\"](\"inner\", () => {});\n",
+        "  test[`describe`](\"sibling\", () => {});\n",
+        "});\n",
+    );
+    let options = PlaywrightOptions {
+        max_nested_describe: 1,
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = threshold_diagnostics(source, &options, "max-nested-describe");
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.data.depth.as_deref())
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[Some("2"), Some("2")]
+    );
+    assert!(diagnostics.iter().all(|diagnostic| {
+        diagnostic.message_id == "exceededMaxDepth" && diagnostic.data.max.as_deref() == Some("1")
+    }));
+    assert_eq!(diagnostics[0].loc.start_column, 2);
+    assert_eq!(diagnostics[0].loc.end_column, 18);
+    assert_eq!(diagnostics[1].loc.start_line, 3);
+    assert_eq!(diagnostics[1].loc.end_column, 18);
+}
+
+#[test]
+fn require_top_level_describe_ignores_configs_and_reports_hooks_tests_and_limits() {
+    let source = concat!(
+        "test.skip(true);\n",
+        "test.describe.configure({ mode: \"parallel\" });\n",
+        "test.beforeEach(() => {});\n",
+        "test(\"top\", () => {});\n",
+        "test.describe(\"one\", () => { test(\"inside\", () => {}); });\n",
+        "test.describe.only(\"two\", () => {});\n",
+        "test.describe.parallel(\"three\", () => {});\n",
+    );
+    let options = PlaywrightOptions {
+        max_top_level_describes: Some(1.5),
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = threshold_diagnostics(source, &options, "require-top-level-describe");
+
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message_id)
+            .collect::<SmallVec<[_; 8]>>()
+            .as_slice(),
+        &[
+            "unexpectedHook",
+            "unexpectedTest",
+            "tooManyDescribes",
+            "tooManyDescribes",
+        ]
+    );
+    assert_eq!(diagnostics[0].loc.start_line, 3);
+    assert_eq!(diagnostics[0].loc.end_column, 15);
+    assert_eq!(diagnostics[1].loc.start_line, 4);
+    assert_eq!(diagnostics[1].loc.end_column, 4);
+    for diagnostic in &diagnostics[2..] {
+        assert_eq!(diagnostic.data.amount.as_deref(), Some("1.5"));
+        assert_eq!(diagnostic.data.s.as_deref(), Some("s"));
+    }
+}
+
+#[test]
+fn threshold_rules_support_import_global_and_extend_aliases() {
+    let source = concat!(
+        "import { test as scenario, expect as assuming } from \"@playwright/test\";\n",
+        "const custom = scenario.extend({});\n",
+        "it(\"global\", () => { verify(1).toBe(1); verify(2).toBe(2); });\n",
+        "scenario.describe(\"outer\", () => { custom.describe(\"inner\", () => {}); });\n",
+        "custom.beforeAll(() => {});\n",
+        "assuming(1).toBe(1);\n",
+    );
+    let options = PlaywrightOptions {
+        expect_aliases: [CompactString::from("verify")].into_iter().collect(),
+        test_aliases: [CompactString::from("it")].into_iter().collect(),
+        max_expects: 1,
+        max_nested_describe: 1,
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = scan_playwright_with_options(source, "fixture.spec.ts", &options);
+
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "max-expects")
+            .count(),
+        1
+    );
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "max-nested-describe")
+            .count(),
+        1
+    );
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "require-top-level-describe")
+            .map(|diagnostic| diagnostic.message_id)
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &["unexpectedTest", "unexpectedHook"]
+    );
+}
+
+#[test]
+fn threshold_locations_use_utf16_and_malformed_sources_fail_closed() {
+    let source = concat!(
+        "const marker = \"🧪\";\n",
+        "test(\"case\", () => {\n",
+        "  expect(1).toBe(1);\n",
+        "  expect(2).toBe(2);\n",
+        "});\n",
+    );
+    let options = PlaywrightOptions {
+        max_expects: 1,
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = threshold_diagnostics(source, &options, "max-expects");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].loc.start_line, 4);
+    assert_eq!(diagnostics[0].loc.start_column, 2);
+    assert_eq!(diagnostics[0].loc.end_column, 19);
+
+    assert!(scan_playwright_with_options("test(\"broken", "fixture.spec.ts", &options).is_empty());
+}
+
+fn threshold_diagnostics(
+    source: &str,
+    options: &PlaywrightOptions,
+    rule_name: &str,
+) -> SmallVec<[crate::Diagnostic; 8]> {
+    scan_playwright_with_options(source, "fixture.spec.ts", options)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.rule_name == rule_name)
+        .collect()
 }
 
 fn representative_options() -> PlaywrightOptions {

--- a/crates/playwright/src/thresholds.rs
+++ b/crates/playwright/src/thresholds.rs
@@ -1,0 +1,493 @@
+//! AST-backed ports of Playwright's numeric threshold rules.
+
+use compact_str::format_compact;
+use oxc_ast::{
+    AstKind,
+    ast::{
+        Argument, BindingPattern, CallExpression, Expression, ImportDeclaration,
+        ImportDeclarationSpecifier, MemberExpression, ModuleExportName, Program,
+        VariableDeclarator, match_member_expression,
+    },
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::types::{Diagnostic, DiagnosticData, LineIndex, PlaywrightOptions};
+
+const MAX_EXPECTS_RULE: &str = "max-expects";
+const MAX_NESTED_DESCRIBE_RULE: &str = "max-nested-describe";
+const REQUIRE_TOP_LEVEL_DESCRIBE_RULE: &str = "require-top-level-describe";
+
+pub(crate) fn scan_threshold_rules<'ast>(
+    program: &Program<'ast>,
+    source_text: &str,
+    line_index: &LineIndex,
+    options: &PlaywrightOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 64]>,
+) {
+    let mut test_names = SmallVec::<[CompactString; 8]>::new();
+    test_names.push(CompactString::from("test"));
+    for alias in &options.test_aliases {
+        push_unique(&mut test_names, alias.as_str());
+    }
+
+    let mut expect_names = SmallVec::<[CompactString; 8]>::new();
+    expect_names.push(CompactString::from("expect"));
+    for alias in &options.expect_aliases {
+        push_unique(&mut expect_names, alias.as_str());
+    }
+
+    let mut extend_declarations = SmallVec::<[(CompactString, CompactString); 16]>::new();
+    ThresholdCollector {
+        expect_names: &mut expect_names,
+        extend_declarations: &mut extend_declarations,
+        test_names: &mut test_names,
+    }
+    .visit_program(program);
+
+    // Resolve `test.extend()` aliases to a fixed point so chained declarations
+    // work regardless of their declaration order.
+    loop {
+        let mut changed = false;
+        for (name, root) in &extend_declarations {
+            if contains_name(&test_names, root.as_str())
+                && !contains_name(&test_names, name.as_str())
+            {
+                test_names.push(name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    ThresholdVisitor {
+        ancestors: SmallVec::new(),
+        describe_depth: 0,
+        diagnostics,
+        expect_count: 0,
+        expect_names,
+        function_resets: SmallVec::new(),
+        line_index,
+        options,
+        source_text,
+        test_names,
+        top_level_describe_count: 0,
+    }
+    .visit_program(program);
+}
+
+struct ThresholdCollector<'storage> {
+    expect_names: &'storage mut SmallVec<[CompactString; 8]>,
+    extend_declarations: &'storage mut SmallVec<[(CompactString, CompactString); 16]>,
+    test_names: &'storage mut SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for ThresholdCollector<'_> {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
+        if declaration.source.value != "@playwright/test" {
+            return;
+        }
+        let Some(specifiers) = &declaration.specifiers else {
+            return;
+        };
+        for specifier in specifiers {
+            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                continue;
+            };
+            match module_export_name(&specifier.imported) {
+                Some("test") => push_unique(self.test_names, specifier.local.name.as_str()),
+                Some("expect") => push_unique(self.expect_names, specifier.local.name.as_str()),
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_variable_declarator(&mut self, declaration: &VariableDeclarator<'ast>) {
+        if let (BindingPattern::BindingIdentifier(identifier), Some(initializer)) =
+            (&declaration.id, &declaration.init)
+            && let Some(root) = test_extend_root(initializer)
+        {
+            self.extend_declarations.push((
+                CompactString::from(identifier.name.as_str()),
+                CompactString::from(root),
+            ));
+        }
+        walk::walk_variable_declarator(self, declaration);
+    }
+}
+
+struct ThresholdVisitor<'ast, 'source, 'options, 'diagnostics> {
+    ancestors: SmallVec<[AstKind<'ast>; 32]>,
+    describe_depth: usize,
+    diagnostics: &'diagnostics mut SmallVec<[Diagnostic; 64]>,
+    expect_count: usize,
+    expect_names: SmallVec<[CompactString; 8]>,
+    function_resets: SmallVec<[bool; 8]>,
+    line_index: &'source LineIndex,
+    options: &'options PlaywrightOptions,
+    source_text: &'source str,
+    test_names: SmallVec<[CompactString; 8]>,
+    top_level_describe_count: usize,
+}
+
+impl<'ast> Visit<'ast> for ThresholdVisitor<'ast, '_, '_, '_> {
+    fn enter_node(&mut self, kind: AstKind<'ast>) {
+        if matches!(
+            kind,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+        ) {
+            let reset = match self.ancestors.last() {
+                Some(AstKind::CallExpression(parent)) => {
+                    matches!(
+                        classify_call(parent, &self.test_names),
+                        Some(PlaywrightCall::Test)
+                    )
+                }
+                _ => true,
+            };
+            if reset {
+                self.expect_count = 0;
+            }
+            self.function_resets.push(reset);
+        }
+        self.ancestors.push(kind);
+    }
+
+    fn leave_node(&mut self, kind: AstKind<'ast>) {
+        self.ancestors.pop();
+        if matches!(
+            kind,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+        ) && self.function_resets.pop().is_some_and(|reset| reset)
+        {
+            self.expect_count = 0;
+        }
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        if is_expect_assertion(call, &self.expect_names, &self.test_names) {
+            self.expect_count += 1;
+            if self.expect_count > self.options.max_expects as usize {
+                self.report(
+                    MAX_EXPECTS_RULE,
+                    "exceededMaxAssertion",
+                    call.span,
+                    DiagnosticData {
+                        count: Some(compact_number(self.expect_count)),
+                        max: Some(compact_number(self.options.max_expects)),
+                        ..DiagnosticData::default()
+                    },
+                );
+            }
+        }
+
+        let call_kind = classify_call(call, &self.test_names);
+        let entered_describe = matches!(call_kind, Some(PlaywrightCall::Describe));
+        if entered_describe {
+            self.describe_depth += 1;
+            if self.describe_depth > self.options.max_nested_describe as usize {
+                self.report(
+                    MAX_NESTED_DESCRIBE_RULE,
+                    "exceededMaxDepth",
+                    call.callee.span(),
+                    DiagnosticData {
+                        depth: Some(compact_number(self.describe_depth)),
+                        max: Some(compact_number(self.options.max_nested_describe)),
+                        ..DiagnosticData::default()
+                    },
+                );
+            }
+
+            if self.describe_depth == 1 {
+                self.top_level_describe_count += 1;
+                if self
+                    .options
+                    .max_top_level_describes
+                    .is_some_and(|max| self.top_level_describe_count as f64 > max)
+                {
+                    let max = self.options.max_top_level_describes.unwrap_or_default();
+                    self.report(
+                        REQUIRE_TOP_LEVEL_DESCRIBE_RULE,
+                        "tooManyDescribes",
+                        call.callee.span(),
+                        DiagnosticData {
+                            amount: Some(compact_number(max)),
+                            s: Some(CompactString::from(if max == 1.0 { "" } else { "s" })),
+                            ..DiagnosticData::default()
+                        },
+                    );
+                }
+            }
+        } else if self.describe_depth == 0 {
+            match call_kind {
+                Some(PlaywrightCall::Test) => self.report(
+                    REQUIRE_TOP_LEVEL_DESCRIBE_RULE,
+                    "unexpectedTest",
+                    call.callee.span(),
+                    DiagnosticData::default(),
+                ),
+                Some(PlaywrightCall::Hook) => self.report(
+                    REQUIRE_TOP_LEVEL_DESCRIBE_RULE,
+                    "unexpectedHook",
+                    call.callee.span(),
+                    DiagnosticData::default(),
+                ),
+                None | Some(PlaywrightCall::Describe) => {}
+            }
+        }
+
+        walk::walk_call_expression(self, call);
+
+        if entered_describe {
+            self.describe_depth = self.describe_depth.saturating_sub(1);
+        }
+    }
+}
+
+impl ThresholdVisitor<'_, '_, '_, '_> {
+    fn report(
+        &mut self,
+        rule_name: &'static str,
+        message_id: &'static str,
+        span: Span,
+        data: DiagnosticData,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+            fix: None,
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PlaywrightCall {
+    Describe,
+    Hook,
+    Test,
+}
+
+fn classify_call(
+    call: &CallExpression<'_>,
+    test_names: &[CompactString],
+) -> Option<PlaywrightCall> {
+    let mut links = SmallVec::<[&str; 8]>::new();
+    let root = callee_chain(&call.callee, &mut links)?;
+    let has_callback = call.arguments.last().is_some_and(is_function_argument);
+
+    if contains_name(test_names, root) {
+        let Some((first, tail)) = links.split_first() else {
+            return (has_callback && call.arguments.len() >= 2).then_some(PlaywrightCall::Test);
+        };
+        return match *first {
+            "describe" if valid_describe_tail(tail) && has_callback => {
+                Some(PlaywrightCall::Describe)
+            }
+            "afterAll" | "afterEach" | "beforeAll" | "beforeEach" if tail.is_empty() => {
+                Some(PlaywrightCall::Hook)
+            }
+            "only" | "skip" | "fixme" | "slow"
+                if tail.is_empty() && has_callback && call.arguments.len() >= 2 =>
+            {
+                Some(PlaywrightCall::Test)
+            }
+            "fail"
+                if matches!(tail, [] | ["only"]) && has_callback && call.arguments.len() >= 2 =>
+            {
+                Some(PlaywrightCall::Test)
+            }
+            _ => None,
+        };
+    }
+
+    if root == "describe" && valid_describe_tail(&links) && has_callback {
+        return Some(PlaywrightCall::Describe);
+    }
+    if matches!(root, "afterAll" | "afterEach" | "beforeAll" | "beforeEach") && links.is_empty() {
+        return Some(PlaywrightCall::Hook);
+    }
+    None
+}
+
+fn valid_describe_tail(tail: &[&str]) -> bool {
+    matches!(
+        tail,
+        [] | ["only"]
+            | ["skip"]
+            | ["fixme"]
+            | ["fixme", "only"]
+            | ["configure"]
+            | ["serial"]
+            | ["serial", "only"]
+            | ["serial", "skip"]
+            | ["serial", "fixme"]
+            | ["serial", "fixme", "only"]
+            | ["parallel"]
+            | ["parallel", "only"]
+            | ["parallel", "skip"]
+            | ["parallel", "fixme"]
+            | ["parallel", "fixme", "only"]
+    )
+}
+
+fn is_expect_assertion(
+    call: &CallExpression<'_>,
+    expect_names: &[CompactString],
+    test_names: &[CompactString],
+) -> bool {
+    let Some(member) = member_from_expression(&call.callee) else {
+        return false;
+    };
+    let Some(matcher) = member_name(member) else {
+        return false;
+    };
+    if matches!(matcher, "not" | "poll" | "rejects" | "resolves" | "soft") {
+        return false;
+    }
+    expression_contains_expect_call(member.object(), expect_names, test_names)
+}
+
+fn expression_contains_expect_call(
+    expression: &Expression<'_>,
+    expect_names: &[CompactString],
+    test_names: &[CompactString],
+) -> bool {
+    match expression.get_inner_expression() {
+        Expression::CallExpression(call) => is_expect_head(call, expect_names, test_names),
+        member @ match_member_expression!(Expression) => expression_contains_expect_call(
+            member.to_member_expression().object(),
+            expect_names,
+            test_names,
+        ),
+        _ => false,
+    }
+}
+
+fn is_expect_head(
+    call: &CallExpression<'_>,
+    expect_names: &[CompactString],
+    test_names: &[CompactString],
+) -> bool {
+    let mut links = SmallVec::<[&str; 8]>::new();
+    let Some(root) = callee_chain(&call.callee, &mut links) else {
+        return false;
+    };
+    if contains_name(expect_names, root) || root.starts_with("expect") || root.ends_with("Expect") {
+        return matches!(links.as_slice(), [] | ["soft"] | ["poll"]);
+    }
+    contains_name(test_names, root)
+        && matches!(
+            links.as_slice(),
+            ["expect"] | ["expect", "soft"] | ["expect", "poll"]
+        )
+}
+
+fn callee_chain<'ast>(
+    expression: &'ast Expression<'ast>,
+    links: &mut SmallVec<[&'ast str; 8]>,
+) -> Option<&'ast str> {
+    match expression.get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        member @ match_member_expression!(Expression) => {
+            let member = member.to_member_expression();
+            let root = callee_chain(member.object(), links)?;
+            links.push(member_name(member)?);
+            Some(root)
+        }
+        _ => None,
+    }
+}
+
+fn member_name<'ast>(member: &'ast MemberExpression<'ast>) -> Option<&'ast str> {
+    if let Some(name) = member.static_property_name() {
+        return Some(name);
+    }
+    match member {
+        MemberExpression::ComputedMemberExpression(member) => {
+            match member.expression.get_inner_expression() {
+                Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+                Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+                Expression::TemplateLiteral(template) if template.expressions.is_empty() => {
+                    template
+                        .quasis
+                        .first()
+                        .and_then(|quasi| quasi.value.cooked.as_ref())
+                        .map(|value| value.as_str())
+                }
+                _ => None,
+            }
+        }
+        MemberExpression::StaticMemberExpression(_)
+        | MemberExpression::PrivateFieldExpression(_) => None,
+    }
+}
+
+fn member_from_expression<'ast>(
+    expression: &'ast Expression<'ast>,
+) -> Option<&'ast MemberExpression<'ast>> {
+    match expression.get_inner_expression() {
+        member @ match_member_expression!(Expression) => Some(member.to_member_expression()),
+        _ => None,
+    }
+}
+
+fn test_extend_root<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return None;
+    };
+    let member = member_from_expression(&call.callee)?;
+    if member_name(member) != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn test_extend_root_from_call<'ast>(call: &'ast CallExpression<'ast>) -> Option<&'ast str> {
+    let member = member_from_expression(&call.callee)?;
+    if member_name(member) != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn is_function_argument(argument: &Argument<'_>) -> bool {
+    matches!(
+        argument,
+        Argument::ArrowFunctionExpression(_) | Argument::FunctionExpression(_)
+    )
+}
+
+fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn compact_number(value: impl std::fmt::Display) -> CompactString {
+    format_compact!("{value}")
+}
+
+fn contains_name(names: &[CompactString], value: &str) -> bool {
+    names.iter().any(|name| name == value)
+}
+
+fn push_unique(names: &mut SmallVec<[CompactString; 8]>, value: &str) {
+    if !contains_name(names, value) {
+        names.push(CompactString::from(value));
+    }
+}

--- a/crates/playwright/src/types.rs
+++ b/crates/playwright/src/types.rs
@@ -9,7 +9,7 @@ pub struct Restriction {
     pub message: Option<CompactString>,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PlaywrightOptions {
     pub restricted_locators: SmallVec<[Restriction; 8]>,
     pub restricted_matchers: SmallVec<[Restriction; 8]>,
@@ -18,6 +18,9 @@ pub struct PlaywrightOptions {
     pub test_aliases: SmallVec<[CompactString; 4]>,
     pub valid_title: ValidTitleOptions,
     pub valid_test_tags: ValidTestTagsOptions,
+    pub max_expects: u32,
+    pub max_nested_describe: u32,
+    pub max_top_level_describes: Option<f64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -71,6 +74,23 @@ pub struct TagPattern {
     pub is_regex: bool,
 }
 
+impl Default for PlaywrightOptions {
+    fn default() -> Self {
+        Self {
+            restricted_locators: SmallVec::new(),
+            restricted_matchers: SmallVec::new(),
+            restricted_roles: SmallVec::new(),
+            expect_aliases: SmallVec::new(),
+            test_aliases: SmallVec::new(),
+            valid_title: ValidTitleOptions::default(),
+            valid_test_tags: ValidTestTagsOptions::default(),
+            max_expects: 5,
+            max_nested_describe: 5,
+            max_top_level_describes: None,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiagnosticLoc {
     pub start_line: u32,
@@ -98,6 +118,10 @@ pub struct DiagnosticFix {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DiagnosticData {
     pub message: CompactString,
+    pub amount: Option<CompactString>,
+    pub count: Option<CompactString>,
+    pub depth: Option<CompactString>,
+    pub max: Option<CompactString>,
     pub method: Option<CompactString>,
     pub restriction: Option<CompactString>,
     pub role: Option<CompactString>,
@@ -105,6 +129,7 @@ pub struct DiagnosticData {
     pub pattern: Option<CompactString>,
     pub tag: Option<CompactString>,
     pub word: Option<CompactString>,
+    pub s: Option<CompactString>,
 }
 
 pub(crate) struct LineIndex {

--- a/npm/playwright/README.md
+++ b/npm/playwright/README.md
@@ -5,6 +5,27 @@ Rust-backed Oxlint plugin port of `eslint-plugin-playwright` v2.10.4.
 This package exposes the `playwright` plugin, recommended configs, and a native
 API for scanning Playwright test source through the Rust implementation.
 
+## Numeric threshold options
+
+The numeric threshold rules implement the complete upstream v2.10.4 option
+contracts:
+
+```json
+{
+  "rules": {
+    "playwright/max-expects": ["error", { "max": 5 }],
+    "playwright/max-nested-describe": ["error", { "max": 5 }],
+    "playwright/require-top-level-describe": ["error", { "maxTopLevelDescribes": 2 }]
+  }
+}
+```
+
+`max-expects` counts Playwright assertion calls per test callback while
+preserving upstream nested-callback reset behavior. `max-nested-describe`
+measures actual AST nesting, and `require-top-level-describe` rejects top-level
+tests and hooks with an optional top-level describe limit. Imported aliases,
+`test.extend()` aliases, and `settings.playwright.globalAliases` are supported.
+
 ## Restricted rule options
 
 The option-bearing `no-restricted-locators`, `no-restricted-matchers`, and
@@ -51,6 +72,11 @@ The direct API accepts the same option values:
 const { scanPlaywright } = require('@oxlint-plugins/oxlint-plugin-playwright/api');
 
 scanPlaywright('page.getByTestId("submit")', 'fixture.spec.ts', {
+  maxExpects: 5,
+  maxNestedDescribe: 5,
+  maxTopLevelDescribes: 2,
+  testAliases: ['it'],
+  expectAliases: ['verify'],
   noRestrictedLocators: ['getByTestId'],
 });
 ```

--- a/npm/playwright/api.d.ts
+++ b/npm/playwright/api.d.ts
@@ -10,6 +10,10 @@ export type PlaywrightDiagnostic = {
   messageId: string;
   data: {
     message: string;
+    amount?: string;
+    count?: string;
+    depth?: string;
+    max?: string;
     method?: string;
     restriction?: string;
     role?: string;
@@ -17,6 +21,7 @@ export type PlaywrightDiagnostic = {
     pattern?: string;
     tag?: string;
     word?: string;
+    s?: string;
   };
   loc: PlaywrightDiagnosticLoc;
   fix?: {
@@ -48,6 +53,9 @@ export type PlaywrightScanOptions = {
   testAliases?: string[];
   validTitle?: PlaywrightValidTitleOptions;
   validTestTags?: PlaywrightValidTestTagsOptions;
+  maxExpects?: number;
+  maxNestedDescribe?: number;
+  maxTopLevelDescribes?: number;
 };
 
 export type PlaywrightTitlePattern =

--- a/npm/playwright/api.js
+++ b/npm/playwright/api.js
@@ -20,6 +20,9 @@ function scanPlaywright(sourceText, filename = 'file.spec.ts', options = {}) {
   const diagnostics = native.scanPlaywright(sourceText, filename, {
     expectAliases: stringList(options.expectAliases),
     testAliases: stringList(options.testAliases),
+    maxExpects: integerOption(options.maxExpects, 'maxExpects', 1),
+    maxNestedDescribe: integerOption(options.maxNestedDescribe, 'maxNestedDescribe', 0),
+    maxTopLevelDescribes: numberOption(options.maxTopLevelDescribes, 'maxTopLevelDescribes', 1),
     restrictedLocators: listRestrictions(options.noRestrictedLocators, 'type'),
     restrictedMatchers: matcherRestrictions(options.noRestrictedMatchers),
     restrictedRoles: listRestrictions(options.noRestrictedRoles, 'role'),
@@ -117,6 +120,26 @@ function tagPatterns(values) {
     }
     return [];
   });
+}
+
+function integerOption(value, name, minimum) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new TypeError(`${name} must be an integer greater than or equal to ${minimum}.`);
+  }
+  return value;
+}
+
+function numberOption(value, name, minimum) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < minimum) {
+    throw new TypeError(`${name} must be a finite number greater than or equal to ${minimum}.`);
+  }
+  return value;
 }
 
 function listRestrictions(values, key) {

--- a/npm/playwright/index.js
+++ b/npm/playwright/index.js
@@ -17,6 +17,11 @@ const restrictedRules = new Set([
   'no-restricted-roles',
 ]);
 const patternRules = new Set(['valid-test-tags', 'valid-title']);
+const thresholdRules = new Set([
+  'max-expects',
+  'max-nested-describe',
+  'require-top-level-describe',
+]);
 
 const sharedGlobals = Object.freeze({
   expect: false,
@@ -134,24 +139,23 @@ function createLegacyRecommendedConfig() {
 }
 
 function createPlaywrightRule(ruleName) {
-  const restrictedMeta = restrictedRuleMeta(ruleName);
-  const patternMeta = patternRuleMeta(ruleName);
-  const exactMeta = restrictedMeta ?? patternMeta;
+  const specializedMeta =
+    restrictedRuleMeta(ruleName) ?? patternRuleMeta(ruleName) ?? thresholdRuleMeta(ruleName);
   return {
     meta: {
       type: ruleType(ruleName),
       docs: {
         description:
-          exactMeta?.description ?? `enforce playwright ${ruleName.replaceAll('-', ' ')}`,
+          specializedMeta?.description ?? `enforce playwright ${ruleName.replaceAll('-', ' ')}`,
         category: 'Best Practices',
         recommended: recommendedRuleConfig[`playwright/${ruleName}`] !== undefined,
         url: `${DOCS_BASE}/${ruleName}.md`,
       },
       fixable: fixableRule(ruleName) ? 'code' : undefined,
-      messages: exactMeta?.messages ?? {
+      messages: specializedMeta?.messages ?? {
         unexpected: 'Unexpected Playwright pattern.',
       },
-      schema: exactMeta?.schema ?? [],
+      schema: specializedMeta?.schema ?? [],
     },
     createOnce(context) {
       return {
@@ -187,7 +191,9 @@ function diagnosticsForRule(context, ruleName) {
   const options =
     restrictedRules.has(ruleName) || patternRules.has(ruleName)
       ? ruleScanOptions(context, ruleName)
-      : undefined;
+      : thresholdRules.has(ruleName)
+        ? thresholdScanOptions(context, ruleName)
+        : undefined;
   return diagnosticsForContext(context, options).filter(
     (diagnostic) => diagnostic.ruleName === ruleName,
   );
@@ -250,6 +256,22 @@ function sourceTextForContext(context) {
     return sourceCode.text;
   }
   return '';
+}
+
+function thresholdScanOptions(context, ruleName) {
+  const options = Array.isArray(context.options) ? context.options : [];
+  const configured = options[0] && typeof options[0] === 'object' ? options[0] : {};
+  const expectAliases = context.settings?.playwright?.globalAliases?.expect;
+  const testAliases = context.settings?.playwright?.globalAliases?.test;
+  return {
+    ...(ruleName === 'max-expects' ? { maxExpects: configured.max } : {}),
+    ...(ruleName === 'max-nested-describe' ? { maxNestedDescribe: configured.max } : {}),
+    ...(ruleName === 'require-top-level-describe'
+      ? { maxTopLevelDescribes: configured.maxTopLevelDescribes }
+      : {}),
+    ...(Array.isArray(expectAliases) ? { expectAliases } : {}),
+    ...(Array.isArray(testAliases) ? { testAliases } : {}),
+  };
 }
 
 function ruleScanOptions(context, ruleName) {
@@ -356,6 +378,55 @@ function tagListSchema() {
       ],
     },
     type: 'array',
+  };
+}
+
+function thresholdRuleMeta(ruleName) {
+  switch (ruleName) {
+    case 'max-expects':
+      return {
+        description: 'Enforces a maximum number assertion calls in a test body',
+        messages: {
+          exceededMaxAssertion:
+            'Too many assertion calls ({{ count }}) - maximum allowed is {{ max }}',
+        },
+        schema: [maximumSchema('max', 1, 'integer')],
+      };
+    case 'max-nested-describe':
+      return {
+        description: 'Enforces a maximum depth to nested describe calls',
+        messages: {
+          exceededMaxDepth:
+            'Maximum describe call depth exceeded ({{ depth }}). Maximum allowed is {{ max }}.',
+        },
+        schema: [maximumSchema('max', 0, 'integer')],
+      };
+    case 'require-top-level-describe':
+      return {
+        description: 'Require test cases and hooks to be inside a `test.describe` block',
+        messages: {
+          tooManyDescribes:
+            'There should not be more than {{amount}} describe{{s}} at the top level',
+          unexpectedHook: 'All hooks must be wrapped in a describe block.',
+          unexpectedTest: 'All test cases must be wrapped in a describe block.',
+        },
+        schema: [maximumSchema('maxTopLevelDescribes', 1, 'number')],
+      };
+    default:
+      return null;
+  }
+}
+
+function maximumSchema(property, minimum, type) {
+  return {
+    additionalProperties: false,
+    properties: {
+      [property]: {
+        minimum,
+        type,
+      },
+    },
+    type: 'object',
   };
 }
 

--- a/npm/playwright/src/lib.rs
+++ b/npm/playwright/src/lib.rs
@@ -34,6 +34,9 @@ mod napi_abi {
         pub test_aliases: Option<Vec<String>>,
         pub valid_title: Option<PlaywrightValidTitleOptions>,
         pub valid_test_tags: Option<PlaywrightValidTestTagsOptions>,
+        pub max_expects: Option<u32>,
+        pub max_nested_describe: Option<u32>,
+        pub max_top_level_describes: Option<f64>,
     }
 
     #[napi(object)]
@@ -109,6 +112,10 @@ mod napi_abi {
     #[derive(Clone, Debug)]
     pub struct DiagnosticData {
         pub message: String,
+        pub amount: Option<String>,
+        pub count: Option<String>,
+        pub depth: Option<String>,
+        pub max: Option<String>,
         pub method: Option<String>,
         pub restriction: Option<String>,
         pub role: Option<String>,
@@ -116,6 +123,7 @@ mod napi_abi {
         pub pattern: Option<String>,
         pub tag: Option<String>,
         pub word: Option<String>,
+        pub s: Option<String>,
     }
 
     #[napi]
@@ -153,6 +161,11 @@ mod napi_abi {
                 .collect(),
             valid_title,
             valid_test_tags,
+            max_expects: options.max_expects.filter(|max| *max >= 1).unwrap_or(5),
+            max_nested_describe: options.max_nested_describe.unwrap_or(5),
+            max_top_level_describes: options
+                .max_top_level_describes
+                .filter(|max| max.is_finite() && *max >= 1.0),
         };
         core::scan_playwright_with_options(&source_text, &filename, &core_options)
             .into_iter()
@@ -161,6 +174,10 @@ mod napi_abi {
                 message_id: diagnostic.message_id.to_owned(),
                 data: DiagnosticData {
                     message: diagnostic.data.message.into_string(),
+                    amount: diagnostic.data.amount.map(CompactString::into_string),
+                    count: diagnostic.data.count.map(CompactString::into_string),
+                    depth: diagnostic.data.depth.map(CompactString::into_string),
+                    max: diagnostic.data.max.map(CompactString::into_string),
                     method: diagnostic.data.method.map(CompactString::into_string),
                     restriction: diagnostic.data.restriction.map(CompactString::into_string),
                     role: diagnostic.data.role.map(CompactString::into_string),
@@ -171,6 +188,7 @@ mod napi_abi {
                     pattern: diagnostic.data.pattern.map(CompactString::into_string),
                     tag: diagnostic.data.tag.map(CompactString::into_string),
                     word: diagnostic.data.word.map(CompactString::into_string),
+                    s: diagnostic.data.s.map(CompactString::into_string),
                 },
                 loc: DiagnosticLoc {
                     start_line: diagnostic.loc.start_line,

--- a/npm/playwright/test/api.test.mjs
+++ b/npm/playwright/test/api.test.mjs
@@ -69,7 +69,7 @@ test("two", async ({ page }) => { await page.click("button"); });
 test("without assertions", async ({ page }) => { await page.click("button"); });
 test("x", async ({ page }) => { await page.click("button"); });
 test("many", () => { expect(a).toBe(1); expect(b).toBe(2); expect(c).toBe(3); });
-test.describe("outer", () => { test.describe("inner", () => {}); });
+test.describe("1", () => { test.describe("2", () => { test.describe("3", () => { test.describe("4", () => { test.describe("5", () => { test.describe("6", () => {}); }); }); }); }); });
 page.click("button");
 // test("commented", () => {});
 test("conditional expect", () => { if (ready) { expect(value).toBe(1); } });

--- a/npm/playwright/test/fixtures/thresholds-v2.10.4.json
+++ b/npm/playwright/test/fixtures/thresholds-v2.10.4.json
@@ -1,0 +1,1244 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-playwright",
+    "version": "2.10.4",
+    "sourceCommit": "894c0ec261763bb1e073b276c70bbf88b4ebad39",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-playwright-threshold-tests.ts",
+    "sourceFiles": [
+      "src/rules/max-expects.ts",
+      "src/rules/max-expects.test.ts",
+      "src/rules/max-nested-describe.ts",
+      "src/rules/max-nested-describe.test.ts",
+      "src/rules/require-top-level-describe.ts",
+      "src/rules/require-top-level-describe.test.ts"
+    ],
+    "sourceHashes": {
+      "src/rules/max-expects.ts": "9c16dc4afd83190d3e7ac4d6a39b3d5db1f49197cfcab633595096135afc2e52",
+      "src/rules/max-expects.test.ts": "d23bcc58ca31bd844483633379d8ef50ced8522eb43f1ccc67b2d7e4ed7e8e1f",
+      "src/rules/max-nested-describe.ts": "206f049fa6c8ca9bf322887951a06c15d6f37f479a9dc5175f942545587670db",
+      "src/rules/max-nested-describe.test.ts": "9c4d910c765b46350bc8ee1d505f072277a74dc2b1d27bc71db0fe0c6d9cb31d",
+      "src/rules/require-top-level-describe.ts": "824cc4ba387ba422ba89c89e1d1ed59b6212e4fbaa6f8f454b61123bdf31e1ea",
+      "src/rules/require-top-level-describe.test.ts": "e14d9378906100095b665fb470467e1762c23814633fc3638fddc5c0cb813a22"
+    },
+    "inventory": {
+      "suites": 3,
+      "valid": 58,
+      "invalid": 42,
+      "diagnostics": 45
+    }
+  },
+  "suites": [
+    {
+      "rule": "max-expects",
+      "valid": [
+        {
+          "code": "test('should pass')",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.skip('should pass', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', function () {\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  // expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', async () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', async () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toEqual(expect.any(Boolean));\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "describe('test', () => {\n  test('should pass', () => {\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.each(['should', 'pass'], () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});\ntest('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "function myHelper() {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n};\n\ntest('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "function myHelper1() {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n};\n\ntest('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});\n\nfunction myHelper2() {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n};",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});\n\nfunction myHelper() {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n};",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const myHelper1 = () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n};\n\ntest('should pass', function() {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});\n\nconst myHelper2 = function() {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n};",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [
+            {
+              "max": 10
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "it('should pass')",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom('should pass');",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom('should pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "import { test as custom, expect as assuming } from '@playwright/test';\ncustom('should pass', () => {\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test('should not pass', function () {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 7,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('should not pass', async () => {\n  await test.step('part 1', async () => {\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n  })\n\n  await test.step('part 1', async () => {\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n  })\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 11,
+                "startColumn": 4
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('should not pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 7,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('should not pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});\ntest('should not pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 7,
+                "startColumn": 2
+              }
+            },
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 15,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "describe('test', () => {\n  test('should not pass', () => {\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n    expect(true).toBeDefined();\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 8,
+                "startColumn": 4
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('should not pass', () => {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [
+            {
+              "max": 1
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 3,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "it('should not pass', function () {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 7,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom('should not pass', function () {\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n  expect(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 8,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "import { test as custom, expect as assuming } from '@playwright/test';\ncustom('should not pass', function () {\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n  assuming(true).toBeDefined();\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {},
+              "loc": {
+                "startLine": 8,
+                "startColumn": 2
+              }
+            }
+          ]
+        },
+        {
+          "code": "test('test', () => {\n  expect.soft(1).toBe(1)\n  expect.soft(2).toBe(2)\n  expect.soft(3).toBe(3)\n  expect.soft(4).toBe(4)\n  expect.soft(5).toBe(5)\n  expect.soft(6).toBe(6)\n})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxAssertion",
+              "data": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rule": "max-nested-describe",
+      "valid": [
+        {
+          "code": "test.describe(\"describe tests\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.only(\"describe focus tests\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.serial.only(\"describe serial focus tests\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.serial.skip(\"describe serial focus tests\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.parallel.fixme(\"describe serial focus tests\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test('foo', function () {\n  expect(true).toBe(true);\n});\ntest('bar', () => {\n  expect(true).toBe(true);\n});",
+          "options": [
+            {
+              "max": 0
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe('foo', function() {\n  test.describe('bar', function () {\n    test.describe('baz', function () {\n      test.describe('qux', function () {\n        test.describe('quxx', function () {\n          test('should get something', () => {\n            expect(getSomething()).toBe('Something');\n          });\n        });\n      });\n    });\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe('foo', () => {\n  test.describe('bar', () => {\n    test.describe('baz', () => {\n      test.describe('qux', () => {\n        test('foo', () => {\n          expect(someCall().property).toBe(true);\n        });\n        test('bar', () => {\n          expect(universe.answer).toBe(42);\n        });\n      });\n      test.describe('quxx', () => {\n        test('baz', () => {\n          expect(2 + 2).toEqual(4);\n        });\n      });\n    });\n  });\n});",
+          "options": [
+            {
+              "max": 4
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe('foo', () => {\n  test.describe.only('bar', () => {\n    test.describe.skip('baz', () => {\n      test('something', async () => {\n        expect('something').toBe('something');\n      });\n    });\n  });\n});",
+          "options": [
+            {
+              "max": 3
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "describe('foo', () => {\n  describe.only('bar', () => {\n    describe.skip('baz', () => {\n      test('something', async () => {\n        expect('something').toBe('something');\n      });\n    });\n  });\n});",
+          "options": [
+            {
+              "max": 3
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "it.describe('foo', () => {\n  it.describe.only('bar', () => {\n    it.describe.skip('baz', () => {\n      it('something', async () => {\n        expect('something').toBe('something');\n      });\n    });\n  });\n});",
+          "options": [
+            {
+              "max": 3
+            }
+          ],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom.describe('foo', () => {\n  custom.describe.only('bar', () => {\n    custom.describe.skip('baz', () => {\n      custom('something', async () => {\n        expect('something').toBe('something');\n      });\n    });\n  });\n});",
+          "options": [
+            {
+              "max": 3
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom('foo', function () {\n  expect(true).toBe(true);\n});",
+          "options": [
+            {
+              "max": 0
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom('foo', function () {\n  expect(true).toBe(true);\n});",
+          "options": [
+            {
+              "max": 0
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test.describe('foo', function() {\n  test.describe('bar', function () {\n    test.describe('baz', function () {\n      test.describe('qux', function () {\n        test.describe('quxx', function () {\n          test.describe('over limit', function () {\n            test('should get something', () => {\n              expect(getSomething()).toBe('Something');\n            });\n          });\n        });\n      });\n    });\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 23
+              }
+            }
+          ]
+        },
+        {
+          "code": "describe('foo', function() {\n  describe('bar', function () {\n    describe('baz', function () {\n      describe('qux', function () {\n        describe('quxx', function () {\n          describe('over limit', function () {\n            test('should get something', () => {\n              expect(getSomething()).toBe('Something');\n            });\n          });\n        });\n      });\n    });\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 18
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe('foo', () => {\n  test.describe('bar', () => {\n    test[\"describe\"]('baz', () => {\n      test.describe('baz1', () => {\n        test.describe('baz2', () => {\n          test[`describe`]('baz3', () => {\n            test('should get something', () => {\n              expect(getSomething()).toBe('Something');\n            });\n          });\n\n          test.describe('baz4', () => {\n            it('should get something', () => {\n              expect(getSomething()).toBe('Something');\n            });\n          });\n        });\n      });\n    });\n\n    test.describe('qux', function () {\n      test('should get something', () => {\n        expect(getSomething()).toBe('Something');\n      });\n    });\n  })\n});",
+          "options": [
+            {
+              "max": 5
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 26
+              }
+            },
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 12,
+                "startColumn": 10,
+                "endLine": 12,
+                "endColumn": 23
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe.only('foo', function() {\n  test.describe('bar', function() {\n    test.describe('baz', function() {\n      test.describe('qux', function() {\n        test.describe('quux', function() {\n          test.describe.only('quuz', function() { });\n        });\n      });\n    });\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 28
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe.serial.only('foo', function() {\n  test.describe('bar', function() {\n    test.describe('baz', function() {\n      test.describe('qux', function() {\n        test.describe('quux', function() {\n          test.describe('quuz', function() { });\n        });\n      });\n    });\n  });\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 23
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe('qux', () => {\n  test('should get something', () => {\n    expect(getSomething()).toBe('Something');\n  });\n});",
+          "options": [
+            {
+              "max": 0
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 13
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe('foo', () => {\n  test.describe('bar', () => {\n    test.describe('baz', () => {\n      test(\"test1\", () => {\n        expect(true).toBe(true);\n      });\n      test(\"test2\", () => {\n        expect(true).toBe(true);\n      });\n    });\n  });\n});",
+          "options": [
+            {
+              "max": 2
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 3,
+                "startColumn": 4,
+                "endLine": 3,
+                "endColumn": 17
+              }
+            }
+          ]
+        },
+        {
+          "code": "it.describe('foo', function() {\n  it.describe('bar', function () {\n    it.describe('baz', function () {\n      it.describe('qux', function () {\n        it.describe('quxx', function () {\n          it.describe('over limit', function () {\n            it('should get something', () => {\n              expect(getSomething()).toBe('Something');\n            });\n          });\n        });\n      });\n    });\n  });\n});",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 21
+              }
+            }
+          ]
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom.describe('qux', () => {\n  custom('should get something', () => {\n    expect(getSomething()).toBe('Something');\n  });\n});",
+          "options": [
+            {
+              "max": 0
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 2,
+                "startColumn": 0,
+                "endLine": 2,
+                "endColumn": 15
+              }
+            }
+          ]
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom.describe('qux', () => {\n  custom('should get something', () => {\n    expect(getSomething()).toBe('Something');\n  });\n});",
+          "options": [
+            {
+              "max": 0
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "exceededMaxDepth",
+              "data": {},
+              "loc": {
+                "startLine": 2,
+                "startColumn": 0,
+                "endLine": 2,
+                "endColumn": 15
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rule": "require-top-level-describe",
+      "valid": [
+        {
+          "code": "foo()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.info()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.use({ locale: \"en-US\" })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.skip(({ browserName }) => browserName === \"Chrome\");",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.skip();",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.skip(true);",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.skip(browserName === \"Chrome\", \"This feature is skipped on Chrome\")",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.slow(({ browserName }) => browserName === \"Chrome\");",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.slow();",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.slow(browserName === \"webkit\", \"This feature is slow on Mac\")",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.configure({ mode: \"parallel\" })",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe(\"suite\", () => { test(\"foo\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.only(\"suite\", () => { test.beforeAll(\"my beforeAll\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.parallel(\"suite\", () => { test.beforeEach(\"my beforeAll\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.serial(\"suite\", () => { test.afterAll(\"my afterAll\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe.parallel.fixme(\"suite\", () => { test.afterEach(\"my afterEach\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe(\"suite\", () => {\n  test.beforeEach(\"a\", () => {});\n  test.describe(\"b\", () => {});\n  test(\"c\", () => {})\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe(\"suite\", () => {\n  test(\"foo\", () => {})\n  test.describe(\"another suite\", () => {});\n  test(\"my other test\", () => {})\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe('one', () => {});\ntest.describe('two', () => {});\ntest.describe('three', () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe(\"suite\", () => {\n  test(\"foo\", { tag: [\"@slow\"] }, () => {})\n  test.describe(\"another suite\", { tag: [\"@slow\"] }, () => {});\n  test(\"my other test\", () => {})\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "test.describe('one', () => {\n  test.describe('two', () => {});\n  test.describe('three', () => {});\n});",
+          "options": [
+            {
+              "maxTopLevelDescribes": 1
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "it.info()",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom.describe(\"suite\", () => { custom(\"foo\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom.describe(\"suite\", () => { custom(\"foo\") });",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": []
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test.beforeAll(() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 14
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.beforeEach(() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 15
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.afterAll(() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 13
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.afterEach(() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 14
+              }
+            }
+          ]
+        },
+        {
+          "code": "test[\"afterEach\"](() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 17
+              }
+            }
+          ]
+        },
+        {
+          "code": "test[`afterEach`](() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 17
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe(\"suite\", () => {});\ntest.afterAll(() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 2,
+                "startColumn": 0,
+                "endLine": 2,
+                "endColumn": 13
+              }
+            }
+          ]
+        },
+        {
+          "code": "test(\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 4
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.skip(\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 9
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.fixme(\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 10
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.only(\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 9
+              }
+            }
+          ]
+        },
+        {
+          "code": "test[\"only\"](\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 12
+              }
+            }
+          ]
+        },
+        {
+          "code": "test[`only`](\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 12
+              }
+            }
+          ]
+        },
+        {
+          "code": "test(\"foo\", { tag: [\"@fast\"] }, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 4
+              }
+            }
+          ]
+        },
+        {
+          "code": "test(\"foo\", () => {})\ntest.describe(\"suite\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 4
+              }
+            }
+          ]
+        },
+        {
+          "code": "test(\"foo\", () => {})\ntest.describe(\"suite\", () => {\n  test(\"bar\", () => {})\n});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 4
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe('one', () => {});\ntest.describe.only('two', () => {});\ntest.describe.parallel('three', () => {});",
+          "options": [
+            {
+              "maxTopLevelDescribes": 2
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "tooManyDescribes",
+              "data": {
+                "amount": 2,
+                "s": "s"
+              },
+              "loc": {
+                "startLine": 3,
+                "startColumn": 0,
+                "endLine": 3,
+                "endColumn": 22
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe('one', () => {\n  test.describe('one (nested)', () => {});\n  test.describe('two (nested)', () => {});\n});\n\ntest[\"describe\"].only('two', () => {\n  test.describe('one (nested)', () => {});\n  test.describe.serial.only('two (nested)', () => {});\n  test.describe.fixme('three (nested)', () => {});\n});\n\ntest[`describe`][`fixme`]('three', () => {\n  test.describe('one (nested)', () => {});\n  test.describe.serial('two (nested)', () => {});\n  test.describe.parallel('three (nested)', () => {});\n});",
+          "options": [
+            {
+              "maxTopLevelDescribes": 2
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "tooManyDescribes",
+              "data": {
+                "amount": 2,
+                "s": "s"
+              },
+              "loc": {
+                "startLine": 12,
+                "startColumn": 0,
+                "endLine": 12,
+                "endColumn": 25
+              }
+            }
+          ]
+        },
+        {
+          "code": "test.describe('one', () => {});\ntest.describe.fixme.only('two', () => {});\ntest.describe.fixme('three', () => {});",
+          "options": [
+            {
+              "maxTopLevelDescribes": 1
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "tooManyDescribes",
+              "data": {
+                "amount": 1,
+                "s": ""
+              },
+              "loc": {
+                "startLine": 2,
+                "startColumn": 0,
+                "endLine": 2,
+                "endColumn": 24
+              }
+            },
+            {
+              "messageId": "tooManyDescribes",
+              "data": {
+                "amount": 1,
+                "s": ""
+              },
+              "loc": {
+                "startLine": 3,
+                "startColumn": 0,
+                "endLine": 3,
+                "endColumn": 19
+              }
+            }
+          ]
+        },
+        {
+          "code": "it.beforeAll(() => {})",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 1,
+                "startColumn": 0,
+                "endLine": 1,
+                "endColumn": 12
+              }
+            }
+          ]
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom.beforeAll(() => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedHook",
+              "data": {},
+              "loc": {
+                "startLine": 2,
+                "startColumn": 0,
+                "endLine": 2,
+                "endColumn": 16
+              }
+            }
+          ]
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom(\"foo\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedTest",
+              "data": {},
+              "loc": {
+                "startLine": 2,
+                "startColumn": 0,
+                "endLine": 2,
+                "endColumn": 6
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/npm/playwright/test/plugin.test.mjs
+++ b/npm/playwright/test/plugin.test.mjs
@@ -78,8 +78,12 @@ const invalidCases = [
   [
     'max-expects',
     'test("x", () => { expect(a).toBe(1); expect(b).toBe(2); expect(c).toBe(3); });\n',
+    [{ max: 2 }],
   ],
-  ['max-nested-describe', 'test.describe("outer", () => { test.describe("inner", () => {}); });\n'],
+  [
+    'max-nested-describe',
+    'test.describe("1", () => { test.describe("2", () => { test.describe("3", () => { test.describe("4", () => { test.describe("5", () => { test.describe("6", () => {}); }); }); }); }); });\n',
+  ],
   ['missing-playwright-await', 'test("x", async ({ page }) => { page.click("button"); });\n'],
   ['no-commented-out-tests', '// test("commented", () => {});\n'],
   ['no-conditional-expect', 'test("x", () => { if (ready) { expect(value).toBe(1); } });\n'],
@@ -148,6 +152,12 @@ const expectedRestrictedMessages = {
   'valid-test-tags': 'Tag must start with @',
   'valid-title': '{{ functionName }} should not have an empty title',
 };
+const expectedThresholdMessages = {
+  'max-expects': 'Too many assertion calls ({{ count }}) - maximum allowed is {{ max }}',
+  'max-nested-describe':
+    'Maximum describe call depth exceeded ({{ depth }}). Maximum allowed is {{ max }}.',
+  'require-top-level-describe': 'All test cases must be wrapped in a describe block.',
+};
 
 function runRule(ruleName, sourceText, options = [], filename = 'fixture.spec.ts') {
   const reports = [];
@@ -201,7 +211,9 @@ describe('playwright plugin adapter', () => {
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      expectedRestrictedMessages[ruleName] ?? 'Unexpected Playwright pattern.',
+      expectedRestrictedMessages[ruleName] ??
+        expectedThresholdMessages[ruleName] ??
+        'Unexpected Playwright pattern.',
     );
   });
 

--- a/npm/playwright/test/thresholds-upstream.test.mjs
+++ b/npm/playwright/test/thresholds-upstream.test.mjs
@@ -1,0 +1,354 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanPlaywright } from '../api.js';
+import plugin from '../index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = dirname(here);
+const workspaceRoot = resolve(packageRoot, '../..');
+const fixture = JSON.parse(readFileSync(join(here, 'fixtures', 'thresholds-v2.10.4.json'), 'utf8'));
+const validCases = fixture.suites.flatMap((suite) =>
+  suite.valid.map((testCase, index) => ({ rule: suite.rule, index, testCase })),
+);
+const invalidCases = fixture.suites.flatMap((suite) =>
+  suite.invalid.map((testCase, index) => ({ rule: suite.rule, index, testCase })),
+);
+
+describe('eslint-plugin-playwright v2.10.4 numeric threshold replay', () => {
+  it('pins the complete authored inventory and exact source hashes', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-playwright',
+      version: '2.10.4',
+      sourceCommit: '894c0ec261763bb1e073b276c70bbf88b4ebad39',
+      license: 'MIT',
+      tool: 'tools/tasks/sync-playwright-threshold-tests.ts',
+      inventory: {
+        suites: 3,
+        valid: 58,
+        invalid: 42,
+        diagnostics: 45,
+      },
+    });
+    expect(fixture.__generated.sourceFiles).toHaveLength(6);
+    expect(Object.values(fixture.__generated.sourceHashes)).toHaveLength(6);
+    expect(
+      Object.values(fixture.__generated.sourceHashes).every((hash) => /^[\da-f]{64}$/u.test(hash)),
+    ).toBe(true);
+  });
+
+  it.each(validCases)(
+    '$rule accepts authored valid case $index in both entry points',
+    ({ rule, testCase }) => {
+      expect(nativeDiagnostics(rule, testCase)).toEqual([]);
+      expect(adapterReports(rule, testCase)).toEqual([]);
+    },
+  );
+
+  it.each(invalidCases)('$rule reproduces authored invalid case $index', ({ rule, testCase }) => {
+    const native = nativeDiagnostics(rule, testCase);
+    const adapter = adapterReports(rule, testCase);
+    expect(native.map(({ messageId }) => messageId)).toEqual(
+      testCase.expectedDiagnostics.map(({ messageId }) => messageId),
+    );
+    expect(adapter).toEqual(
+      native.map(({ messageId, data, loc }) => ({
+        messageId,
+        data,
+        loc: {
+          start: {
+            line: loc.startLine,
+            column: loc.startColumn,
+          },
+          end: {
+            line: loc.endLine,
+            column: loc.endColumn,
+          },
+        },
+      })),
+    );
+    for (const [index, expected] of testCase.expectedDiagnostics.entries()) {
+      if (expected.loc) {
+        expect(native[index].loc).toMatchObject(expected.loc);
+      }
+      for (const [key, value] of Object.entries(expected.data)) {
+        expect(native[index].data[key]).toBe(String(value));
+      }
+      expectThresholdData(rule, native[index]);
+    }
+    expect(
+      adapter.map((report) =>
+        renderMessage(plugin.rules[rule].meta.messages[report.messageId], report.data),
+      ),
+    ).toEqual(
+      native.map((diagnostic) =>
+        renderMessage(plugin.rules[rule].meta.messages[diagnostic.messageId], diagnostic.data),
+      ),
+    );
+  });
+
+  it('exposes the exact upstream messages, descriptions, types, and schemas', () => {
+    expect(plugin.rules['max-expects'].meta).toMatchObject({
+      type: 'suggestion',
+      docs: {
+        description: 'Enforces a maximum number assertion calls in a test body',
+        recommended: false,
+      },
+      messages: {
+        exceededMaxAssertion:
+          'Too many assertion calls ({{ count }}) - maximum allowed is {{ max }}',
+      },
+      schema: [maximumSchema('max', 1, 'integer')],
+    });
+    expect(plugin.rules['max-nested-describe'].meta).toMatchObject({
+      type: 'suggestion',
+      docs: {
+        description: 'Enforces a maximum depth to nested describe calls',
+        recommended: true,
+      },
+      messages: {
+        exceededMaxDepth:
+          'Maximum describe call depth exceeded ({{ depth }}). Maximum allowed is {{ max }}.',
+      },
+      schema: [maximumSchema('max', 0, 'integer')],
+    });
+    expect(plugin.rules['require-top-level-describe'].meta).toMatchObject({
+      type: 'suggestion',
+      docs: {
+        description: 'Require test cases and hooks to be inside a `test.describe` block',
+        recommended: false,
+      },
+      messages: {
+        tooManyDescribes: 'There should not be more than {{amount}} describe{{s}} at the top level',
+        unexpectedHook: 'All hooks must be wrapped in a describe block.',
+        unexpectedTest: 'All test cases must be wrapped in a describe block.',
+      },
+      schema: [maximumSchema('maxTopLevelDescribes', 1, 'number')],
+    });
+  });
+
+  it('rejects malformed direct API threshold values', () => {
+    const source = 'test("case", () => {});';
+    expect(() => scanPlaywright(source, 'fixture.spec.ts', { maxExpects: 0 })).toThrow(
+      'maxExpects must be an integer greater than or equal to 1.',
+    );
+    expect(() => scanPlaywright(source, 'fixture.spec.ts', { maxExpects: 1.5 })).toThrow(
+      'maxExpects must be an integer greater than or equal to 1.',
+    );
+    expect(() => scanPlaywright(source, 'fixture.spec.ts', { maxNestedDescribe: -1 })).toThrow(
+      'maxNestedDescribe must be an integer greater than or equal to 0.',
+    );
+    expect(() =>
+      scanPlaywright(source, 'fixture.spec.ts', { maxTopLevelDescribes: Number.POSITIVE_INFINITY }),
+    ).toThrow('maxTopLevelDescribes must be a finite number greater than or equal to 1.');
+  });
+
+  it('preserves exact UTF-16 locations and complete assertion data', () => {
+    const source = [
+      'const marker = "🧪";',
+      'test("case", () => {',
+      '  expect(1).toBe(1);',
+      '  expect(2).toBe(2);',
+      '});',
+    ].join('\n');
+    expect(
+      scanPlaywright(source, 'fixture.spec.ts', { maxExpects: 1 }).filter(
+        ({ ruleName }) => ruleName === 'max-expects',
+      ),
+    ).toMatchObject([
+      {
+        messageId: 'exceededMaxAssertion',
+        data: { count: '2', max: '1' },
+        loc: {
+          startLine: 4,
+          startColumn: 2,
+          endLine: 4,
+          endColumn: 19,
+        },
+      },
+    ]);
+  });
+
+  it('supports configured, imported, and test.extend aliases in TypeScript sources', () => {
+    const source = [
+      'import { test as scenario, expect as assuming } from "@playwright/test";',
+      'const custom = scenario.extend({});',
+      'it("global", () => { verify(1).toBe(1); verify(2).toBe(2); });',
+      'scenario.describe("outer", () => { custom.describe("inner", () => {}); });',
+      'custom.beforeAll(() => {});',
+      'assuming(1).toBe(1);',
+    ].join('\n');
+    const diagnostics = scanPlaywright(source, 'fixture.spec.ts', {
+      testAliases: ['it'],
+      expectAliases: ['verify'],
+      maxExpects: 1,
+      maxNestedDescribe: 1,
+    });
+    expect(
+      diagnostics
+        .filter(({ ruleName }) =>
+          ['max-expects', 'max-nested-describe', 'require-top-level-describe'].includes(ruleName),
+        )
+        .map(({ ruleName, messageId }) => [ruleName, messageId]),
+    ).toEqual([
+      ['require-top-level-describe', 'unexpectedTest'],
+      ['max-expects', 'exceededMaxAssertion'],
+      ['max-nested-describe', 'exceededMaxDepth'],
+      ['require-top-level-describe', 'unexpectedHook'],
+    ]);
+  });
+
+  it('is inert on malformed input and keeps rule selection isolated', () => {
+    expect(scanPlaywright('test("broken', 'fixture.spec.ts', { maxExpects: 1 })).toEqual([]);
+    expect(
+      runRule(
+        'max-nested-describe',
+        'test("top", () => { expect(1).toBe(1); expect(2).toBe(2); });',
+        [{ max: 0 }],
+      ),
+    ).toEqual([]);
+  });
+
+  it('runs all three rules through real Oxlint on TypeScript', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-playwright-thresholds-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.spec.ts'),
+        [
+          'import { test as scenario, expect as assuming } from "@playwright/test";',
+          'scenario("top", () => { assuming(1).toBe(1); assuming(2).toBe(2); });',
+          'scenario.describe("outer", () => { scenario.describe("inner", () => {}); });',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [{ name: 'playwright', specifier: join(packageRoot, 'index.js') }],
+          rules: {
+            'playwright/max-expects': ['error', { max: 1 }],
+            'playwright/max-nested-describe': ['error', { max: 1 }],
+            'playwright/require-top-level-describe': 'error',
+          },
+        }),
+      );
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.spec.ts'],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics.map(({ code, message }) => [code, message])).toEqual([
+        ['playwright(max-expects)', 'Too many assertion calls (2) - maximum allowed is 1'],
+        [
+          'playwright(max-nested-describe)',
+          'Maximum describe call depth exceeded (2). Maximum allowed is 1.',
+        ],
+        [
+          'playwright(require-top-level-describe)',
+          'All test cases must be wrapped in a describe block.',
+        ],
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function nativeDiagnostics(rule, testCase) {
+  return scanPlaywright(testCase.code, 'fixture.spec.ts', scanOptions(rule, testCase)).filter(
+    ({ ruleName }) => ruleName === rule,
+  );
+}
+
+function adapterReports(rule, testCase) {
+  return runRule(rule, testCase.code, testCase.options, testCase.settings);
+}
+
+function runRule(ruleName, sourceText, options = [], settings = null) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename: 'fixture.spec.ts',
+    options,
+    settings: settings ?? {},
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function scanOptions(rule, testCase) {
+  const configured = testCase.options[0] ?? {};
+  const globalAliases = testCase.settings?.playwright?.globalAliases ?? {};
+  return {
+    ...(rule === 'max-expects' ? { maxExpects: configured.max } : {}),
+    ...(rule === 'max-nested-describe' ? { maxNestedDescribe: configured.max } : {}),
+    ...(rule === 'require-top-level-describe'
+      ? { maxTopLevelDescribes: configured.maxTopLevelDescribes }
+      : {}),
+    ...(Array.isArray(globalAliases.expect) ? { expectAliases: globalAliases.expect } : {}),
+    ...(Array.isArray(globalAliases.test) ? { testAliases: globalAliases.test } : {}),
+  };
+}
+
+function expectThresholdData(rule, diagnostic) {
+  if (rule === 'max-expects') {
+    expect(diagnostic.data).toMatchObject({
+      count: expect.stringMatching(/^\d+$/u),
+      max: expect.stringMatching(/^\d+$/u),
+    });
+  } else if (rule === 'max-nested-describe') {
+    expect(diagnostic.data).toMatchObject({
+      depth: expect.stringMatching(/^\d+$/u),
+      max: expect.stringMatching(/^\d+$/u),
+    });
+  } else if (diagnostic.messageId === 'tooManyDescribes') {
+    expect(diagnostic.data).toMatchObject({
+      amount: expect.stringMatching(/^\d+(?:\.\d+)?$/u),
+      s: expect.stringMatching(/^s?$/u),
+    });
+  }
+}
+
+function maximumSchema(property, minimum, type) {
+  return {
+    additionalProperties: false,
+    properties: {
+      [property]: { minimum, type },
+    },
+    type: 'object',
+  };
+}
+
+function renderMessage(template, data) {
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/gu, (_match, key) => data?.[key] ?? '');
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+  return candidates[candidates.length - 1];
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:playwright:patterns": "node tools/tasks/sync-playwright-pattern-tests.ts",
+    "port:tests:playwright:thresholds": "node tools/tasks/sync-playwright-threshold-tests.ts",
     "port:tests:regexp": "node tools/tasks/sync-regexp-tests.ts",
     "port:tests:security": "node tools/tasks/sync-eslint-security-tests.ts",
     "port:tests:simple-import-sort": "node tools/tasks/sync-simple-import-sort-tests.ts",

--- a/tools/tasks/sync-playwright-threshold-tests.ts
+++ b/tools/tasks/sync-playwright-threshold-tests.ts
@@ -1,0 +1,214 @@
+// Captures every authored eslint-plugin-playwright v2.10.4 RuleTester case for
+// the three numeric threshold rules from the exact vendored commit.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type RawCase =
+  | string
+  | {
+      code: string;
+      errors?: RawError[];
+      options?: unknown[];
+      settings?: unknown;
+    };
+type RawError = {
+  column?: number;
+  data?: Record<string, unknown>;
+  endColumn?: number;
+  endLine?: number;
+  line?: number;
+  messageId?: string;
+};
+type CapturedSuite = {
+  invalid: RawCase[];
+  valid: RawCase[];
+};
+type Manifest = {
+  plugins: Array<{
+    baselineVersion: string;
+    id: string;
+    license: string;
+    pinnedRef?: string;
+    submodule: string;
+  }>;
+};
+
+const ROOT = process.cwd();
+const VERSION = '2.10.4';
+const PINNED_COMMIT = '894c0ec261763bb1e073b276c70bbf88b4ebad39';
+const RULES = ['max-expects', 'max-nested-describe', 'require-top-level-describe'] as const;
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-playwright');
+if (!plugin) throw new Error('eslint-plugin-playwright is not registered');
+if (plugin.baselineVersion !== VERSION || plugin.pinnedRef !== `v${VERSION}`) {
+  throw new Error(`Expected eslint-plugin-playwright v${VERSION}`);
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Run \`git submodule update --init ${plugin.submodule}\` first.`);
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}.`);
+}
+
+const sourceFiles = RULES.flatMap((rule) => [`src/rules/${rule}.ts`, `src/rules/${rule}.test.ts`]);
+const sourceHashes = Object.fromEntries(
+  sourceFiles.map((sourceFile) => [
+    sourceFile,
+    createHash('sha256').update(upstreamSource(sourceFile)).digest('hex'),
+  ]),
+);
+const suites = RULES.map((rule) => {
+  const captured = captureSuite(rule, upstreamSource(`src/rules/${rule}.test.ts`));
+  return {
+    rule,
+    valid: captured.valid.map((testCase, index) =>
+      normalizeCase(testCase, false, `${rule} valid ${index}`),
+    ),
+    invalid: captured.invalid.map((testCase, index) =>
+      normalizeCase(testCase, true, `${rule} invalid ${index}`),
+    ),
+  };
+});
+const inventory = {
+  suites: suites.length,
+  valid: suites.reduce((total, suite) => total + suite.valid.length, 0),
+  invalid: suites.reduce((total, suite) => total + suite.invalid.length, 0),
+  diagnostics: suites.reduce(
+    (total, suite) =>
+      total +
+      suite.invalid.reduce(
+        (suiteTotal, testCase) => suiteTotal + testCase.expectedDiagnostics.length,
+        0,
+      ),
+    0,
+  ),
+};
+const fixture = {
+  __generated: {
+    source: 'eslint-plugin-playwright',
+    version: VERSION,
+    sourceCommit: PINNED_COMMIT,
+    license: plugin.license,
+    tool: 'tools/tasks/sync-playwright-threshold-tests.ts',
+    sourceFiles,
+    sourceHashes,
+    inventory,
+  },
+  suites,
+};
+
+const outputDirectory = join(ROOT, 'npm', 'playwright', 'test', 'fixtures');
+mkdirSync(outputDirectory, { recursive: true });
+const outputPath = join(outputDirectory, `thresholds-v${VERSION}.json`);
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { stdio: 'ignore' });
+console.log(
+  `Captured ${inventory.valid} valid, ${inventory.invalid} invalid, and ` +
+    `${inventory.diagnostics} diagnostics across ${inventory.suites} suites.`,
+);
+
+function captureSuite(rule: string, source: string): CapturedSuite {
+  const executable = source.replace(/^import .*$/gmu, '');
+  const sandbox: {
+    captured?: CapturedSuite;
+    dedent: typeof dedent;
+    rule: object;
+    runRuleTester: (
+      capturedRule: string,
+      capturedRuleModule: unknown,
+      suite: CapturedSuite,
+    ) => void;
+  } = {
+    dedent,
+    rule: {},
+    runRuleTester(capturedRule, _capturedRuleModule, suite) {
+      if (capturedRule !== rule) {
+        throw new Error(`Expected ${rule}, captured ${capturedRule}.`);
+      }
+      sandbox.captured = suite;
+    },
+  };
+  runInNewContext(`"use strict";\n${executable}`, sandbox);
+  if (!sandbox.captured) throw new Error(`Failed to capture ${rule}.`);
+  return sandbox.captured;
+}
+
+function normalizeCase(testCase: RawCase, invalid: boolean, label: string) {
+  const normalized = typeof testCase === 'string' ? { code: testCase } : testCase;
+  if (typeof normalized.code !== 'string') throw new Error(`${label} is missing source code.`);
+  const errors = invalid ? normalized.errors : [];
+  if (invalid && (!Array.isArray(errors) || errors.length === 0)) {
+    throw new Error(`${label} is missing expected errors.`);
+  }
+  return {
+    code: normalized.code,
+    options: normalized.options ?? [],
+    settings: normalized.settings ?? null,
+    expectedDiagnostics: (errors ?? []).map((error, index) =>
+      normalizeError(error, `${label} error ${index}`),
+    ),
+  };
+}
+
+function normalizeError(error: RawError, label: string) {
+  if (typeof error.messageId !== 'string') throw new Error(`${label} is missing messageId.`);
+  const line = error.line ?? 1;
+  return {
+    messageId: error.messageId,
+    data: error.data ?? {},
+    ...(typeof error.column === 'number'
+      ? {
+          loc: {
+            startLine: line,
+            startColumn: error.column - 1,
+            ...(typeof error.endColumn === 'number'
+              ? {
+                  endLine: error.endLine ?? line,
+                  endColumn: error.endColumn - 1,
+                }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function upstreamSource(sourceFile: string): string {
+  return execFileSync('git', ['-C', submodule, 'show', `${PINNED_COMMIT}:${sourceFile}`], {
+    encoding: 'utf8',
+  });
+}
+
+function dedent(
+  strings: TemplateStringsArray | string,
+  ...values: Array<string | number | bigint | boolean | null | undefined>
+): string {
+  const value =
+    typeof strings === 'string'
+      ? strings
+      : strings.reduce(
+          (output, segment, index) => output + segment + String(values[index] ?? ''),
+          '',
+        );
+  const lines = value
+    .replace(/^\n/u, '')
+    .replace(/\n\s*$/u, '')
+    .split('\n');
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^\s*/u)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join('\n');
+}


### PR DESCRIPTION
## Summary

- port `max-expects`, `max-nested-describe`, and `require-top-level-describe` with Oxc AST traversal
- forward numeric options, aliases, diagnostic data, schemas, NAPI/API types, playground data, and docs
- pin the complete upstream threshold inventory: 100 authored cases (58 valid, 42 invalid, 45 diagnostics)

## Validation

- Rust Playwright tests: 15 passed
- playground adapter tests: 4 passed
- targeted API/plugin/upstream tests: 171 passed
- `CARGO_TARGET_DIR=... pnpm verify` (111 JS files; 16,979 passed, 1,159 skipped; Rust workspace, bench compile, security, licenses, status, and publish-readiness all passed)
- post-rebase targeted suite repeated on latest `main`

Refs #420

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->