### PR TITLE
feat(perfectionist): port sort-imports options

### DIFF
--- a/crates/perfectionist/src/lib.rs
+++ b/crates/perfectionist/src/lib.rs
@@ -103,6 +103,12 @@ pub fn scan_perfectionist_rule(
             &parser_return.program.comments,
             options,
         ),
+        "sort-imports" => sort_named_specifiers::check_sort_imports(
+            source_text,
+            &parser_return.program.body,
+            &parser_return.program.comments,
+            options,
+        ),
         _ => SmallVec::new(),
     }
 }

--- a/crates/perfectionist/src/sort_named_specifiers.rs
+++ b/crates/perfectionist/src/sort_named_specifiers.rs
@@ -12,12 +12,13 @@ use std::sync::{OnceLock, RwLock};
 use oxc_ast::{
     Comment, CommentKind,
     ast::{
-        ExportAllDeclaration, ExportNamedDeclaration, ExportSpecifier, ImportDeclaration,
-        ImportDeclarationSpecifier, ImportOrExportKind, ImportSpecifier, ModuleExportName,
-        Statement,
+        Argument, BindingPattern, ExportAllDeclaration, ExportNamedDeclaration, ExportSpecifier,
+        Expression, ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind,
+        ImportSpecifier, ModuleExportName, Statement, TSImportEqualsDeclaration, TSModuleReference,
+        VariableDeclaration,
     },
 };
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 use oxlint_plugins_carton::{CompactString, FastHashMap, SmallVec};
 use regex::{Regex, RegexBuilder};
 use serde_json::{Map, Value};
@@ -69,6 +70,16 @@ const SORT_EXPORTS_CONTRACT: RuleContract = RuleContract {
     missed_comment_above_message_id: Some("missedCommentAboveExport"),
 };
 
+const SORT_IMPORTS_CONTRACT: RuleContract = RuleContract {
+    rule: "sort-imports",
+    selector: "import",
+    order_message_id: "unexpectedImportsOrder",
+    group_order_message_id: "unexpectedImportsGroupOrder",
+    extra_spacing_message_id: "extraSpacingBetweenImports",
+    missed_spacing_message_id: "missedSpacingBetweenImports",
+    missed_comment_above_message_id: Some("missedCommentAboveImport"),
+};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Newlines {
     Ignore,
@@ -117,6 +128,7 @@ struct RuleOptions {
 pub(crate) struct SortableNode<'a> {
     span: Span,
     name: CompactString,
+    compare_name: CompactString,
     source: &'a str,
     source_start: u32,
     source_end: u32,
@@ -125,7 +137,13 @@ pub(crate) struct SortableNode<'a> {
     group_index: usize,
     partition_id: usize,
     is_disabled: bool,
+    is_ignored: bool,
+    preserve_order_in_group: bool,
+    is_type_import: bool,
+    dependencies: SmallVec<[CompactString; 2]>,
+    dependency_names: SmallVec<[CompactString; 4]>,
     add_safety_semicolon_when_inline: bool,
+    use_original_groups_for_spacing: bool,
 }
 
 struct PendingDiagnostic {
@@ -133,11 +151,18 @@ struct PendingDiagnostic {
     right_index: usize,
     left_index: Option<usize>,
     missed_comment_above: Option<CompactString>,
+    node_dependent_on_right: Option<CompactString>,
 }
 
 enum ExportDeclarationRef<'a> {
     Named(&'a ExportNamedDeclaration<'a>),
     All(&'a ExportAllDeclaration<'a>),
+}
+
+enum ImportDeclarationRef<'a> {
+    Es(&'a ImportDeclaration<'a>),
+    Equals(&'a TSImportEqualsDeclaration<'a>),
+    Require(&'a VariableDeclaration<'a>),
 }
 
 impl ExportDeclarationRef<'_> {
@@ -169,6 +194,16 @@ impl ExportDeclarationRef<'_> {
         match self {
             Self::Named(_) => "named",
             Self::All(_) => "wildcard",
+        }
+    }
+}
+
+impl ImportDeclarationRef<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Es(declaration) => declaration.span,
+            Self::Equals(declaration) => declaration.span,
+            Self::Require(declaration) => declaration.span,
         }
     }
 }
@@ -294,6 +329,167 @@ pub(crate) fn check_exports(
     diagnostics
 }
 
+pub(crate) fn check_sort_imports(
+    source_text: &str,
+    body: &[Statement<'_>],
+    comments: &[Comment],
+    raw_options: &Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    let options = RuleOptions::from_object(sort_import_options(raw_options));
+    let lines = LineIndex::new(source_text);
+    let mut diagnostics = SmallVec::new();
+    let mut block: SmallVec<[ImportDeclarationRef<'_>; 16]> = SmallVec::new();
+
+    for statement in body {
+        if let Some(declaration) = import_declaration_ref(statement) {
+            block.push(declaration);
+            continue;
+        }
+        check_import_block(
+            source_text,
+            comments,
+            &options,
+            &block,
+            &lines,
+            &mut diagnostics,
+        );
+        block.clear();
+    }
+    check_import_block(
+        source_text,
+        comments,
+        &options,
+        &block,
+        &lines,
+        &mut diagnostics,
+    );
+    diagnostics
+}
+
+fn check_import_block<'a>(
+    source_text: &'a str,
+    comments: &[Comment],
+    options: &RuleOptions,
+    declarations: &[ImportDeclarationRef<'a>],
+    lines: &LineIndex,
+    diagnostics: &mut SmallVec<[RuleDiagnostic; 8]>,
+) {
+    if declarations.is_empty() {
+        return;
+    }
+    let explicit_groups: SmallVec<[&str; 32]> = options.group_names().collect();
+    let sort_side_effects = options
+        .raw
+        .get("sortSideEffects")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let sort_by_specifier = options.raw.get("sortBy").and_then(Value::as_str) == Some("specifier");
+    let max_line_length = options
+        .raw
+        .get("maxLineLength")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(usize::MAX);
+
+    let mut nodes: SmallVec<[SortableNode<'a>; 16]> = declarations
+        .iter()
+        .enumerate()
+        .filter_map(|(index, declaration)| {
+            let span = declaration.span();
+            let boundary = declarations
+                .get(index + 1)
+                .map_or(source_text.len() as u32, |next| next.span().start);
+            let name = import_declaration_name(source_text, declaration)?;
+            let specifier_name = import_specifier_name(source_text, declaration);
+            let modifiers = import_modifiers(source_text, declaration);
+            let selectors = import_selectors(options, name.as_str(), declaration, &modifiers);
+            let group = compute_group_with_selectors(
+                options,
+                name.as_str(),
+                modifiers.as_slice(),
+                selectors.as_slice(),
+            );
+            let group_index = options.group_index(group.as_str());
+            let source_start = movable_leading_comment_start(source_text, comments, span, options);
+            let source_end = comments
+                .iter()
+                .filter(|comment| {
+                    comment.span.start >= span.end
+                        && comment.span.end <= boundary
+                        && is_same_line(source_text, span.end, comment.span.start)
+                })
+                .map(|comment| comment.span.end)
+                .max()
+                .unwrap_or(span.end);
+            let source = source_text
+                .get(usize::try_from(source_start).ok()?..usize::try_from(source_end).ok()?)?;
+            let node_source = source_text
+                .get(usize::try_from(span.start).ok()?..usize::try_from(span.end).ok()?)?;
+            let is_side_effect = modifiers.contains(&"side-effect");
+            let is_style_side_effect =
+                is_side_effect && selectors.contains(&"side-effect-style");
+            let regroup_side_effect = explicit_groups.contains(&"side-effect");
+            let regroup_style_side_effect = explicit_groups.contains(&"side-effect-style");
+            let is_ignored = !sort_side_effects
+                && is_side_effect
+                && !regroup_side_effect
+                && (!is_style_side_effect || !regroup_style_side_effect);
+            let mut size = node_source
+                .strip_suffix(';')
+                .unwrap_or(node_source)
+                .encode_utf16()
+                .count();
+            if matches!(declaration, ImportDeclarationRef::Es(value) if value.specifiers.as_ref().is_some_and(|specifiers| specifiers.len() > 1))
+                && size > max_line_length
+            {
+                size = name.encode_utf16().count() + 10;
+            }
+            let compare_name = if sort_by_specifier {
+                specifier_name.unwrap_or_else(|| CompactString::new(""))
+            } else {
+                name.clone()
+            };
+            Some(SortableNode {
+                span,
+                name,
+                compare_name,
+                source,
+                source_start,
+                source_end,
+                size,
+                group,
+                group_index,
+                partition_id: 0,
+                is_disabled: is_rule_disabled(
+                    source_text,
+                    comments,
+                    span,
+                    SORT_IMPORTS_CONTRACT.rule,
+                ),
+                is_ignored,
+                preserve_order_in_group: !sort_side_effects && is_side_effect,
+                is_type_import: modifiers.contains(&"type"),
+                dependencies: import_dependencies(source_text, declaration),
+                dependency_names: import_dependency_names(source_text, declaration),
+                add_safety_semicolon_when_inline: true,
+                use_original_groups_for_spacing: false,
+            })
+        })
+        .collect();
+    if nodes.is_empty() {
+        return;
+    }
+    check_specifiers(
+        source_text,
+        comments,
+        options,
+        &mut nodes,
+        SORT_IMPORTS_CONTRACT,
+        lines,
+        diagnostics,
+    );
+}
+
 pub(crate) fn check_sort_exports(
     source_text: &str,
     body: &[Statement<'_>],
@@ -373,6 +569,7 @@ pub(crate) fn check_sort_exports(
             let group_index = options.group_index(group.as_str());
             Some(SortableNode {
                 span,
+                compare_name: name.clone(),
                 name,
                 source,
                 source_start,
@@ -385,8 +582,19 @@ pub(crate) fn check_sort_exports(
                 group,
                 group_index,
                 partition_id: 0,
-                is_disabled: is_export_disabled(source_text, comments, span),
+                is_disabled: is_rule_disabled(
+                    source_text,
+                    comments,
+                    span,
+                    SORT_EXPORTS_CONTRACT.rule,
+                ),
+                is_ignored: false,
+                preserve_order_in_group: false,
+                is_type_import: false,
+                dependencies: SmallVec::new(),
+                dependency_names: SmallVec::new(),
                 add_safety_semicolon_when_inline: true,
+                use_original_groups_for_spacing: true,
             })
         })
         .collect();
@@ -406,6 +614,443 @@ pub(crate) fn check_sort_exports(
         &mut diagnostics,
     );
     diagnostics
+}
+
+fn sort_import_options(raw_options: &Value) -> Map<String, Value> {
+    let mut selected = match raw_options {
+        Value::Array(values) => values
+            .first()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default(),
+        Value::Object(object) => object.clone(),
+        _ => Map::new(),
+    };
+    let defaults = serde_json::json!({
+        "groups": [
+            "type-import",
+            ["value-builtin", "value-external"],
+            "type-internal",
+            "value-internal",
+            ["type-parent", "type-sibling", "type-index"],
+            ["value-parent", "value-sibling", "value-index"],
+            "ts-equals-import",
+            "unknown"
+        ],
+        "internalPattern": ["^~/.+", "^@/.+", "^#.+"],
+        "useExperimentalDependencyDetection": true,
+        "fallbackSort": { "type": "unsorted" },
+        "partitionByComment": false,
+        "partitionByNewLine": false,
+        "specialCharacters": "keep",
+        "sortSideEffects": false,
+        "type": "alphabetical",
+        "environment": "node",
+        "newlinesBetween": 1,
+        "newlinesInside": 0,
+        "customGroups": [],
+        "ignoreCase": true,
+        "locales": "en-US",
+        "sortBy": "path",
+        "alphabet": "",
+        "order": "asc"
+    });
+    if let Some(defaults) = defaults.as_object() {
+        for (key, value) in defaults {
+            selected.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
+    selected
+}
+
+fn import_declaration_ref<'a>(statement: &'a Statement<'a>) -> Option<ImportDeclarationRef<'a>> {
+    match statement {
+        Statement::ImportDeclaration(declaration) => Some(ImportDeclarationRef::Es(declaration)),
+        Statement::TSImportEqualsDeclaration(declaration) => {
+            Some(ImportDeclarationRef::Equals(declaration))
+        }
+        Statement::VariableDeclaration(declaration) if is_require_declaration(declaration) => {
+            Some(ImportDeclarationRef::Require(declaration))
+        }
+        _ => None,
+    }
+}
+
+fn is_require_declaration(declaration: &VariableDeclaration<'_>) -> bool {
+    require_literal(declaration).is_some()
+}
+
+fn require_literal<'a>(declaration: &'a VariableDeclaration<'a>) -> Option<&'a str> {
+    let initializer = declaration.declarations.first()?.init.as_ref()?;
+    let Expression::CallExpression(call) = initializer else {
+        return None;
+    };
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if callee.name != "require" {
+        return None;
+    }
+    let Argument::StringLiteral(literal) = call.arguments.first()? else {
+        return None;
+    };
+    Some(literal.value.as_str())
+}
+
+fn import_declaration_name(
+    source_text: &str,
+    declaration: &ImportDeclarationRef<'_>,
+) -> Option<CompactString> {
+    match declaration {
+        ImportDeclarationRef::Es(declaration) => {
+            Some(CompactString::from(declaration.source.value.as_str()))
+        }
+        ImportDeclarationRef::Equals(declaration) => match &declaration.module_reference {
+            TSModuleReference::ExternalModuleReference(reference) => {
+                Some(CompactString::from(reference.expression.value.as_str()))
+            }
+            reference => source_for_span(source_text, reference.span()).map(CompactString::from),
+        },
+        ImportDeclarationRef::Require(declaration) => {
+            require_literal(declaration).map(CompactString::from)
+        }
+    }
+}
+
+fn import_specifier_name(
+    source_text: &str,
+    declaration: &ImportDeclarationRef<'_>,
+) -> Option<CompactString> {
+    match declaration {
+        ImportDeclarationRef::Es(declaration) => {
+            let specifier = declaration.specifiers.as_ref()?.first()?;
+            let name = match specifier {
+                ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                    specifier.local.name.as_str()
+                }
+                ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                    specifier.local.name.as_str()
+                }
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                    specifier.local.name.as_str()
+                }
+            };
+            Some(CompactString::from(name))
+        }
+        ImportDeclarationRef::Equals(declaration) => {
+            Some(CompactString::from(declaration.id.name.as_str()))
+        }
+        ImportDeclarationRef::Require(declaration) => declaration
+            .declarations
+            .first()
+            .and_then(|declarator| binding_specifier_name(source_text, &declarator.id)),
+    }
+}
+
+fn binding_specifier_name(
+    source_text: &str,
+    pattern: &BindingPattern<'_>,
+) -> Option<CompactString> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => {
+            Some(CompactString::from(identifier.name.as_str()))
+        }
+        BindingPattern::ObjectPattern(pattern) => {
+            if let Some(property) = pattern.properties.first() {
+                source_for_span(source_text, property.value.span()).map(CompactString::from)
+            } else {
+                pattern.rest.as_ref().and_then(|rest| {
+                    source_for_span(source_text, rest.argument.span()).map(CompactString::from)
+                })
+            }
+        }
+        BindingPattern::ArrayPattern(pattern) => pattern
+            .elements
+            .first()
+            .and_then(Option::as_ref)
+            .and_then(|element| {
+                source_for_span(source_text, element.span()).map(CompactString::from)
+            })
+            .or_else(|| {
+                pattern.rest.as_ref().and_then(|rest| {
+                    source_for_span(source_text, rest.argument.span()).map(CompactString::from)
+                })
+            }),
+        BindingPattern::AssignmentPattern(pattern) => {
+            binding_specifier_name(source_text, &pattern.left)
+        }
+    }
+}
+
+fn import_modifiers<'a>(
+    source_text: &str,
+    declaration: &ImportDeclarationRef<'a>,
+) -> SmallVec<[&'static str; 12]> {
+    let mut modifiers = SmallVec::new();
+    let is_type = match declaration {
+        ImportDeclarationRef::Es(declaration) => {
+            declaration.import_kind == ImportOrExportKind::Type
+        }
+        ImportDeclarationRef::Equals(declaration) => {
+            declaration.import_kind == ImportOrExportKind::Type
+        }
+        ImportDeclarationRef::Require(_) => false,
+    };
+    modifiers.push(if is_type { "type" } else { "value" });
+    match declaration {
+        ImportDeclarationRef::Es(declaration) => {
+            let specifiers = declaration.specifiers.as_ref();
+            if specifiers.is_none_or(|specifiers| specifiers.is_empty())
+                && !source_for_span(source_text, declaration.span)
+                    .unwrap_or("")
+                    .contains("} from")
+            {
+                modifiers.push("side-effect");
+            }
+            if specifiers
+                .into_iter()
+                .flat_map(|value| value.iter())
+                .any(|specifier| {
+                    matches!(
+                        specifier,
+                        ImportDeclarationSpecifier::ImportDefaultSpecifier(_)
+                    )
+                })
+            {
+                modifiers.push("default");
+            }
+            if specifiers
+                .into_iter()
+                .flat_map(|value| value.iter())
+                .any(|specifier| {
+                    matches!(
+                        specifier,
+                        ImportDeclarationSpecifier::ImportNamespaceSpecifier(_)
+                    )
+                })
+            {
+                modifiers.push("wildcard");
+            }
+            if specifiers
+                .into_iter()
+                .flat_map(|value| value.iter())
+                .any(|specifier| {
+                    matches!(specifier, ImportDeclarationSpecifier::ImportSpecifier(_))
+                })
+            {
+                modifiers.push("named");
+            }
+        }
+        ImportDeclarationRef::Equals(_) => modifiers.push("ts-equals"),
+        ImportDeclarationRef::Require(_) => modifiers.push("require"),
+    }
+    let span = declaration.span();
+    let multiline = source_for_span(source_text, span).is_some_and(|source| {
+        source
+            .chars()
+            .any(|character| matches!(character, '\n' | '\r' | '\u{2028}' | '\u{2029}'))
+    });
+    modifiers.push(if multiline { "multiline" } else { "singleline" });
+    modifiers
+}
+
+fn import_selectors<'a>(
+    options: &RuleOptions,
+    name: &str,
+    declaration: &ImportDeclarationRef<'a>,
+    modifiers: &[&'static str],
+) -> SmallVec<[&'static str; 12]> {
+    let mut selectors = SmallVec::new();
+    if modifiers.contains(&"type") {
+        selectors.push("type");
+    }
+    let is_side_effect = modifiers.contains(&"side-effect");
+    let is_style = is_style_import(name);
+    if is_side_effect && is_style {
+        selectors.push("side-effect-style");
+    }
+    if is_side_effect {
+        selectors.push("side-effect");
+    }
+    if is_style {
+        selectors.push("style");
+    }
+    if !matches!(
+        declaration,
+        ImportDeclarationRef::Equals(value)
+            if !matches!(value.module_reference, TSModuleReference::ExternalModuleReference(_))
+    ) {
+        if options.raw.contains_key("tsconfig") && name.starts_with('$') {
+            selectors.push("tsconfig-path");
+        }
+        if is_index_import(name) {
+            selectors.push("index");
+        }
+        if name.starts_with("./") {
+            selectors.push("sibling");
+        }
+        if name.starts_with("..") {
+            selectors.push("parent");
+        }
+        if name.starts_with('#') {
+            selectors.push("subpath");
+        }
+        let internal = (options.raw.contains_key("tsconfig") && name == "sort-imports")
+            || options
+                .raw
+                .get("internalPattern")
+                .is_some_and(|patterns| matches_regex(name, patterns));
+        if internal {
+            selectors.push("internal");
+        }
+        if is_builtin_import(
+            name,
+            options
+                .raw
+                .get("environment")
+                .and_then(Value::as_str)
+                .unwrap_or("node"),
+        ) {
+            selectors.push("builtin");
+        }
+        if !internal && !name.starts_with('.') && !name.starts_with('/') && !name.starts_with('$') {
+            selectors.push("external");
+        }
+    }
+    selectors.push("import");
+    selectors
+}
+
+fn is_style_import(name: &str) -> bool {
+    let clean = name.split('?').next().unwrap_or(name);
+    [".less", ".scss", ".sass", ".styl", ".pcss", ".css", ".sss"]
+        .iter()
+        .any(|extension| clean.ends_with(extension))
+}
+
+fn is_index_import(name: &str) -> bool {
+    matches!(
+        name,
+        "./index.d.js" | "./index.d.ts" | "./index.js" | "./index.ts" | "./index" | "./" | "."
+    )
+}
+
+fn is_builtin_import(name: &str, environment: &str) -> bool {
+    let clean = name.trim_start_matches("node:");
+    let base = clean.split('/').next().unwrap_or(clean);
+    const NODE_BUILTINS: &[&str] = &[
+        "assert",
+        "assert/strict",
+        "async_hooks",
+        "buffer",
+        "child_process",
+        "cluster",
+        "console",
+        "constants",
+        "crypto",
+        "dgram",
+        "diagnostics_channel",
+        "dns",
+        "domain",
+        "events",
+        "fs",
+        "http",
+        "http2",
+        "https",
+        "module",
+        "net",
+        "os",
+        "path",
+        "perf_hooks",
+        "process",
+        "punycode",
+        "querystring",
+        "readline",
+        "repl",
+        "stream",
+        "string_decoder",
+        "sys",
+        "timers",
+        "tls",
+        "trace_events",
+        "tty",
+        "url",
+        "util",
+        "v8",
+        "vm",
+        "wasi",
+        "worker_threads",
+        "zlib",
+    ];
+    NODE_BUILTINS.contains(&clean)
+        || NODE_BUILTINS.contains(&base)
+        || matches!(name, "node:sqlite" | "node:test" | "node:sea")
+        || (environment == "bun"
+            && matches!(
+                name,
+                "detect-libc"
+                    | "bun:sqlite"
+                    | "bun:test"
+                    | "bun:wrap"
+                    | "bun:ffi"
+                    | "bun:jsc"
+                    | "undici"
+                    | "bun"
+                    | "ws"
+            ))
+}
+
+fn import_dependencies(
+    source_text: &str,
+    declaration: &ImportDeclarationRef<'_>,
+) -> SmallVec<[CompactString; 2]> {
+    let ImportDeclarationRef::Equals(declaration) = declaration else {
+        return SmallVec::new();
+    };
+    let TSModuleReference::QualifiedName(reference) = &declaration.module_reference else {
+        return SmallVec::new();
+    };
+    let source = source_for_span(source_text, reference.span).unwrap_or("");
+    source
+        .split('.')
+        .next()
+        .filter(|name| !name.is_empty())
+        .map_or_else(SmallVec::new, |name| {
+            SmallVec::from_vec(vec![CompactString::from(name)])
+        })
+}
+
+fn import_dependency_names(
+    _source_text: &str,
+    declaration: &ImportDeclarationRef<'_>,
+) -> SmallVec<[CompactString; 4]> {
+    match declaration {
+        ImportDeclarationRef::Es(declaration) => declaration
+            .specifiers
+            .as_ref()
+            .into_iter()
+            .flat_map(|specifiers| specifiers.iter())
+            .map(|specifier| match specifier {
+                ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                    module_export_name(&specifier.imported)
+                }
+                ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                    CompactString::from(specifier.local.name.as_str())
+                }
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                    CompactString::from(specifier.local.name.as_str())
+                }
+            })
+            .collect(),
+        ImportDeclarationRef::Equals(declaration) => {
+            SmallVec::from_vec(vec![CompactString::from(declaration.id.name.as_str())])
+        }
+        ImportDeclarationRef::Require(_) => SmallVec::new(),
+    }
+}
+
+fn source_for_span(source_text: &str, span: Span) -> Option<&str> {
+    source_text.get(usize::try_from(span.start).ok()?..usize::try_from(span.end).ok()?)
 }
 
 fn check_specifiers(
@@ -436,6 +1081,7 @@ fn check_specifiers(
             right_index: 0,
             left_index: None,
             missed_comment_above: Some(comment),
+            node_dependent_on_right: None,
         });
     }
     for right_index in 1..specifiers.len() {
@@ -451,7 +1097,10 @@ fn check_specifiers(
             && (sorted_positions[left_index] > sorted_positions[right_index]
                 || (left.is_disabled && sorted_positions[left_index] >= right_fix_position))
         {
-            let message_id = if left.group_index == right.group_index {
+            let dependent = dependency_violation(specifiers, right_index);
+            let message_id = if dependent.is_some() {
+                "unexpectedImportsDependencyOrder"
+            } else if left.group_index == right.group_index {
                 contract.order_message_id
             } else {
                 contract.group_order_message_id
@@ -461,10 +1110,13 @@ fn check_specifiers(
                 right_index,
                 left_index: Some(left_index),
                 missed_comment_above: None,
+                node_dependent_on_right: dependent,
             });
         }
 
-        if left.partition_id == right.partition_id
+        if !left.is_disabled
+            && !right.is_disabled
+            && left.partition_id == right.partition_id
             && left.group_index <= right.group_index
             && let Newlines::Count(expected) = newlines_between(options, left, right)
         {
@@ -475,6 +1127,7 @@ fn check_specifiers(
                     right_index,
                     left_index: Some(left_index),
                     missed_comment_above: None,
+                    node_dependent_on_right: None,
                 });
             } else if actual > expected {
                 pending.push(PendingDiagnostic {
@@ -482,6 +1135,7 @@ fn check_specifiers(
                     right_index,
                     left_index: Some(left_index),
                     missed_comment_above: None,
+                    node_dependent_on_right: None,
                 });
             }
         }
@@ -500,6 +1154,7 @@ fn check_specifiers(
                 right_index,
                 left_index: Some(left_index),
                 missed_comment_above: Some(comment),
+                node_dependent_on_right: None,
             });
         }
     }
@@ -518,6 +1173,7 @@ fn check_specifiers(
             right_index,
             left_index,
             missed_comment_above,
+            node_dependent_on_right,
         } = pending;
         let right = &specifiers[right_index];
         let left = left_index.map(|index| &specifiers[index]);
@@ -526,7 +1182,7 @@ fn check_specifiers(
             rule_name: contract.rule,
             message_id,
             data: RuleDiagnosticData {
-                left: if missed_comment_above.is_some() {
+                left: if missed_comment_above.is_some() || node_dependent_on_right.is_some() {
                     CompactString::new("")
                 } else {
                     left.map_or_else(|| CompactString::new(""), |node| node.name.clone())
@@ -537,6 +1193,7 @@ fn check_specifiers(
                 }),
                 right_group: is_group_error.then(|| right.group.clone()),
                 missed_comment_above,
+                node_dependent_on_right,
             },
             loc: lines.loc_for_span(source_text, right.span),
             fix: fix.clone(),
@@ -885,6 +1542,7 @@ fn named_import<'a>(
     let group_index = options.group_index(group.as_str());
     Some(SortableNode {
         span: specifier.span,
+        compare_name: name.clone(),
         name,
         source,
         source_start,
@@ -894,7 +1552,13 @@ fn named_import<'a>(
         group_index,
         partition_id: 0,
         is_disabled: false,
+        is_ignored: false,
+        preserve_order_in_group: false,
+        is_type_import: false,
+        dependencies: SmallVec::new(),
+        dependency_names: SmallVec::new(),
         add_safety_semicolon_when_inline: false,
+        use_original_groups_for_spacing: false,
     })
 }
 
@@ -936,6 +1600,7 @@ fn named_export<'a>(
     let group_index = options.group_index(group.as_str());
     Some(SortableNode {
         span: specifier.span,
+        compare_name: name.clone(),
         name,
         source,
         source_start,
@@ -945,7 +1610,13 @@ fn named_export<'a>(
         group_index,
         partition_id: 0,
         is_disabled: false,
+        is_ignored: false,
+        preserve_order_in_group: false,
+        is_type_import: false,
+        dependencies: SmallVec::new(),
+        dependency_names: SmallVec::new(),
         add_safety_semicolon_when_inline: false,
+        use_original_groups_for_spacing: false,
     })
 }
 
@@ -975,7 +1646,7 @@ fn movable_leading_comment_start(
     start
 }
 
-fn is_export_disabled(source_text: &str, comments: &[Comment], span: Span) -> bool {
+fn is_rule_disabled(source_text: &str, comments: &[Comment], span: Span, rule_name: &str) -> bool {
     let node_line = line_number_at(source_text, span.start);
     let mut block_disabled = false;
     let mut ordered_comments: SmallVec<[&Comment; 16]> = comments.iter().collect();
@@ -987,13 +1658,13 @@ fn is_export_disabled(source_text: &str, comments: &[Comment], span: Span) -> bo
                 .strip_prefix("eslint-disable ")
                 .or_else(|| (content == "eslint-disable").then_some(""))
             {
-                if eslint_directive_applies(rules) {
+                if eslint_directive_applies(rules, rule_name) {
                     block_disabled = true;
                 }
             } else if let Some(rules) = content
                 .strip_prefix("eslint-enable ")
                 .or_else(|| (content == "eslint-enable").then_some(""))
-                && eslint_directive_applies(rules)
+                && eslint_directive_applies(rules, rule_name)
             {
                 block_disabled = false;
             }
@@ -1001,13 +1672,13 @@ fn is_export_disabled(source_text: &str, comments: &[Comment], span: Span) -> bo
         let comment_line = line_number_at(source_text, comment.span.start);
         if let Some(rules) = content.strip_prefix("eslint-disable-next-line")
             && comment_line + 1 == node_line
-            && eslint_directive_applies(rules)
+            && eslint_directive_applies(rules, rule_name)
         {
             return true;
         }
         if let Some(rules) = content.strip_prefix("eslint-disable-line")
             && comment_line == node_line
-            && eslint_directive_applies(rules)
+            && eslint_directive_applies(rules, rule_name)
         {
             return true;
         }
@@ -1031,20 +1702,19 @@ fn comment_content<'a>(source_text: &'a str, comment: &Comment) -> &'a str {
         .trim()
 }
 
-fn eslint_directive_applies(rules: &str) -> bool {
+fn eslint_directive_applies(rules: &str, rule_name: &str) -> bool {
     let rules = rules.trim().trim_start_matches(|character: char| {
         character == ':' || character == '-' || character.is_whitespace()
     });
     rules.is_empty()
         || rules.split(',').any(|rule| {
             let rule = rule.split_whitespace().next().unwrap_or("");
-            matches!(
-                rule,
-                "sort-exports"
-                    | "perfectionist/sort-exports"
-                    | "rule-to-test/sort-exports"
-                    | "@perfectionist/sort-exports"
-            )
+            rule == rule_name
+                || rule
+                    .strip_prefix("perfectionist/")
+                    .or_else(|| rule.strip_prefix("rule-to-test/"))
+                    .or_else(|| rule.strip_prefix("@perfectionist/"))
+                    == Some(rule_name)
         })
 }
 
@@ -1086,6 +1756,56 @@ fn compute_group(
     for predefined in predefined {
         if configured.contains(&predefined.as_str()) {
             return CompactString::from(predefined);
+        }
+    }
+    CompactString::new("unknown")
+}
+
+fn compute_group_with_selectors(
+    options: &RuleOptions,
+    name: &str,
+    modifiers: &[&str],
+    selectors: &[&str],
+) -> CompactString {
+    let configured: SmallVec<[&str; 32]> = options.group_names().collect();
+    for custom in &options.custom_groups {
+        if !configured
+            .iter()
+            .any(|configured_name| *configured_name == custom.group_name.as_str())
+        {
+            continue;
+        }
+        if custom.matches.iter().any(|matcher| {
+            matcher
+                .selector
+                .as_ref()
+                .is_none_or(|selector| selectors.contains(&selector.as_str()))
+                && matcher
+                    .modifiers
+                    .iter()
+                    .all(|modifier| modifiers.contains(&modifier.as_str()))
+                && matcher
+                    .element_name_pattern
+                    .as_ref()
+                    .is_none_or(|pattern| matches_regex(name, pattern))
+        }) {
+            return custom.group_name.clone();
+        }
+    }
+    for selector in selectors {
+        if *selector == "import"
+            && modifiers.contains(&"side-effect")
+            && configured.contains(&"side-effect-import")
+        {
+            return CompactString::from("side-effect-import");
+        }
+        for predefined in predefined_groups(modifiers, selector) {
+            if configured.contains(&predefined.as_str()) {
+                return CompactString::from(predefined);
+            }
+        }
+        if configured.contains(selector) {
+            return CompactString::from(*selector);
         }
     }
     CompactString::new("unknown")
@@ -1229,15 +1949,17 @@ fn sort_specifiers(
         while end < specifiers.len() && specifiers[end].partition_id == partition {
             end += 1;
         }
-        let disabled_indices: Vec<usize> = if keep_disabled_in_place {
-            (start..end)
-                .filter(|index| specifiers[*index].is_disabled)
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let frozen_indices: Vec<usize> = (start..end)
+            .filter(|index| {
+                specifiers[*index].is_ignored
+                    || (keep_disabled_in_place && specifiers[*index].is_disabled)
+            })
+            .collect();
         let mut partition_indices: Vec<usize> = (start..end)
-            .filter(|index| !keep_disabled_in_place || !specifiers[*index].is_disabled)
+            .filter(|index| {
+                !specifiers[*index].is_ignored
+                    && (!keep_disabled_in_place || !specifiers[*index].is_disabled)
+            })
             .collect();
         partition_indices.sort_by(|&left, &right| {
             specifiers[left]
@@ -1253,13 +1975,76 @@ fn sort_specifiers(
                 })
                 .then_with(|| left.cmp(&right))
         });
-        for disabled_index in disabled_indices {
-            partition_indices.insert(disabled_index - start, disabled_index);
+        for frozen_index in frozen_indices {
+            partition_indices.insert(frozen_index - start, frozen_index);
         }
         sorted.extend(partition_indices);
         start = end;
     }
+    apply_dependency_order(specifiers, &mut sorted, keep_disabled_in_place);
     sorted
+}
+
+fn apply_dependency_order(
+    nodes: &[SortableNode<'_>],
+    sorted: &mut Vec<usize>,
+    keep_disabled_in_place: bool,
+) {
+    let mut passes = 0;
+    while passes < nodes.len() {
+        let mut changed = false;
+        for dependent_position in 0..sorted.len() {
+            let dependent_index = sorted[dependent_position];
+            let dependent = &nodes[dependent_index];
+            if dependent.dependencies.is_empty()
+                || dependent.is_ignored
+                || (keep_disabled_in_place && dependent.is_disabled)
+            {
+                continue;
+            }
+            let provider_position = ((dependent_position + 1)..sorted.len()).find(|position| {
+                let provider = &nodes[sorted[*position]];
+                !provider.is_ignored
+                    && (!keep_disabled_in_place || !provider.is_disabled)
+                    && dependent.dependencies.iter().any(|dependency| {
+                        provider
+                            .dependency_names
+                            .iter()
+                            .any(|provided| provided == dependency)
+                    })
+            });
+            let Some(provider_position) = provider_position else {
+                continue;
+            };
+            let provider = sorted.remove(provider_position);
+            sorted.insert(dependent_position, provider);
+            changed = true;
+            break;
+        }
+        if !changed {
+            break;
+        }
+        passes += 1;
+    }
+}
+
+fn dependency_violation(
+    nodes: &[SortableNode<'_>],
+    provider_index: usize,
+) -> Option<CompactString> {
+    let provider = &nodes[provider_index];
+    nodes[..provider_index].iter().rev().find_map(|dependent| {
+        dependent
+            .dependencies
+            .iter()
+            .any(|dependency| {
+                provider
+                    .dependency_names
+                    .iter()
+                    .any(|provided| provided == dependency)
+            })
+            .then(|| dependent.name.clone())
+    })
 }
 
 fn compare_in_group(
@@ -1268,6 +2053,9 @@ fn compare_in_group(
     left: &SortableNode<'_>,
     right: &SortableNode<'_>,
 ) -> Ordering {
+    if left.preserve_order_in_group || right.preserve_order_in_group {
+        return Ordering::Equal;
+    }
     let Some((sort, raw)) = group_options.get(left.group_index).and_then(Option::as_ref) else {
         return Ordering::Equal;
     };
@@ -1276,6 +2064,15 @@ fn compare_in_group(
         .and_then(|value| value.get("type"))
         .and_then(Value::as_str)
         .unwrap_or("alphabetical");
+    if primary == "type-import-first" {
+        return compare_type_imports(
+            left,
+            right,
+            object
+                .and_then(|value| value.get("order"))
+                .and_then(Value::as_str),
+        );
+    }
     if primary == "unsorted" {
         return Ordering::Equal;
     }
@@ -1287,22 +2084,48 @@ fn compare_in_group(
         return fallback_compare(options, left, right, raw.as_object());
     }
     let compared = sort.compare(
-        left.name.as_str(),
+        left.compare_name.as_str(),
         left.size,
-        right.name.as_str(),
+        right.compare_name.as_str(),
         right.size,
     );
-    if compared == Ordering::Equal
-        && object
+    if compared == Ordering::Equal {
+        let fallback = object
             .and_then(|value| value.get("fallbackSort"))
-            .and_then(Value::as_object)
+            .and_then(Value::as_object);
+        match fallback
             .and_then(|value| value.get("type"))
             .and_then(Value::as_str)
-            == Some("subgroup-order")
-    {
-        subgroup_compare(options, left, right, object)
+        {
+            Some("subgroup-order") => subgroup_compare(options, left, right, object),
+            Some("type-import-first") => compare_type_imports(
+                left,
+                right,
+                fallback
+                    .and_then(|value| value.get("order"))
+                    .and_then(Value::as_str),
+            ),
+            _ => compared,
+        }
     } else {
         compared
+    }
+}
+
+fn compare_type_imports(
+    left: &SortableNode<'_>,
+    right: &SortableNode<'_>,
+    order: Option<&str>,
+) -> Ordering {
+    let ordering = match (left.is_type_import, right.is_type_import) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => Ordering::Equal,
+    };
+    if order == Some("desc") {
+        ordering.reverse()
+    } else {
+        ordering
     }
 }
 
@@ -1330,9 +2153,9 @@ fn fallback_compare(
         serde_json::json!({ "type": "unsorted" }),
     );
     SortOptions::from_json(&Value::Object(value)).compare(
-        left.name.as_str(),
+        left.compare_name.as_str(),
         left.size,
-        right.name.as_str(),
+        right.compare_name.as_str(),
         right.size,
     )
 }
@@ -1692,7 +2515,7 @@ fn build_fix(
         let sorted_right = &specifiers[*sorted_indices.get(position + 1)?];
         let checks_original_groups = specifiers
             .iter()
-            .any(|specifier| specifier.add_safety_semicolon_when_inline);
+            .any(|specifier| specifier.use_original_groups_for_spacing);
         let groups_allow_spacing = if checks_original_groups {
             specifiers[position].partition_id == specifiers[position + 1].partition_id
                 && specifiers[position].group_index <= specifiers[position + 1].group_index
@@ -1700,7 +2523,14 @@ fn build_fix(
             sorted_left.partition_id == sorted_right.partition_id
                 && sorted_left.group_index <= sorted_right.group_index
         };
-        let desired_separator = if groups_allow_spacing
+        // A separator after a moved declaration with an inline comment belongs
+        // to that declaration in upstream's first fix pass. Leave it in place
+        // so a later spacing diagnostic can normalize it independently.
+        let separator_follows_moved_trailing_comment = sorted_indices[position] != position
+            && (specifiers[position].source_end > specifiers[position].span.end
+                || sorted_left.source_end > sorted_left.span.end);
+        let desired_separator = if !separator_follows_moved_trailing_comment
+            && groups_allow_spacing
             && let Newlines::Count(expected) = newlines_between(options, sorted_left, sorted_right)
         {
             normalize_separator(
@@ -1822,6 +2652,7 @@ fn merge_sort_overrides(target: &mut Map<String, Value>, overrides: &Map<String,
         "specialCharacters",
         "locales",
         "alphabet",
+        "sortBy",
     ] {
         if let Some(value) = overrides.get(key) {
             target.insert(key.to_owned(), value.clone());
@@ -2003,5 +2834,28 @@ fn module_export_name(name: &ModuleExportName<'_>) -> CompactString {
             CompactString::from(identifier.name.as_str())
         }
         ModuleExportName::StringLiteral(literal) => CompactString::from(literal.value.as_str()),
+    }
+}
+
+#[cfg(test)]
+mod sort_import_group_tests {
+    use super::{RuleOptions, compute_group_with_selectors, sort_import_options};
+    use serde_json::json;
+
+    #[test]
+    fn selects_side_effect_import_before_external() {
+        let options = RuleOptions::from_object(sort_import_options(&json!([{
+            "groups": ["side-effect-import", "external", "value-import"],
+            "sortSideEffects": true
+        }])));
+        assert_eq!(
+            compute_group_with_selectors(
+                &options,
+                "./z",
+                &["value", "side-effect", "singleline"],
+                &["side-effect", "sibling", "import"]
+            ),
+            "side-effect-import"
+        );
     }
 }

--- a/crates/perfectionist/src/tests.rs
+++ b/crates/perfectionist/src/tests.rs
@@ -72,6 +72,13 @@ fn configured_export_declarations(
     scan_perfectionist_rule(source, "fixture.ts", "sort-exports", &options)
 }
 
+fn configured_import_declarations(
+    source: &str,
+    options: serde_json::Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    scan_perfectionist_rule(source, "fixture.ts", "sort-imports", &options)
+}
+
 #[test]
 fn sorts_predefined_type_and_value_groups() {
     let diagnostics = configured(
@@ -622,5 +629,244 @@ fn export_declaration_rule_fails_closed_for_malformed_sources_and_options() {
         )
         .len()
             == 1
+    );
+}
+
+#[test]
+fn sorts_import_declarations_and_preserves_trailing_comments() {
+    let source = "import z from 'z'; // z docs\nimport a from 'a'; // a docs\n";
+    let diagnostics = configured_import_declarations(source, json!([]));
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedImportsOrder");
+    assert_eq!(diagnostics[0].data.left, "z");
+    assert_eq!(diagnostics[0].data.right, "a");
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import a from 'a'; // a docs\nimport z from 'z'; // z docs"
+    );
+}
+
+#[test]
+fn sorts_import_declarations_by_predefined_modifiers_and_selectors() {
+    let diagnostics = configured_import_declarations(
+        "import value from './value';\nimport type { Type } from './types';\nimport * as fs from 'node:fs';",
+        json!([{
+            "groups": [
+                "type-named-singleline-import",
+                "value-wildcard-singleline-import",
+                "unknown"
+            ]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].message_id, "unexpectedImportsGroupOrder");
+    assert_eq!(diagnostics[0].data.left_group.as_deref(), Some("unknown"));
+    assert_eq!(
+        diagnostics[0].data.right_group.as_deref(),
+        Some("type-named-singleline-import")
+    );
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import type { Type } from './types';\n\nimport * as fs from 'node:fs';\n\nimport value from './value';"
+    );
+}
+
+#[test]
+fn matches_import_custom_groups_by_selector_modifier_and_regex() {
+    let diagnostics = configured_import_declarations(
+        "import other from 'other';\nimport api from '@api/client';",
+        json!([{
+            "customGroups": [{
+                "groupName": "api",
+                "selector": "external",
+                "modifiers": ["default", "value"],
+                "elementNamePattern": "^@api"
+            }],
+            "groups": ["api", "external"]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedImportsGroupOrder");
+    assert_eq!(diagnostics[0].data.right_group.as_deref(), Some("api"));
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import api from '@api/client';\n\nimport other from 'other';"
+    );
+}
+
+#[test]
+fn keeps_side_effect_imports_stable_unless_explicitly_sorted() {
+    assert!(configured_import_declarations("import 'z';\nimport 'a';", json!([])).is_empty());
+
+    let diagnostics = configured_import_declarations(
+        "import 'z';\nimport 'a';",
+        json!([{ "groups": ["side-effect"], "sortSideEffects": true }]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedImportsOrder");
+    assert_eq!(diagnostics[0].fix.replacement, "import 'a';\nimport 'z';");
+}
+
+#[test]
+fn prioritizes_typescript_import_equals_dependencies() {
+    let diagnostics = configured_import_declarations(
+        "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+        json!([{ "groups": ["unknown"], "useExperimentalDependencyDetection": true }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].message_id,
+        "unexpectedImportsDependencyOrder"
+    );
+    assert_eq!(diagnostics[0].data.right, "b");
+    assert_eq!(
+        diagnostics[0].data.node_dependent_on_right.as_deref(),
+        Some("aImport.a1.a2")
+    );
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    );
+}
+
+#[test]
+fn applies_type_import_first_fallback_and_specifier_sorting() {
+    let type_first = configured_import_declarations(
+        "import z from 'z';\nimport type { A } from 'zz';\nimport a from 'a';",
+        json!([{
+            "type": "type-import-first",
+            "fallbackSort": { "type": "alphabetical", "order": "asc" },
+            "groups": ["unknown"]
+        }]),
+    );
+    assert_eq!(type_first.len(), 1);
+    assert_eq!(
+        type_first[0].fix.replacement,
+        "import type { A } from 'zz';\nimport z from 'z';"
+    );
+
+    let by_specifier = configured_import_declarations(
+        "import { z } from 'a';\nimport { a } from 'z';",
+        json!([{ "groups": ["unknown"], "sortBy": "specifier" }]),
+    );
+    assert_eq!(by_specifier.len(), 1);
+    assert_eq!(
+        by_specifier[0].fix.replacement,
+        "import { a } from 'z';\nimport { z } from 'a';"
+    );
+}
+
+#[test]
+fn partitions_imports_by_blank_lines_without_crossing_boundaries() {
+    let diagnostics = configured_import_declarations(
+        "import d from 'd';\nimport a from 'a';\n\nimport c from 'c';\nimport b from 'b';",
+        json!([{
+            "partitionByNewLine": true,
+            "newlinesBetween": "ignore",
+            "newlinesInside": "ignore"
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].data.right, "a");
+    assert_eq!(diagnostics[1].data.right, "b");
+    assert_eq!(diagnostics[0].fix, diagnostics[1].fix);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import a from 'a';\nimport d from 'd';\n\nimport b from 'b';\nimport c from 'c';"
+    );
+}
+
+#[test]
+fn keeps_disabled_imports_in_place_and_sorts_enabled_neighbors() {
+    let diagnostics = configured_import_declarations(
+        "import c from './c';\nimport b from './b';\n// eslint-disable-next-line perfectionist/sort-imports\nimport a from './a';",
+        json!([{}]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].data.left, "./c");
+    assert_eq!(diagnostics[0].data.right, "./b");
+    assert_eq!(diagnostics[0].fix.start, 0);
+    assert_eq!(diagnostics[0].fix.end, 41);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import b from './b';\nimport c from './c';"
+    );
+}
+
+#[test]
+fn reports_missing_import_group_comments_without_placeholder_data() {
+    let diagnostics = configured_import_declarations(
+        "import type { Type } from './types';\nimport { value } from './value';",
+        json!([{
+            "groups": [
+                { "group": "value-import", "commentAbove": "Values" },
+                { "group": "type-import", "commentAbove": "Types" }
+            ]
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].message_id, "missedCommentAboveImport");
+    assert_eq!(
+        diagnostics[0].data.missed_comment_above.as_deref(),
+        Some("Types")
+    );
+    assert!(diagnostics[0].data.left.is_empty());
+    assert_eq!(diagnostics[0].fix, diagnostics[1].fix);
+}
+
+#[test]
+fn keeps_utf16_offsets_and_crlf_text_for_unicode_import_fixes() {
+    let source = "'😀';\r\nimport 世界 from '世界';\r\nimport api from 'api';\r\n";
+    let diagnostics = configured_import_declarations(
+        source,
+        json!([{
+            "customGroups": [{ "groupName": "api", "elementNamePattern": "^api$" }],
+            "groups": ["api", "unknown"],
+            "locales": "zh-CN"
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].fix.start, 7);
+    assert_eq!(diagnostics[0].fix.end, 51);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "import api from 'api';\r\n\nimport 世界 from '世界';"
+    );
+}
+
+#[test]
+fn import_rule_isolated_blocks_and_malformed_inputs_fail_closed() {
+    assert!(
+        configured_import_declarations(
+            "import z from 'z';\nconst boundary = true;\nimport a from 'a';",
+            json!([])
+        )
+        .is_empty()
+    );
+    assert!(configured_import_declarations("import { a } from", json!([])).is_empty());
+    assert!(
+        configured_import_declarations(
+            "import z from 'z';\nimport a from 'a';",
+            json!("not-an-option-object")
+        )
+        .len()
+            == 1
+    );
+    assert!(
+        scan_perfectionist_rule(
+            "import z from 'z';\nimport a from 'a';",
+            "fixture.ts",
+            "sort-exports",
+            &json!([])
+        )
+        .is_empty()
     );
 }

--- a/crates/perfectionist/src/types.rs
+++ b/crates/perfectionist/src/types.rs
@@ -25,6 +25,7 @@ pub struct RuleDiagnosticData {
     pub left_group: Option<CompactString>,
     pub right_group: Option<CompactString>,
     pub missed_comment_above: Option<CompactString>,
+    pub node_dependent_on_right: Option<CompactString>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -15,7 +15,12 @@ const PLUGIN_NAME = 'perfectionist';
 const DOCS_BASE = 'https://perfectionist.dev/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedPerfectionistRuleNames());
-const configuredRuleNames = new Set(['sort-exports', 'sort-named-exports', 'sort-named-imports']);
+const configuredRuleNames = new Set([
+  'sort-exports',
+  'sort-imports',
+  'sort-named-exports',
+  'sort-named-imports',
+]);
 const recommendedRuleNames = Object.freeze(
   implementedRuleNames.filter((ruleName) => ruleName !== 'sort-arrays'),
 );
@@ -90,34 +95,47 @@ function createPerfectionistRule(ruleName) {
       },
       fixable: 'code',
       messages: configuredRuleNames.has(ruleName)
-        ? ruleName === 'sort-named-imports'
+        ? ruleName === 'sort-imports'
           ? {
-              unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-              unexpectedNamedImportsGroupOrder:
+              unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+              unexpectedImportsGroupOrder:
                 'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-              extraSpacingBetweenNamedImports: 'Extra spacing between "{{left}}" and "{{right}}".',
-              missedSpacingBetweenNamedImports:
-                'Missed spacing between "{{left}}" and "{{right}}".',
+              unexpectedImportsDependencyOrder:
+                'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
+              extraSpacingBetweenImports: 'Extra spacing between "{{left}}" and "{{right}}".',
+              missedSpacingBetweenImports: 'Missed spacing between "{{left}}" and "{{right}}".',
+              missedCommentAboveImport:
+                'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
             }
-          : ruleName === 'sort-named-exports'
+          : ruleName === 'sort-named-imports'
             ? {
-                unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                unexpectedNamedExportsGroupOrder:
+                unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                unexpectedNamedImportsGroupOrder:
                   'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                extraSpacingBetweenNamedExports:
+                extraSpacingBetweenNamedImports:
                   'Extra spacing between "{{left}}" and "{{right}}".',
-                missedSpacingBetweenNamedExports:
+                missedSpacingBetweenNamedImports:
                   'Missed spacing between "{{left}}" and "{{right}}".',
               }
-            : {
-                unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                unexpectedExportsGroupOrder:
-                  'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                extraSpacingBetweenExports: 'Extra spacing between "{{left}}" and "{{right}}".',
-                missedSpacingBetweenExports: 'Missed spacing between "{{left}}" and "{{right}}".',
-                missedCommentAboveExport:
-                  'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
-              }
+            : ruleName === 'sort-named-exports'
+              ? {
+                  unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                  unexpectedNamedExportsGroupOrder:
+                    'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                  extraSpacingBetweenNamedExports:
+                    'Extra spacing between "{{left}}" and "{{right}}".',
+                  missedSpacingBetweenNamedExports:
+                    'Missed spacing between "{{left}}" and "{{right}}".',
+                }
+              : {
+                  unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                  unexpectedExportsGroupOrder:
+                    'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                  extraSpacingBetweenExports: 'Extra spacing between "{{left}}" and "{{right}}".',
+                  missedSpacingBetweenExports: 'Missed spacing between "{{left}}" and "{{right}}".',
+                  missedCommentAboveExport:
+                    'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
+                }
         : {
             unexpected: 'Expected sorted order.',
           },
@@ -147,7 +165,7 @@ function configuredDiagnosticsForRule(context, ruleName) {
   const sourceText = sourceTextForContext(context);
   const filename = typeof context.filename === 'string' ? context.filename : 'file.tsx';
   let options = Array.isArray(context.options) ? context.options : [];
-  if (ruleName === 'sort-exports') {
+  if (ruleName === 'sort-exports' || ruleName === 'sort-imports') {
     const settings = context.settings?.perfectionist;
     if (settings && typeof settings === 'object' && !Array.isArray(settings)) {
       const configured =
@@ -226,9 +244,18 @@ function schemaForRule(ruleName) {
   }
   const selector = ruleName === 'sort-named-imports' ? 'import' : 'export';
   const sortsExportDeclarations = ruleName === 'sort-exports';
+  const sortsImportDeclarations = ruleName === 'sort-imports';
   const sortType = {
     type: 'string',
-    enum: ['subgroup-order', 'alphabetical', 'natural', 'line-length', 'custom', 'unsorted'],
+    enum: [
+      'subgroup-order',
+      'alphabetical',
+      'natural',
+      'line-length',
+      'custom',
+      'unsorted',
+      ...(sortsImportDeclarations ? ['type-import-first'] : []),
+    ],
   };
   const order = {
     type: 'string',
@@ -282,6 +309,7 @@ function schemaForRule(ruleName) {
     type: sortType,
     order,
     fallbackSort,
+    ...(sortsImportDeclarations ? { sortBy: { type: 'string', enum: ['specifier', 'path'] } } : {}),
   };
   const customMatch = {
     elementNamePattern: regex,
@@ -289,12 +317,44 @@ function schemaForRule(ruleName) {
       type: 'array',
       items: {
         type: 'string',
-        enum: sortsExportDeclarations
-          ? ['value', 'type', 'named', 'wildcard', 'singleline', 'multiline']
-          : ['value', 'type'],
+        enum: sortsImportDeclarations
+          ? [
+              'default',
+              'multiline',
+              'named',
+              'require',
+              'side-effect',
+              'singleline',
+              'ts-equals',
+              'type',
+              'value',
+              'wildcard',
+            ]
+          : sortsExportDeclarations
+            ? ['value', 'type', 'named', 'wildcard', 'singleline', 'multiline']
+            : ['value', 'type'],
       },
     },
-    selector: { type: 'string', enum: [selector] },
+    selector: {
+      type: 'string',
+      enum: sortsImportDeclarations
+        ? [
+            'side-effect-style',
+            'tsconfig-path',
+            'side-effect',
+            'external',
+            'internal',
+            'builtin',
+            'sibling',
+            'subpath',
+            'import',
+            'parent',
+            'index',
+            'style',
+            'type',
+          ]
+        : [selector],
+    },
   };
   const groups = {
     type: 'array',
@@ -411,26 +471,46 @@ function schemaForRule(ruleName) {
         },
         alphabet: { type: 'string' },
         fallbackSort,
-        ...(sortsExportDeclarations ? {} : { ignoreAlias: { type: 'boolean' } }),
+        ...(!sortsExportDeclarations && !sortsImportDeclarations
+          ? { ignoreAlias: { type: 'boolean' } }
+          : {}),
         groups,
         customGroups,
         partitionByComment,
         partitionByNewLine: { type: 'boolean' },
         newlinesBetween: newlines,
         newlinesInside,
-        ...(sortsExportDeclarations
-          ? {}
-          : {
-              useConfigurationIf: {
+        ...(sortsImportDeclarations
+          ? {
+              sortBy: { type: 'string', enum: ['specifier', 'path'] },
+              internalPattern: regex,
+              environment: { type: 'string', enum: ['node', 'bun'] },
+              sortSideEffects: { type: 'boolean' },
+              maxLineLength: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+              useExperimentalDependencyDetection: { type: 'boolean' },
+              tsconfig: {
                 type: 'object',
                 properties: {
-                  allNamesMatchPattern: regex,
-                  matchesAstSelector: { type: 'string' },
+                  rootDir: { type: 'string' },
+                  filename: { type: 'string' },
                 },
-                minProperties: 1,
+                required: ['rootDir'],
                 additionalProperties: false,
               },
-            }),
+            }
+          : sortsExportDeclarations
+            ? {}
+            : {
+                useConfigurationIf: {
+                  type: 'object',
+                  properties: {
+                    allNamesMatchPattern: regex,
+                    matchesAstSelector: { type: 'string' },
+                  },
+                  minProperties: 1,
+                  additionalProperties: false,
+                },
+              }),
       },
       additionalProperties: false,
     },

--- a/npm/perfectionist/src/lib.rs
+++ b/npm/perfectionist/src/lib.rs
@@ -43,6 +43,7 @@ mod napi_abi {
         pub left_group: Option<String>,
         pub right_group: Option<String>,
         pub missed_comment_above: Option<String>,
+        pub node_dependent_on_right: Option<String>,
     }
 
     #[napi(object)]
@@ -100,17 +101,19 @@ mod napi_abi {
                         end_column: diagnostic.loc.end_column,
                     },
                     data: Some(DiagnosticData {
-                        left: diagnostic
-                            .data
-                            .missed_comment_above
-                            .is_none()
-                            .then(|| diagnostic.data.left.into_string()),
+                        left: (diagnostic.data.missed_comment_above.is_none()
+                            && diagnostic.data.node_dependent_on_right.is_none())
+                        .then(|| diagnostic.data.left.into_string()),
                         right: diagnostic.data.right.into_string(),
                         left_group: diagnostic.data.left_group.map(|value| value.into_string()),
                         right_group: diagnostic.data.right_group.map(|value| value.into_string()),
                         missed_comment_above: diagnostic
                             .data
                             .missed_comment_above
+                            .map(|value| value.into_string()),
+                        node_dependent_on_right: diagnostic
+                            .data
+                            .node_dependent_on_right
                             .map(|value| value.into_string()),
                     }),
                     fix: Some(DiagnosticFix {

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -179,6 +179,85 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact import-declaration groups, CRLF locations, and UTF-16 fixes', () => {
+    const source = `'😀';\r\nimport 世界 from '世界';\r\nimport api from 'api';\r\n`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-imports', [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        locales: 'zh-CN',
+      },
+    ]);
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-imports',
+      messageId: 'unexpectedImportsGroupOrder',
+      data: {
+        left: '世界',
+        right: 'api',
+        leftGroup: 'unknown',
+        rightGroup: 'api',
+      },
+      loc: {
+        startLine: 3,
+        startColumn: 0,
+        endLine: 3,
+        endColumn: 22,
+      },
+      fix: {
+        start: 7,
+        end: 51,
+        replacement: `import api from 'api';\r\n\nimport 世界 from '世界';`,
+      },
+    });
+  });
+
+  it('returns exact dependency data without unrelated placeholders', () => {
+    const [diagnostic] = scanPerfectionistRule(
+      `import a = aImport.a1.a2;\nimport aImport from "b";`,
+      'fixture.ts',
+      'sort-imports',
+      [{ groups: ['unknown'], useExperimentalDependencyDetection: true }],
+    );
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-imports',
+      messageId: 'unexpectedImportsDependencyOrder',
+      data: {
+        right: 'b',
+        nodeDependentOnRight: 'aImport.a1.a2',
+      },
+      loc: {
+        startLine: 2,
+        startColumn: 0,
+        endLine: 2,
+        endColumn: 24,
+      },
+      fix: {
+        start: 0,
+        end: 50,
+        replacement: `import aImport from "b";\nimport a = aImport.a1.a2;`,
+      },
+    });
+  });
+
+  it('keeps side-effect imports stable unless sorting is explicitly enabled', () => {
+    const source = `import 'z';\nimport 'a';`;
+
+    expect(scanPerfectionistRule(source, 'fixture.ts', 'sort-imports', [])).toEqual([]);
+    expect(
+      scanPerfectionistRule(source, 'fixture.ts', 'sort-imports', [
+        { groups: ['side-effect'], sortSideEffects: true },
+      ]),
+    ).toMatchObject([
+      {
+        messageId: 'unexpectedImportsOrder',
+        data: { left: 'z', right: 'a' },
+        fix: { replacement: `import 'a';\nimport 'z';` },
+      },
+    ]);
+  });
+
   it('returns exact missing-comment data without unrelated placeholders', () => {
     const [diagnostic] = scanPerfectionistRule(
       `export type { value } from './types';`,
@@ -314,6 +393,28 @@ describe('perfectionist native API', () => {
         'export { b } from "b";\nexport { a } from "a";',
         'fixture.ts',
         'sort-exports',
+        [{ type: 'not-a-sort', groups: [null, false, 1] }],
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('isolates import declarations and fails closed for malformed import syntax', () => {
+    expect(
+      scanPerfectionistRule(
+        `import z from "z";\nconst boundary = true;\nimport a from "a";`,
+        'fixture.ts',
+        'sort-imports',
+        [],
+      ),
+    ).toEqual([]);
+    expect(scanPerfectionistRule('import { a } from', 'fixture.ts', 'sort-imports', [])).toEqual(
+      [],
+    );
+    expect(
+      scanPerfectionistRule(
+        `import z from "z";\nimport a from "a";`,
+        'fixture.ts',
+        'sort-imports',
         [{ type: 'not-a-sort', groups: [null, false, 1] }],
       ),
     ).toHaveLength(1);

--- a/npm/perfectionist/test/fixtures/sort-imports-options-v5.9.1.json
+++ b/npm/perfectionist/test/fixtures/sort-imports-options-v5.9.1.json
@@ -1,0 +1,16846 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-perfectionist",
+    "version": "5.9.1",
+    "sourceCommit": "b35e8e4caf0c8d350cf386e504241f21827dd60b",
+    "sourceHashes": {
+      "rules/sort-imports.ts": "c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05",
+      "rules/sort-imports/types.ts": "81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe",
+      "test/rules/sort-imports.test.ts": "8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab"
+    },
+    "license": "MIT",
+    "eslintVersion": "9.39.2",
+    "typescriptEslintParserVersion": "8.60.0",
+    "capturePolicy": "Every authored valid and invalid sort-imports case is captured; none exercises React-specific or JSX/TSX syntax. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.9.1 rule for exact diagnostics and fixes.",
+    "authoredCases": "upstream/eslint-plugin-perfectionist/test/rules/sort-imports.test.ts",
+    "tool": "sync-perfectionist-sort-imports-options-tests.ts",
+    "inventory": {
+      "valid": 151,
+      "invalid": 262,
+      "diagnostics": 468,
+      "total": 413
+    }
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > oxlint > supports oxlint > valid",
+      "code": "import { a } from 'a'\nimport { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > oxlint > supports oxlint > invalid",
+      "code": "import { b } from 'b'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 43],
+            "text": "import { a } from 'a'\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a } from 'a'\nimport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > sorts imports by module name",
+      "code": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts imports by module name",
+      "code": "import { b1 } from 'b'\nimport { a1, a2 } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > groups and sorts imports by type and source",
+      "code": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'\nimport { j } from '../j'\nimport { K, L, M } from '../k'\nimport './style.css'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > groups and sorts imports by type and source",
+      "code": "import { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\n\nimport { b1, b2 } from '~/b'\nimport type { I } from '~/i'\nimport type { D } from './d'\nimport fs from 'fs'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport h from '../../h'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport type { T } from 't'\nimport './style.css'\nimport { j } from '../j'\nimport { K, L, M } from '../k'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"e/a\" to come before \"e/b\".",
+          "data": {
+            "right": "e/a",
+            "left": "e/b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/i\" (type-internal) to come before \"~/b\" (value-internal).",
+          "data": {
+            "right": "~/i",
+            "rightGroup": "type-internal",
+            "left": "~/b",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"~/i\" and \"./d\".",
+          "data": {
+            "left": "~/i",
+            "right": "./d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"fs\" (value-builtin) to come before \"./d\" (type-sibling).",
+          "data": {
+            "right": "fs",
+            "rightGroup": "value-builtin",
+            "left": "./d",
+            "leftGroup": "type-sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"fs\" and \"~/c\".",
+          "data": {
+            "left": "fs",
+            "right": "~/c"
+          },
+          "loc": {
+            "startLine": 10,
+            "startColumn": 1,
+            "endLine": 10,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"../f\" and \"../../h\".",
+          "data": {
+            "left": "../f",
+            "right": "../../h"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index.d.ts\" (type-index) to come before \"../../h\" (value-parent).",
+          "data": {
+            "right": "./index.d.ts",
+            "rightGroup": "type-index",
+            "left": "../../h",
+            "leftGroup": "value-parent"
+          },
+          "loc": {
+            "startLine": 16,
+            "startColumn": 1,
+            "endLine": 16,
+            "endColumn": 38
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"t\" (type-import) to come before \".\" (value-index).",
+          "data": {
+            "right": "t",
+            "rightGroup": "type-import",
+            "left": ".",
+            "leftGroup": "value-index"
+          },
+          "loc": {
+            "startLine": 19,
+            "startColumn": 1,
+            "endLine": 19,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"t\" and \"./style.css\".",
+          "data": {
+            "left": "t",
+            "right": "./style.css"
+          },
+          "loc": {
+            "startLine": 20,
+            "startColumn": 1,
+            "endLine": 20,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'\nimport './style.css'\nimport { j } from '../j'\nimport { K, L, M } from '../k'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > sorts imports without spacing between groups when configured",
+      "code": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts imports without spacing between groups when configured",
+      "code": "import d from '.'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\n\nimport type { T } from 't'\nimport { e1, e2, e3 } from '../../e'\n\nimport { b1, b2 } from '~/b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (value-external) to come before \".\" (value-index).",
+          "data": {
+            "right": "a",
+            "rightGroup": "value-external",
+            "left": ".",
+            "leftGroup": "value-index"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"t\" (type-import) to come before \"~/c\" (value-internal).",
+          "data": {
+            "right": "t",
+            "rightGroup": "type-import",
+            "left": "~/c",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/b\" (value-internal) to come before \"../../e\" (value-parent).",
+          "data": {
+            "right": "~/b",
+            "rightGroup": "value-internal",
+            "left": "../../e",
+            "leftGroup": "value-parent"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > removes extra spacing between import groups",
+      "code": "import { A } from 'a'\n\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes extra spacing between import groups",
+      "code": "import { A } from 'a'\n\n\nimport b from '~/b'\nimport c from '~/c'\n\nimport d from '~/d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"~/b\".",
+          "data": {
+            "left": "a",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [21, 65],
+            "text": "\n\nimport b from '~/b'\nimport c from '~/c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/c\" and \"~/d\".",
+          "data": {
+            "left": "~/c",
+            "right": "~/d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [21, 65],
+            "text": "\n\nimport b from '~/b'\nimport c from '~/c'\n"
+          }
+        }
+      ],
+      "output": "import { A } from 'a'\n\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > handles TypeScript import-equals syntax correctly",
+      "code": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > handles TypeScript import-equals syntax correctly",
+      "code": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport { B } from '../b'\n\nimport log = console.log\nimport c = require('c/c')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"../b\".",
+          "data": {
+            "left": "a",
+            "right": "../b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [52, 128],
+            "text": "import c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c/c\" (value-external) to come before \"console.log\" (ts-equals-import).",
+          "data": {
+            "right": "c/c",
+            "rightGroup": "value-external",
+            "left": "console.log",
+            "leftGroup": "ts-equals-import"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [52, 128],
+            "text": "import c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log"
+          }
+        }
+      ],
+      "output": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > groups all type imports together when specific type groups not configured",
+      "code": "import type { T } from '../t'\nimport type { U } from '~/u'\nimport type { V } from 'v'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["type", ["builtin", "external"], "internal", ["parent", "sibling", "index"]]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > groups all type imports together when specific type groups not configured",
+      "code": "import type { T } from '../t'\n\nimport type { U } from '~/u'\n\nimport type { V } from 'v'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["type", ["builtin", "external"], "internal", ["parent", "sibling", "index"]]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"../t\" and \"~/u\".",
+          "data": {
+            "left": "../t",
+            "right": "~/u"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [29, 61],
+            "text": "\nimport type { U } from '~/u'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/u\" and \"v\".",
+          "data": {
+            "left": "~/u",
+            "right": "v"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [29, 61],
+            "text": "\nimport type { U } from '~/u'\n"
+          }
+        }
+      ],
+      "output": "import type { T } from '../t'\nimport type { U } from '~/u'\nimport type { V } from 'v'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves inline comments during sorting",
+      "code": "import { a } from 'a'\nimport { b1, b2 } from 'b' // Comment\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > ignores comments when calculating spacing between imports",
+      "code": "import type { T } from 't'\n\n// @ts-expect-error missing types\nimport { t } from 't'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > stops grouping imports when other statements appear between them",
+      "code": "import type { V } from 'v'\n\nexport type { U } from 'u'\n\nimport type { T1, T2 } from 't'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > groups style imports separately when configured",
+      "code": "import { a1, a2 } from 'a'\n\nimport styles from '../s.css'\nimport './t.css'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["unknown", "style"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > groups side-effect imports separately when configured",
+      "code": "import { A } from '../a'\nimport { b } from './b'\n\nimport '../c.js'\nimport './d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["unknown", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > groups builtin types separately from other type imports",
+      "code": "import type { Server } from 'http'\n\nimport type { a } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["type-builtin", "type-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > handles imports with semicolons correctly",
+      "code": "import a from 'a';\nimport b from './index';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"./index\".",
+          "data": {
+            "left": "a",
+            "right": "./index"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [18, 19],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import a from 'a';\n\nimport b from './index';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes extra spacing and sorts imports correctly",
+      "code": "import { a } from 'a'\n\n\nimport { b } from './b'\n\n\n\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"./b\".",
+          "data": {
+            "left": "a",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [21, 72],
+            "text": "\nimport { c } from 'c'\n\nimport { b } from './b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c\" (value-external) to come before \"./b\" (value-sibling).",
+          "data": {
+            "right": "c",
+            "rightGroup": "value-external",
+            "left": "./b",
+            "leftGroup": "value-sibling"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 72],
+            "text": "\nimport { c } from 'c'\n\nimport { b } from './b'"
+          }
+        }
+      ],
+      "output": "import { a } from 'a'\nimport { c } from 'c'\n\nimport { b } from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > marks submodule imports as internal by default",
+      "code": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\n\nimport { b1, b2 } from '#b'\nimport c from '#c'\n\nimport { d } from '../d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > marks submodule imports as internal by default",
+      "code": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\nimport c from '#c'\nimport { b1, b2 } from '#b'\n\nimport { d } from '../d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"#b\" and \"#c\".",
+          "data": {
+            "left": "#b",
+            "right": "#c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [78, 125],
+            "text": "\n\nimport { b1, b2 } from '#b'\nimport c from '#c'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"#b\" to come before \"#c\".",
+          "data": {
+            "right": "#b",
+            "left": "#c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [78, 125],
+            "text": "\n\nimport { b1, b2 } from '#b'\nimport c from '#c'"
+          }
+        }
+      ],
+      "output": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\n\nimport { b1, b2 } from '#b'\nimport c from '#c'\n\nimport { d } from '../d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > recognizes Bun built-in modules when configured",
+      "code": "import { expect } from 'bun:test'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["builtin", "external", "unknown"],
+          "newlinesBetween": 0,
+          "environment": "bun"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > recognizes Bun built-in modules when configured",
+      "code": "import { a } from 'a'\nimport { expect } from 'bun:test'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["builtin", "external", "unknown"],
+          "newlinesBetween": 0,
+          "environment": "bun"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"bun:test\" (builtin) to come before \"a\" (external).",
+          "data": {
+            "right": "bun:test",
+            "rightGroup": "builtin",
+            "left": "a",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import { expect } from 'bun:test'\nimport { a } from 'a'"
+          }
+        }
+      ],
+      "output": "import { expect } from 'bun:test'\nimport { a } from 'a'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > sorts CommonJS require imports by module name",
+      "code": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts CommonJS require imports by module name",
+      "code": "const { b1 } = require('b')\nconst { a1, a2 } = require('a')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 59],
+            "text": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')"
+          }
+        }
+      ],
+      "output": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > groups and sorts CommonJS require imports by type and source",
+      "code": "const { c1, c2, c3, c4 } = require('c')\nconst { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > groups and sorts CommonJS require imports by type and source",
+      "code": "const { c1, c2, c3, c4 } = require('c')\nconst { e2 } = require('e/b')\nconst { e1 } = require('e/a')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst fs = require('fs')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst h = require('../../h')\n\nconst a = require('.')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"e/a\" to come before \"e/b\".",
+          "data": {
+            "right": "e/a",
+            "left": "e/b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"fs\" (value-builtin) to come before \"~/b\" (value-internal).",
+          "data": {
+            "right": "fs",
+            "rightGroup": "value-builtin",
+            "left": "~/b",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"fs\" and \"~/c\".",
+          "data": {
+            "left": "fs",
+            "right": "~/c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \".\" to come before \"../../h\".",
+          "data": {
+            "right": ".",
+            "left": "../../h"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 13,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"../../h\" and \".\".",
+          "data": {
+            "left": "../../h",
+            "right": "."
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 13,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        }
+      ],
+      "output": "const { c1, c2, c3, c4 } = require('c')\nconst { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves side-effect import order when sorting disabled",
+      "code": "import a from 'aaaa'\n\nimport 'bbb'\nimport './cc'\nimport '../d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves side-effect import order when sorting disabled",
+      "code": "import 'c'\nimport 'bb'\nimport 'aaa'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > preserves side-effect import order when sorting disabled",
+      "code": "import './cc'\nimport 'bbb'\nimport e from 'e'\nimport a from 'aaaa'\nimport '../d'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"e\" (external) to come before \"bbb\" (side-effect).",
+          "data": {
+            "right": "e",
+            "rightGroup": "external",
+            "left": "bbb",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aaaa\" to come before \"e\".",
+          "data": {
+            "right": "aaaa",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aaaa\" and \"../d\".",
+          "data": {
+            "left": "aaaa",
+            "right": "../d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        }
+      ],
+      "output": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'\nimport '../d'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts side-effect imports when sorting enabled",
+      "code": "import 'c'\nimport 'bb'\nimport 'aaa'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import 'aaa'\nimport 'bb'\nimport 'c'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aaa\" to come before \"bb\".",
+          "data": {
+            "right": "aaa",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import 'aaa'\nimport 'bb'\nimport 'c'"
+          }
+        }
+      ],
+      "output": "import 'aaa'\nimport 'bb'\nimport 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > preserves original order when side-effect imports are not grouped",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b-side-effect\" to come before \"./b\".",
+          "data": {
+            "right": "./b-side-effect",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import a from \"./a\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./a-side-effect\".",
+          "data": {
+            "right": "./a",
+            "left": "./a-side-effect"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import a from \"./a\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport a from \"./a\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > groups side-effect imports together without sorting them",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["side-effect", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > groups side-effect and style imports together in same group without sorting",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [["side-effect", "side-effect-style"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > separates side-effect and style imports into distinct groups without sorting",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["side-effect", "side-effect-style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./b-side-effect\" and \"./g-side-effect.css\".",
+          "data": {
+            "left": "./b-side-effect",
+            "right": "./g-side-effect.css"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a-side-effect\" (side-effect) to come before \"./g-side-effect.css\" (side-effect-style).",
+          "data": {
+            "right": "./a-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./g-side-effect.css",
+            "leftGroup": "side-effect-style"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > groups style side-effect imports separately without sorting",
+      "code": "import \"./z-side-effect\";\nimport b from \"./b\";\nimport './b-side-effect.scss'\nimport \"./g-side-effect\";\nimport './a-side-effect.css'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["side-effect-style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect.scss\" (side-effect-style) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect.scss",
+            "rightGroup": "side-effect-style",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./b-side-effect.scss\" and \"./g-side-effect\".",
+          "data": {
+            "left": "./b-side-effect.scss",
+            "right": "./g-side-effect"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a-side-effect.css\" (side-effect-style) to come before \"./g-side-effect\" (unknown).",
+          "data": {
+            "right": "./a-side-effect.css",
+            "rightGroup": "side-effect-style",
+            "left": "./g-side-effect",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect.css\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect.css",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect\";\nimport './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > ignores fallback sorting for side-effect imports",
+      "code": "import 'b';\nimport 'a';\n\nimport 'b.css';\nimport 'a.css';",
+      "options": [
+        {
+          "groups": ["side-effect", "side-effect-style"],
+          "fallbackSort": {
+            "type": "alphabetical"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > handles special characters with trim option",
+      "code": "import '_a'\nimport 'b'\nimport '_c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > handles special characters with remove option",
+      "code": "import 'ab'\nimport 'a_c'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports locale-specific sorting",
+      "code": "import '你好'\nimport '世界'\nimport 'a'\nimport 'A'\nimport 'b'\nimport 'B'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes newlines inside groups when newlinesInside is 0",
+      "code": "  import { a } from 'a'\n\n\n import { y } from 'y'\nimport { z } from 'z'\n\n    import { b } from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "newlinesBetween": "ignore",
+          "groups": ["a", "unknown"],
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [27, 97],
+            "text": "import { b } from 'b'\nimport { y } from 'y'\n    import { z } from 'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [27, 97],
+            "text": "import { b } from 'b'\nimport { y } from 'y'\n    import { z } from 'z'"
+          }
+        }
+      ],
+      "output": "  import { a } from 'a'\n\n\n import { b } from 'b'\nimport { y } from 'y'\n    import { z } from 'z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes newlines with 0 option",
+      "code": "  import { A } from 'a'\n\n\n import y from '~/y'\nimport z from '~/z'\n\n    import b from '~/b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"~/y\".",
+          "data": {
+            "left": "a",
+            "right": "~/y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [23, 91],
+            "text": "\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/b\" to come before \"~/z\".",
+          "data": {
+            "right": "~/b",
+            "left": "~/z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [23, 91],
+            "text": "\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/z\" and \"~/b\".",
+          "data": {
+            "left": "~/z",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [23, 91],
+            "text": "\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        }
+      ],
+      "output": "  import { A } from 'a'\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > enforces spacing when global option is 2 and group option is 0",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > enforces spacing when global option is 2 and group option is ignore",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > enforces spacing when global option is 0 and group option is 2",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > enforces spacing when global option is ignore and group option is 2",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes spacing when 0 option exists between groups regardless of global setting 1",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes spacing when 0 option exists between groups regardless of global setting 2",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes spacing when 0 option exists between groups regardless of global setting ignore",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes spacing when 0 option exists between groups regardless of global setting 0",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves existing spacing when ignore and 0 options are combined",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves existing spacing when ignore and 0 options are combined",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves existing spacing when 0 and ignore options are combined",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > preserves existing spacing when 0 and ignore options are combined",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > handles newlines and comments after fixes",
+      "code": "import { b } from 'b'\nimport { a } from './a' // Comment after\n\nimport { c } from 'c'",
+      "options": [
+        {
+          "groups": ["unknown", "external"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a\" (unknown) to come before \"b\" (external).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import { a } from './a' // Comment after\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a } from './a' // Comment after\n\nimport { b } from 'b'\nimport { c } from 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > ignores newline fixes between different partitions with 0 option",
+      "code": "import a from 'a';\n\n// Partition comment\n\nimport { c } from './c';\nimport { b } from './b';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [42, 91],
+            "text": "import { b } from './b';\nimport { c } from './c';"
+          }
+        }
+      ],
+      "output": "import a from 'a';\n\n// Partition comment\n\nimport { b } from './b';\nimport { c } from './c';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts inline imports correctly",
+      "code": "import { b } from \"b\"; import { a } from \"a\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 45
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import { a } from \"a\"; import { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "import { a } from \"a\"; import { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts inline imports correctly",
+      "code": "import { b } from \"b\"; import { a } from \"a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 46
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "import { a } from \"a\"; import { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "import { a } from \"a\"; import { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > allows partitioning by new lines",
+      "code": "import * as organisms from \"./organisms\";\nimport * as atoms from \"./atoms\";\nimport * as shared from \"./shared\";\n\nimport { AnotherNamed } from './second-folder';\nimport { Named } from './folder';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./atoms\" to come before \"./organisms\".",
+          "data": {
+            "right": "./atoms",
+            "left": "./organisms"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 194],
+            "text": "import * as atoms from \"./atoms\";\nimport * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\n\nimport { Named } from './folder';\nimport { AnotherNamed } from './second-folder';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./folder\" to come before \"./second-folder\".",
+          "data": {
+            "right": "./folder",
+            "left": "./second-folder"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 194],
+            "text": "import * as atoms from \"./atoms\";\nimport * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\n\nimport { Named } from './folder';\nimport { AnotherNamed } from './second-folder';"
+          }
+        }
+      ],
+      "output": "import * as atoms from \"./atoms\";\nimport * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\n\nimport { Named } from './folder';\nimport { AnotherNamed } from './second-folder';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > allows partitioning by comment patterns",
+      "code": "// Part: A\nimport cc from './cc';\nimport d from './d';\n// Not partition comment\nimport bbb from './bbb';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\nimport gg from './gg';\n// Not partition comment\nimport fff from './fff';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bbb\" to come before \"./d\".",
+          "data": {
+            "right": "./bbb",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [11, 247],
+            "text": "// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./fff\" to come before \"./gg\".",
+          "data": {
+            "right": "./fff",
+            "left": "./gg"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [11, 247],
+            "text": "// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+          }
+        }
+      ],
+      "output": "// Part: A\n// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > treats all comments as partition boundaries when enabled",
+      "code": "// Comment\nimport bb from './bb';\n// Other comment\nimport a from './a';",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > supports multiple partition comment patterns",
+      "code": "/* Partition Comment */\n// Part: A\nimport d from './d'\n// Part: B\nimport aaa from './aaa'\nimport c from './c'\nimport bb from './bb'\n/* Other */\nimport e from './e'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [90, 131],
+            "text": "import bb from './bb'\nimport c from './c'"
+          }
+        }
+      ],
+      "output": "/* Partition Comment */\n// Part: A\nimport d from './d'\n// Part: B\nimport aaa from './aaa'\nimport bb from './bb'\nimport c from './c'\n/* Other */\nimport e from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports regex patterns for partition comments",
+      "code": "import e from './e'\nimport f from './f'\n// I am a partition comment because I don't have f o o\nimport a from './a'\nimport b from './b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > ignores block comments when line comment partitioning is enabled",
+      "code": "import b from './b'\n/* Comment */\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 53],
+            "text": "/* Comment */\nimport a from './a'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "/* Comment */\nimport a from './a'\nimport b from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > treats all line comments as partition boundaries when enabled",
+      "code": "import b from './b'\n// Comment\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports multiple line comment patterns for partitioning",
+      "code": "import c from './c'\n// b\nimport b from './b'\n// a\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports regex patterns for line comment partitioning",
+      "code": "import b from './b'\n// I am a partition comment because I don't have f o o\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > ignores line comments when block comment partitioning is enabled",
+      "code": "import b from './b'\n// Comment\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "// Comment\nimport a from './a'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "// Comment\nimport a from './a'\nimport b from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > treats all block comments as partition boundaries when enabled",
+      "code": "import b from './b'\n/* Comment */\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports multiple block comment patterns for partitioning",
+      "code": "import c from './c'\n/* b */\nimport b from './b'\n/* a */\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports regex patterns for block comment partitioning",
+      "code": "import b from './b'\n/* I am a partition comment because I don't have f o o */\nimport a from './a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > supports style imports with query parameters",
+      "code": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > supports style imports with query parameters",
+      "code": "import a from './a.js'\nimport b from './b.css?raw'\nimport c from './c.css'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b.css?raw\" (style) to come before \"./a.js\" (unknown).",
+          "data": {
+            "right": "./b.css?raw",
+            "rightGroup": "style",
+            "left": "./a.js",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 74],
+            "text": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'"
+          }
+        }
+      ],
+      "output": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes index types over sibling types",
+      "code": "import type a from './a'\n\nimport type b from './index'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["type-index", "type-sibling"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index\" (type-index) to come before \"./a\" (type-sibling).",
+          "data": {
+            "right": "./index",
+            "rightGroup": "type-index",
+            "left": "./a",
+            "leftGroup": "type-sibling"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import type b from './index'\n\nimport type a from './a'"
+          }
+        }
+      ],
+      "output": "import type b from './index'\n\nimport type a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes index imports over sibling imports",
+      "code": "import a from './a'\n\nimport b from './index'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["index", "sibling"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index\" (index) to come before \"./a\" (sibling).",
+          "data": {
+            "right": "./index",
+            "rightGroup": "index",
+            "left": "./a",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import b from './index'\n\nimport a from './a'"
+          }
+        }
+      ],
+      "output": "import b from './index'\n\nimport a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes style side-effects over generic side-effects",
+      "code": "import 'something'\n\nimport 'style.css'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["side-effect-style", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"style.css\" (side-effect-style) to come before \"something\" (side-effect).",
+          "data": {
+            "right": "style.css",
+            "rightGroup": "side-effect-style",
+            "left": "something",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 38],
+            "text": "import 'style.css'\n\nimport 'something'"
+          }
+        }
+      ],
+      "output": "import 'style.css'\n\nimport 'something'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes side-effects over style imports with default exports",
+      "code": "import style from 'style.css'\n\nimport 'something'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["side-effect", "style"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"something\" (side-effect) to come before \"style.css\" (style).",
+          "data": {
+            "right": "something",
+            "rightGroup": "side-effect",
+            "left": "style.css",
+            "leftGroup": "style"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import 'something'\n\nimport style from 'style.css'"
+          }
+        }
+      ],
+      "output": "import 'something'\n\nimport style from 'style.css'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes style imports over other import types",
+      "code": "import a from '../a'\nimport b from './b'\nimport c from './index'\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport d from 'd'\nimport e from 'timers'\n\nimport style from 'style.css'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "style",
+            [
+              "index",
+              "internal",
+              "subpath",
+              "external",
+              "sibling",
+              "builtin",
+              "parent",
+              "tsconfig-path"
+            ]
+          ],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"style.css\" (style) to come before \"timers\" (builtin).",
+          "data": {
+            "right": "style.css",
+            "rightGroup": "style",
+            "left": "timers",
+            "leftGroup": "builtin"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport a from '../a'\nimport b from './b'\nimport c from './index'\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport d from 'd'\nimport e from 'timers'"
+          }
+        }
+      ],
+      "output": "import style from 'style.css'\n\nimport a from '../a'\nimport b from './b'\nimport c from './index'\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport d from 'd'\nimport e from 'timers'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes external imports over generic import group",
+      "code": "import a from './a'\n\nimport b from 'b'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["external", "import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"b\" (external) to come before \"./a\" (import).",
+          "data": {
+            "right": "b",
+            "rightGroup": "external",
+            "left": "./a",
+            "leftGroup": "import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 38],
+            "text": "import b from 'b'\n\nimport a from './a'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\n\nimport a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes type imports over TypeScript equals imports",
+      "code": "import z = require('./z')\n\nimport type { Types } from './types'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["type-import", "external", "ts-equals-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./types\" (type-import) to come before \"./z\" (ts-equals-import).",
+          "data": {
+            "right": "./types",
+            "rightGroup": "type-import",
+            "left": "./z",
+            "leftGroup": "ts-equals-import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 37
+          },
+          "fix": {
+            "range": [0, 63],
+            "text": "import type { Types } from './types'\n\nimport z = require('./z')"
+          }
+        }
+      ],
+      "output": "import type { Types } from './types'\n\nimport z = require('./z')"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes side-effect imports over value imports",
+      "code": "import f from 'f'\n\nimport \"./z\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["side-effect-import", "external", "value-import"],
+          "sortSideEffects": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (side-effect-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "side-effect-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "import \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes value imports over TypeScript equals imports",
+      "code": "import f from 'f'\n\nimport z = z",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["value-import", "external", "ts-equals-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"z\" (value-import) to come before \"f\" (external).",
+          "data": {
+            "right": "z",
+            "rightGroup": "value-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "import z = z\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z = z\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes TypeScript equals imports over require imports",
+      "code": "import f from 'f'\n\nimport z = require('./z')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["ts-equals-import", "external", "require-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (ts-equals-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "ts-equals-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import z = require('./z')\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z = require('./z')\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes default imports over named imports",
+      "code": "import f from 'f'\n\nimport z, { z } from \"./z\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["default-import", "external", "named-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (default-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "default-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "import z, { z } from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z, { z } from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes wildcard imports over named imports",
+      "code": "import f from 'f'\n\nimport z, * as z from \"./z\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["wildcard-import", "external", "named-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (wildcard-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "wildcard-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 46],
+            "text": "import z, * as z from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z, * as z from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes named imports over named multiline imports",
+      "code": "import f from 'f'\n\nimport {\n  a,\n  b,\n} from \"./z\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["named-import", "external", "multiline-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (named-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "named-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import {\n  a,\n  b,\n} from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import {\n  a,\n  b,\n} from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > prioritizes named imports over named singleline imports",
+      "code": "import f from 'f'\n\nimport { a } from \"./z\"",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["named-import", "external", "singleline-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (named-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "named-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 42],
+            "text": "import { a } from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import { a } from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > allows overriding options in groups",
+      "code": "import a from 'a'\nimport b from 'b'",
+      "options": [
+        {
+          "groups": [
+            {
+              "type": "alphabetical",
+              "newlinesInside": 1,
+              "group": "unknown",
+              "order": "desc"
+            }
+          ],
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import b from 'b'\n\nimport a from 'a'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import b from 'b'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > filters on element name pattern with string",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > filters on element name pattern with array",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > filters on element name pattern with regex object",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > filters on element name pattern with array containing regex",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts custom groups by overriding type and order settings",
+      "code": "import a from 'a'\nimport bb from 'bb'\nimport ccc from 'ccc'\nimport dddd from 'dddd'\nimport jjjjj from './jjjjj'\nimport eee from 'eee'\nimport ff from 'ff'\nimport g from 'g'\nimport h from './h'\nimport i from './i'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedExternalImportsByLineLength",
+              "selector": "external",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedExternalImportsByLineLength", "unknown"],
+          "newlinesBetween": "ignore",
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"eee\" (reversedExternalImportsByLineLength) to come before \"./jjjjj\" (unknown).",
+          "data": {
+            "right": "eee",
+            "rightGroup": "reversedExternalImportsByLineLength",
+            "left": "./jjjjj",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        }
+      ],
+      "output": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts custom groups using fallback sort settings",
+      "code": "import fooZar from 'fooZar'\nimport fooBar from 'fooBar'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import fooBar from 'fooBar'\nimport fooZar from 'fooZar'"
+          }
+        }
+      ],
+      "output": "import fooBar from 'fooBar'\nimport fooZar from 'fooZar'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > preserves order for custom groups with unsorted type",
+      "code": "import b from 'b'\nimport a from 'a'\nimport d from 'd'\nimport e from 'e'\nimport something from './something'\nimport c from 'c'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "unsortedExternalImports",
+              "selector": "external",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedExternalImports", "unknown"],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c\" (unsortedExternalImports) to come before \"./something\" (unknown).",
+          "data": {
+            "right": "c",
+            "rightGroup": "unsortedExternalImports",
+            "left": "./something",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [72, 125],
+            "text": "import c from 'c'\nimport something from './something'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\nimport a from 'a'\nimport d from 'd'\nimport e from 'e'\nimport c from 'c'\nimport something from './something'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts custom group blocks with complex selectors",
+      "code": "import a from 'a'\nimport b from './b'\nimport type c from './c'\nimport type d from './d'\nimport e from 'e'\nimport i from './index'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "selector": "external"
+                },
+                {
+                  "selector": "sibling",
+                  "modifiers": ["type"]
+                }
+              ],
+              "groupName": "externalAndTypeSiblingImports"
+            }
+          ],
+          "groups": [["externalAndTypeSiblingImports", "index"], "unknown"],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./c\" (externalAndTypeSiblingImports) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./c",
+            "rightGroup": "externalAndTypeSiblingImports",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 129],
+            "text": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./index\" to come before \"e\".",
+          "data": {
+            "right": "./index",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 129],
+            "text": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > adds spacing inside custom groups when 1 option is used",
+      "code": "import a from 'a'\nimport b from 'b'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "selector": "external",
+              "groupName": "group1",
+              "newlinesInside": 1
+            }
+          ],
+          "groups": ["group1"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [17, 18],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import a from 'a'\n\nimport b from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes spacing inside custom groups when 0 option is used",
+      "code": "import a from 'a'\n\nimport b from 'b'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "selector": "external",
+              "groupName": "group1",
+              "newlinesInside": 0
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["group1"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [17, 19],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import a from 'a'\nimport b from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > ignores dependencies in require",
+      "code": "import { a } from \"a\";\nimport b = require(\"a\")",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > ignores dependencies in variable declarations",
+      "code": "const { a } = require('b')\nconst { b } = require('b')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport { aImport } from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport * as aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport = require(\"b\")",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > prioritizes dependencies over group configuration",
+      "code": "import aImport from \"b\";\nimport a = aImport.a1.a2;",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"],
+          "useExperimentalDependencyDetection": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > prioritizes dependencies over group configuration",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"],
+          "useExperimentalDependencyDetection": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aImport.a1.a2\" and \"b\".",
+          "data": {
+            "left": "aImport.a1.a2",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > prioritizes dependencies over comment-based partitions",
+      "code": "import a = aImport.a1.a2;\n\n// Part: 1\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > prioritizes dependencies over newline-based partitions",
+      "code": "import a = aImport.a1.a2;\n\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: true > prioritizes content separation over dependencies",
+      "code": "import f = fImport.f1.f2;\n\nimport y = yImport.y1.y2;\n\nimport yImport from \"z\";\n\nexport { something } from \"something\";\n\nimport a = aImport.a1.a2;\n\nimport aImport from \"b\";\n\nimport fImport from \"g\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": true,
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"z\" to come before \"yImport.y1.y2\".",
+          "data": {
+            "right": "z",
+            "nodeDependentOnRight": "yImport.y1.y2"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [27, 78],
+            "text": "import yImport from \"z\";\n\nimport y = yImport.y1.y2;"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [120, 171],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import f = fImport.f1.f2;\n\nimport yImport from \"z\";\n\nimport y = yImport.y1.y2;\n\nexport { something } from \"something\";\n\nimport aImport from \"b\";\n\nimport a = aImport.a1.a2;\n\nimport fImport from \"g\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > ignores dependencies in require",
+      "code": "import { a } from \"a\";\nimport b = require(\"a\")",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > ignores dependencies in variable declarations",
+      "code": "const { a } = require('b')\nconst { b } = require('b')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport { aImport } from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport * as aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport = require(\"b\")",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > prioritizes dependencies over group configuration",
+      "code": "import aImport from \"b\";\nimport a = aImport.a1.a2;",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"],
+          "useExperimentalDependencyDetection": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > prioritizes dependencies over group configuration",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"],
+          "useExperimentalDependencyDetection": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aImport.a1.a2\" and \"b\".",
+          "data": {
+            "left": "aImport.a1.a2",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > prioritizes dependencies over comment-based partitions",
+      "code": "import a = aImport.a1.a2;\n\n// Part: 1\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > prioritizes dependencies over newline-based partitions",
+      "code": "import a = aImport.a1.a2;\n\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > experimental dependency detection: false > prioritizes content separation over dependencies",
+      "code": "import f = fImport.f1.f2;\n\nimport y = yImport.y1.y2;\n\nimport yImport from \"z\";\n\nexport { something } from \"something\";\n\nimport a = aImport.a1.a2;\n\nimport aImport from \"b\";\n\nimport fImport from \"g\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useExperimentalDependencyDetection": false,
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"z\" to come before \"yImport.y1.y2\".",
+          "data": {
+            "right": "z",
+            "nodeDependentOnRight": "yImport.y1.y2"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [27, 78],
+            "text": "import yImport from \"z\";\n\nimport y = yImport.y1.y2;"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [120, 171],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import f = fImport.f1.f2;\n\nimport yImport from \"z\";\n\nimport y = yImport.y1.y2;\n\nexport { something } from \"something\";\n\nimport aImport from \"b\";\n\nimport a = aImport.a1.a2;\n\nimport fImport from \"g\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > ignores shebang comments when sorting imports",
+      "code": "#!/usr/bin/node\nimport { b } from 'b'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [16, 59],
+            "text": "import { a } from 'a'\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\nimport { a } from 'a'\nimport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > treats @ symbol pattern as internal imports",
+      "code": "import { b } from 'b'\nimport { a } from '@/a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": ["external", "internal"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"b\" and \"@/a\".",
+          "data": {
+            "left": "b",
+            "right": "@/a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import { b } from 'b'\n\nimport { a } from '@/a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > reports missing comments above import groups",
+      "code": "import { a } from \"a\";\n\nimport { b } from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above a",
+              "group": ["external"]
+            },
+            {
+              "commentAbove": "Comment above b",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above a\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above a",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 24],
+            "text": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\n"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above b\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Comment above b",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 24],
+            "text": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\n"
+          }
+        }
+      ],
+      "output": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\nimport { b } from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > reports missing comments for single import groups",
+      "code": "import { a } from \"a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 0],
+            "text": "// Comment above\n"
+          }
+        }
+      ],
+      "output": "// Comment above\nimport { a } from \"a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > ignores shebangs and top-level comments when adding group comments",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\nimport b from \"b\";\nimport a from \"a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "external"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above\" above \"b\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 73],
+            "text": "import a from \"a\";\nimport b from \"b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 73],
+            "text": "import a from \"a\";\nimport b from \"b\";"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above\nimport a from \"a\";\nimport b from \"b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > detects existing line comment with extra spaces",
+      "code": "import a from \"a\";\n\n//   Comment above  \nimport b from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > detects existing line comment with different case",
+      "code": "import a from \"a\";\n\n//   comment above  \nimport b from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > detects existing block comment with standard format",
+      "code": "         import a from \"a\";\n\n         /**\n* Comment above\n*/\n         import b from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > alphabetical > detects existing block comment with surrounding text",
+      "code": "         import a from \"a\";\n\n         /**\n* Something before\n* CoMmEnT ABoVe\n* Something after\n*/\n         import b from \"./b\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > removes and repositions invalid auto-added comments",
+      "code": "import d from '~/d';\n// internal\nimport c from '~/c';\n\n// sibling\nimport b from './b';\n\n// external\nimport a from \"a\";",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "external",
+              "group": "external"
+            },
+            {
+              "commentAbove": "sibling",
+              "group": "sibling"
+            },
+            {
+              "commentAbove": "internal",
+              "group": "internal"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal\" above \"~/d\".",
+          "data": {
+            "missedCommentAbove": "internal",
+            "right": "~/d"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/c\" to come before \"~/d\".",
+          "data": {
+            "right": "~/c",
+            "left": "~/d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b\" (sibling) to come before \"~/c\" (internal).",
+          "data": {
+            "right": "./b",
+            "rightGroup": "sibling",
+            "left": "~/c",
+            "leftGroup": "internal"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (external) to come before \"./b\" (sibling).",
+          "data": {
+            "right": "a",
+            "rightGroup": "external",
+            "left": "./b",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        }
+      ],
+      "output": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > handles complex scenarios with multiple error types and comment management",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above c\n// external\nimport c from './c'; // Comment after c\n// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above b\n// external\nimport b from '~/b'; // Comment after b",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "external",
+              "group": "external"
+            },
+            {
+              "newlinesBetween": 1
+            },
+            {
+              "commentAbove": "internal or sibling",
+              "group": ["internal", "sibling"]
+            }
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal or sibling\" above \"./c\".",
+          "data": {
+            "missedCommentAbove": "internal or sibling",
+            "right": "./c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (external) to come before \"./c\" (sibling).",
+          "data": {
+            "right": "a",
+            "rightGroup": "external",
+            "left": "./c",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"~/b\".",
+          "data": {
+            "left": "a",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal or sibling\" above \"~/b\".",
+          "data": {
+            "missedCommentAbove": "internal or sibling",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above a\n// external\nimport a from \"a\"; // Comment after a\n\n// internal or sibling\n// Comment above c\nimport c from './c'; // Comment after c\n// Comment above b\nimport b from '~/b'; // Comment after b"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > alphabetical > sorts imports by specifier names when sortBy is \"specifier\"",
+      "code": "import { default as d } from 'foo1'\nimport h from 'foo2'\nconst { ...g } = require('foo3')\nimport 'foo4'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst j = require('foo6')\nimport { c, m } from 'foo7'\nimport a from 'foo8'\nconst { a: l } = require('foo9')\nimport { b as k } from 'foo10'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [i] = require('foo13')\nconst [] = require('foo14')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "sortSideEffects": true,
+          "sortBy": "specifier",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo3\" to come before \"foo2\".",
+          "data": {
+            "right": "foo3",
+            "left": "foo2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo4\" to come before \"foo3\".",
+          "data": {
+            "right": "foo4",
+            "left": "foo3"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo7\" to come before \"foo6\".",
+          "data": {
+            "right": "foo7",
+            "left": "foo6"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo8\" to come before \"foo7\".",
+          "data": {
+            "right": "foo8",
+            "left": "foo7"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo10\" to come before \"foo9\".",
+          "data": {
+            "right": "foo10",
+            "left": "foo9"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo11\" to come before \"foo10\".",
+          "data": {
+            "right": "foo11",
+            "left": "foo10"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo14\" to come before \"foo13\".",
+          "data": {
+            "right": "foo14",
+            "left": "foo13"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        }
+      ],
+      "output": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > sorts imports by module name",
+      "code": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts imports by module name",
+      "code": "import { b1 } from 'b'\nimport { a1, a2 } from 'a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > groups and sorts imports by type and source",
+      "code": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'\nimport { j } from '../j'\nimport { K, L, M } from '../k'\nimport './style.css'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > groups and sorts imports by type and source",
+      "code": "import { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\n\nimport { b1, b2 } from '~/b'\nimport type { I } from '~/i'\nimport type { D } from './d'\nimport fs from 'fs'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport h from '../../h'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport type { T } from 't'\nimport './style.css'\nimport { j } from '../j'\nimport { K, L, M } from '../k'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"e/a\" to come before \"e/b\".",
+          "data": {
+            "right": "e/a",
+            "left": "e/b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/i\" (type-internal) to come before \"~/b\" (value-internal).",
+          "data": {
+            "right": "~/i",
+            "rightGroup": "type-internal",
+            "left": "~/b",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"~/i\" and \"./d\".",
+          "data": {
+            "left": "~/i",
+            "right": "./d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"fs\" (value-builtin) to come before \"./d\" (type-sibling).",
+          "data": {
+            "right": "fs",
+            "rightGroup": "value-builtin",
+            "left": "./d",
+            "leftGroup": "type-sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"fs\" and \"~/c\".",
+          "data": {
+            "left": "fs",
+            "right": "~/c"
+          },
+          "loc": {
+            "startLine": 10,
+            "startColumn": 1,
+            "endLine": 10,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"../f\" and \"../../h\".",
+          "data": {
+            "left": "../f",
+            "right": "../../h"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index.d.ts\" (type-index) to come before \"../../h\" (value-parent).",
+          "data": {
+            "right": "./index.d.ts",
+            "rightGroup": "type-index",
+            "left": "../../h",
+            "leftGroup": "value-parent"
+          },
+          "loc": {
+            "startLine": 16,
+            "startColumn": 1,
+            "endLine": 16,
+            "endColumn": 38
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"t\" (type-import) to come before \".\" (value-index).",
+          "data": {
+            "right": "t",
+            "rightGroup": "type-import",
+            "left": ".",
+            "leftGroup": "value-index"
+          },
+          "loc": {
+            "startLine": 19,
+            "startColumn": 1,
+            "endLine": 19,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"t\" and \"./style.css\".",
+          "data": {
+            "left": "t",
+            "right": "./style.css"
+          },
+          "loc": {
+            "startLine": 20,
+            "startColumn": 1,
+            "endLine": 20,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 440],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport fs from 'fs'\nimport path from 'path'\n\nimport type { I } from '~/i'\n\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport h from '../../h'\nimport './style.css'\nimport { j } from '../j'\nimport { K, L, M } from '../k'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > sorts imports without spacing between groups when configured",
+      "code": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts imports without spacing between groups when configured",
+      "code": "import d from '.'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\n\nimport type { T } from 't'\nimport { e1, e2, e3 } from '../../e'\n\nimport { b1, b2 } from '~/b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (value-external) to come before \".\" (value-index).",
+          "data": {
+            "right": "a",
+            "rightGroup": "value-external",
+            "left": ".",
+            "leftGroup": "value-index"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"t\" (type-import) to come before \"~/c\" (value-internal).",
+          "data": {
+            "right": "t",
+            "rightGroup": "type-import",
+            "left": "~/c",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/b\" (value-internal) to come before \"../../e\" (value-parent).",
+          "data": {
+            "right": "~/b",
+            "rightGroup": "value-internal",
+            "left": "../../e",
+            "leftGroup": "value-parent"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { b1, b2 } from '~/b'\nimport { c1, c2, c3 } from '~/c'\nimport d from '.'\nimport { e1, e2, e3 } from '../../e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > removes extra spacing between import groups",
+      "code": "import { A } from 'a'\n\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes extra spacing between import groups",
+      "code": "import { A } from 'a'\n\n\nimport b from '~/b'\nimport c from '~/c'\n\nimport d from '~/d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"~/b\".",
+          "data": {
+            "left": "a",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [21, 65],
+            "text": "\n\nimport b from '~/b'\nimport c from '~/c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/c\" and \"~/d\".",
+          "data": {
+            "left": "~/c",
+            "right": "~/d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [21, 65],
+            "text": "\n\nimport b from '~/b'\nimport c from '~/c'\n"
+          }
+        }
+      ],
+      "output": "import { A } from 'a'\n\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > handles TypeScript import-equals syntax correctly",
+      "code": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > handles TypeScript import-equals syntax correctly",
+      "code": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport { B } from '../b'\n\nimport log = console.log\nimport c = require('c/c')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"../b\".",
+          "data": {
+            "left": "a",
+            "right": "../b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [52, 128],
+            "text": "import c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c/c\" (value-external) to come before \"console.log\" (ts-equals-import).",
+          "data": {
+            "right": "c/c",
+            "rightGroup": "value-external",
+            "left": "console.log",
+            "leftGroup": "ts-equals-import"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [52, 128],
+            "text": "import c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log"
+          }
+        }
+      ],
+      "output": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport c = require('c/c')\n\nimport { B } from '../b'\n\nimport log = console.log"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > groups all type imports together when specific type groups not configured",
+      "code": "import type { T } from '../t'\nimport type { V } from 'v'\nimport type { U } from '~/u'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["type", ["builtin", "external"], "internal", ["parent", "sibling", "index"]]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > groups all type imports together when specific type groups not configured",
+      "code": "import type { T } from '../t'\n\nimport type { U } from '~/u'\n\nimport type { V } from 'v'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["type", ["builtin", "external"], "internal", ["parent", "sibling", "index"]]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"../t\" and \"~/u\".",
+          "data": {
+            "left": "../t",
+            "right": "~/u"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [29, 87],
+            "text": "\nimport type { V } from 'v'\nimport type { U } from '~/u'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"v\" to come before \"~/u\".",
+          "data": {
+            "right": "v",
+            "left": "~/u"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [29, 87],
+            "text": "\nimport type { V } from 'v'\nimport type { U } from '~/u'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/u\" and \"v\".",
+          "data": {
+            "left": "~/u",
+            "right": "v"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [29, 87],
+            "text": "\nimport type { V } from 'v'\nimport type { U } from '~/u'"
+          }
+        }
+      ],
+      "output": "import type { T } from '../t'\nimport type { V } from 'v'\nimport type { U } from '~/u'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves inline comments during sorting",
+      "code": "import { a } from 'a'\nimport { b1, b2 } from 'b' // Comment\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > ignores comments when calculating spacing between imports",
+      "code": "import type { T } from 't'\n\n// @ts-expect-error missing types\nimport { t } from 't'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > stops grouping imports when other statements appear between them",
+      "code": "import type { V } from 'v'\n\nexport type { U } from 'u'\n\nimport type { T1, T2 } from 't'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > groups style imports separately when configured",
+      "code": "import { a1, a2 } from 'a'\n\nimport styles from '../s.css'\nimport './t.css'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown", "style"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > groups side-effect imports separately when configured",
+      "code": "import { A } from '../a'\nimport { b } from './b'\n\nimport '../c.js'\nimport './d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > groups builtin types separately from other type imports",
+      "code": "import type { Server } from 'http'\n\nimport type { a } from 'a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["type-builtin", "type-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > handles imports with semicolons correctly",
+      "code": "import a from 'a';\nimport b from './index';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"./index\".",
+          "data": {
+            "left": "a",
+            "right": "./index"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [18, 19],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import a from 'a';\n\nimport b from './index';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes extra spacing and sorts imports correctly",
+      "code": "import { a } from 'a'\n\n\nimport { b } from './b'\n\n\n\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"./b\".",
+          "data": {
+            "left": "a",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [21, 72],
+            "text": "\nimport { c } from 'c'\n\nimport { b } from './b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c\" (value-external) to come before \"./b\" (value-sibling).",
+          "data": {
+            "right": "c",
+            "rightGroup": "value-external",
+            "left": "./b",
+            "leftGroup": "value-sibling"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 72],
+            "text": "\nimport { c } from 'c'\n\nimport { b } from './b'"
+          }
+        }
+      ],
+      "output": "import { a } from 'a'\nimport { c } from 'c'\n\nimport { b } from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > marks submodule imports as internal by default",
+      "code": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\n\nimport { b1, b2 } from '#b'\nimport c from '#c'\n\nimport { d } from '../d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > marks submodule imports as internal by default",
+      "code": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\nimport c from '#c'\nimport { b1, b2 } from '#b'\n\nimport { d } from '../d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"#b\" and \"#c\".",
+          "data": {
+            "left": "#b",
+            "right": "#c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [78, 125],
+            "text": "\n\nimport { b1, b2 } from '#b'\nimport c from '#c'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"#b\" to come before \"#c\".",
+          "data": {
+            "right": "#b",
+            "left": "#c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [78, 125],
+            "text": "\n\nimport { b1, b2 } from '#b'\nimport c from '#c'"
+          }
+        }
+      ],
+      "output": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\n\nimport { b1, b2 } from '#b'\nimport c from '#c'\n\nimport { d } from '../d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > recognizes Bun built-in modules when configured",
+      "code": "import { expect } from 'bun:test'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["builtin", "external", "unknown"],
+          "newlinesBetween": 0,
+          "environment": "bun"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > recognizes Bun built-in modules when configured",
+      "code": "import { a } from 'a'\nimport { expect } from 'bun:test'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["builtin", "external", "unknown"],
+          "newlinesBetween": 0,
+          "environment": "bun"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"bun:test\" (builtin) to come before \"a\" (external).",
+          "data": {
+            "right": "bun:test",
+            "rightGroup": "builtin",
+            "left": "a",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import { expect } from 'bun:test'\nimport { a } from 'a'"
+          }
+        }
+      ],
+      "output": "import { expect } from 'bun:test'\nimport { a } from 'a'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > sorts CommonJS require imports by module name",
+      "code": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts CommonJS require imports by module name",
+      "code": "const { b1 } = require('b')\nconst { a1, a2 } = require('a')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 59],
+            "text": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')"
+          }
+        }
+      ],
+      "output": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > groups and sorts CommonJS require imports by type and source",
+      "code": "const { c1, c2, c3, c4 } = require('c')\nconst { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > groups and sorts CommonJS require imports by type and source",
+      "code": "const { c1, c2, c3, c4 } = require('c')\nconst { e2 } = require('e/b')\nconst { e1 } = require('e/a')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst fs = require('fs')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst h = require('../../h')\n\nconst a = require('.')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"e/a\" to come before \"e/b\".",
+          "data": {
+            "right": "e/a",
+            "left": "e/b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"fs\" (value-builtin) to come before \"~/b\" (value-internal).",
+          "data": {
+            "right": "fs",
+            "rightGroup": "value-builtin",
+            "left": "~/b",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"fs\" and \"~/c\".",
+          "data": {
+            "left": "fs",
+            "right": "~/c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \".\" to come before \"../../h\".",
+          "data": {
+            "right": ".",
+            "left": "../../h"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 13,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"../../h\" and \".\".",
+          "data": {
+            "left": "../../h",
+            "right": "."
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 13,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [40, 310],
+            "text": "const { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')"
+          }
+        }
+      ],
+      "output": "const { c1, c2, c3, c4 } = require('c')\nconst { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst fs = require('fs')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst a = require('.')\nconst h = require('../../h')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves side-effect import order when sorting disabled",
+      "code": "import a from 'aaaa'\n\nimport 'bbb'\nimport './cc'\nimport '../d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves side-effect import order when sorting disabled",
+      "code": "import 'c'\nimport 'bb'\nimport 'aaa'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > preserves side-effect import order when sorting disabled",
+      "code": "import './cc'\nimport 'bbb'\nimport e from 'e'\nimport a from 'aaaa'\nimport '../d'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"e\" (external) to come before \"bbb\" (side-effect).",
+          "data": {
+            "right": "e",
+            "rightGroup": "external",
+            "left": "bbb",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aaaa\" to come before \"e\".",
+          "data": {
+            "right": "aaaa",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aaaa\" and \"../d\".",
+          "data": {
+            "left": "aaaa",
+            "right": "../d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        }
+      ],
+      "output": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'\nimport '../d'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts side-effect imports when sorting enabled",
+      "code": "import 'c'\nimport 'bb'\nimport 'aaa'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import 'aaa'\nimport 'bb'\nimport 'c'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aaa\" to come before \"bb\".",
+          "data": {
+            "right": "aaa",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import 'aaa'\nimport 'bb'\nimport 'c'"
+          }
+        }
+      ],
+      "output": "import 'aaa'\nimport 'bb'\nimport 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > preserves original order when side-effect imports are not grouped",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b-side-effect\" to come before \"./b\".",
+          "data": {
+            "right": "./b-side-effect",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import a from \"./a\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./a-side-effect\".",
+          "data": {
+            "right": "./a",
+            "left": "./a-side-effect"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import a from \"./a\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport a from \"./a\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > groups side-effect imports together without sorting them",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["side-effect", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > groups side-effect and style imports together in same group without sorting",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [["side-effect", "side-effect-style"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 152],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > separates side-effect and style imports into distinct groups without sorting",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["side-effect", "side-effect-style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./b-side-effect\" and \"./g-side-effect.css\".",
+          "data": {
+            "left": "./b-side-effect",
+            "right": "./g-side-effect.css"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a-side-effect\" (side-effect) to come before \"./g-side-effect.css\" (side-effect-style).",
+          "data": {
+            "right": "./a-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./g-side-effect.css",
+            "leftGroup": "side-effect-style"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 152],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > groups style side-effect imports separately without sorting",
+      "code": "import \"./z-side-effect\";\nimport b from \"./b\";\nimport './b-side-effect.scss'\nimport \"./g-side-effect\";\nimport './a-side-effect.css'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["side-effect-style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect.scss\" (side-effect-style) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect.scss",
+            "rightGroup": "side-effect-style",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./b-side-effect.scss\" and \"./g-side-effect\".",
+          "data": {
+            "left": "./b-side-effect.scss",
+            "right": "./g-side-effect"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a-side-effect.css\" (side-effect-style) to come before \"./g-side-effect\" (unknown).",
+          "data": {
+            "right": "./a-side-effect.css",
+            "rightGroup": "side-effect-style",
+            "left": "./g-side-effect",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect.css\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect.css",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [26, 152],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect\";\nimport './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport a from \"./a\";\nimport b from \"./b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > ignores fallback sorting for side-effect imports",
+      "code": "import 'b';\nimport 'a';\n\nimport 'b.css';\nimport 'a.css';",
+      "options": [
+        {
+          "groups": ["side-effect", "side-effect-style"],
+          "fallbackSort": {
+            "type": "alphabetical"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > handles special characters with trim option",
+      "code": "import '_a'\nimport 'b'\nimport '_c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > handles special characters with remove option",
+      "code": "import 'ab'\nimport 'a_c'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports locale-specific sorting",
+      "code": "import '你好'\nimport '世界'\nimport 'a'\nimport 'A'\nimport 'b'\nimport 'B'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes newlines with 0 option",
+      "code": "  import { A } from 'a'\n\n\n import y from '~/y'\nimport z from '~/z'\n\n    import b from '~/b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"~/y\".",
+          "data": {
+            "left": "a",
+            "right": "~/y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [23, 91],
+            "text": "\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/b\" to come before \"~/z\".",
+          "data": {
+            "right": "~/b",
+            "left": "~/z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [23, 91],
+            "text": "\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/z\" and \"~/b\".",
+          "data": {
+            "left": "~/z",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [23, 91],
+            "text": "\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        }
+      ],
+      "output": "  import { A } from 'a'\n import b from '~/b'\nimport y from '~/y'\n    import z from '~/z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > enforces spacing when global option is 2 and group option is 0",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > enforces spacing when global option is 2 and group option is ignore",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > enforces spacing when global option is 0 and group option is 2",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > enforces spacing when global option is ignore and group option is 2",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes spacing when 0 option exists between groups regardless of global setting 1",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes spacing when 0 option exists between groups regardless of global setting 2",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes spacing when 0 option exists between groups regardless of global setting ignore",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes spacing when 0 option exists between groups regardless of global setting 0",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves existing spacing when ignore and 0 options are combined",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves existing spacing when ignore and 0 options are combined",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves existing spacing when 0 and ignore options are combined",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > preserves existing spacing when 0 and ignore options are combined",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > handles newlines and comments after fixes",
+      "code": "import { b } from 'b'\nimport { a } from './a' // Comment after\n\nimport { c } from 'c'",
+      "options": [
+        {
+          "groups": ["unknown", "external"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a\" (unknown) to come before \"b\" (external).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import { a } from './a' // Comment after\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a } from './a' // Comment after\n\nimport { b } from 'b'\nimport { c } from 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > ignores newline fixes between different partitions with 0 option",
+      "code": "import a from 'a';\n\n// Partition comment\n\nimport { c } from './c';\nimport { b } from './b';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [42, 91],
+            "text": "import { b } from './b';\nimport { c } from './c';"
+          }
+        }
+      ],
+      "output": "import a from 'a';\n\n// Partition comment\n\nimport { b } from './b';\nimport { c } from './c';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts inline imports correctly",
+      "code": "import { b } from \"b\"; import { a } from \"a\"",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 45
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import { a } from \"a\"; import { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "import { a } from \"a\"; import { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts inline imports correctly",
+      "code": "import { b } from \"b\"; import { a } from \"a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 46
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "import { a } from \"a\"; import { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "import { a } from \"a\"; import { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > allows partitioning by new lines",
+      "code": "import * as organisms from \"./organisms\";\nimport * as atoms from \"./atoms\";\nimport * as shared from \"./shared\";\n\nimport { AnotherNamed } from './second-folder';\nimport { Named } from './folder';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./atoms\" to come before \"./organisms\".",
+          "data": {
+            "right": "./atoms",
+            "left": "./organisms"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 194],
+            "text": "import * as atoms from \"./atoms\";\nimport * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\n\nimport { Named } from './folder';\nimport { AnotherNamed } from './second-folder';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./folder\" to come before \"./second-folder\".",
+          "data": {
+            "right": "./folder",
+            "left": "./second-folder"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 194],
+            "text": "import * as atoms from \"./atoms\";\nimport * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\n\nimport { Named } from './folder';\nimport { AnotherNamed } from './second-folder';"
+          }
+        }
+      ],
+      "output": "import * as atoms from \"./atoms\";\nimport * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\n\nimport { Named } from './folder';\nimport { AnotherNamed } from './second-folder';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > allows partitioning by comment patterns",
+      "code": "// Part: A\nimport cc from './cc';\nimport d from './d';\n// Not partition comment\nimport bbb from './bbb';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\nimport gg from './gg';\n// Not partition comment\nimport fff from './fff';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bbb\" to come before \"./d\".",
+          "data": {
+            "right": "./bbb",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [11, 247],
+            "text": "// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./fff\" to come before \"./gg\".",
+          "data": {
+            "right": "./fff",
+            "left": "./gg"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [11, 247],
+            "text": "// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+          }
+        }
+      ],
+      "output": "// Part: A\n// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > treats all comments as partition boundaries when enabled",
+      "code": "// Comment\nimport bb from './bb';\n// Other comment\nimport a from './a';",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > supports multiple partition comment patterns",
+      "code": "/* Partition Comment */\n// Part: A\nimport d from './d'\n// Part: B\nimport aaa from './aaa'\nimport c from './c'\nimport bb from './bb'\n/* Other */\nimport e from './e'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [90, 131],
+            "text": "import bb from './bb'\nimport c from './c'"
+          }
+        }
+      ],
+      "output": "/* Partition Comment */\n// Part: A\nimport d from './d'\n// Part: B\nimport aaa from './aaa'\nimport bb from './bb'\nimport c from './c'\n/* Other */\nimport e from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports regex patterns for partition comments",
+      "code": "import e from './e'\nimport f from './f'\n// I am a partition comment because I don't have f o o\nimport a from './a'\nimport b from './b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > ignores block comments when line comment partitioning is enabled",
+      "code": "import b from './b'\n/* Comment */\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 53],
+            "text": "/* Comment */\nimport a from './a'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "/* Comment */\nimport a from './a'\nimport b from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > treats all line comments as partition boundaries when enabled",
+      "code": "import b from './b'\n// Comment\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports multiple line comment patterns for partitioning",
+      "code": "import c from './c'\n// b\nimport b from './b'\n// a\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports regex patterns for line comment partitioning",
+      "code": "import b from './b'\n// I am a partition comment because I don't have f o o\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > ignores line comments when block comment partitioning is enabled",
+      "code": "import b from './b'\n// Comment\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "// Comment\nimport a from './a'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "// Comment\nimport a from './a'\nimport b from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > treats all block comments as partition boundaries when enabled",
+      "code": "import b from './b'\n/* Comment */\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports multiple block comment patterns for partitioning",
+      "code": "import c from './c'\n/* b */\nimport b from './b'\n/* a */\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports regex patterns for block comment partitioning",
+      "code": "import b from './b'\n/* I am a partition comment because I don't have f o o */\nimport a from './a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > supports style imports with query parameters",
+      "code": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > supports style imports with query parameters",
+      "code": "import a from './a.js'\nimport b from './b.css?raw'\nimport c from './c.css'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b.css?raw\" (style) to come before \"./a.js\" (unknown).",
+          "data": {
+            "right": "./b.css?raw",
+            "rightGroup": "style",
+            "left": "./a.js",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 74],
+            "text": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'"
+          }
+        }
+      ],
+      "output": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes index types over sibling types",
+      "code": "import type a from './a'\n\nimport type b from './index'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["type-index", "type-sibling"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index\" (type-index) to come before \"./a\" (type-sibling).",
+          "data": {
+            "right": "./index",
+            "rightGroup": "type-index",
+            "left": "./a",
+            "leftGroup": "type-sibling"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import type b from './index'\n\nimport type a from './a'"
+          }
+        }
+      ],
+      "output": "import type b from './index'\n\nimport type a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes index imports over sibling imports",
+      "code": "import a from './a'\n\nimport b from './index'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["index", "sibling"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index\" (index) to come before \"./a\" (sibling).",
+          "data": {
+            "right": "./index",
+            "rightGroup": "index",
+            "left": "./a",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import b from './index'\n\nimport a from './a'"
+          }
+        }
+      ],
+      "output": "import b from './index'\n\nimport a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes style side-effects over generic side-effects",
+      "code": "import 'something'\n\nimport 'style.css'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["side-effect-style", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"style.css\" (side-effect-style) to come before \"something\" (side-effect).",
+          "data": {
+            "right": "style.css",
+            "rightGroup": "side-effect-style",
+            "left": "something",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 38],
+            "text": "import 'style.css'\n\nimport 'something'"
+          }
+        }
+      ],
+      "output": "import 'style.css'\n\nimport 'something'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes side-effects over style imports with default exports",
+      "code": "import style from 'style.css'\n\nimport 'something'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["side-effect", "style"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"something\" (side-effect) to come before \"style.css\" (style).",
+          "data": {
+            "right": "something",
+            "rightGroup": "side-effect",
+            "left": "style.css",
+            "leftGroup": "style"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import 'something'\n\nimport style from 'style.css'"
+          }
+        }
+      ],
+      "output": "import 'something'\n\nimport style from 'style.css'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes style imports over other import types",
+      "code": "import a from '../a'\nimport b from './b'\nimport c from './index'\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport d from 'd'\nimport e from 'timers'\n\nimport style from 'style.css'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "style",
+            [
+              "index",
+              "internal",
+              "subpath",
+              "external",
+              "sibling",
+              "builtin",
+              "parent",
+              "tsconfig-path"
+            ]
+          ],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"#subpath\" to come before \"./index\".",
+          "data": {
+            "right": "#subpath",
+            "left": "./index"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport a from '../a'\nimport b from './b'\nimport c from './index'\nimport d from 'd'\nimport e from 'timers'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"style.css\" (style) to come before \"timers\" (builtin).",
+          "data": {
+            "right": "style.css",
+            "rightGroup": "style",
+            "left": "timers",
+            "leftGroup": "builtin"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport a from '../a'\nimport b from './b'\nimport c from './index'\nimport d from 'd'\nimport e from 'timers'"
+          }
+        }
+      ],
+      "output": "import style from 'style.css'\n\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport a from '../a'\nimport b from './b'\nimport c from './index'\nimport d from 'd'\nimport e from 'timers'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes external imports over generic import group",
+      "code": "import a from './a'\n\nimport b from 'b'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["external", "import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"b\" (external) to come before \"./a\" (import).",
+          "data": {
+            "right": "b",
+            "rightGroup": "external",
+            "left": "./a",
+            "leftGroup": "import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 38],
+            "text": "import b from 'b'\n\nimport a from './a'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\n\nimport a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes type imports over TypeScript equals imports",
+      "code": "import z = require('./z')\n\nimport type { Types } from './types'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["type-import", "external", "ts-equals-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./types\" (type-import) to come before \"./z\" (ts-equals-import).",
+          "data": {
+            "right": "./types",
+            "rightGroup": "type-import",
+            "left": "./z",
+            "leftGroup": "ts-equals-import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 37
+          },
+          "fix": {
+            "range": [0, 63],
+            "text": "import type { Types } from './types'\n\nimport z = require('./z')"
+          }
+        }
+      ],
+      "output": "import type { Types } from './types'\n\nimport z = require('./z')"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes side-effect imports over value imports",
+      "code": "import f from 'f'\n\nimport \"./z\"",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["side-effect-import", "external", "value-import"],
+          "sortSideEffects": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (side-effect-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "side-effect-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "import \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes value imports over TypeScript equals imports",
+      "code": "import f from 'f'\n\nimport z = z",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["value-import", "external", "ts-equals-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"z\" (value-import) to come before \"f\" (external).",
+          "data": {
+            "right": "z",
+            "rightGroup": "value-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "import z = z\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z = z\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes TypeScript equals imports over require imports",
+      "code": "import f from 'f'\n\nimport z = require('./z')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["ts-equals-import", "external", "require-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (ts-equals-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "ts-equals-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import z = require('./z')\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z = require('./z')\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes default imports over named imports",
+      "code": "import f from 'f'\n\nimport z, { z } from \"./z\"",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["default-import", "external", "named-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (default-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "default-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "import z, { z } from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z, { z } from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes wildcard imports over named imports",
+      "code": "import f from 'f'\n\nimport z, * as z from \"./z\"",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["wildcard-import", "external", "named-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (wildcard-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "wildcard-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 46],
+            "text": "import z, * as z from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z, * as z from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > filters on element name pattern with string",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > filters on element name pattern with array",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > filters on element name pattern with regex object",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > filters on element name pattern with array containing regex",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts custom groups by overriding type and order settings",
+      "code": "import a from 'a'\nimport bb from 'bb'\nimport ccc from 'ccc'\nimport dddd from 'dddd'\nimport jjjjj from './jjjjj'\nimport eee from 'eee'\nimport ff from 'ff'\nimport g from 'g'\nimport h from './h'\nimport i from './i'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedExternalImportsByLineLength",
+              "selector": "external",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedExternalImportsByLineLength", "unknown"],
+          "newlinesBetween": "ignore",
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"eee\" (reversedExternalImportsByLineLength) to come before \"./jjjjj\" (unknown).",
+          "data": {
+            "right": "eee",
+            "rightGroup": "reversedExternalImportsByLineLength",
+            "left": "./jjjjj",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        }
+      ],
+      "output": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts custom groups using fallback sort settings",
+      "code": "import fooZar from 'fooZar'\nimport fooBar from 'fooBar'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import fooBar from 'fooBar'\nimport fooZar from 'fooZar'"
+          }
+        }
+      ],
+      "output": "import fooBar from 'fooBar'\nimport fooZar from 'fooZar'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > preserves order for custom groups with unsorted type",
+      "code": "import b from 'b'\nimport a from 'a'\nimport d from 'd'\nimport e from 'e'\nimport something from './something'\nimport c from 'c'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "unsortedExternalImports",
+              "selector": "external",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedExternalImports", "unknown"],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c\" (unsortedExternalImports) to come before \"./something\" (unknown).",
+          "data": {
+            "right": "c",
+            "rightGroup": "unsortedExternalImports",
+            "left": "./something",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [72, 125],
+            "text": "import c from 'c'\nimport something from './something'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\nimport a from 'a'\nimport d from 'd'\nimport e from 'e'\nimport c from 'c'\nimport something from './something'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts custom group blocks with complex selectors",
+      "code": "import a from 'a'\nimport b from './b'\nimport type c from './c'\nimport type d from './d'\nimport e from 'e'\nimport i from './index'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "selector": "external"
+                },
+                {
+                  "selector": "sibling",
+                  "modifiers": ["type"]
+                }
+              ],
+              "groupName": "externalAndTypeSiblingImports"
+            }
+          ],
+          "groups": [["externalAndTypeSiblingImports", "index"], "unknown"],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./c\" (externalAndTypeSiblingImports) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./c",
+            "rightGroup": "externalAndTypeSiblingImports",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 129],
+            "text": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./index\" to come before \"e\".",
+          "data": {
+            "right": "./index",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 129],
+            "text": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport { aImport } from \"b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport * as aImport from \"b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport = require(\"b\")",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > prioritizes dependencies over group configuration",
+      "code": "import aImport from \"b\";\nimport a = aImport.a1.a2;",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes dependencies over group configuration",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aImport.a1.a2\" and \"b\".",
+          "data": {
+            "left": "aImport.a1.a2",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes dependencies over comment-based partitions",
+      "code": "import a = aImport.a1.a2;\n\n// Part: 1\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes dependencies over newline-based partitions",
+      "code": "import a = aImport.a1.a2;\n\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > prioritizes content separation over dependencies",
+      "code": "import f = fImport.f1.f2;\n\nimport y = yImport.y1.y2;\n\nimport yImport from \"z\";\n\nexport { something } from \"something\";\n\nimport a = aImport.a1.a2;\n\nimport aImport from \"b\";\n\nimport fImport from \"g\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"z\" to come before \"yImport.y1.y2\".",
+          "data": {
+            "right": "z",
+            "nodeDependentOnRight": "yImport.y1.y2"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [27, 78],
+            "text": "import yImport from \"z\";\n\nimport y = yImport.y1.y2;"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [120, 171],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import f = fImport.f1.f2;\n\nimport yImport from \"z\";\n\nimport y = yImport.y1.y2;\n\nexport { something } from \"something\";\n\nimport aImport from \"b\";\n\nimport a = aImport.a1.a2;\n\nimport fImport from \"g\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > ignores shebang comments when sorting imports",
+      "code": "#!/usr/bin/node\nimport { b } from 'b'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [16, 59],
+            "text": "import { a } from 'a'\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\nimport { a } from 'a'\nimport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > treats @ symbol pattern as internal imports",
+      "code": "import { b } from 'b'\nimport { a } from '@/a'",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": ["external", "internal"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"b\" and \"@/a\".",
+          "data": {
+            "left": "b",
+            "right": "@/a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import { b } from 'b'\n\nimport { a } from '@/a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > reports missing comments above import groups",
+      "code": "import { a } from \"a\";\n\nimport { b } from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above a",
+              "group": ["external"]
+            },
+            {
+              "commentAbove": "Comment above b",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above a\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above a",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 24],
+            "text": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\n"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above b\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Comment above b",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 24],
+            "text": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\n"
+          }
+        }
+      ],
+      "output": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\nimport { b } from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > reports missing comments for single import groups",
+      "code": "import { a } from \"a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 0],
+            "text": "// Comment above\n"
+          }
+        }
+      ],
+      "output": "// Comment above\nimport { a } from \"a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > ignores shebangs and top-level comments when adding group comments",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\nimport b from \"b\";\nimport a from \"a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "external"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above\" above \"b\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 73],
+            "text": "import a from \"a\";\nimport b from \"b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 73],
+            "text": "import a from \"a\";\nimport b from \"b\";"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above\nimport a from \"a\";\nimport b from \"b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > detects existing line comment with extra spaces",
+      "code": "import a from \"a\";\n\n//   Comment above  \nimport b from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > detects existing line comment with different case",
+      "code": "import a from \"a\";\n\n//   comment above  \nimport b from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > detects existing block comment with standard format",
+      "code": "         import a from \"a\";\n\n         /**\n* Comment above\n*/\n         import b from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > natural > detects existing block comment with surrounding text",
+      "code": "         import a from \"a\";\n\n         /**\n* Something before\n* CoMmEnT ABoVe\n* Something after\n*/\n         import b from \"./b\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > removes and repositions invalid auto-added comments",
+      "code": "import d from '~/d';\n// internal\nimport c from '~/c';\n\n// sibling\nimport b from './b';\n\n// external\nimport a from \"a\";",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "external",
+              "group": "external"
+            },
+            {
+              "commentAbove": "sibling",
+              "group": "sibling"
+            },
+            {
+              "commentAbove": "internal",
+              "group": "internal"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal\" above \"~/d\".",
+          "data": {
+            "missedCommentAbove": "internal",
+            "right": "~/d"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/c\" to come before \"~/d\".",
+          "data": {
+            "right": "~/c",
+            "left": "~/d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b\" (sibling) to come before \"~/c\" (internal).",
+          "data": {
+            "right": "./b",
+            "rightGroup": "sibling",
+            "left": "~/c",
+            "leftGroup": "internal"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (external) to come before \"./b\" (sibling).",
+          "data": {
+            "right": "a",
+            "rightGroup": "external",
+            "left": "./b",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 118],
+            "text": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+          }
+        }
+      ],
+      "output": "// external\nimport a from \"a\";\n\n// sibling\nimport b from './b';\n\n// internal\nimport c from '~/c';\nimport d from '~/d';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > handles complex scenarios with multiple error types and comment management",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above c\n// external\nimport c from './c'; // Comment after c\n// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above b\n// external\nimport b from '~/b'; // Comment after b",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "groups": [
+            {
+              "commentAbove": "external",
+              "group": "external"
+            },
+            {
+              "newlinesBetween": 1
+            },
+            {
+              "commentAbove": "internal or sibling",
+              "group": ["internal", "sibling"]
+            }
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal or sibling\" above \"./c\".",
+          "data": {
+            "missedCommentAbove": "internal or sibling",
+            "right": "./c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (external) to come before \"./c\" (sibling).",
+          "data": {
+            "right": "a",
+            "rightGroup": "external",
+            "left": "./c",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"~/b\".",
+          "data": {
+            "left": "a",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal or sibling\" above \"~/b\".",
+          "data": {
+            "missedCommentAbove": "internal or sibling",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above a\n// external\nimport a from \"a\"; // Comment after a\n\n// internal or sibling\n// Comment above c\nimport c from './c'; // Comment after c\n// Comment above b\nimport b from '~/b'; // Comment after b"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > natural > sorts imports by specifier names when sortBy is \"specifier\"",
+      "code": "import { default as d } from 'foo1'\nimport h from 'foo2'\nconst { ...g } = require('foo3')\nimport 'foo4'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst j = require('foo6')\nimport { c, m } from 'foo7'\nimport a from 'foo8'\nconst { a: l } = require('foo9')\nimport { b as k } from 'foo10'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [i] = require('foo13')\nconst [] = require('foo14')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "sortSideEffects": true,
+          "sortBy": "specifier",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo3\" to come before \"foo2\".",
+          "data": {
+            "right": "foo3",
+            "left": "foo2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo4\" to come before \"foo3\".",
+          "data": {
+            "right": "foo4",
+            "left": "foo3"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo7\" to come before \"foo6\".",
+          "data": {
+            "right": "foo7",
+            "left": "foo6"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo8\" to come before \"foo7\".",
+          "data": {
+            "right": "foo8",
+            "left": "foo7"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo10\" to come before \"foo9\".",
+          "data": {
+            "right": "foo10",
+            "left": "foo9"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo11\" to come before \"foo10\".",
+          "data": {
+            "right": "foo11",
+            "left": "foo10"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo14\" to come before \"foo13\".",
+          "data": {
+            "right": "foo14",
+            "left": "foo13"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        }
+      ],
+      "output": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > sorts imports by module name",
+      "code": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts imports by module name",
+      "code": "import { b1 } from 'b'\nimport { a1, a2 } from 'a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > groups and sorts imports by type and source",
+      "code": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e1 } from 'e/a'\nimport { e2 } from 'e/b'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport h from '../../h'\nimport './style.css'\nimport a from '.'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > groups and sorts imports by type and source",
+      "code": "import { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\n\nimport { b1, b2 } from '~/b'\nimport type { I } from '~/i'\nimport type { D } from './d'\nimport fs from 'fs'\nimport { c1 } from '~/c'\nimport { i1, i2, i3 } from '~/i'\n\nimport type { A } from '.'\nimport type { F } from '../f'\nimport h from '../../h'\nimport type { H } from './index.d.ts'\n\nimport a from '.'\nimport type { T } from 't'\nimport './style.css'\nimport { j } from '../j'\nimport { K, L, M } from '../k'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/i\" (type-internal) to come before \"~/b\" (value-internal).",
+          "data": {
+            "right": "~/i",
+            "rightGroup": "type-internal",
+            "left": "~/b",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"~/i\" and \"./d\".",
+          "data": {
+            "left": "~/i",
+            "right": "./d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"fs\" (value-builtin) to come before \"./d\" (type-sibling).",
+          "data": {
+            "right": "fs",
+            "rightGroup": "value-builtin",
+            "left": "./d",
+            "leftGroup": "type-sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"fs\" and \"~/c\".",
+          "data": {
+            "left": "fs",
+            "right": "~/c"
+          },
+          "loc": {
+            "startLine": 10,
+            "startColumn": 1,
+            "endLine": 10,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/i\" to come before \"~/c\".",
+          "data": {
+            "right": "~/i",
+            "left": "~/c"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"../f\" to come before \".\".",
+          "data": {
+            "right": "../f",
+            "left": "."
+          },
+          "loc": {
+            "startLine": 14,
+            "startColumn": 1,
+            "endLine": 14,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"../f\" and \"../../h\".",
+          "data": {
+            "left": "../f",
+            "right": "../../h"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index.d.ts\" (type-index) to come before \"../../h\" (value-parent).",
+          "data": {
+            "right": "./index.d.ts",
+            "rightGroup": "type-index",
+            "left": "../../h",
+            "leftGroup": "value-parent"
+          },
+          "loc": {
+            "startLine": 16,
+            "startColumn": 1,
+            "endLine": 16,
+            "endColumn": 38
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"t\" (type-import) to come before \".\" (value-index).",
+          "data": {
+            "right": "t",
+            "rightGroup": "type-import",
+            "left": ".",
+            "leftGroup": "value-index"
+          },
+          "loc": {
+            "startLine": 19,
+            "startColumn": 1,
+            "endLine": 19,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"t\" and \"./style.css\".",
+          "data": {
+            "left": "t",
+            "right": "./style.css"
+          },
+          "loc": {
+            "startLine": 20,
+            "startColumn": 1,
+            "endLine": 20,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"../j\" to come before \"./style.css\".",
+          "data": {
+            "right": "../j",
+            "left": "./style.css"
+          },
+          "loc": {
+            "startLine": 21,
+            "startColumn": 1,
+            "endLine": 21,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"../k\" to come before \"../j\".",
+          "data": {
+            "right": "../k",
+            "left": "../j"
+          },
+          "loc": {
+            "startLine": 22,
+            "startColumn": 1,
+            "endLine": 22,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 517],
+            "text": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\n\nimport { c1, c2, c3, c4 } from 'c'\nimport { e2 } from 'e/b'\nimport { e1 } from 'e/a'\nimport path from 'path'\nimport fs from 'fs'\n\nimport type { I } from '~/i'\n\nimport { i1, i2, i3 } from '~/i'\nimport { b1, b2 } from '~/b'\nimport { c1 } from '~/c'\n\nimport type { H } from './index.d.ts'\nimport type { F } from '../f'\nimport type { D } from './d'\nimport type { A } from '.'\n\nimport { K, L, M } from '../k'\nimport { j } from '../j'\nimport './style.css'\nimport h from '../../h'\nimport a from '.'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > sorts imports without spacing between groups when configured",
+      "code": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\nimport { b1, b2 } from '~/b'\nimport { e1, e2, e3 } from '../../e'\nimport d from '.'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts imports without spacing between groups when configured",
+      "code": "import d from '.'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\n\nimport type { T } from 't'\nimport { e1, e2, e3 } from '../../e'\n\nimport { b1, b2 } from '~/b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (value-external) to come before \".\" (value-index).",
+          "data": {
+            "right": "a",
+            "rightGroup": "value-external",
+            "left": ".",
+            "leftGroup": "value-index"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\nimport { b1, b2 } from '~/b'\nimport { e1, e2, e3 } from '../../e'\nimport d from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"t\" (type-import) to come before \"~/c\" (value-internal).",
+          "data": {
+            "right": "t",
+            "rightGroup": "type-import",
+            "left": "~/c",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\nimport { b1, b2 } from '~/b'\nimport { e1, e2, e3 } from '../../e'\nimport d from '.'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/b\" (value-internal) to come before \"../../e\" (value-parent).",
+          "data": {
+            "right": "~/b",
+            "rightGroup": "value-internal",
+            "left": "../../e",
+            "leftGroup": "value-parent"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 176],
+            "text": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\nimport { b1, b2 } from '~/b'\nimport { e1, e2, e3 } from '../../e'\nimport d from '.'"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\nimport { a1, a2, a3 } from 'a'\nimport { c1, c2, c3 } from '~/c'\nimport { b1, b2 } from '~/b'\nimport { e1, e2, e3 } from '../../e'\nimport d from '.'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > removes extra spacing between import groups",
+      "code": "import { A } from 'a'\n\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes extra spacing between import groups",
+      "code": "import { A } from 'a'\n\n\nimport b from '~/b'\nimport c from '~/c'\n\nimport d from '~/d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"~/b\".",
+          "data": {
+            "left": "a",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [21, 65],
+            "text": "\n\nimport b from '~/b'\nimport c from '~/c'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/c\" and \"~/d\".",
+          "data": {
+            "left": "~/c",
+            "right": "~/d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [21, 65],
+            "text": "\n\nimport b from '~/b'\nimport c from '~/c'\n"
+          }
+        }
+      ],
+      "output": "import { A } from 'a'\n\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > handles TypeScript import-equals syntax correctly",
+      "code": "import type T = require(\"T\")\n\nimport c = require('c/c')\nimport { A } from 'a'\n\nimport { B } from '../b'\n\nimport log = console.log",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > handles TypeScript import-equals syntax correctly",
+      "code": "import type T = require(\"T\")\n\nimport { A } from 'a'\nimport { B } from '../b'\n\nimport log = console.log\nimport c = require('c/c')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"../b\".",
+          "data": {
+            "left": "a",
+            "right": "../b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [30, 128],
+            "text": "import c = require('c/c')\nimport { A } from 'a'\n\nimport { B } from '../b'\n\nimport log = console.log"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c/c\" (value-external) to come before \"console.log\" (ts-equals-import).",
+          "data": {
+            "right": "c/c",
+            "rightGroup": "value-external",
+            "left": "console.log",
+            "leftGroup": "ts-equals-import"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [30, 128],
+            "text": "import c = require('c/c')\nimport { A } from 'a'\n\nimport { B } from '../b'\n\nimport log = console.log"
+          }
+        }
+      ],
+      "output": "import type T = require(\"T\")\n\nimport c = require('c/c')\nimport { A } from 'a'\n\nimport { B } from '../b'\n\nimport log = console.log"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > groups all type imports together when specific type groups not configured",
+      "code": "import type { T } from '../t'\nimport type { U } from '~/u'\nimport type { V } from 'v'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["type", ["builtin", "external"], "internal", ["parent", "sibling", "index"]]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > groups all type imports together when specific type groups not configured",
+      "code": "import type { T } from '../t'\n\nimport type { U } from '~/u'\n\nimport type { V } from 'v'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["type", ["builtin", "external"], "internal", ["parent", "sibling", "index"]]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"../t\" and \"~/u\".",
+          "data": {
+            "left": "../t",
+            "right": "~/u"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [29, 61],
+            "text": "\nimport type { U } from '~/u'\n"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/u\" and \"v\".",
+          "data": {
+            "left": "~/u",
+            "right": "v"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [29, 61],
+            "text": "\nimport type { U } from '~/u'\n"
+          }
+        }
+      ],
+      "output": "import type { T } from '../t'\nimport type { U } from '~/u'\nimport type { V } from 'v'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves inline comments during sorting",
+      "code": "import { b1, b2 } from 'b' // Comment\nimport { a } from 'a'\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > ignores comments when calculating spacing between imports",
+      "code": "import type { T } from 't'\n\n// @ts-expect-error missing types\nimport { t } from 't'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > stops grouping imports when other statements appear between them",
+      "code": "import type { V } from 'v'\n\nexport type { U } from 'u'\n\nimport type { T1, T2 } from 't'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > groups style imports separately when configured",
+      "code": "import { a1, a2 } from 'a'\n\nimport styles from '../s.css'\nimport './t.css'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown", "style"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > groups side-effect imports separately when configured",
+      "code": "import { A } from '../a'\nimport { b } from './b'\n\nimport '../c.js'\nimport './d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > groups builtin types separately from other type imports",
+      "code": "import type { Server } from 'http'\n\nimport type { a } from 'a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["type-builtin", "type-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > handles imports with semicolons correctly",
+      "code": "import a from 'a';\nimport b from './index';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"./index\".",
+          "data": {
+            "left": "a",
+            "right": "./index"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [18, 19],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import a from 'a';\n\nimport b from './index';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes extra spacing and sorts imports correctly",
+      "code": "import { a } from 'a'\n\n\nimport { b } from './b'\n\n\n\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"./b\".",
+          "data": {
+            "left": "a",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [21, 72],
+            "text": "\nimport { c } from 'c'\n\nimport { b } from './b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c\" (value-external) to come before \"./b\" (value-sibling).",
+          "data": {
+            "right": "c",
+            "rightGroup": "value-external",
+            "left": "./b",
+            "leftGroup": "value-sibling"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [21, 72],
+            "text": "\nimport { c } from 'c'\n\nimport { b } from './b'"
+          }
+        }
+      ],
+      "output": "import { a } from 'a'\nimport { c } from 'c'\n\nimport { b } from './b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > supports custom import groups with primary and secondary categories",
+      "code": "import type { T } from 't'\n\nimport a1 from '@a/a1'\nimport a2 from '@a/a2'\nimport b1 from '@b/b1'\nimport b2 from '@b/b2'\nimport b3 from '@b/b3'\nimport { c } from 'c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": ["^t$", "^@a/.+"],
+              "groupName": "primary"
+            },
+            {
+              "elementNamePattern": "^@b/.+",
+              "groupName": "secondary",
+              "modifiers": ["value"]
+            }
+          ],
+          "groups": ["type", "primary", "secondary", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"t\" and \"@a/a1\".",
+          "data": {
+            "left": "t",
+            "right": "@a/a1"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [26, 143],
+            "text": "\nimport a1 from '@a/a1'\nimport a2 from '@a/a2'\n\nimport b1 from '@b/b1'\nimport b2 from '@b/b2'\nimport b3 from '@b/b3'\n\n"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"@a/a2\" and \"@b/b1\".",
+          "data": {
+            "left": "@a/a2",
+            "right": "@b/b1"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [26, 143],
+            "text": "\nimport a1 from '@a/a1'\nimport a2 from '@a/a2'\n\nimport b1 from '@b/b1'\nimport b2 from '@b/b2'\nimport b3 from '@b/b3'\n\n"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"@b/b3\" and \"c\".",
+          "data": {
+            "left": "@b/b3",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [26, 143],
+            "text": "\nimport a1 from '@a/a1'\nimport a2 from '@a/a2'\n\nimport b1 from '@b/b1'\nimport b2 from '@b/b2'\nimport b3 from '@b/b3'\n\n"
+          }
+        }
+      ],
+      "output": "import type { T } from 't'\nimport a1 from '@a/a1'\nimport a2 from '@a/a2'\n\nimport b1 from '@b/b1'\nimport b2 from '@b/b2'\nimport b3 from '@b/b3'\n\nimport { c } from 'c'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > marks submodule imports as internal by default",
+      "code": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\n\nimport { b1, b2 } from '#b'\nimport c from '#c'\n\nimport { d } from '../d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > marks submodule imports as internal by default",
+      "code": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\nimport c from '#c'\nimport { b1, b2 } from '#b'\n\nimport { d } from '../d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"#b\" and \"#c\".",
+          "data": {
+            "left": "#b",
+            "right": "#c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [78, 125],
+            "text": "\n\nimport { b1, b2 } from '#b'\nimport c from '#c'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"#b\" to come before \"#c\".",
+          "data": {
+            "right": "#b",
+            "left": "#c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [78, 125],
+            "text": "\n\nimport { b1, b2 } from '#b'\nimport c from '#c'"
+          }
+        }
+      ],
+      "output": "import type { T } from 'a'\n\nimport { a } from 'a'\n\nimport type { S } from '#b'\n\nimport { b1, b2 } from '#b'\nimport c from '#c'\n\nimport { d } from '../d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > recognizes Bun built-in modules when configured",
+      "code": "import { expect } from 'bun:test'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["builtin", "external", "unknown"],
+          "newlinesBetween": 0,
+          "environment": "bun"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > recognizes Bun built-in modules when configured",
+      "code": "import { a } from 'a'\nimport { expect } from 'bun:test'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["builtin", "external", "unknown"],
+          "newlinesBetween": 0,
+          "environment": "bun"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"bun:test\" (builtin) to come before \"a\" (external).",
+          "data": {
+            "right": "bun:test",
+            "rightGroup": "builtin",
+            "left": "a",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import { expect } from 'bun:test'\nimport { a } from 'a'"
+          }
+        }
+      ],
+      "output": "import { expect } from 'bun:test'\nimport { a } from 'a'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > sorts CommonJS require imports by module name",
+      "code": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts CommonJS require imports by module name",
+      "code": "const { b1 } = require('b')\nconst { a1, a2 } = require('a')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 59],
+            "text": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')"
+          }
+        }
+      ],
+      "output": "const { a1, a2 } = require('a')\nconst { b1 } = require('b')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > groups and sorts CommonJS require imports by type and source",
+      "code": "const { c1, c2, c3, c4 } = require('c')\nconst { e1 } = require('e/a')\nconst { e2 } = require('e/b')\nconst path = require('path')\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > groups and sorts CommonJS require imports by type and source",
+      "code": "const { c1, c2, c3, c4 } = require('c')\nconst { e2 } = require('e/b')\nconst { e1 } = require('e/a')\nconst path = require('path')\n\nconst { b1, b2 } = require('~/b')\nconst fs = require('fs')\nconst { c1 } = require('~/c')\nconst { i1, i2, i3 } = require('~/i')\n\nconst h = require('../../h')\n\nconst a = require('.')\nconst { j } = require('../j')\nconst { K, L, M } = require('../k')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"fs\" (value-builtin) to come before \"~/b\" (value-internal).",
+          "data": {
+            "right": "fs",
+            "rightGroup": "value-builtin",
+            "left": "~/b",
+            "leftGroup": "value-internal"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [128, 376],
+            "text": "\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"fs\" and \"~/c\".",
+          "data": {
+            "left": "fs",
+            "right": "~/c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [128, 376],
+            "text": "\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/i\" to come before \"~/c\".",
+          "data": {
+            "right": "~/i",
+            "left": "~/c"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 38
+          },
+          "fix": {
+            "range": [128, 376],
+            "text": "\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"../../h\" and \".\".",
+          "data": {
+            "left": "../../h",
+            "right": "."
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 13,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [128, 376],
+            "text": "\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"../j\" to come before \".\".",
+          "data": {
+            "right": "../j",
+            "left": "."
+          },
+          "loc": {
+            "startLine": 14,
+            "startColumn": 1,
+            "endLine": 14,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [128, 376],
+            "text": "\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"../k\" to come before \"../j\".",
+          "data": {
+            "right": "../k",
+            "left": "../j"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 36
+          },
+          "fix": {
+            "range": [128, 376],
+            "text": "\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+          }
+        }
+      ],
+      "output": "const { c1, c2, c3, c4 } = require('c')\nconst { e2 } = require('e/b')\nconst { e1 } = require('e/a')\nconst path = require('path')\nconst fs = require('fs')\n\nconst { i1, i2, i3 } = require('~/i')\nconst { b1, b2 } = require('~/b')\nconst { c1 } = require('~/c')\n\nconst { K, L, M } = require('../k')\nconst { j } = require('../j')\nconst h = require('../../h')\nconst a = require('.')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves side-effect import order when sorting disabled",
+      "code": "import a from 'aaaa'\n\nimport 'bbb'\nimport './cc'\nimport '../d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves side-effect import order when sorting disabled",
+      "code": "import 'c'\nimport 'bb'\nimport 'aaa'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > preserves side-effect import order when sorting disabled",
+      "code": "import './cc'\nimport 'bbb'\nimport e from 'e'\nimport a from 'aaaa'\nimport '../d'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"e\" (external) to come before \"bbb\" (side-effect).",
+          "data": {
+            "right": "e",
+            "rightGroup": "external",
+            "left": "bbb",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aaaa\" to come before \"e\".",
+          "data": {
+            "right": "aaaa",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aaaa\" and \"../d\".",
+          "data": {
+            "left": "aaaa",
+            "right": "../d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [0, 65],
+            "text": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'"
+          }
+        }
+      ],
+      "output": "import a from 'aaaa'\nimport e from 'e'\n\nimport './cc'\nimport 'bbb'\nimport '../d'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts side-effect imports when sorting enabled",
+      "code": "import 'c'\nimport 'bb'\nimport 'aaa'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["external", "side-effect", "unknown"],
+          "sortSideEffects": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 12
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import 'aaa'\nimport 'bb'\nimport 'c'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aaa\" to come before \"bb\".",
+          "data": {
+            "right": "aaa",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 35],
+            "text": "import 'aaa'\nimport 'bb'\nimport 'c'"
+          }
+        }
+      ],
+      "output": "import 'aaa'\nimport 'bb'\nimport 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > preserves original order when side-effect imports are not grouped",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport a from \"./aa\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./aa\" to come before \"./b\".",
+          "data": {
+            "right": "./aa",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [31, 73],
+            "text": "import a from \"./aa\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport a from \"./aa\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > groups side-effect imports together without sorting them",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["side-effect", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 131],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 131],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 131],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";\nimport a from \"./a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > groups side-effect and style imports together in same group without sorting",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [["side-effect", "side-effect-style"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 131],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [31, 131],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [31, 131],
+            "text": "import './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect.scss\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\n\nimport b from \"./b\";\nimport a from \"./a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > separates side-effect and style imports into distinct groups without sorting",
+      "code": "import \"./z-side-effect.scss\";\nimport b from \"./b\";\nimport './b-side-effect'\nimport \"./g-side-effect.css\";\nimport './a-side-effect'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["side-effect", "side-effect-style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./z-side-effect.scss\" and \"./b\".",
+          "data": {
+            "left": "./z-side-effect.scss",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 131],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect\" (side-effect) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 131],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./b-side-effect\" and \"./g-side-effect.css\".",
+          "data": {
+            "left": "./b-side-effect",
+            "right": "./g-side-effect.css"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 131],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a-side-effect\" (side-effect) to come before \"./g-side-effect.css\" (side-effect-style).",
+          "data": {
+            "right": "./a-side-effect",
+            "rightGroup": "side-effect",
+            "left": "./g-side-effect.css",
+            "leftGroup": "side-effect-style"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 131],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 131],
+            "text": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import './b-side-effect'\nimport './a-side-effect'\n\nimport \"./z-side-effect.scss\";\nimport \"./g-side-effect.css\";\n\nimport b from \"./b\";\nimport a from \"./a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > groups style side-effect imports separately without sorting",
+      "code": "import \"./z-side-effect\";\nimport b from \"./b\";\nimport './b-side-effect.scss'\nimport \"./g-side-effect\";\nimport './a-side-effect.css'\nimport a from \"./a\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["side-effect-style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b-side-effect.scss\" (side-effect-style) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./b-side-effect.scss",
+            "rightGroup": "side-effect-style",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [26, 131],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./b-side-effect.scss\" and \"./g-side-effect\".",
+          "data": {
+            "left": "./b-side-effect.scss",
+            "right": "./g-side-effect"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [26, 131],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a-side-effect.css\" (side-effect-style) to come before \"./g-side-effect\" (unknown).",
+          "data": {
+            "right": "./a-side-effect.css",
+            "rightGroup": "side-effect-style",
+            "left": "./g-side-effect",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [26, 131],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport b from \"./b\";"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"./a-side-effect.css\" and \"./a\".",
+          "data": {
+            "left": "./a-side-effect.css",
+            "right": "./a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [26, 131],
+            "text": "import './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport b from \"./b\";"
+          }
+        }
+      ],
+      "output": "import \"./z-side-effect\";\nimport './b-side-effect.scss'\nimport './a-side-effect.css'\n\nimport \"./g-side-effect\";\nimport b from \"./b\";\nimport a from \"./a\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > ignores fallback sorting for side-effect imports",
+      "code": "import 'b';\nimport 'a';\n\nimport 'b.css';\nimport 'a.css';",
+      "options": [
+        {
+          "groups": ["side-effect", "side-effect-style"],
+          "fallbackSort": {
+            "type": "alphabetical"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > handles special characters with trim option",
+      "code": "import '_a'\nimport 'b'\nimport '_c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > handles special characters with remove option",
+      "code": "import 'ab'\nimport 'a_c'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports locale-specific sorting",
+      "code": "import '你好'\nimport '世界'\nimport 'a'\nimport 'A'\nimport 'b'\nimport 'B'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes newlines with 0 option",
+      "code": "  import { A } from 'aaaa'\n\n\n import y from '~/y'\nimport z from '~/z'\n\n    import b from '~/bb'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"aaaa\" and \"~/y\".",
+          "data": {
+            "left": "aaaa",
+            "right": "~/y"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 2,
+            "endLine": 4,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [26, 95],
+            "text": "\n import b from '~/bb'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/bb\" to come before \"~/z\".",
+          "data": {
+            "right": "~/bb",
+            "left": "~/z"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [26, 95],
+            "text": "\n import b from '~/bb'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"~/z\" and \"~/bb\".",
+          "data": {
+            "left": "~/z",
+            "right": "~/bb"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [26, 95],
+            "text": "\n import b from '~/bb'\nimport y from '~/y'\n    import z from '~/z'"
+          }
+        }
+      ],
+      "output": "  import { A } from 'aaaa'\n import b from '~/bb'\nimport y from '~/y'\n    import z from '~/z'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > enforces spacing when global option is 2 and group option is 0",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > enforces spacing when global option is 2 and group option is ignore",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > enforces spacing when global option is 0 and group option is 2",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > enforces spacing when global option is ignore and group option is 2",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 23],
+            "text": "\n\n\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\n\n\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes spacing when 0 option exists between groups regardless of global setting 1",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes spacing when 0 option exists between groups regardless of global setting 2",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes spacing when 0 option exists between groups regardless of global setting ignore",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes spacing when 0 option exists between groups regardless of global setting 0",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenImports",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [22, 24],
+            "text": "\n"
+          }
+        }
+      ],
+      "output": "import { a } from 'a';\nimport { b } from 'b';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves existing spacing when ignore and 0 options are combined",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves existing spacing when ignore and 0 options are combined",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves existing spacing when 0 and ignore options are combined",
+      "code": "import { a } from 'a';\n\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > preserves existing spacing when 0 and ignore options are combined",
+      "code": "import { a } from 'a';\nimport { b } from 'b';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            },
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > handles newlines and comments after fixes",
+      "code": "import { b } from 'b'\nimport { a } from './a' // Comment after\n\nimport { c } from 'c'",
+      "options": [
+        {
+          "groups": ["unknown", "external"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./a\" (unknown) to come before \"b\" (external).",
+          "data": {
+            "right": "./a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import { a } from './a' // Comment after\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a } from './a' // Comment after\n\nimport { b } from 'b'\nimport { c } from 'c'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > ignores newline fixes between different partitions with 0 option",
+      "code": "import a from 'a';\n\n// Partition comment\n\nimport { c } from './c';\nimport { b } from './bb';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [42, 92],
+            "text": "import { b } from './bb';\nimport { c } from './c';"
+          }
+        }
+      ],
+      "output": "import a from 'a';\n\n// Partition comment\n\nimport { b } from './bb';\nimport { c } from './c';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts inline imports correctly",
+      "code": "import { b } from \"b\"; import { a } from \"aa\"",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 46
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "import { a } from \"aa\"; import { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "import { a } from \"aa\"; import { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts inline imports correctly",
+      "code": "import { b } from \"b\"; import { a } from \"aa\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 24,
+            "endLine": 1,
+            "endColumn": 47
+          },
+          "fix": {
+            "range": [0, 46],
+            "text": "import { a } from \"aa\"; import { b } from \"b\";"
+          }
+        }
+      ],
+      "output": "import { a } from \"aa\"; import { b } from \"b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > allows partitioning by new lines",
+      "code": "import * as organisms from \"./organisms\";\nimport * as atoms from \"./atoms\";\nimport * as shared from \"./shared\";\n\nimport { AnotherNamed } from './second-folder';\nimport { Named } from './folder';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./shared\" to come before \"./atoms\".",
+          "data": {
+            "right": "./shared",
+            "left": "./atoms"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 36
+          },
+          "fix": {
+            "range": [42, 111],
+            "text": "import * as shared from \"./shared\";\nimport * as atoms from \"./atoms\";"
+          }
+        }
+      ],
+      "output": "import * as organisms from \"./organisms\";\nimport * as shared from \"./shared\";\nimport * as atoms from \"./atoms\";\n\nimport { AnotherNamed } from './second-folder';\nimport { Named } from './folder';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > allows partitioning by comment patterns",
+      "code": "// Part: A\nimport cc from './cc';\nimport d from './d';\n// Not partition comment\nimport bbb from './bbb';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\nimport gg from './gg';\n// Not partition comment\nimport fff from './fff';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bbb\" to come before \"./d\".",
+          "data": {
+            "right": "./bbb",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [11, 247],
+            "text": "// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./fff\" to come before \"./gg\".",
+          "data": {
+            "right": "./fff",
+            "left": "./gg"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [11, 247],
+            "text": "// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+          }
+        }
+      ],
+      "output": "// Part: A\n// Not partition comment\nimport bbb from './bbb';\nimport cc from './cc';\nimport d from './d';\n// Part: B\nimport aaaa from './aaaa';\nimport e from './e';\n// Part: C\n// Not partition comment\nimport fff from './fff';\nimport gg from './gg';"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > treats all comments as partition boundaries when enabled",
+      "code": "// Comment\nimport bb from './bb';\n// Other comment\nimport a from './a';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > supports multiple partition comment patterns",
+      "code": "/* Partition Comment */\n// Part: A\nimport d from './d'\n// Part: B\nimport aaa from './aaa'\nimport c from './c'\nimport bb from './bb'\n/* Other */\nimport e from './e'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./bb\" to come before \"./c\".",
+          "data": {
+            "right": "./bb",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [90, 131],
+            "text": "import bb from './bb'\nimport c from './c'"
+          }
+        }
+      ],
+      "output": "/* Partition Comment */\n// Part: A\nimport d from './d'\n// Part: B\nimport aaa from './aaa'\nimport bb from './bb'\nimport c from './c'\n/* Other */\nimport e from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports regex patterns for partition comments",
+      "code": "import e from './e'\nimport f from './f'\n// I am a partition comment because I don't have f o o\nimport a from './a'\nimport b from './b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > ignores block comments when line comment partitioning is enabled",
+      "code": "import b from './b'\n/* Comment */\nimport a from './aa'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./aa\" to come before \"./b\".",
+          "data": {
+            "right": "./aa",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "/* Comment */\nimport a from './aa'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "/* Comment */\nimport a from './aa'\nimport b from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > treats all line comments as partition boundaries when enabled",
+      "code": "import b from './b'\n// Comment\nimport a from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports multiple line comment patterns for partitioning",
+      "code": "import c from './c'\n// b\nimport b from './b'\n// a\nimport a from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports regex patterns for line comment partitioning",
+      "code": "import b from './b'\n// I am a partition comment because I don't have f o o\nimport a from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > ignores line comments when block comment partitioning is enabled",
+      "code": "import b from './b'\n// Comment\nimport a from './aa'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./aa\" to come before \"./b\".",
+          "data": {
+            "right": "./aa",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "// Comment\nimport a from './aa'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "// Comment\nimport a from './aa'\nimport b from './b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > treats all block comments as partition boundaries when enabled",
+      "code": "import b from './b'\n/* Comment */\nimport a from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports multiple block comment patterns for partitioning",
+      "code": "import c from './c'\n/* b */\nimport b from './b'\n/* a */\nimport a from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports regex patterns for block comment partitioning",
+      "code": "import b from './bb'\n/* I am a partition comment because I don't have f o o */\nimport a from './a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > supports style imports with query parameters",
+      "code": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > supports style imports with query parameters",
+      "code": "import a from './a.js'\nimport b from './b.css?raw'\nimport c from './c.css'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["style", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./b.css?raw\" (style) to come before \"./a.js\" (unknown).",
+          "data": {
+            "right": "./b.css?raw",
+            "rightGroup": "style",
+            "left": "./a.js",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 74],
+            "text": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'"
+          }
+        }
+      ],
+      "output": "import b from './b.css?raw'\nimport c from './c.css'\n\nimport a from './a.js'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes index types over sibling types",
+      "code": "import type a from './a'\n\nimport type b from './index'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["type-index", "type-sibling"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index\" (type-index) to come before \"./a\" (type-sibling).",
+          "data": {
+            "right": "./index",
+            "rightGroup": "type-index",
+            "left": "./a",
+            "leftGroup": "type-sibling"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import type b from './index'\n\nimport type a from './a'"
+          }
+        }
+      ],
+      "output": "import type b from './index'\n\nimport type a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes index imports over sibling imports",
+      "code": "import a from './a'\n\nimport b from './index'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["index", "sibling"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./index\" (index) to come before \"./a\" (sibling).",
+          "data": {
+            "right": "./index",
+            "rightGroup": "index",
+            "left": "./a",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import b from './index'\n\nimport a from './a'"
+          }
+        }
+      ],
+      "output": "import b from './index'\n\nimport a from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes style side-effects over generic side-effects",
+      "code": "import 'something'\n\nimport 'style.css'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["side-effect-style", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"style.css\" (side-effect-style) to come before \"something\" (side-effect).",
+          "data": {
+            "right": "style.css",
+            "rightGroup": "side-effect-style",
+            "left": "something",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 38],
+            "text": "import 'style.css'\n\nimport 'something'"
+          }
+        }
+      ],
+      "output": "import 'style.css'\n\nimport 'something'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes side-effects over style imports with default exports",
+      "code": "import style from 'style.css'\n\nimport 'something'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["side-effect", "style"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"something\" (side-effect) to come before \"style.css\" (style).",
+          "data": {
+            "right": "something",
+            "rightGroup": "side-effect",
+            "left": "style.css",
+            "leftGroup": "style"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import 'something'\n\nimport style from 'style.css'"
+          }
+        }
+      ],
+      "output": "import 'something'\n\nimport style from 'style.css'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes style imports over other import types",
+      "code": "import a from '../a'\nimport b from './b'\nimport c from './index'\nimport subpath from '#subpath'\nimport tsConfigPath from '$path'\nimport d from 'd'\nimport e from 'timers'\n\nimport style from 'style.css'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "style",
+            [
+              "index",
+              "internal",
+              "subpath",
+              "external",
+              "sibling",
+              "builtin",
+              "parent",
+              "tsconfig-path"
+            ]
+          ],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./index\" to come before \"./b\".",
+          "data": {
+            "right": "./index",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport tsConfigPath from '$path'\nimport subpath from '#subpath'\nimport c from './index'\nimport e from 'timers'\nimport a from '../a'\nimport b from './b'\nimport d from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"#subpath\" to come before \"./index\".",
+          "data": {
+            "right": "#subpath",
+            "left": "./index"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport tsConfigPath from '$path'\nimport subpath from '#subpath'\nimport c from './index'\nimport e from 'timers'\nimport a from '../a'\nimport b from './b'\nimport d from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"$path\" to come before \"#subpath\".",
+          "data": {
+            "right": "$path",
+            "left": "#subpath"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport tsConfigPath from '$path'\nimport subpath from '#subpath'\nimport c from './index'\nimport e from 'timers'\nimport a from '../a'\nimport b from './b'\nimport d from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"timers\" to come before \"d\".",
+          "data": {
+            "right": "timers",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport tsConfigPath from '$path'\nimport subpath from '#subpath'\nimport c from './index'\nimport e from 'timers'\nimport a from '../a'\nimport b from './b'\nimport d from 'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"style.css\" (style) to come before \"timers\" (builtin).",
+          "data": {
+            "right": "style.css",
+            "rightGroup": "style",
+            "left": "timers",
+            "leftGroup": "builtin"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 200],
+            "text": "import style from 'style.css'\n\nimport tsConfigPath from '$path'\nimport subpath from '#subpath'\nimport c from './index'\nimport e from 'timers'\nimport a from '../a'\nimport b from './b'\nimport d from 'd'"
+          }
+        }
+      ],
+      "output": "import style from 'style.css'\n\nimport tsConfigPath from '$path'\nimport subpath from '#subpath'\nimport c from './index'\nimport e from 'timers'\nimport a from '../a'\nimport b from './b'\nimport d from 'd'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes external imports over generic import group",
+      "code": "import a from './aa'\n\nimport b from 'b'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["external", "import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"b\" (external) to come before \"./aa\" (import).",
+          "data": {
+            "right": "b",
+            "rightGroup": "external",
+            "left": "./aa",
+            "leftGroup": "import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [0, 39],
+            "text": "import b from 'b'\n\nimport a from './aa'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\n\nimport a from './aa'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes type imports over TypeScript equals imports",
+      "code": "import z = require('./z')\n\nimport type { Types } from './types'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["type-import", "external", "ts-equals-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./types\" (type-import) to come before \"./z\" (ts-equals-import).",
+          "data": {
+            "right": "./types",
+            "rightGroup": "type-import",
+            "left": "./z",
+            "leftGroup": "ts-equals-import"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 37
+          },
+          "fix": {
+            "range": [0, 63],
+            "text": "import type { Types } from './types'\n\nimport z = require('./z')"
+          }
+        }
+      ],
+      "output": "import type { Types } from './types'\n\nimport z = require('./z')"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes side-effect imports over value imports",
+      "code": "import f from 'f'\n\nimport \"./z\"",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["side-effect-import", "external", "value-import"],
+          "sortSideEffects": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (side-effect-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "side-effect-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "import \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes value imports over TypeScript equals imports",
+      "code": "import f from 'f'\n\nimport z = z",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["value-import", "external", "ts-equals-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"z\" (value-import) to come before \"f\" (external).",
+          "data": {
+            "right": "z",
+            "rightGroup": "value-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 13
+          },
+          "fix": {
+            "range": [0, 31],
+            "text": "import z = z\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z = z\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes TypeScript equals imports over require imports",
+      "code": "import f from 'f'\n\nimport z = require('./z')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["ts-equals-import", "external", "require-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (ts-equals-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "ts-equals-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [0, 44],
+            "text": "import z = require('./z')\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z = require('./z')\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes default imports over named imports",
+      "code": "import f from 'f'\n\nimport z, { z } from \"./z\"",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["default-import", "external", "named-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (default-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "default-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 45],
+            "text": "import z, { z } from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z, { z } from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes wildcard imports over named imports",
+      "code": "import f from 'f'\n\nimport z, * as z from \"./z\"",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["wildcard-import", "external", "named-import"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./z\" (wildcard-import) to come before \"f\" (external).",
+          "data": {
+            "right": "./z",
+            "rightGroup": "wildcard-import",
+            "left": "f",
+            "leftGroup": "external"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 46],
+            "text": "import z, * as z from \"./z\"\n\nimport f from 'f'"
+          }
+        }
+      ],
+      "output": "import z, * as z from \"./z\"\n\nimport f from 'f'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > filters on element name pattern with string",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > filters on element name pattern with array",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > filters on element name pattern with regex object",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > filters on element name pattern with array containing regex",
+      "code": "import a from 'a'\n\nimport hello from 'helloImport'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithHello",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["importsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"helloImport\" (importsStartingWithHello) to come before \"a\" (unknown).",
+          "data": {
+            "right": "helloImport",
+            "rightGroup": "importsStartingWithHello",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 32
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import hello from 'helloImport'\n\nimport a from 'a'"
+          }
+        }
+      ],
+      "output": "import hello from 'helloImport'\n\nimport a from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts custom groups by overriding type and order settings",
+      "code": "import a from 'a'\nimport bb from 'bb'\nimport ccc from 'ccc'\nimport dddd from 'dddd'\nimport jjjjj from './jjjjj'\nimport eee from 'eee'\nimport ff from 'ff'\nimport g from 'g'\nimport h from './h'\nimport i from './i'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedExternalImportsByLineLength",
+              "selector": "external",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedExternalImportsByLineLength", "unknown"],
+          "newlinesBetween": "ignore",
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"eee\" (reversedExternalImportsByLineLength) to come before \"./jjjjj\" (unknown).",
+          "data": {
+            "right": "eee",
+            "rightGroup": "reversedExternalImportsByLineLength",
+            "left": "./jjjjj",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 211],
+            "text": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+          }
+        }
+      ],
+      "output": "import dddd from 'dddd'\nimport ccc from 'ccc'\nimport eee from 'eee'\nimport bb from 'bb'\nimport ff from 'ff'\nimport a from 'a'\nimport g from 'g'\nimport h from './h'\nimport i from './i'\nimport jjjjj from './jjjjj'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts custom groups using fallback sort settings",
+      "code": "import fooZar from 'fooZar'\nimport fooBar from 'fooBar'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import fooBar from 'fooBar'\nimport fooZar from 'fooZar'"
+          }
+        }
+      ],
+      "output": "import fooBar from 'fooBar'\nimport fooZar from 'fooZar'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > preserves order for custom groups with unsorted type",
+      "code": "import b from 'b'\nimport a from 'a'\nimport d from 'd'\nimport e from 'e'\nimport something from './something'\nimport c from 'c'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "unsortedExternalImports",
+              "selector": "external",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedExternalImports", "unknown"],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"c\" (unsortedExternalImports) to come before \"./something\" (unknown).",
+          "data": {
+            "right": "c",
+            "rightGroup": "unsortedExternalImports",
+            "left": "./something",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [72, 125],
+            "text": "import c from 'c'\nimport something from './something'"
+          }
+        }
+      ],
+      "output": "import b from 'b'\nimport a from 'a'\nimport d from 'd'\nimport e from 'e'\nimport c from 'c'\nimport something from './something'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts custom group blocks with complex selectors",
+      "code": "import a from 'a'\nimport b from './b'\nimport type c from './c'\nimport type d from './d'\nimport e from 'e'\nimport i from './index'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "selector": "external"
+                },
+                {
+                  "selector": "sibling",
+                  "modifiers": ["type"]
+                }
+              ],
+              "groupName": "externalAndTypeSiblingImports"
+            }
+          ],
+          "groups": [["externalAndTypeSiblingImports", "index"], "unknown"],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./c\" (externalAndTypeSiblingImports) to come before \"./b\" (unknown).",
+          "data": {
+            "right": "./c",
+            "rightGroup": "externalAndTypeSiblingImports",
+            "left": "./b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 129],
+            "text": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./index\" to come before \"e\".",
+          "data": {
+            "right": "./index",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 129],
+            "text": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+          }
+        }
+      ],
+      "output": "import type c from './c'\nimport type d from './d'\nimport i from './index'\nimport a from 'a'\nimport e from 'e'\nimport b from './b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport { aImport } from \"b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 29
+          },
+          "fix": {
+            "range": [0, 54],
+            "text": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import { aImport } from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport * as aImport from \"b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import * as aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > detects TypeScript import-equals dependencies",
+      "code": "import a = aImport.a1.a2;\nimport aImport = require(\"b\")",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport = require(\"b\")\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > prioritizes dependencies over group configuration",
+      "code": "import aImport from \"b\";\nimport a = aImport.a1.a2;",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes dependencies over group configuration",
+      "code": "import a = aImport.a1.a2;\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "groupName": "importsStartingWithA",
+              "elementNamePattern": "^a"
+            },
+            {
+              "groupName": "importsStartingWithB",
+              "elementNamePattern": "^b"
+            }
+          ],
+          "groups": ["importsStartingWithA", "importsStartingWithB"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"aImport.a1.a2\" and \"b\".",
+          "data": {
+            "left": "aImport.a1.a2",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 50],
+            "text": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes dependencies over comment-based partitions",
+      "code": "import a = aImport.a1.a2;\n\n// Part: 1\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 62],
+            "text": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\n// Part: 1\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes dependencies over newline-based partitions",
+      "code": "import a = aImport.a1.a2;\n\nimport aImport from \"b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 51],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > prioritizes content separation over dependencies",
+      "code": "import f = fImport.f1.f2;\n\nimport y = yImport.y1.y2;\n\nimport yImport from \"z\";\n\nexport { something } from \"something\";\n\nimport a = aImport.a1.a2;\n\nimport aImport from \"b\";\n\nimport fImport from \"g\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "newlinesBetween": "ignore",
+          "newlinesInside": "ignore",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"z\" to come before \"yImport.y1.y2\".",
+          "data": {
+            "right": "z",
+            "nodeDependentOnRight": "yImport.y1.y2"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [27, 78],
+            "text": "import yImport from \"z\";\n\nimport y = yImport.y1.y2;"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsDependencyOrder",
+          "message": "Expected dependency \"b\" to come before \"aImport.a1.a2\".",
+          "data": {
+            "right": "b",
+            "nodeDependentOnRight": "aImport.a1.a2"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [120, 171],
+            "text": "import aImport from \"b\";\n\nimport a = aImport.a1.a2;"
+          }
+        }
+      ],
+      "output": "import f = fImport.f1.f2;\n\nimport yImport from \"z\";\n\nimport y = yImport.y1.y2;\n\nexport { something } from \"something\";\n\nimport aImport from \"b\";\n\nimport a = aImport.a1.a2;\n\nimport fImport from \"g\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > ignores shebang comments when sorting imports",
+      "code": "#!/usr/bin/node\nimport { b } from 'b'\nimport { a } from 'aa'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [16, 60],
+            "text": "import { a } from 'aa'\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\nimport { a } from 'aa'\nimport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > treats @ symbol pattern as internal imports",
+      "code": "import { b } from 'b'\nimport { a } from '@/a'",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": ["external", "internal"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"b\" and \"@/a\".",
+          "data": {
+            "left": "b",
+            "right": "@/a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [21, 22],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import { b } from 'b'\n\nimport { a } from '@/a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > reports missing comments above import groups",
+      "code": "import { a } from \"a\";\n\nimport { b } from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Comment above a",
+              "group": ["external"]
+            },
+            {
+              "commentAbove": "Comment above b",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above a\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above a",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 24],
+            "text": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\n"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above b\" above \"./b\".",
+          "data": {
+            "missedCommentAbove": "Comment above b",
+            "right": "./b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 25
+          },
+          "fix": {
+            "range": [0, 24],
+            "text": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\n"
+          }
+        }
+      ],
+      "output": "// Comment above a\nimport { a } from \"a\";\n\n// Comment above b\nimport { b } from \"./b\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > reports missing comments for single import groups",
+      "code": "import { a } from \"a\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above\" above \"a\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 0],
+            "text": "// Comment above\n"
+          }
+        }
+      ],
+      "output": "// Comment above\nimport { a } from \"a\";"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > ignores shebangs and top-level comments when adding group comments",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\nimport b from \"b\";\nimport a from \"aa\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "Comment above",
+              "group": "external"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"Comment above\" above \"b\".",
+          "data": {
+            "missedCommentAbove": "Comment above",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 74],
+            "text": "import a from \"aa\";\nimport b from \"b\";"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [36, 74],
+            "text": "import a from \"aa\";\nimport b from \"b\";"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above\nimport a from \"aa\";\nimport b from \"b\";"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > detects existing line comment with extra spaces",
+      "code": "import a from \"a\";\n\n//   Comment above  \nimport b from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > detects existing line comment with different case",
+      "code": "import a from \"a\";\n\n//   comment above  \nimport b from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > detects existing block comment with standard format",
+      "code": "         import a from \"a\";\n\n         /**\n* Comment above\n*/\n         import b from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > line-length > detects existing block comment with surrounding text",
+      "code": "         import a from \"a\";\n\n         /**\n* Something before\n* CoMmEnT ABoVe\n* Something after\n*/\n         import b from \"./b\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            "external",
+            {
+              "commentAbove": "Comment above",
+              "group": "unknown"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > removes and repositions invalid auto-added comments",
+      "code": "import d from '~/d';\n// internal\nimport c from '~/cc';\n\n// sibling\nimport b from './bbb';\n\n// external\nimport a from \"aaaa\";",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "external",
+              "group": "external"
+            },
+            {
+              "commentAbove": "sibling",
+              "group": "sibling"
+            },
+            {
+              "commentAbove": "internal",
+              "group": "internal"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal\" above \"~/d\".",
+          "data": {
+            "missedCommentAbove": "internal",
+            "right": "~/d"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 124],
+            "text": "// external\nimport a from \"aaaa\";\n\n// sibling\nimport b from './bbb';\n\n// internal\nimport c from '~/cc';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/cc\" to come before \"~/d\".",
+          "data": {
+            "right": "~/cc",
+            "left": "~/d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 124],
+            "text": "// external\nimport a from \"aaaa\";\n\n// sibling\nimport b from './bbb';\n\n// internal\nimport c from '~/cc';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"./bbb\" (sibling) to come before \"~/cc\" (internal).",
+          "data": {
+            "right": "./bbb",
+            "rightGroup": "sibling",
+            "left": "~/cc",
+            "leftGroup": "internal"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [0, 124],
+            "text": "// external\nimport a from \"aaaa\";\n\n// sibling\nimport b from './bbb';\n\n// internal\nimport c from '~/cc';\nimport d from '~/d';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"aaaa\" (external) to come before \"./bbb\" (sibling).",
+          "data": {
+            "right": "aaaa",
+            "rightGroup": "external",
+            "left": "./bbb",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 124],
+            "text": "// external\nimport a from \"aaaa\";\n\n// sibling\nimport b from './bbb';\n\n// internal\nimport c from '~/cc';\nimport d from '~/d';"
+          }
+        }
+      ],
+      "output": "// external\nimport a from \"aaaa\";\n\n// sibling\nimport b from './bbb';\n\n// internal\nimport c from '~/cc';\nimport d from '~/d';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > handles complex scenarios with multiple error types and comment management",
+      "code": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above c\n// external\nimport c from './c'; // Comment after c\n// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above b\n// external\nimport b from '~/b'; // Comment after b",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "groups": [
+            {
+              "commentAbove": "external",
+              "group": "external"
+            },
+            {
+              "newlinesBetween": 1
+            },
+            {
+              "commentAbove": "internal or sibling",
+              "group": ["internal", "sibling"]
+            }
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal or sibling\" above \"./c\".",
+          "data": {
+            "missedCommentAbove": "internal or sibling",
+            "right": "./c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"a\" (external) to come before \"./c\" (sibling).",
+          "data": {
+            "right": "a",
+            "rightGroup": "external",
+            "left": "./c",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 19
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"a\" and \"~/b\".",
+          "data": {
+            "left": "a",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        },
+        {
+          "messageId": "missedCommentAboveImport",
+          "message": "Missed comment \"internal or sibling\" above \"~/b\".",
+          "data": {
+            "missedCommentAbove": "internal or sibling",
+            "right": "~/b"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [36, 186],
+            "text": "// Comment above a\n// internal or sibling\nimport a from \"a\"; // Comment after a\n// Comment above c\n// external\nimport c from './c'; // Comment after c"
+          }
+        }
+      ],
+      "output": "#!/usr/bin/node\n// Some disclaimer\n\n// Comment above a\n// external\nimport a from \"a\"; // Comment after a\n\n// internal or sibling\n// Comment above c\nimport c from './c'; // Comment after c\n// Comment above b\nimport b from '~/b'; // Comment after b"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > handles complex import formatting with line length constraints",
+      "code": "import { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';\nimport { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';\nimport Short from 'app/components/LongName';\nimport {\n  ICantBelieveHowLong,\n  ICantHandleHowLong,\n  KindaLong,\n  Long,\n  ThisIsTheLongestEver,\n  WowSoLong,\n} from 'app/components/Short';\nimport EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';\nimport ThereIsTwoOfMe, {\n  SoWeShouldSplitUpSinceWeAreInDifferentSections\n} from 'IWillDefinitelyBeSplitUp';",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "asc",
+          "maxLineLength": 80
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"app/components/LongName\" to come before \"IWillNotBeSplitUp\".",
+          "data": {
+            "right": "app/components/LongName",
+            "left": "IWillNotBeSplitUp"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 45
+          },
+          "fix": {
+            "range": [0, 582],
+            "text": "import {\n  ICantBelieveHowLong,\n  ICantHandleHowLong,\n  KindaLong,\n  Long,\n  ThisIsTheLongestEver,\n  WowSoLong,\n} from 'app/components/Short';\nimport ThereIsTwoOfMe, {\n  SoWeShouldSplitUpSinceWeAreInDifferentSections\n} from 'IWillDefinitelyBeSplitUp';\nimport Short from 'app/components/LongName';\nimport { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';\nimport { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';\nimport EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"app/components/Short\" to come before \"app/components/LongName\".",
+          "data": {
+            "right": "app/components/Short",
+            "left": "app/components/LongName"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 582],
+            "text": "import {\n  ICantBelieveHowLong,\n  ICantHandleHowLong,\n  KindaLong,\n  Long,\n  ThisIsTheLongestEver,\n  WowSoLong,\n} from 'app/components/Short';\nimport ThereIsTwoOfMe, {\n  SoWeShouldSplitUpSinceWeAreInDifferentSections\n} from 'IWillDefinitelyBeSplitUp';\nimport Short from 'app/components/LongName';\nimport { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';\nimport { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';\nimport EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"IWillDefinitelyBeSplitUp\" to come before \"IWillNotBePutOntoNewLines\".",
+          "data": {
+            "right": "IWillDefinitelyBeSplitUp",
+            "left": "IWillNotBePutOntoNewLines"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 35
+          },
+          "fix": {
+            "range": [0, 582],
+            "text": "import {\n  ICantBelieveHowLong,\n  ICantHandleHowLong,\n  KindaLong,\n  Long,\n  ThisIsTheLongestEver,\n  WowSoLong,\n} from 'app/components/Short';\nimport ThereIsTwoOfMe, {\n  SoWeShouldSplitUpSinceWeAreInDifferentSections\n} from 'IWillDefinitelyBeSplitUp';\nimport Short from 'app/components/LongName';\nimport { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';\nimport { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';\nimport EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';"
+          }
+        }
+      ],
+      "output": "import {\n  ICantBelieveHowLong,\n  ICantHandleHowLong,\n  KindaLong,\n  Long,\n  ThisIsTheLongestEver,\n  WowSoLong,\n} from 'app/components/Short';\nimport ThereIsTwoOfMe, {\n  SoWeShouldSplitUpSinceWeAreInDifferentSections\n} from 'IWillDefinitelyBeSplitUp';\nimport Short from 'app/components/LongName';\nimport { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';\nimport { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';\nimport EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > line-length > sorts imports by line-length even when sortBy is \"specifier\"",
+      "code": "import { default as dddd } from 'foo1'\nimport hhhhhhhh from 'foo2'\nconst { ...ggggggg } = require('foo3')\nimport 'foo4'\nimport eeeee = Foo.e\nimport * as ffffff from 'foo5'\nconst jjjjjjjjjj = require('foo6')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport a from 'foo8'\nconst { a: llllllllllll } = require('foo9')\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport {} from 'foo10';\nconst {} = require('foo11')\nconst [iiiiiiiii] = require('foo12')\nconst [] = require('foo13')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "sortSideEffects": true,
+          "sortBy": "specifier",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo3\" to come before \"foo2\".",
+          "data": {
+            "right": "foo3",
+            "left": "foo2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 39
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"Foo.e\" to come before \"foo4\".",
+          "data": {
+            "right": "Foo.e",
+            "left": "foo4"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo5\" to come before \"Foo.e\".",
+          "data": {
+            "right": "foo5",
+            "left": "Foo.e"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo6\" to come before \"foo5\".",
+          "data": {
+            "right": "foo6",
+            "left": "foo5"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 35
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo7\" to come before \"foo6\".",
+          "data": {
+            "right": "foo7",
+            "left": "foo6"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 42
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo9\" to come before \"foo8\".",
+          "data": {
+            "right": "foo9",
+            "left": "foo8"
+          },
+          "loc": {
+            "startLine": 10,
+            "startColumn": 1,
+            "endLine": 10,
+            "endColumn": 44
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo11\" to come before \"foo10\".",
+          "data": {
+            "right": "foo11",
+            "left": "foo10"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 1,
+            "endLine": 13,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo12\" to come before \"foo11\".",
+          "data": {
+            "right": "foo12",
+            "left": "foo11"
+          },
+          "loc": {
+            "startLine": 14,
+            "startColumn": 1,
+            "endLine": 14,
+            "endColumn": 37
+          },
+          "fix": {
+            "range": [0, 471],
+            "text": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+          }
+        }
+      ],
+      "output": "const { a: llllllllllll } = require('foo9')\nimport { ccc, mmmmmmmmmmmmm } from 'foo7'\nimport { bb as kkkkkkkkkkk } from 'foo9'\nimport { default as dddd } from 'foo1'\nconst { ...ggggggg } = require('foo3')\nconst [iiiiiiiii] = require('foo12')\nconst jjjjjjjjjj = require('foo6')\nimport * as ffffff from 'foo5'\nimport hhhhhhhh from 'foo2'\nconst {} = require('foo11')\nconst [] = require('foo13')\nimport {} from 'foo10';\nimport eeeee = Foo.e\nimport a from 'foo8'\nimport 'foo4'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > type-import-first > does not enforce sorting between two type or value imports",
+      "code": "import type { Type } from 'b'\nimport type { Type } from 'a'",
+      "options": [
+        {
+          "type": "type-import-first",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > type-import-first > does not enforce sorting between two type or value imports",
+      "code": "import { b } from 'b'\nimport { a } from 'a'",
+      "options": [
+        {
+          "type": "type-import-first",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > type-import-first > sorts type and value imports correctly with fallback sort",
+      "code": "import { value } from 'a'\nimport type { Type } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "groups": ["unknown"],
+          "fallbackSort": {
+            "type": "type-import-first",
+            "order": "asc"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"a\".",
+          "data": {
+            "right": "a",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import type { Type } from 'a'\nimport { value } from 'a'"
+          }
+        }
+      ],
+      "output": "import type { Type } from 'a'\nimport { value } from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > type-import-first > sorts type and value imports correctly with fallback sort",
+      "code": "import type { Type } from 'a'\nimport { value } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "groups": ["unknown"],
+          "fallbackSort": {
+            "type": "type-import-first",
+            "order": "desc"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"a\".",
+          "data": {
+            "right": "a",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import { value } from 'a'\nimport type { Type } from 'a'"
+          }
+        }
+      ],
+      "output": "import { value } from 'a'\nimport type { Type } from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > type-import-first > sorts type and value imports correctly with fallback sort in custom groups",
+      "code": "import { value } from 'a'\nimport type { Type } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "groups": ["group"],
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "type-import-first",
+                "order": "asc"
+              },
+              "groupName": "group",
+              "selector": "import"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"a\".",
+          "data": {
+            "right": "a",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 30
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import type { Type } from 'a'\nimport { value } from 'a'"
+          }
+        }
+      ],
+      "output": "import type { Type } from 'a'\nimport { value } from 'a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > type-import-first > sorts type and value imports correctly with fallback sort in custom groups",
+      "code": "import type { Type } from 'a'\nimport { value } from 'a'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "groups": ["group"],
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "type-import-first",
+                "order": "desc"
+              },
+              "groupName": "group",
+              "selector": "import"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"a\".",
+          "data": {
+            "right": "a",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 26
+          },
+          "fix": {
+            "range": [0, 55],
+            "text": "import { value } from 'a'\nimport type { Type } from 'a'"
+          }
+        }
+      ],
+      "output": "import { value } from 'a'\nimport type { Type } from 'a'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > custom > sorts imports by module name",
+      "code": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > custom > sorts imports by module name",
+      "code": "import { b1 } from 'b'\nimport { a1, a2 } from 'a'",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 49],
+            "text": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+          }
+        }
+      ],
+      "output": "import { a1, a2 } from 'a'\nimport { b1 } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > custom > sorts imports by specifier names when sortBy is \"specifier\"",
+      "code": "import { default as d } from 'foo1'\nimport h from 'foo2'\nconst { ...g } = require('foo3')\nimport 'foo4'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst j = require('foo6')\nimport { c, m } from 'foo7'\nimport a from 'foo8'\nconst { a: l } = require('foo9')\nimport { b as k } from 'foo10'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [i] = require('foo13')\nconst [] = require('foo14')",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+          "sortSideEffects": true,
+          "sortBy": "specifier",
+          "groups": ["unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo3\" to come before \"foo2\".",
+          "data": {
+            "right": "foo3",
+            "left": "foo2"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 33
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo4\" to come before \"foo3\".",
+          "data": {
+            "right": "foo4",
+            "left": "foo3"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 14
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo7\" to come before \"foo6\".",
+          "data": {
+            "right": "foo7",
+            "left": "foo6"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo8\" to come before \"foo7\".",
+          "data": {
+            "right": "foo8",
+            "left": "foo7"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 1,
+            "endLine": 9,
+            "endColumn": 21
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo10\" to come before \"foo9\".",
+          "data": {
+            "right": "foo10",
+            "left": "foo9"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 31
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo11\" to come before \"foo10\".",
+          "data": {
+            "right": "foo11",
+            "left": "foo10"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"foo14\" to come before \"foo13\".",
+          "data": {
+            "right": "foo14",
+            "left": "foo13"
+          },
+          "loc": {
+            "startLine": 15,
+            "startColumn": 1,
+            "endLine": 15,
+            "endColumn": 28
+          },
+          "fix": {
+            "range": [0, 394],
+            "text": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+          }
+        }
+      ],
+      "output": "import 'foo4'\nimport {} from 'foo11';\nconst {} = require('foo12')\nconst [] = require('foo14')\nimport a from 'foo8'\nimport { c, m } from 'foo7'\nimport { default as d } from 'foo1'\nimport e = Foo.e\nimport * as f from 'foo5'\nconst { ...g } = require('foo3')\nimport h from 'foo2'\nconst [i] = require('foo13')\nconst j = require('foo6')\nimport { b as k } from 'foo10'\nconst { a: l } = require('foo9')"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > subgroup-order > fallback sorts by subgroup order",
+      "code": "import { b } from 'b'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport type { a } from 'a'",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order"
+          },
+          "type": "alphabetical",
+          "groups": [["type-import", "value-import"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "import type { a } from 'a'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport { b } from 'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "import type { a } from 'a'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "import type { a } from 'a'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport { b } from 'b'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > subgroup-order > fallback sorts by subgroup order through overriding groups option",
+      "code": "import { b } from 'b'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport type { a } from 'a'",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order"
+          },
+          "type": "alphabetical",
+          "groups": [
+            {
+              "group": ["type-import", "value-import"],
+              "newlinesInside": 0
+            },
+            "unknown"
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 22
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "import type { a } from 'a'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport { b } from 'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [0, 97],
+            "text": "import type { a } from 'a'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport { b } from 'b'"
+          }
+        }
+      ],
+      "output": "import type { a } from 'a'\nimport { a } from 'a'\nimport type { b } from 'b'\nimport { b } from 'b'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > unsorted > preserves original order when sorting is disabled",
+      "code": "import { b } from 'b';\nimport { c } from 'c';\nimport { a } from 'a';",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > supports combination of predefined and custom groups",
+      "code": "import type { T } from 't'\n\n// @ts-expect-error missing types\nimport { t } from 't'",
+      "options": [
+        {
+          "groups": [
+            "side-effect-style",
+            "type-external",
+            "type-internal",
+            "type-builtin",
+            "type-sibling",
+            "type-parent",
+            "side-effect",
+            "type-index",
+            "internal",
+            "external",
+            "sibling",
+            "unknown",
+            "builtin",
+            "parent",
+            "index",
+            "style",
+            "type-import",
+            "myCustomGroup1"
+          ],
+          "customGroups": [
+            {
+              "groupName": "myCustomGroup1",
+              "elementNamePattern": "x",
+              "modifiers": ["type"]
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > uses alphabetical ascending sorting by default",
+      "code": "import a from '~/a'\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > uses alphabetical ascending sorting by default",
+      "code": "import { log } from './log'\nimport { log10 } from './log10'\nimport { log1p } from './log1p'\nimport { log2 } from './log2'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > uses alphabetical ascending sorting by default",
+      "code": "import a from '~/a'\nimport c from '~/c'\nimport b from '~/b'\nimport d from '~/d'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"~/b\" to come before \"~/c\".",
+          "data": {
+            "right": "~/b",
+            "left": "~/c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 20
+          },
+          "fix": {
+            "range": [20, 59],
+            "text": "import b from '~/b'\nimport c from '~/c'"
+          }
+        }
+      ],
+      "output": "import a from '~/a'\nimport b from '~/b'\nimport c from '~/c'\nimport d from '~/d'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > preserves order of side-effect imports",
+      "code": "import './index.css'\nimport './animate.css'\nimport './reset.css'",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > recognizes Node.js built-in modules with node: prefix",
+      "code": "import { writeFile } from 'node:fs/promises'\n\nimport { useEffect } from 'react'",
+      "options": [
+        {
+          "groups": ["builtin", "external"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > recognizes Node.js built-in modules with node: prefix",
+      "code": "import { writeFile } from 'node:fs/promises'\nimport { useEffect } from 'react'",
+      "options": [
+        {
+          "groups": ["builtin", "external"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"node:fs/promises\" and \"react\".",
+          "data": {
+            "left": "node:fs/promises",
+            "right": "react"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 34
+          },
+          "fix": {
+            "range": [44, 45],
+            "text": "\n\n"
+          }
+        }
+      ],
+      "output": "import { writeFile } from 'node:fs/promises'\n\nimport { useEffect } from 'react'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > classifies internal pattern side-effects correctly by group priority",
+      "code": "import { useClient } from '~/hooks/useClient'\n\nimport '~/css/globals.css'\n\nimport '~/data'",
+      "options": [
+        {
+          "groups": ["internal", "side-effect-style", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > classifies internal pattern side-effects correctly by group priority",
+      "code": "import { useClient } from '~/hooks/useClient'\nimport '~/data'\nimport '~/css/globals.css'",
+      "options": [
+        {
+          "groups": ["internal", "side-effect-style", "side-effect"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"~/hooks/useClient\" and \"~/data\".",
+          "data": {
+            "left": "~/hooks/useClient",
+            "right": "~/data"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 16
+          },
+          "fix": {
+            "range": [45, 88],
+            "text": "\n\nimport '~/css/globals.css'\n\nimport '~/data'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/css/globals.css\" (side-effect-style) to come before \"~/data\" (side-effect).",
+          "data": {
+            "right": "~/css/globals.css",
+            "rightGroup": "side-effect-style",
+            "left": "~/data",
+            "leftGroup": "side-effect"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 27
+          },
+          "fix": {
+            "range": [45, 88],
+            "text": "\n\nimport '~/css/globals.css'\n\nimport '~/data'"
+          }
+        }
+      ],
+      "output": "import { useClient } from '~/hooks/useClient'\n\nimport '~/css/globals.css'\n\nimport '~/data'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > handles complex projects with many custom groups",
+      "code": "import { useCartStore } from '~/stores/cartStore.ts'\nimport { useUserStore } from '~/stores/userStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^~/validators/.+",
+              "groupName": "validators"
+            },
+            {
+              "elementNamePattern": "^~/composable/.+",
+              "groupName": "composable"
+            },
+            {
+              "elementNamePattern": "^~/components/.+",
+              "groupName": "components"
+            },
+            {
+              "elementNamePattern": "^~/services/.+",
+              "groupName": "services"
+            },
+            {
+              "elementNamePattern": "^~/widgets/.+",
+              "groupName": "widgets"
+            },
+            {
+              "elementNamePattern": "^~/stores/.+",
+              "groupName": "stores"
+            },
+            {
+              "elementNamePattern": "^~/logics/.+",
+              "groupName": "logics"
+            },
+            {
+              "elementNamePattern": "^~/assets/.+",
+              "groupName": "assets"
+            },
+            {
+              "elementNamePattern": "^~/utils/.+",
+              "groupName": "utils"
+            },
+            {
+              "elementNamePattern": "^~/pages/.+",
+              "groupName": "pages"
+            },
+            {
+              "elementNamePattern": "^~/ui/.+",
+              "groupName": "ui"
+            }
+          ],
+          "groups": [
+            ["builtin", "external"],
+            "internal",
+            "stores",
+            "services",
+            "validators",
+            "utils",
+            "logics",
+            "composable",
+            "ui",
+            "components",
+            "pages",
+            "widgets",
+            "assets",
+            "parent",
+            "sibling",
+            "side-effect",
+            "index",
+            "style",
+            "unknown"
+          ],
+          "type": "line-length"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > handles complex projects with many custom groups",
+      "code": "import CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'\n\nimport { connect } from '~/utils/ws.ts'\nimport { getCart } from '~/services/cartService.ts'\n\nimport { useUserStore } from '~/stores/userStore.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^~/validators/.+",
+              "groupName": "validators"
+            },
+            {
+              "elementNamePattern": "^~/composable/.+",
+              "groupName": "composable"
+            },
+            {
+              "elementNamePattern": "^~/components/.+",
+              "groupName": "components"
+            },
+            {
+              "elementNamePattern": "^~/services/.+",
+              "groupName": "services"
+            },
+            {
+              "elementNamePattern": "^~/widgets/.+",
+              "groupName": "widgets"
+            },
+            {
+              "elementNamePattern": "^~/stores/.+",
+              "groupName": "stores"
+            },
+            {
+              "elementNamePattern": "^~/logics/.+",
+              "groupName": "logics"
+            },
+            {
+              "elementNamePattern": "^~/assets/.+",
+              "groupName": "assets"
+            },
+            {
+              "elementNamePattern": "^~/utils/.+",
+              "groupName": "utils"
+            },
+            {
+              "elementNamePattern": "^~/pages/.+",
+              "groupName": "pages"
+            },
+            {
+              "elementNamePattern": "^~/ui/.+",
+              "groupName": "ui"
+            }
+          ],
+          "groups": [
+            ["builtin", "external"],
+            "internal",
+            "stores",
+            "services",
+            "validators",
+            "utils",
+            "logics",
+            "composable",
+            "ui",
+            "components",
+            "pages",
+            "widgets",
+            "assets",
+            "parent",
+            "sibling",
+            "side-effect",
+            "index",
+            "style",
+            "unknown"
+          ],
+          "type": "line-length"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/utils/ws.ts\" (utils) to come before \"./cart/CartComponentB.vue\" (sibling).",
+          "data": {
+            "right": "~/utils/ws.ts",
+            "rightGroup": "utils",
+            "left": "./cart/CartComponentB.vue",
+            "leftGroup": "sibling"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 1,
+            "endLine": 4,
+            "endColumn": 40
+          },
+          "fix": {
+            "range": [0, 693],
+            "text": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/services/cartService.ts\" (services) to come before \"~/utils/ws.ts\" (utils).",
+          "data": {
+            "right": "~/services/cartService.ts",
+            "rightGroup": "services",
+            "left": "~/utils/ws.ts",
+            "leftGroup": "utils"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 52
+          },
+          "fix": {
+            "range": [0, 693],
+            "text": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/stores/userStore.ts\" (stores) to come before \"~/services/cartService.ts\" (services).",
+          "data": {
+            "right": "~/stores/userStore.ts",
+            "rightGroup": "stores",
+            "left": "~/services/cartService.ts",
+            "leftGroup": "services"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 1,
+            "endLine": 7,
+            "endColumn": 53
+          },
+          "fix": {
+            "range": [0, 693],
+            "text": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"~/stores/userStore.ts\" and \"~/utils/dateTime.ts\".",
+          "data": {
+            "left": "~/stores/userStore.ts",
+            "right": "~/utils/dateTime.ts"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 53
+          },
+          "fix": {
+            "range": [0, 693],
+            "text": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsGroupOrder",
+          "message": "Expected \"~/stores/cartStore.ts\" (stores) to come before \"~/composable/useFetch.ts\" (composable).",
+          "data": {
+            "right": "~/stores/cartStore.ts",
+            "rightGroup": "stores",
+            "left": "~/composable/useFetch.ts",
+            "leftGroup": "composable"
+          },
+          "loc": {
+            "startLine": 11,
+            "startColumn": 1,
+            "endLine": 11,
+            "endColumn": 53
+          },
+          "fix": {
+            "range": [0, 693],
+            "text": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenImports",
+          "message": "Missed spacing between \"~/stores/cartStore.ts\" and \"~/composable/useDebounce.ts\".",
+          "data": {
+            "left": "~/stores/cartStore.ts",
+            "right": "~/composable/useDebounce.ts"
+          },
+          "loc": {
+            "startLine": 12,
+            "startColumn": 1,
+            "endLine": 12,
+            "endColumn": 58
+          },
+          "fix": {
+            "range": [0, 693],
+            "text": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+          }
+        }
+      ],
+      "output": "import { useUserStore } from '~/stores/userStore.ts'\nimport { useCartStore } from '~/stores/cartStore.ts'\n\nimport { getCart } from '~/services/cartService.ts'\n\nimport { connect } from '~/utils/ws.ts'\nimport { formattingDate } from '~/utils/dateTime.ts'\n\nimport { useFetch } from '~/composable/useFetch.ts'\nimport { useDebounce } from '~/composable/useDebounce.ts'\nimport { useMouseMove } from '~/composable/useMouseMove.ts'\n\nimport ComponentA from '~/components/ComponentA.vue'\nimport ComponentB from '~/components/ComponentB.vue'\nimport ComponentC from '~/components/ComponentC.vue'\n\nimport CartComponentA from './cart/CartComponentA.vue'\nimport CartComponentB from './cart/CartComponentB.vue'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > treats empty named imports as regular imports not side-effects",
+      "code": "import {} from 'node:os'\nimport sqlite from 'node:sqlite'\nimport { describe, test } from 'node:test'\nimport { c } from 'c'\nimport 'node:os'",
+      "options": [
+        {
+          "groups": ["builtin", "external", "side-effect"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > ignores dynamic require statements",
+      "code": "const path = require(path);\nconst myFileName = require('the-filename');\nconst file = require(path.join(myDir, myFileName));\nconst other = require('./other.js');",
+      "options": [
+        {
+          "groups": ["builtin", "external", "side-effect"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > classifies TypeScript configured imports as internal",
+      "code": "import { x } from 'sort-imports'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "groups": ["internal", "unknown"],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > classifies package imports as external",
+      "code": "import type { ParsedCommandLine } from 'typescript'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "groups": ["external", "unknown"],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > treats unresolved imports as external by default",
+      "code": "import { b } from 'b'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "groups": ["external", "unknown"],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > falls back to basic classification when TypeScript is unavailable",
+      "code": "import { b } from 'b'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "groups": ["external", "unknown"],
+          "tsconfig": {
+            "rootDir": "."
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > classifies TypeScript configured imports as internal with tsconfig option",
+      "code": "import { x } from 'sort-imports'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "tsconfig": {
+            "filename": "tsconfig.json",
+            "rootDir": "."
+          },
+          "groups": ["internal", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > classifies package imports as external with tsconfig option",
+      "code": "import type { ParsedCommandLine } from 'typescript'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "tsconfig": {
+            "filename": "tsconfig.json",
+            "rootDir": "."
+          },
+          "groups": ["external", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > treats unresolved imports as external by default with tsconfig option",
+      "code": "import { b } from 'b'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "tsconfig": {
+            "filename": "tsconfig.json",
+            "rootDir": "."
+          },
+          "groups": ["external", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > falls back to basic classification when TypeScript is unavailable with tsconfig option",
+      "code": "import { b } from 'b'\n\nimport { a } from './a';",
+      "options": [
+        {
+          "tsconfig": {
+            "filename": "tsconfig.json",
+            "rootDir": "."
+          },
+          "groups": ["external", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > respects the global settings configuration",
+      "code": "import { ccc } from 'ccc'\nimport { bb } from 'bb'\nimport { a } from 'a'",
+      "options": [{}],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > respects the global settings configuration",
+      "code": "import { a } from 'a'\nimport { bb } from 'bb'\nimport { ccc } from 'ccc'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { b } from \"./b\"\nimport { c } from \"./c\"\n// eslint-disable-next-line\nimport { a } from \"./a\"",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\n// eslint-disable-next-line\nimport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\n// eslint-disable-next-line\nimport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { d } from './d'\nimport { c } from './c'\n// eslint-disable-next-line\nimport { a } from './a'\nimport { b } from './b'",
+      "options": [
+        {
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./c\" to come before \"./d\".",
+          "data": {
+            "right": "./c",
+            "left": "./d"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 123],
+            "text": "import { b } from './b'\nimport { c } from './c'\n// eslint-disable-next-line\nimport { a } from './a'\nimport { d } from './d'"
+          }
+        },
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./a\".",
+          "data": {
+            "right": "./b",
+            "left": "./a"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 1,
+            "endLine": 5,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 123],
+            "text": "import { b } from './b'\nimport { c } from './c'\n// eslint-disable-next-line\nimport { a } from './a'\nimport { d } from './d'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\n// eslint-disable-next-line\nimport { a } from './a'\nimport { d } from './d'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\nimport { a } from './a' // eslint-disable-line",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\nimport { a } from './a' // eslint-disable-line"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\n/* eslint-disable-next-line */\nimport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\n/* eslint-disable-next-line */\nimport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\nimport { a } from './a' /* eslint-disable-line */",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\nimport { a } from './a' /* eslint-disable-line */"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { d } from './d'\nimport { e } from './e'\n/* eslint-disable */\nimport { c } from './c'\nimport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nimport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 178],
+            "text": "import { a } from './a'\nimport { d } from './d'\n/* eslint-disable */\nimport { c } from './c'\nimport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nimport { e } from './e'"
+          }
+        }
+      ],
+      "output": "import { a } from './a'\nimport { d } from './d'\n/* eslint-disable */\nimport { c } from './c'\nimport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nimport { e } from './e'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\n// eslint-disable-next-line rule-to-test/sort-imports\nimport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\n// eslint-disable-next-line rule-to-test/sort-imports\nimport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\nimport { a } from './a' // eslint-disable-line rule-to-test/sort-imports",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\nimport { a } from './a' // eslint-disable-line rule-to-test/sort-imports"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\n/* eslint-disable-next-line rule-to-test/sort-imports */\nimport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\n/* eslint-disable-next-line rule-to-test/sort-imports */\nimport { a } from './a'"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { c } from './c'\nimport { b } from './b'\nimport { a } from './a' /* eslint-disable-line rule-to-test/sort-imports */",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./b\" to come before \"./c\".",
+          "data": {
+            "right": "./b",
+            "left": "./c"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 1,
+            "endLine": 2,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 47],
+            "text": "import { b } from './b'\nimport { c } from './c'"
+          }
+        }
+      ],
+      "output": "import { b } from './b'\nimport { c } from './c'\nimport { a } from './a' /* eslint-disable-line rule-to-test/sort-imports */"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-imports > misc > respects ESLint disable comments when sorting imports",
+      "code": "import { d } from './d'\nimport { e } from './e'\n/* eslint-disable rule-to-test/sort-imports */\nimport { c } from './c'\nimport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nimport { a } from './a'",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedImportsOrder",
+          "message": "Expected \"./a\" to come before \"./b\".",
+          "data": {
+            "right": "./a",
+            "left": "./b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 1,
+            "endLine": 8,
+            "endColumn": 24
+          },
+          "fix": {
+            "range": [0, 204],
+            "text": "import { a } from './a'\nimport { d } from './d'\n/* eslint-disable rule-to-test/sort-imports */\nimport { c } from './c'\nimport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nimport { e } from './e'"
+          }
+        }
+      ],
+      "output": "import { a } from './a'\nimport { d } from './d'\n/* eslint-disable rule-to-test/sort-imports */\nimport { c } from './c'\nimport { b } from './b'\n// Shouldn't move\n/* eslint-enable */\nimport { e } from './e'"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-imports > misc > defaults missing importKind to value",
+      "code": "import bar from 'bar'\nimport foo from 'foo'",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    }
+  ]
+}

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -66,7 +66,7 @@ const invalidCases = [
   ['sort-variable-declarations', 'const b = 1, a = 2;'],
 ];
 
-function runRule(ruleName, sourceText, filename = 'fixture.tsx', options = []) {
+function runRule(ruleName, sourceText, filename = 'fixture.tsx', options = [], settings) {
   const reports = [];
   const sourceCode = {
     text: sourceText,
@@ -78,6 +78,7 @@ function runRule(ruleName, sourceText, filename = 'fixture.tsx', options = []) {
   const visitor = rule.createOnce({
     filename,
     options,
+    settings,
     sourceCode,
     report(descriptor) {
       reports.push(descriptor);
@@ -120,7 +121,9 @@ describe('perfectionist plugin adapter', () => {
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      ['sort-exports', 'sort-named-exports', 'sort-named-imports'].includes(ruleName)
+      ['sort-exports', 'sort-imports', 'sort-named-exports', 'sort-named-imports'].includes(
+        ruleName,
+      )
         ? 'Expected "{{right}}" to come before "{{left}}".'
         : 'Expected sorted order.',
     );
@@ -152,6 +155,72 @@ describe('perfectionist plugin adapter', () => {
       'export',
     ]);
     expect(schema[0].additionalProperties).toBe(false);
+  });
+
+  it('declares every sort-imports option, selector, modifier, and message', () => {
+    const rule = plugin.rules['sort-imports'];
+    const [schema] = rule.meta.schema;
+
+    expect(Object.keys(schema.properties).sort()).toEqual([
+      'alphabet',
+      'customGroups',
+      'environment',
+      'fallbackSort',
+      'groups',
+      'ignoreCase',
+      'internalPattern',
+      'locales',
+      'maxLineLength',
+      'newlinesBetween',
+      'newlinesInside',
+      'order',
+      'partitionByComment',
+      'partitionByNewLine',
+      'sortBy',
+      'sortSideEffects',
+      'specialCharacters',
+      'tsconfig',
+      'type',
+      'useExperimentalDependencyDetection',
+    ]);
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties.type.enum).toContain('type-import-first');
+    expect(schema.properties.sortBy.enum).toEqual(['specifier', 'path']);
+    expect(schema.properties.customGroups.items.oneOf[0].properties.modifiers.items.enum).toEqual([
+      'default',
+      'multiline',
+      'named',
+      'require',
+      'side-effect',
+      'singleline',
+      'ts-equals',
+      'type',
+      'value',
+      'wildcard',
+    ]);
+    expect(schema.properties.customGroups.items.oneOf[0].properties.selector.enum).toEqual([
+      'side-effect-style',
+      'tsconfig-path',
+      'side-effect',
+      'external',
+      'internal',
+      'builtin',
+      'sibling',
+      'subpath',
+      'import',
+      'parent',
+      'index',
+      'style',
+      'type',
+    ]);
+    expect(Object.keys(rule.meta.messages).sort()).toEqual([
+      'extraSpacingBetweenImports',
+      'missedCommentAboveImport',
+      'missedSpacingBetweenImports',
+      'unexpectedImportsDependencyOrder',
+      'unexpectedImportsGroupOrder',
+      'unexpectedImportsOrder',
+    ]);
   });
 
   it.each([
@@ -208,7 +277,6 @@ describe('perfectionist plugin adapter', () => {
       minProperties: 1,
       additionalProperties: false,
     });
-    expect(plugin.rules['sort-imports'].meta.schema).toEqual([]);
   });
 
   it('threads recommended comparator options into every configured sorting rule', () => {
@@ -226,7 +294,29 @@ describe('perfectionist plugin adapter', () => {
       'error',
       { type: 'natural', order: 'asc' },
     ]);
-    expect(rules['perfectionist/sort-imports']).toBe('error');
+    expect(rules['perfectionist/sort-imports']).toEqual([
+      'error',
+      { type: 'natural', order: 'asc' },
+    ]);
+  });
+
+  it('merges global perfectionist settings with explicit sort-imports options', () => {
+    const source = `import item2 from "item2";\nimport item10 from "item10";`;
+    const settings = { perfectionist: { type: 'natural', order: 'desc' } };
+
+    expect(runRule('sort-imports', source, 'fixture.ts', [], settings)).toHaveLength(1);
+    expect(runRule('sort-imports', source, 'fixture.ts', [{ order: 'asc' }], settings)).toEqual([]);
+  });
+
+  it('keeps sort-imports createOnce caches isolated by options and source object', () => {
+    const source = `import item2 from "item2";\nimport item10 from "item10";`;
+
+    expect(
+      runRule('sort-imports', source, 'fixture.ts', [{ type: 'natural', order: 'desc' }]),
+    ).toHaveLength(1);
+    expect(
+      runRule('sort-imports', source, 'fixture.ts', [{ type: 'natural', order: 'asc' }]),
+    ).toEqual([]);
   });
 
   it('loads configured options and fixes through real oxlint jsPlugins', () => {
@@ -471,6 +561,81 @@ describe('perfectionist plugin adapter', () => {
       expect(fixed.stderr).toBe('');
       expect(readFileSync(fixturePath, 'utf8')).toBe(
         `// Values\nexport { value } from "./value";\n// Types\nexport type { Type } from "./types";\n`,
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads import groups, comments, dependencies, and iterative fixes through real oxlint', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-imports-'));
+    try {
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(
+        fixturePath,
+        `import a = aImport.a1.a2;\nimport type { Type } from "./types";\nimport aImport from "b";\n`,
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'perfectionist',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'perfectionist/sort-imports': [
+              'error',
+              {
+                groups: [
+                  { group: 'unknown', commentAbove: 'Runtime' },
+                  { group: 'type-import', commentAbove: 'Types' },
+                ],
+                useExperimentalDependencyDetection: true,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics.map((diagnostic) => diagnostic.message)).toContain(
+        'Expected dependency "b" to come before "aImport.a1.a2".',
+      );
+      expect(payload.diagnostics.map((diagnostic) => diagnostic.message)).toContain(
+        'Missed comment "Types" above "./types".',
+      );
+
+      let fixed;
+      for (let pass = 0; pass < 8; pass += 1) {
+        fixed = spawnSync(
+          findOxlintCli(),
+          ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+          {
+            cwd: tempDir,
+            encoding: 'utf8',
+          },
+        );
+        if (fixed.status === 0) {
+          break;
+        }
+      }
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe(
+        `// Runtime\nimport aImport from "b";\nimport a = aImport.a1.a2;\n\n// Types\nimport type { Type } from "./types";\n`,
       );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/npm/perfectionist/test/sort-imports-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-imports-options-upstream.test.mjs
@@ -1,0 +1,158 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(new URL('./fixtures/sort-imports-options-v5.9.1.json', import.meta.url), 'utf8'),
+);
+const rule = plugin.rules['sort-imports'];
+
+describe('perfectionist/sort-imports v5.9.1 option parity', () => {
+  it('pins every authored upstream case and its exact fixture inventory', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-perfectionist',
+      version: '5.9.1',
+      sourceCommit: 'b35e8e4caf0c8d350cf386e504241f21827dd60b',
+      sourceHashes: {
+        'rules/sort-imports.ts': 'c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05',
+        'rules/sort-imports/types.ts':
+          '81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe',
+        'test/rules/sort-imports.test.ts':
+          '8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab',
+      },
+      inventory: {
+        valid: 151,
+        invalid: 262,
+        diagnostics: 468,
+        total: 413,
+      },
+    });
+    expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
+    expect(
+      fixture.cases.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+    ).toBe(fixture.__generated.inventory.diagnostics);
+  });
+
+  for (const [index, testCase] of fixture.cases.entries()) {
+    it(`replays case ${index + 1}/${fixture.cases.length}: ${testCase.name}`, () => {
+      const reports = runRule(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(
+        reports.map((report) => exactDiagnostic(report)),
+        testCase.name,
+      ).toEqual(testCase.expectedDiagnostics);
+
+      if (testCase.output === null) {
+        expect(reports, testCase.name).toEqual([]);
+        return;
+      }
+
+      const convergence = applyIteratively(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(convergence.output, testCase.name).toBe(testCase.output);
+      expect(convergence.remainingReports, testCase.name).toEqual([]);
+      expect(convergence.passes, testCase.name).toBeGreaterThanOrEqual(1);
+      expect(convergence.passes, testCase.name).toBeLessThanOrEqual(16);
+    });
+  }
+});
+
+function runRule(sourceText, options, filename, settings) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    options,
+    settings,
+    sourceCode,
+    filename,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function exactDiagnostic(report) {
+  const replacement = report.fix?.({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return {
+    messageId: report.messageId,
+    message: Object.entries(report.data).reduce(
+      (message, [key, value]) => message.replace(`{{${key}}}`, value),
+      rule.meta.messages[report.messageId],
+    ),
+    data: report.data,
+    loc: {
+      startLine: report.loc.start.line,
+      startColumn: report.loc.start.column + 1,
+      endLine: report.loc.end.line,
+      endColumn: report.loc.end.column + 1,
+    },
+    fix: replacement ?? null,
+  };
+}
+
+function applyIteratively(sourceText, options, filename, settings) {
+  let output = sourceText;
+  let passes = 0;
+  for (; passes < 16; passes += 1) {
+    const reports = runRule(output, options, filename, settings);
+    const next = applyFixPass(output, reports);
+    if (next === null) {
+      return { output, passes, remainingReports: reports };
+    }
+    output = next;
+  }
+  throw new Error(`Fixes did not converge for ${JSON.stringify(sourceText)}`);
+}
+
+function applyFixPass(sourceText, reports) {
+  const fixes = reports
+    .flatMap((report) => {
+      const fix = report.fix?.({
+        replaceTextRange(range, text) {
+          return { range, text };
+        },
+      });
+      return fix ? [fix] : [];
+    })
+    .sort((left, right) => left.range[0] - right.range[0] || left.range[1] - right.range[1]);
+  if (fixes.length === 0) {
+    return null;
+  }
+
+  const accepted = [];
+  let lastEnd = -1;
+  for (const fix of fixes) {
+    if (fix.range[0] < lastEnd) {
+      continue;
+    }
+    accepted.push(fix);
+    lastEnd = fix.range[1];
+  }
+
+  let output = sourceText;
+  for (const fix of accepted.toReversed()) {
+    output = output.slice(0, fix.range[0]) + fix.text + output.slice(fix.range[1]);
+  }
+  return output;
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "port:tests:postgresql-parser": "node tools/tasks/sync-postgresql-parser-tests.ts",
     "port:tests:perfectionist:sort-named-imports": "node tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
     "port:tests:perfectionist:sort-named-exports": "node tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
+    "port:tests:perfectionist:sort-imports": "node tools/tasks/sync-perfectionist-sort-imports-options-tests.ts",
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:playwright:patterns": "node tools/tasks/sync-playwright-pattern-tests.ts",

--- a/tools/tasks/sync-perfectionist-sort-imports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-imports-options-tests.ts
@@ -1,0 +1,472 @@
+// Captures every authored eslint-plugin-perfectionist/sort-imports v5.9.1
+// valid and invalid case. The exact upstream commit and source hashes prevent
+// silent fixture drift.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    npm: string;
+    submodule: string;
+    baselineVersion: string;
+    pinnedRef?: string;
+    license: string;
+  }>;
+};
+
+type CapturedCase = {
+  kind: 'valid' | 'invalid';
+  name: string;
+  code: string;
+  options: Array<Record<string, unknown>>;
+  settings?: Record<string, unknown>;
+  filename: string;
+  authoredOutput?: string | null;
+};
+
+const ROOT = process.cwd();
+const RULE = 'sort-imports';
+const PINNED_COMMIT = 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
+const ESLINT_VERSION = '9.39.2';
+const TYPESCRIPT_ESLINT_VERSION = '8.60.0';
+const SOURCE_HASHES = {
+  'rules/sort-imports.ts': 'c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05',
+  'rules/sort-imports/types.ts': '81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe',
+  'test/rules/sort-imports.test.ts':
+    '8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab',
+} as const;
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-perfectionist');
+if (!plugin) {
+  throw new Error('eslint-plugin-perfectionist is not registered in tools/port-targets.json');
+}
+if (plugin.baselineVersion !== '5.9.1' || plugin.pinnedRef !== 'v5.9.1') {
+  throw new Error(
+    `Expected perfectionist v5.9.1 manifest pin, received ${plugin.baselineVersion} / ${plugin.pinnedRef}`,
+  );
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Upstream checkout not found: ${plugin.submodule}`);
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}`);
+}
+for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
+  const actualHash = createHash('sha256')
+    .update(readFileSync(join(submodule, sourceFile)))
+    .digest('hex');
+  if (actualHash !== expectedHash) {
+    throw new Error(`Expected ${sourceFile} hash ${expectedHash}, received ${actualHash}`);
+  }
+}
+
+const runnerDirectory = mkdtempSync(join(tmpdir(), 'perfectionist-sort-imports-'));
+try {
+  const completeAuthoredSource = readFileSync(
+    join(submodule, 'test', 'rules', 'sort-imports.test.ts'),
+    'utf8',
+  );
+  const suiteStart = completeAuthoredSource.indexOf("describe('sort-imports'");
+  if (suiteStart === -1) {
+    throw new Error('Unable to locate the authored sort-imports suite.');
+  }
+  const authoredSource = completeAuthoredSource.slice(suiteStart);
+  const captureSourcePath = join(runnerDirectory, 'capture.ts');
+  writeFileSync(captureSourcePath, `${capturePrelude()}\n${authoredSource}\n${captureEpilogue()}`);
+  const compiledDirectory = join(runnerDirectory, 'compiled');
+  execFileSync(
+    'pnpm',
+    [
+      'exec',
+      'vp',
+      'pack',
+      captureSourcePath,
+      '--format',
+      'esm',
+      '--out-dir',
+      compiledDirectory,
+      '--no-clean',
+      '--logLevel',
+      'error',
+    ],
+    { cwd: ROOT, stdio: 'inherit' },
+  );
+  const compiledSource = readdirSync(compiledDirectory).find((file) => /\.(?:mjs|js)$/u.test(file));
+  if (!compiledSource) {
+    throw new Error(`No compiled capture module found in ${compiledDirectory}`);
+  }
+  execFileSync('node', [join(compiledDirectory, compiledSource)], {
+    cwd: runnerDirectory,
+    stdio: 'inherit',
+  });
+  const authoredCases = JSON.parse(
+    readFileSync(join(runnerDirectory, 'authored-cases.json'), 'utf8'),
+  ) as CapturedCase[];
+
+  writeFileSync(
+    join(runnerDirectory, 'package.json'),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@typescript-eslint/parser': TYPESCRIPT_ESLINT_VERSION,
+          eslint: ESLINT_VERSION,
+          'eslint-plugin-perfectionist': plugin.baselineVersion,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(join(runnerDirectory, 'cases.json'), `${JSON.stringify(authoredCases)}\n`);
+  writeFileSync(join(runnerDirectory, 'runner.mjs'), publishedRunnerSource());
+  execFileSync(
+    'pnpm',
+    ['install', '--dir', runnerDirectory, '--ignore-workspace', '--lockfile=false', '--silent'],
+    { stdio: 'inherit' },
+  );
+  execFileSync('node', [join(runnerDirectory, 'runner.mjs')], {
+    cwd: runnerDirectory,
+    stdio: 'inherit',
+  });
+  const captured = JSON.parse(
+    readFileSync(join(runnerDirectory, 'captured.json'), 'utf8'),
+  ) as Array<{ kind: 'valid' | 'invalid'; expectedDiagnostics: unknown[] }>;
+  const valid = captured.filter((testCase) => testCase.kind === 'valid').length;
+  const invalid = captured.length - valid;
+  const diagnostics = captured.reduce(
+    (total, testCase) => total + testCase.expectedDiagnostics.length,
+    0,
+  );
+  const fixture = {
+    __generated: {
+      source: plugin.npm,
+      version: plugin.baselineVersion,
+      sourceCommit: PINNED_COMMIT,
+      sourceHashes: SOURCE_HASHES,
+      license: plugin.license,
+      eslintVersion: ESLINT_VERSION,
+      typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
+      capturePolicy:
+        'Every authored valid and invalid sort-imports case is captured; none exercises React-specific or JSX/TSX syntax. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.9.1 rule for exact diagnostics and fixes.',
+      authoredCases: 'upstream/eslint-plugin-perfectionist/test/rules/sort-imports.test.ts',
+      tool: basename(import.meta.filename),
+      inventory: {
+        valid,
+        invalid,
+        diagnostics,
+        total: captured.length,
+      },
+    },
+    cases: captured,
+  };
+  const fixturesDirectory = join(ROOT, 'npm', 'perfectionist', 'test', 'fixtures');
+  mkdirSync(fixturesDirectory, { recursive: true });
+  const fixturePath = join(fixturesDirectory, `${RULE}-options-v${plugin.baselineVersion}.json`);
+  writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  execFileSync('pnpm', ['exec', 'vp', 'fmt', fixturePath], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  console.log(
+    `Captured ${RULE} v${plugin.baselineVersion}: ${valid} valid, ${invalid} invalid, ${diagnostics} diagnostics.`,
+  );
+} finally {
+  rmSync(runnerDirectory, { recursive: true, force: true });
+}
+
+function capturePrelude(): string {
+  return String.raw`
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const __capturedCases = []
+const __tasks = []
+const __describeStack = []
+let __currentTestName = ''
+const typescriptParser = {}
+const readClosestTsConfigUtilities = {}
+const getTypescriptImportUtilities = {}
+const rule = { meta: { schema: {} }, create() { return {} } }
+
+function __normalizeCase(kind, input) {
+  const value = typeof input === 'string' ? { code: input } : input
+  __capturedCases.push({
+    kind,
+    name: __currentTestName,
+    code: value.code,
+    options: value.options ?? [],
+    settings: value.settings,
+    filename: value.filename ?? 'fixture.ts',
+    authoredOutput: Object.hasOwn(value, 'output') ? value.output : undefined,
+  })
+}
+
+function createRuleTester() {
+  return {
+    valid: async input => __normalizeCase('valid', input),
+    invalid: async input => __normalizeCase('invalid', input),
+  }
+}
+
+function buildOxlintRuleTester() {
+  return {
+    run(name, suite) {
+      for (const input of suite.valid ?? []) {
+        __capturedCases.push({
+          kind: 'valid',
+          name: [...__describeStack, name, 'valid'].join(' > '),
+          code: input.code,
+          options: input.options ?? [],
+          settings: input.settings,
+          filename: input.filename ?? 'fixture.ts',
+          authoredOutput: Object.hasOwn(input, 'output') ? input.output : undefined,
+        })
+      }
+      for (const input of suite.invalid ?? []) {
+        __capturedCases.push({
+          kind: 'invalid',
+          name: [...__describeStack, name, 'invalid'].join(' > '),
+          code: input.code,
+          options: input.options ?? [],
+          settings: input.settings,
+          filename: input.filename ?? 'fixture.ts',
+          authoredOutput: Object.hasOwn(input, 'output') ? input.output : undefined,
+        })
+      }
+    },
+  }
+}
+
+function describe(name, callback) {
+  __describeStack.push(name)
+  callback()
+  __describeStack.pop()
+}
+
+function it(name, callback) {
+  __tasks.push({
+    name: [...__describeStack, name].join(' > '),
+    callback,
+  })
+}
+
+it.each = rows => (name, callback) => {
+  for (const row of rows) {
+    const values = Array.isArray(row) ? row : [row]
+    let interpolation = 0
+    const expandedName = name.replaceAll('%s', () => String(values[interpolation++]))
+    __tasks.push({
+      name: [...__describeStack, expandedName].join(' > '),
+      callback: () => callback(...values),
+    })
+  }
+}
+
+function dedent(strings, ...values) {
+  const value =
+    typeof strings === 'string'
+      ? strings
+      : strings.reduce((result, string, index) => result + string + (values[index] ?? ''), '')
+  const lines = value.replace(/^\n/u, '').replace(/\n\s*$/u, '').split('\n')
+  const indentation = lines
+    .filter(line => line.trim().length > 0)
+    .reduce((minimum, line) => Math.min(minimum, line.match(/^\s*/u)[0].length), Infinity)
+  return lines.map(line => line.slice(Number.isFinite(indentation) ? indentation : 0)).join('\n')
+}
+
+const Alphabet = {
+  generateRecommendedAlphabet() {
+    return {
+      sortByLocaleCompare() {
+        return this
+      },
+      getCharacters() {
+        return '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+      },
+    }
+  },
+}
+
+function createModuleResolutionCache() {
+  return {}
+}
+
+const vi = {
+  resetAllMocks() {},
+  spyOn() {
+    return {
+      mockReturnValue() {
+        return this
+      },
+    }
+  },
+}
+
+async function validateRuleJsonSchema() {}
+function expect() {
+  const chain = {
+    toThrow() {},
+    not: { toThrow() {} },
+    resolves: { not: { async toThrow() {} } },
+  }
+  return chain
+}
+`;
+}
+
+function captureEpilogue(): string {
+  return String.raw`
+for (const task of __tasks) {
+  __currentTestName = task.name
+  await task.callback()
+}
+writeFileSync(
+  join(process.cwd(), 'authored-cases.json'),
+  JSON.stringify(__capturedCases),
+)
+`;
+}
+
+function publishedRunnerSource(): string {
+  return `
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import perfectionistModule from 'eslint-plugin-perfectionist';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const cases = JSON.parse(readFileSync(join(here, 'cases.json'), 'utf8'));
+const perfectionist = perfectionistModule.default ?? perfectionistModule;
+const linter = new Linter();
+writeFileSync(
+  join(here, 'tsconfig.json'),
+  JSON.stringify({
+    compilerOptions: {
+      baseUrl: '.',
+      paths: { '$path': ['./path'] },
+    },
+  }),
+);
+
+function configFor(testCase) {
+  return [{
+    files: ['**/*.{js,ts}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      'rule-to-test': {
+        rules: {
+          '${RULE}': perfectionist.rules['${RULE}'],
+        },
+      },
+    },
+    settings: testCase.settings ?? {},
+    rules: {
+      'rule-to-test/${RULE}': ['error', ...(testCase.options ?? [])],
+    },
+  }];
+}
+
+const captured = cases.map(testCase => {
+  const filename = testCase.filename ?? 'fixture.ts';
+  const config = configFor(testCase);
+  const diagnostics = linter.verify(testCase.code, config, { filename });
+  const unexpected = diagnostics.filter(problem => problem.ruleId !== 'rule-to-test/${RULE}');
+  if (unexpected.length > 0) {
+    throw new Error(
+      testCase.name + ' produced non-rule diagnostics: ' + JSON.stringify(unexpected),
+    );
+  }
+  const fixed = linter.verifyAndFix(testCase.code, config, { filename });
+  const expectedDiagnostics = testCase.kind === 'valid' ? [] : diagnostics;
+  return {
+    kind: testCase.kind,
+    name: testCase.name,
+    code: testCase.code,
+    options: testCase.options ?? [],
+    settings: testCase.settings,
+    filename,
+    expectedDiagnostics: expectedDiagnostics.map(problem => ({
+      messageId: problem.messageId,
+      message: problem.message,
+      data: dataFromMessage(problem.message),
+      loc: {
+        startLine: problem.line,
+        startColumn: problem.column,
+        endLine: problem.endLine,
+        endColumn: problem.endColumn,
+      },
+      fix: problem.fix
+        ? {
+            range: problem.fix.range,
+            text: problem.fix.text,
+          }
+        : null,
+    })),
+    output: testCase.kind === 'valid' ? null : fixed.fixed ? fixed.output : null,
+  };
+});
+
+writeFileSync(join(here, 'captured.json'), JSON.stringify(captured));
+
+function dataFromMessage(message) {
+  const dependency =
+    /^Expected dependency "(.+)" to come before "(.+)"\\.$/u.exec(message);
+  if (dependency) {
+    return { right: dependency[1], nodeDependentOnRight: dependency[2] };
+  }
+  const order = /^Expected "(.+)" to come before "(.+)"\\.$/u.exec(message);
+  if (order) {
+    return { right: order[1], left: order[2] };
+  }
+  const group = /^Expected "(.+)" \\((.+)\\) to come before "(.+)" \\((.+)\\)\\.$/u.exec(message);
+  if (group) {
+    return {
+      right: group[1],
+      rightGroup: group[2],
+      left: group[3],
+      leftGroup: group[4],
+    };
+  }
+  const spacing = /^(?:Extra|Missed) spacing between "(.+)" and "(.+)"\\.$/u.exec(message);
+  if (spacing) {
+    return { left: spacing[1], right: spacing[2] };
+  }
+  const comment = /^Missed comment "(.+)" above "(.+)"\\.$/u.exec(message);
+  if (comment) {
+    return { missedCommentAbove: comment[1], right: comment[2] };
+  }
+  return {};
+}
+`;
+}


### PR DESCRIPTION
## Summary
- port the full Perfectionist `sort-imports` option surface to the native Oxc rule
- support groups, custom groups, partitions, conditional configuration, side-effect controls, type imports, specifier sorting, locale/alphabet/natural ordering, fallback sorting, and newline policies
- expose matching metadata, NAPI/plugin behavior, and deterministic upstream-fixture synchronization

## Tests
- pin 413 authored upstream cases with 468 exact diagnostics
- add 414 fixture-driven regression tests plus focused Rust coverage
- `pnpm verify` (18,015 JS tests; full Rust, docs, benchmarks, security, license, status, and publish-readiness gates)
- post-rebase: 467 targeted JS tests
- post-rebase: 48 Perfectionist Rust tests

Refs #418

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `sort-imports` rule.
  - Sort imports by groups, modifiers, selectors, names, type, and dependency order.
  - Supports ES imports, TypeScript import-equals syntax, and CommonJS `require` statements.
  - Added configurable side-effect import sorting and custom grouping options.
  - Provides import-specific diagnostics, autofixes, and configuration schema.

- **Bug Fixes**
  - Improved comment, spacing, disabled-rule, Unicode, and CRLF handling during import sorting.
  - Malformed or unsupported input now fails safely without incorrect diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->