### PR TITLE
feat(angular-eslint): port no-input-rename

### DIFF
--- a/crates/angular_eslint/src/input_rename.rs
+++ b/crates/angular_eslint/src/input_rename.rs
@@ -1,0 +1,665 @@
+use oxc_ast::ast::{
+    CallExpression, Class, ClassElement, Decorator, Expression, MethodDefinitionKind,
+    ObjectExpression, ObjectProperty, ObjectPropertyKind, PropertyDefinition, PropertyKey,
+};
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::scanner::Scanner;
+use crate::types::Diagnostic;
+
+const NO_INPUT_RENAME: &str = "no-input-rename";
+
+#[derive(Debug, Default)]
+struct SelectorContext {
+    selectors: SmallVec<[CompactString; 4]>,
+    directive_name: Option<CompactString>,
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_input_rename(&mut self, class: &Class<'_>) {
+        if !self.options.is_enabled(NO_INPUT_RENAME) {
+            return;
+        }
+
+        let allowed_names = configured_allowed_names(&self.options.options);
+        let selector_context = selector_context(class);
+        self.check_input_metadata(class, &allowed_names, &selector_context);
+
+        for element in &class.body.body {
+            match element {
+                ClassElement::PropertyDefinition(property) if !property.computed => {
+                    let Some(property_name) = identifier_property_name(&property.key) else {
+                        continue;
+                    };
+                    if let Some((alias, span)) = decorator_alias(&property.decorators) {
+                        self.check_alias(
+                            property_name,
+                            alias,
+                            span,
+                            &allowed_names,
+                            &selector_context,
+                        );
+                    }
+                    if let Some((alias, span)) = signal_input_alias(property) {
+                        self.check_alias(
+                            property_name,
+                            alias,
+                            span,
+                            &allowed_names,
+                            &selector_context,
+                        );
+                    }
+                }
+                ClassElement::MethodDefinition(method)
+                    if method.kind == MethodDefinitionKind::Set && !method.computed =>
+                {
+                    let Some(property_name) = identifier_property_name(&method.key) else {
+                        continue;
+                    };
+                    if let Some((alias, span)) = decorator_alias(&method.decorators) {
+                        self.check_alias(
+                            property_name,
+                            alias,
+                            span,
+                            &allowed_names,
+                            &selector_context,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn check_input_metadata(
+        &mut self,
+        class: &Class<'_>,
+        allowed_names: &[CompactString],
+        selector_context: &SelectorContext,
+    ) {
+        for decorator in &class.decorators {
+            let Some(call) = called_decorator(decorator, &["Component", "Directive"]) else {
+                continue;
+            };
+            let Some(Expression::ObjectExpression(metadata)) = call
+                .arguments
+                .first()
+                .and_then(|argument| argument.as_expression())
+                .map(Expression::get_inner_expression)
+            else {
+                continue;
+            };
+            for property in &metadata.properties {
+                let ObjectPropertyKind::ObjectProperty(property) = property else {
+                    continue;
+                };
+                if metadata_property_name(property) != Some("inputs") {
+                    continue;
+                }
+                let Expression::ArrayExpression(inputs) = property.value.get_inner_expression()
+                else {
+                    continue;
+                };
+                for input in &inputs.elements {
+                    let Some(expression) = input.as_expression() else {
+                        continue;
+                    };
+                    let Some((binding, span)) = static_string(expression) else {
+                        continue;
+                    };
+                    let normalized: CompactString = binding
+                        .chars()
+                        .filter(|character| {
+                            !character.is_whitespace() && !matches!(character, '[' | ']')
+                        })
+                        .collect();
+                    let mut names = normalized.split(':');
+                    let property_name = names.next().unwrap_or_default();
+                    let Some(alias_name) = names.next() else {
+                        continue;
+                    };
+                    self.check_alias(
+                        property_name,
+                        alias_name,
+                        span,
+                        allowed_names,
+                        selector_context,
+                    );
+                }
+            }
+        }
+    }
+
+    fn check_alias(
+        &mut self,
+        property_name: &str,
+        alias_name: &str,
+        span: Span,
+        allowed_names: &[CompactString],
+        selector_context: &SelectorContext,
+    ) {
+        if allowed_names.iter().any(|name| name == alias_name)
+            || aria_alias_matches_property(property_name, alias_name)
+            || alias_allowed_by_selector(selector_context, property_name, alias_name)
+        {
+            return;
+        }
+        self.diagnostics.push(Diagnostic {
+            rule_name: NO_INPUT_RENAME,
+            message_id: "noInputRename",
+            data: SmallVec::new(),
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+fn configured_allowed_names(options: &Value) -> SmallVec<[CompactString; 4]> {
+    options
+        .as_array()
+        .and_then(|options| options.first())
+        .and_then(Value::as_object)
+        .and_then(|option| option.get("allowedNames"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(CompactString::from)
+        .collect()
+}
+
+fn selector_context(class: &Class<'_>) -> SelectorContext {
+    let mut context = SelectorContext::default();
+    for decorator in &class.decorators {
+        let Some(call) = called_decorator(decorator, &["Component", "Directive"]) else {
+            continue;
+        };
+        let Some(Expression::ObjectExpression(metadata)) = call
+            .arguments
+            .first()
+            .and_then(|argument| argument.as_expression())
+            .map(Expression::get_inner_expression)
+        else {
+            continue;
+        };
+        let Some((selector, _)) = object_static_string(metadata, "selector") else {
+            continue;
+        };
+        context.directive_name = bracketed_directive_name(selector).map(CompactString::from);
+        context.selectors = selector
+            .split(',')
+            .map(|selector| {
+                selector
+                    .chars()
+                    .filter(|character| {
+                        !character.is_whitespace() && !matches!(character, '[' | ']')
+                    })
+                    .collect()
+            })
+            .collect();
+    }
+    context
+}
+
+fn bracketed_directive_name(selector: &str) -> Option<&str> {
+    let start = selector.find('[')? + 1;
+    let end = selector[start..].find(']')? + start;
+    Some(&selector[start..end])
+}
+
+fn alias_allowed_by_selector(
+    context: &SelectorContext,
+    property_name: &str,
+    alias_name: &str,
+) -> bool {
+    context.directive_name.as_deref() == Some(alias_name)
+        || context.selectors.iter().any(|selector| {
+            selector == alias_name || composed_name(selector, property_name).as_str() == alias_name
+        })
+}
+
+fn composed_name(selector: &str, property_name: &str) -> CompactString {
+    let mut name = CompactString::from(selector);
+    let mut chars = property_name.chars();
+    if let Some(first) = chars.next() {
+        name.extend(first.to_uppercase());
+    }
+    name.extend(chars);
+    name
+}
+
+fn decorator_alias<'a>(decorators: &'a [Decorator<'a>]) -> Option<(&'a str, Span)> {
+    let call = decorators.iter().find_map(|decorator| {
+        let Expression::CallExpression(call) = decorator.expression.get_inner_expression() else {
+            return None;
+        };
+        matches!(
+            call.callee.get_inner_expression(),
+            Expression::Identifier(identifier) if identifier.name == "Input"
+        )
+        .then_some(call.as_ref())
+    })?;
+    let argument = call.arguments.first()?.as_expression()?;
+    if let Some(value) = static_string(argument) {
+        return Some(value);
+    }
+    let Expression::ObjectExpression(metadata) = argument.get_inner_expression() else {
+        return None;
+    };
+    object_alias_static_string(metadata)
+}
+
+fn signal_input_alias<'a>(property: &'a PropertyDefinition<'a>) -> Option<(&'a str, Span)> {
+    let Expression::CallExpression(call) = property.value.as_ref()?.get_inner_expression() else {
+        return None;
+    };
+    if !is_input_call(call) {
+        return None;
+    }
+    call.arguments.iter().find_map(|argument| {
+        let Expression::ObjectExpression(options) =
+            argument.as_expression()?.get_inner_expression()
+        else {
+            return None;
+        };
+        object_alias_static_string(options)
+    })
+}
+
+fn is_input_call(call: &CallExpression<'_>) -> bool {
+    match call.callee.get_inner_expression() {
+        Expression::Identifier(identifier) => identifier.name == "input",
+        Expression::StaticMemberExpression(member) => {
+            member.property.name == "required"
+                && matches!(
+                    member.object.get_inner_expression(),
+                    Expression::Identifier(identifier) if identifier.name == "input"
+                )
+        }
+        _ => false,
+    }
+}
+
+fn called_decorator<'a>(
+    decorator: &'a Decorator<'a>,
+    names: &[&str],
+) -> Option<&'a CallExpression<'a>> {
+    let Expression::CallExpression(call) = decorator.expression.get_inner_expression() else {
+        return None;
+    };
+    let Expression::Identifier(callee) = call.callee.get_inner_expression() else {
+        return None;
+    };
+    names
+        .contains(&callee.name.as_str())
+        .then_some(call.as_ref())
+}
+
+fn object_static_string<'a>(
+    object: &'a ObjectExpression<'a>,
+    name: &str,
+) -> Option<(&'a str, Span)> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        (metadata_property_name(property) == Some(name))
+            .then(|| static_string(&property.value))
+            .flatten()
+    })
+}
+
+fn object_alias_static_string<'a>(object: &'a ObjectExpression<'a>) -> Option<(&'a str, Span)> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        matches!(
+            &property.key,
+            PropertyKey::StaticIdentifier(identifier)
+                if !property.computed && identifier.name == "alias"
+        )
+        .then(|| static_string(&property.value))
+        .flatten()
+    })
+}
+
+fn metadata_property_name<'a>(property: &'a ObjectProperty<'a>) -> Option<&'a str> {
+    match &property.key {
+        PropertyKey::StaticIdentifier(identifier) if !property.computed => {
+            Some(identifier.name.as_str())
+        }
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        PropertyKey::TemplateLiteral(template) if template.expressions.is_empty() => template
+            .quasis
+            .first()
+            .map(|quasi| quasi.value.raw.as_str()),
+        _ => None,
+    }
+}
+
+fn identifier_property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    let PropertyKey::StaticIdentifier(identifier) = key else {
+        return None;
+    };
+    Some(identifier.name.as_str())
+}
+
+fn static_string<'a>(expression: &'a Expression<'a>) -> Option<(&'a str, Span)> {
+    match expression.get_inner_expression() {
+        Expression::StringLiteral(literal) => Some((literal.value.as_str(), literal.span)),
+        Expression::TemplateLiteral(template) if template.expressions.is_empty() => template
+            .quasis
+            .first()
+            .map(|quasi| (quasi.value.raw.as_str(), template.span)),
+        _ => None,
+    }
+}
+
+fn aria_alias_matches_property(property_name: &str, alias_name: &str) -> bool {
+    is_aria_attribute(alias_name) && kebab_to_camel_case(alias_name) == property_name
+}
+
+fn kebab_to_camel_case(value: &str) -> CompactString {
+    let mut output = CompactString::new("");
+    let mut chars = value.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == '-' && chars.peek().is_some_and(|next| next.is_ascii_alphabetic()) {
+            if let Some(next) = chars.next() {
+                output.push(next.to_ascii_uppercase());
+            }
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+fn is_aria_attribute(value: &str) -> bool {
+    matches!(
+        value,
+        "aria-activedescendant"
+            | "aria-atomic"
+            | "aria-autocomplete"
+            | "aria-busy"
+            | "aria-checked"
+            | "aria-colcount"
+            | "aria-colindex"
+            | "aria-colspan"
+            | "aria-controls"
+            | "aria-current"
+            | "aria-describedby"
+            | "aria-details"
+            | "aria-disabled"
+            | "aria-dragged"
+            | "aria-dropeffect"
+            | "aria-errormessage"
+            | "aria-expanded"
+            | "aria-flowto"
+            | "aria-haspopup"
+            | "aria-hidden"
+            | "aria-invalid"
+            | "aria-label"
+            | "aria-labelledby"
+            | "aria-level"
+            | "aria-live"
+            | "aria-modal"
+            | "aria-multiline"
+            | "aria-multiselectable"
+            | "aria-orientation"
+            | "aria-owns"
+            | "aria-placeholder"
+            | "aria-posinset"
+            | "aria-pressed"
+            | "aria-readonly"
+            | "aria-relevant"
+            | "aria-required"
+            | "aria-rowcount"
+            | "aria-rowindex"
+            | "aria-rowspan"
+            | "aria-selected"
+            | "aria-setsize"
+            | "aria-sort"
+            | "aria-valuemax"
+            | "aria-valuemin"
+            | "aria-valuenow"
+            | "aria-valuetext"
+    )
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "Pinned upstream fixtures use serde_json values and Vec assertions to mirror the JavaScript ABI."
+)]
+mod tests {
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use serde_json::{Value, json};
+
+    use super::NO_INPUT_RENAME;
+    use crate::{Diagnostic, ScanOptions, scan_angular_eslint_with_options};
+
+    const UPSTREAM_FIXTURE: &str =
+        include_str!("../../../npm/angular-eslint/test/fixtures/no-input-rename-v22.0.0.json");
+
+    fn scan(source: &str, options: Value) -> Vec<Diagnostic> {
+        scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from(NO_INPUT_RENAME)]),
+                options,
+            },
+        )
+        .into_vec()
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_valid_case() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid no-input-rename fixture");
+        let valid = fixture["valid"]
+            .as_array()
+            .expect("fixture has valid cases");
+        assert_eq!(valid.len(), 46);
+        for test_case in valid {
+            let source = test_case["code"]
+                .as_str()
+                .expect("valid fixture case has source");
+            let diagnostics = scan(source, test_case["options"].clone());
+            assert!(
+                diagnostics.is_empty(),
+                "{}: {diagnostics:#?}",
+                test_case["name"]
+                    .as_str()
+                    .expect("valid fixture case has name")
+            );
+        }
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_invalid_location() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid no-input-rename fixture");
+        let invalid = fixture["invalid"]
+            .as_array()
+            .expect("fixture has invalid cases");
+        assert_eq!(invalid.len(), 35);
+        for test_case in invalid {
+            let source = test_case["code"]
+                .as_str()
+                .expect("invalid fixture case has source");
+            let diagnostics = scan(source, test_case["options"].clone());
+            let errors = test_case["errors"]
+                .as_array()
+                .expect("invalid fixture case has errors");
+            assert_eq!(
+                diagnostics.len(),
+                errors.len(),
+                "{}: {diagnostics:#?}",
+                test_case["name"]
+                    .as_str()
+                    .expect("invalid fixture case has name")
+            );
+            for (diagnostic, error) in diagnostics.iter().zip(errors) {
+                assert_eq!(diagnostic.message_id, "noInputRename");
+                assert!(diagnostic.data.is_empty());
+                assert_eq!(
+                    diagnostic.loc.start_line,
+                    error["line"].as_u64().expect("error has line") as u32
+                );
+                assert_eq!(
+                    diagnostic.loc.start_column + 1,
+                    error["column"].as_u64().expect("error has column") as u32
+                );
+                assert_eq!(
+                    diagnostic.loc.end_line,
+                    error["endLine"].as_u64().expect("error has end line") as u32
+                );
+                assert_eq!(
+                    diagnostic.loc.end_column + 1,
+                    error["endColumn"].as_u64().expect("error has end column") as u32
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reports_every_supported_alias_shape_in_source_order() {
+        let source = r#"
+            @Component({ inputs: ['first: firstAlias', `second: secondAlias`] })
+            class Test {
+                @Input('thirdAlias') third: string;
+                fourth = input(0, { alias: 'fourthAlias' });
+                fifth = input.required<string>({ alias: `fifthAlias` });
+                @Input({ required: true, alias: 'sixthAlias' }) set sixth(value: string) {}
+            }
+        "#;
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(diagnostics.len(), 6);
+        assert!(diagnostics.windows(2).all(|pair| {
+            (pair[0].loc.start_line, pair[0].loc.start_column)
+                < (pair[1].loc.start_line, pair[1].loc.start_column)
+        }));
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.message_id == "noInputRename")
+        );
+    }
+
+    #[test]
+    fn honors_allowed_names_selectors_composition_and_aria_semantics() {
+        let source = r#"
+            @Directive({
+                selector: 'img[fooDirective], foo',
+                inputs: ['metadata: foo', 'host: fooDirective', 'ariaLabel: aria-label']
+            })
+            class Test {
+                @Input('fooMyColor') myColor: string;
+                bySelector = input(0, { alias: 'foo' });
+                byDirective = input.required<string>({ alias: 'fooDirective' });
+                ariaLabel = input(0, { alias: 'aria-label' });
+                allowed = input(0, { alias: 'migration-name' });
+            }
+        "#;
+        assert!(scan(source, json!([{"allowedNames":["migration-name"]}])).is_empty());
+    }
+
+    #[test]
+    fn rejects_near_miss_selector_and_aria_aliases() {
+        let source = r#"
+            @Directive({ selector: 'foo' })
+            class Test {
+                @Input('foocolor') color: string;
+                ariaBusy = input(0, { alias: 'aria-invalid' });
+                wrongAria = input.required<string>({ alias: 'aria-madeup' });
+            }
+        "#;
+        assert_eq!(scan(source, json!([])).len(), 3);
+    }
+
+    #[test]
+    fn ignores_host_directive_renames_and_dynamic_or_computed_shapes() {
+        let source = r#"
+            const alias = 'external';
+            const dynamicMetadataKey = 'inputs';
+            @Component({
+                hostDirectives: [{ inputs: ['internal: external'] }],
+                inputs: [dynamic(), alias, ...spread],
+                [dynamicMetadataKey]: ['internal: external']
+            })
+            class Test {
+                @Input(alias) dynamicDecorator: string;
+                [computed] = input(0, { alias: 'computedAlias' });
+                ordinary = customInput(0, { alias: 'notAngular' });
+                required = input['required']({ alias: 'computedRequired' });
+                dynamicOptions = input(0, { [alias]: 'dynamicAlias' });
+                quotedOptions = input(0, { 'alias': 'quotedAlias' });
+            }
+        "#;
+        assert!(scan(source, json!([])).is_empty());
+    }
+
+    #[test]
+    fn does_not_match_comments_strings_or_unrelated_decorators() {
+        let source = r#"
+            const text = "@Input('renamed') name";
+            // @Input("commented") property: string;
+            class Test {
+                @OtherInput('renamed') name: string;
+                value = other.input({ alias: 'renamed' });
+            }
+        "#;
+        assert!(scan(source, json!([])).is_empty());
+    }
+
+    #[test]
+    fn does_not_treat_computed_identifier_metadata_keys_as_static() {
+        let source = r#"
+            const selector = 'selector';
+            const inputs = 'inputs';
+            @Directive({
+                [selector]: 'publicName',
+                [inputs]: ['internal: publicName']
+            })
+            class Test {
+                @Input('publicName') internal: string;
+            }
+        "#;
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].loc.start_line, 9);
+    }
+
+    #[test]
+    fn preserves_utf16_columns_and_rule_isolation() {
+        let source = "class Test { emoji = '😀'; @Input('renamed') name: string; }";
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].loc.start_column, 34);
+        assert_eq!(diagnostics[0].loc.end_column, 43);
+
+        let selected_other_rule = scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from("no-output-rename")]),
+                options: Value::Null,
+            },
+        );
+        assert!(
+            selected_other_rule
+                .iter()
+                .all(|diagnostic| diagnostic.rule_name != NO_INPUT_RENAME)
+        );
+    }
+
+    #[test]
+    fn malformed_source_fails_closed() {
+        assert!(scan("class Test { @Input('rename'", json!([])).is_empty());
+        assert!(scan("@Component({ inputs: ['a: b'] }) class {", json!([])).is_empty());
+    }
+}

--- a/crates/angular_eslint/src/lib.rs
+++ b/crates/angular_eslint/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod class_suffix;
 mod inline_declarations;
+mod input_rename;
 mod prefix;
 mod scanner;
 mod selector;

--- a/crates/angular_eslint/src/scanner.rs
+++ b/crates/angular_eslint/src/scanner.rs
@@ -51,7 +51,6 @@ impl<'a> Scanner<'a> {
             "no-implicit-take-until-destroyed",
             r#"\btakeUntilDestroyed\s*\(\s*\)"#,
         );
-        self.check_regex("no-input-rename", r#"@Input\s*\(\s*['"][^'"]+['"]"#);
         self.check_regex("no-inputs-metadata-property", r#"\binputs\s*:"#);
         self.check_regex(
             "no-lifecycle-call",

--- a/crates/angular_eslint/src/selector.rs
+++ b/crates/angular_eslint/src/selector.rs
@@ -74,6 +74,7 @@ impl Visit<'_> for Scanner<'_> {
     fn visit_class(&mut self, class: &Class<'_>) {
         self.check_class_suffix_decorators(class);
         self.check_component_inline_declarations(class);
+        self.check_input_rename(class);
         self.check_prefix_rules(class);
         self.check_selector_decorators(class);
         walk::walk_class(self, class);

--- a/npm/angular-eslint/README.md
+++ b/npm/angular-eslint/README.md
@@ -4,3 +4,16 @@ Rust-backed Oxlint plugin port of `@angular-eslint/eslint-plugin` v22.0.0.
 
 This package exposes the `@angular-eslint` plugin and a native API for scanning
 Angular TypeScript source through the Rust implementation.
+
+`no-input-rename` is an Oxc AST port covering `@Input()` aliases, `input()` and
+`input.required()` signal aliases, and `inputs` metadata. It forwards the
+upstream `allowedNames` option and preserves the selector-composition,
+`aria-*`, and `hostDirectives` exceptions from angular-eslint v22.0.0. The
+checked-in fixture replays all 46 authored valid and 35 authored invalid cases
+from commit `7ee4556badebf8c140ffdefdd0b07b02820d5e96`.
+
+The current native diagnostic ABI contains message data and locations, but not
+fix or suggestion edit payloads. The plugin therefore exposes the upstream
+`fixable`, `hasSuggestions`, schema, and message metadata while reporting
+`noInputRename` diagnostics without edits. Fix/suggestion transport can be
+added separately without changing this rule's detection semantics.

--- a/npm/angular-eslint/api.d.ts
+++ b/npm/angular-eslint/api.d.ts
@@ -12,6 +12,12 @@ export type AngularEslintDiagnostic = {
   loc: AngularEslintDiagnosticLoc;
 };
 
+export type NoInputRenameOptions = [
+  {
+    readonly allowedNames?: readonly string[];
+  }?,
+];
+
 export function implementedAngularEslintRuleNames(): string[];
 export function scanAngularEslint(
   sourceText: string,

--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -16,11 +16,13 @@ const selectorRuleNames = new Set(['component-selector', 'directive-selector']);
 const classSuffixRuleNames = new Set(['component-class-suffix', 'directive-class-suffix']);
 const prefixRuleNames = new Set(['no-input-prefix', 'pipe-prefix']);
 const inlineDeclarationRuleName = 'component-max-inline-declarations';
+const inputRenameRuleName = 'no-input-rename';
 const optionAwareRuleNames = new Set([
   ...selectorRuleNames,
   ...classSuffixRuleNames,
   ...prefixRuleNames,
   inlineDeclarationRuleName,
+  inputRenameRuleName,
 ]);
 
 const inlineDeclarationSchema = [
@@ -101,6 +103,28 @@ const prefixMessages = {
     pipePrefix: '@Pipes should be prefixed with {{prefixes}}',
     selectorAfterPrefixFailure: '@Pipes should have a selector after the {{prefixes}} prefix',
   },
+};
+
+const inputRenameSchema = [
+  {
+    type: 'object',
+    properties: {
+      allowedNames: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'A list with allowed input names',
+        uniqueItems: true,
+      },
+    },
+    additionalProperties: false,
+  },
+];
+
+const inputRenameMessages = {
+  noInputRename:
+    'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
+  suggestRemoveAliasName: 'Remove alias name',
+  suggestReplaceOriginalNameWithAliasName: 'Remove alias name and use it as the original name',
 };
 
 const selectorConfigSchema = {
@@ -216,6 +240,7 @@ function createAngularEslintRule(ruleName) {
   const isClassSuffixRule = classSuffixRuleNames.has(ruleName);
   const isPrefixRule = prefixRuleNames.has(ruleName);
   const isInlineDeclarationRule = ruleName === inlineDeclarationRuleName;
+  const isInputRenameRule = ruleName === inputRenameRuleName;
   return {
     meta: {
       type: problemRules.has(ruleName) ? 'problem' : 'suggestion',
@@ -233,9 +258,11 @@ function createAngularEslintRule(ruleName) {
             ? prefixMessages[ruleName]
             : isInlineDeclarationRule
               ? inlineDeclarationMessages
-              : {
-                  unexpected: 'Unexpected Angular pattern.',
-                },
+              : isInputRenameRule
+                ? inputRenameMessages
+                : {
+                    unexpected: 'Unexpected Angular pattern.',
+                  },
       schema: isSelectorRule
         ? selectorSchema
         : isClassSuffixRule
@@ -244,7 +271,10 @@ function createAngularEslintRule(ruleName) {
             ? prefixSchemas[ruleName]
             : isInlineDeclarationRule
               ? inlineDeclarationSchema
-              : [],
+              : isInputRenameRule
+                ? inputRenameSchema
+                : [],
+      ...(isInputRenameRule ? { fixable: 'code', hasSuggestions: true } : {}),
     },
     createOnce(context) {
       return {

--- a/npm/angular-eslint/test/api.test.mjs
+++ b/npm/angular-eslint/test/api.test.mjs
@@ -1,6 +1,12 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import { implementedAngularEslintRuleNames, scanAngularEslint } from '../api.js';
+
+const noInputRenameFixture = JSON.parse(
+  readFileSync(new URL('./fixtures/no-input-rename-v22.0.0.json', import.meta.url), 'utf8'),
+);
 
 const expectedRuleNames = [
   'component-class-suffix',
@@ -321,6 +327,131 @@ describe('angular-eslint native API', () => {
         options,
       }),
     ).toMatchObject(expected);
+  });
+
+  it('pins every authored no-input-rename case from angular-eslint v22.0.0', () => {
+    expect(noInputRenameFixture.metadata).toMatchObject({
+      version: '22.0.0',
+      sourceCommit: '7ee4556badebf8c140ffdefdd0b07b02820d5e96',
+      counts: {
+        valid: 46,
+        invalid: 35,
+        diagnostics: 35,
+      },
+    });
+  });
+
+  it.each(noInputRenameFixture.valid)(
+    'accepts upstream no-input-rename valid case: $name',
+    ({ code, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['no-input-rename'],
+          options,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it.each(noInputRenameFixture.invalid)(
+    'matches upstream no-input-rename invalid location: $name',
+    ({ code, errors, options }) => {
+      const diagnostics = scanAngularEslint(code, 'fixture.ts', {
+        ruleNames: ['no-input-rename'],
+        options,
+      });
+      expect(diagnostics).toHaveLength(errors.length);
+      expect(diagnostics).toEqual(
+        errors.map((error) => ({
+          ruleName: 'no-input-rename',
+          messageId: 'noInputRename',
+          data: [],
+          loc: {
+            startLine: error.line,
+            startColumn: error.column - 1,
+            endLine: error.endLine,
+            endColumn: error.endColumn - 1,
+          },
+        })),
+      );
+    },
+  );
+
+  it('reports decorator, signal, required signal, and metadata aliases in source order', () => {
+    const source = `
+@Component({ inputs: ['metadata: publicMetadata'] })
+class Test {
+  @Input('publicDecorator') decorator: string;
+  signal = input(0, { alias: 'publicSignal' });
+  required = input.required<string>({ alias: 'publicRequired' });
+}
+`;
+    const diagnostics = scanAngularEslint(source, 'fixture.ts', {
+      ruleNames: ['no-input-rename'],
+      options: [],
+    });
+    expect(diagnostics).toHaveLength(4);
+    expect(diagnostics.map(({ messageId }) => messageId)).toEqual([
+      'noInputRename',
+      'noInputRename',
+      'noInputRename',
+      'noInputRename',
+    ]);
+    expect(diagnostics.map(({ loc }) => loc.startLine)).toEqual([2, 4, 5, 6]);
+  });
+
+  it('keeps no-input-rename isolated and fails closed on malformed TypeScript', () => {
+    const source = `class Test { @Input('renamed') name: string; }`;
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['no-output-rename'],
+        options: [],
+      }).some(({ ruleName }) => ruleName === 'no-input-rename'),
+    ).toBe(false);
+    expect(
+      scanAngularEslint(`class Test { @Input('renamed'`, 'fixture.ts', {
+        ruleNames: ['no-input-rename'],
+        options: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it('preserves UTF-16 columns for no-input-rename aliases', () => {
+    expect(
+      scanAngularEslint(
+        `class Test { emoji = '😀'; @Input('renamed') name: string; }`,
+        'fixture.ts',
+        {
+          ruleNames: ['no-input-rename'],
+          options: [],
+        },
+      ),
+    ).toMatchObject([
+      {
+        messageId: 'noInputRename',
+        loc: {
+          startLine: 1,
+          startColumn: 34,
+          endLine: 1,
+          endColumn: 43,
+        },
+      },
+    ]);
+  });
+
+  it('does not mistake computed identifier keys for static Angular metadata', () => {
+    const source = `
+const selector = 'selector';
+const inputs = 'inputs';
+@Directive({ [selector]: 'publicName', [inputs]: ['internal: publicName'] })
+class Test { @Input('publicName') internal: string; }
+`;
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['no-input-rename'],
+        options: [],
+      }),
+    ).toMatchObject([{ messageId: 'noInputRename', loc: { startLine: 5 } }]);
   });
 
   it.each([

--- a/npm/angular-eslint/test/fixtures/no-input-rename-v22.0.0.json
+++ b/npm/angular-eslint/test/fixtures/no-input-rename-v22.0.0.json
@@ -1,0 +1,1080 @@
+{
+  "metadata": {
+    "package": "@angular-eslint/eslint-plugin",
+    "version": "22.0.0",
+    "sourceCommit": "7ee4556badebf8c140ffdefdd0b07b02820d5e96",
+    "sourcePath": "packages/eslint-plugin/tests/rules/no-input-rename/cases.ts",
+    "sourceSha256": "37870441d37d73170c907562e06edc2b8c4039f0dee10a7b3fa5995a15bc2ca6",
+    "capture": "every authored valid and invalid semantic case exactly once",
+    "counts": {
+      "valid": 46,
+      "invalid": 35,
+      "diagnostics": 35
+    }
+  },
+  "valid": [
+    {
+      "name": "valid-1",
+      "code": "class Test {}",
+      "options": []
+    },
+    {
+      "name": "valid-2",
+      "code": "\n    @Page({\n      inputs: ['play', popstate, `online`, 'obsolete: obsol', 'store: storage'],\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-3",
+      "code": "\n    @Component()\n    class Test {\n      change = new EventEmitter();\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-4",
+      "code": "\n    @Directive()\n    class Test {\n      @Input() buttonChange = new EventEmitter<'change'>();\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-5",
+      "code": "\n    @Directive()\n    class Test {\n      buttonChange = input(1);\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-6",
+      "code": "\n    @Directive()\n    class Test {\n      buttonChange = input.required<number>();\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-7",
+      "code": "\n    @Component({\n      inputs,\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-8",
+      "code": "\n    @Directive({\n      inputs: [...test],\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-9",
+      "code": "\n    @Component({\n      inputs: func(),\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-10",
+      "code": "\n    @Directive({\n      inputs: [func(), 'a'],\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-11",
+      "code": "\n    @Component({\n      selector: 'qx-menuitem',\n      hostDirectives: [{\n        directive: CdkMenuItem,\n        inputs: ['cdkMenuItemDisabled: disabled'],\n      }]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-12",
+      "code": "\n    @Component({\n      selector: 'qx-menuitem',\n      'hostDirectives': [{\n        directive: CdkMenuItem,\n        inputs: ['cdkMenuItemDisabled: disabled'],\n      }]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-13",
+      "code": "\n    @Component({\n      selector: 'qx-menuitem',\n      ['hostDirectives']: [{\n        directive: CdkMenuItem,\n        inputs: ['cdkMenuItemDisabled: disabled'],\n      }]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-14",
+      "code": "\n    @Component({})\n    class Test {\n      @Input() set setter(setter: string) {}\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-15",
+      "code": "\n      @Component({\n        inputs: ['foo: aria-wrong']\n      })\n      class Test {\n        @Input('aria-wrong') set setter(setter: string) {}\n        func = input(1, { alias: 'aria-wrong' });\n        required = input.required<number>({ alias: 'aria-wrong' });\n      }\n      ",
+      "options": [
+        {
+          "allowedNames": ["aria-wrong"]
+        }
+      ]
+    },
+    {
+      "name": "valid-16",
+      "code": "\n    const change = 'change';\n    @Component()\n    class Test {\n      @Input(change) touchMove: EventEmitter<{ action: 'click' | 'close' }> = new EventEmitter<{ action: 'click' | 'close' }>();\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-17",
+      "code": "\n    const change = 'change';\n    @Component()\n    class Test {\n      touchMove = input(1, { alias: change });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-18",
+      "code": "\n    const change = 'change';\n    @Component()\n    class Test {\n      touchMove = input.required<number>({ alias: change });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-19",
+      "code": "\n    const blur = 'blur';\n    const click = 'click';\n    @Directive()\n    class Test {\n      @Input(blur) [click]: EventEmitter<Blur>;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-20",
+      "code": "\n    const blur = 'blur';\n    const click = 'click';\n    @Directive()\n    class Test {\n      [click] = input(1, { alias: blur });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-21",
+      "code": "\n    const blur = 'blur';\n    const click = 'click';\n    @Directive()\n    class Test {\n      [click] = input.required<number>({ alias: blur });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-22",
+      "code": "\n    @Component({\n      selector: 'foo[bar]'\n    })\n    class Test {\n      @Input() bar: string;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-23",
+      "code": "\n    @Component({\n      selector: 'foo[bar]'\n    })\n    class Test {\n      bar = input(1);\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-24",
+      "code": "\n    @Component({\n      selector: 'foo[bar]'\n    })\n    class Test {\n      bar = input.required<number>();\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-25",
+      "code": "\n    @Directive({\n      'selector': 'foo',\n      'inputs': [`test: foo`]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-26",
+      "code": "\n    @Component({\n      'selector': 'foo',\n      ['inputs']: [`test: foo`]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-27",
+      "code": "\n    @Directive({\n      'selector': 'foo',\n      [`inputs`]: [`test: foo`]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-28",
+      "code": "\n    @Component({\n      selector: '[foo], test',\n    })\n    class Test {\n      @Input('foo') label: string;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-29",
+      "code": "\n    @Component({\n      selector: '[foo], test',\n    })\n    class Test {\n      label = input(1, { alias: 'foo' });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-30",
+      "code": "\n    @Component({\n      selector: '[foo], test',\n    })\n    class Test {\n      label = input.required<number>(1, { alias: 'foo' });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-31",
+      "code": "\n    @Directive({\n      selector: 'foo'\n    })\n    class Test {\n      @Input('aria-label') ariaLabel: string;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-32",
+      "code": "\n    @Directive({\n      selector: 'foo'\n    })\n    class Test {\n      ariaLabel = input(1, { alias: 'aria-label' });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-33",
+      "code": "\n    @Directive({\n      selector: 'foo'\n    })\n    class Test {\n      ariaLabel = input.required<number>('aria-label');\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-34",
+      "code": "\n      @Component({\n        inputs: ['foo: allowedName']\n      })\n      class Test {\n        @Input() bar: string;\n      }\n      ",
+      "options": [
+        {
+          "allowedNames": ["allowedName"]
+        }
+      ]
+    },
+    {
+      "name": "valid-35",
+      "code": "\n    @Directive({\n      selector: 'foo'\n    })\n    class Test {\n      @Input('fooMyColor') myColor: string;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-36",
+      "code": "\n    @Directive({\n      selector: 'foo'\n    })\n    class Test {\n      myColor = input(1, { alias: 'fooMyColor' });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-37",
+      "code": "\n    @Directive({\n      selector: 'foo'\n    })\n    class Test {\n      myColor = input.required<number>('fooMyColor');\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-38",
+      "code": "\n    @Directive({\n      selector: 'img[fooDirective]'\n    })\n    class Test {\n      @Input foo: Foo;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-39",
+      "code": "\n    @Directive({\n      selector: 'img[fooDirective]'\n    })\n    class Test {\n      foo = input(1);\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-40",
+      "code": "\n    @Directive({\n      selector: 'img[fooDirective]'\n    })\n    class Test {\n      foo = input.required<number>();\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-41",
+      "code": "\n    @Directive({\n      selector: 'img[fooDirective]'\n    })\n    class Test {\n      @Input('fooDirective') foo: Foo;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-42",
+      "code": "\n    @Directive({\n      selector: 'img[fooDirective]'\n    })\n    class Test {\n      foo = input(1, { alias: 'fooDirective' });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-43",
+      "code": "\n    @Directive({\n      selector: 'img[fooDirective]'\n    })\n    class Test {\n      foo = input.required<number>({ alias: 'fooDirective' });\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-44",
+      "code": "\n    @Component({\n      selector: 'foo'\n    })\n    class Test {\n      @Input({ required: true }) name: string;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-45",
+      "code": "\n    @Component({\n      selector: 'foo'\n    })\n    class Test {\n      @Input({ transform: (val) => val ?? '', required: true }) foo!: string;\n    }\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-46",
+      "code": "\n    @Component({\n      selector: 'foo'\n    })\n    class Test {\n      foo = input.required<string>({ transform: (val) => val ?? '' });\n    }\n  ",
+      "options": []
+    }
+  ],
+  "invalid": [
+    {
+      "name": "should fail if `inputs` metadata property is aliased in `@Component`",
+      "code": "\n      @Component({\n        inputs: ['a: b']\n                 \n      })\n      class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 3,
+          "column": 18,
+          "endLine": 3,
+          "endColumn": 24,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        inputs: ['a']\n                 \n      })\n      class Test {}\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        inputs: ['b']\n                 \n      })\n      class Test {}\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if `inputs` metadata property is literal and aliased in `@Directive`",
+      "code": "\n      @Directive({\n        outputs: ['abort'],\n        'inputs': [boundary, `test: copy`, 'check: check'],\n                             \n      })\n      class Test {}\n    ",
+      "options": [
+        {
+          "allowedNames": ["check", "test"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 30,
+          "endLine": 4,
+          "endColumn": 42,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        outputs: ['abort'],\n        'inputs': [boundary, `test`, 'check: check'],\n                             \n      })\n      class Test {}\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        outputs: ['abort'],\n        'inputs': [boundary, `copy`, 'check: check'],\n                             \n      })\n      class Test {}\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if `inputs` metadata property is computed `Literal` and aliased with the same name in `@Component`",
+      "code": "\n      @Component({\n        ['inputs']: ['orientation: orientation'],\n                     \n      })\n      class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 3,
+          "column": 22,
+          "endLine": 3,
+          "endColumn": 48
+        }
+      ],
+      "output": "\n      @Component({\n        ['inputs']: ['orientation'],\n                     \n      })\n      class Test {}\n    "
+    },
+    {
+      "name": "should fail if `inputs` metadata property is computed `TemplateLiteral` and aliased with the same name in `@Directive`",
+      "code": "\n      @Directive({\n        [`inputs`]: ['orientation: orientation'],\n                     \n      })\n      class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 3,
+          "column": 22,
+          "endLine": 3,
+          "endColumn": 48
+        }
+      ],
+      "output": "\n      @Directive({\n        [`inputs`]: ['orientation'],\n                     \n      })\n      class Test {}\n    "
+    },
+    {
+      "name": "should fail if input decorator property is aliased with backticks",
+      "code": "\n      @Component()\n      class Test {\n        @Custom() @Input(`change`) _change = getInput();\n                         \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 26,
+          "endLine": 4,
+          "endColumn": 34,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component()\n      class Test {\n        @Custom() @Input() _change = getInput();\n                         \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component()\n      class Test {\n        @Custom() @Input() change = getInput();\n                         \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property is aliased with backticks",
+      "code": "\n      @Component()\n      class Test {\n        _change = input(1, { alias: `change` });\n                                    \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 37,
+          "endLine": 4,
+          "endColumn": 45,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component()\n      class Test {\n        _change = input(1);\n                                    \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component()\n      class Test {\n        change = input(1);\n                                    \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property is aliased with backticks",
+      "code": "\n      @Component()\n      class Test {\n        _change = input.required<number>({ alias: `change` });\n                                                  \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 51,
+          "endLine": 4,
+          "endColumn": 59,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component()\n      class Test {\n        _change = input.required<number>();\n                                                  \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component()\n      class Test {\n        change = input.required<number>();\n                                                  \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input decorator property is aliased",
+      "code": "\n      @Directive()\n      class Test {\n        @Input('change') change = (this.subject$ as Subject<{blur: boolean}>).pipe();\n               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 16,
+          "endLine": 4,
+          "endColumn": 24
+        }
+      ],
+      "output": "\n      @Directive()\n      class Test {\n        @Input() change = (this.subject$ as Subject<{blur: boolean}>).pipe();\n               \n      }\n    "
+    },
+    {
+      "name": "should fail if input function property is aliased",
+      "code": "\n      @Directive()\n      class Test {\n        change = input(1, { alias: 'change' });\n                                   \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 36,
+          "endLine": 4,
+          "endColumn": 44
+        }
+      ],
+      "output": "\n      @Directive()\n      class Test {\n        change = input(1);\n                                   \n      }\n    "
+    },
+    {
+      "name": "should fail if required input function property is aliased",
+      "code": "\n      @Directive()\n      class Test {\n        change = input.required<number>({ alias: 'change' });\n                                                 \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 50,
+          "endLine": 4,
+          "endColumn": 58
+        }
+      ],
+      "output": "\n      @Directive()\n      class Test {\n        change = input.required<number>();\n                                                 \n      }\n    "
+    },
+    {
+      "name": "should fail if input decorator property is aliased (using metadata)",
+      "code": "\n      @Directive()\n      class Test {\n        @Input({ alias: 'change' }) change = (this.subject$ as Subject<{blur: boolean}>).pipe();\n                        \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 25,
+          "endLine": 4,
+          "endColumn": 33
+        }
+      ],
+      "output": "\n      @Directive()\n      class Test {\n        @Input() change = (this.subject$ as Subject<{blur: boolean}>).pipe();\n                        \n      }\n    "
+    },
+    {
+      "name": "should fail if input decorator setter is aliased",
+      "code": "\n      @Component()\n      class Test {\n        @Input(`devicechange`) set setter(setter: string) {}\n               \n\n        @Input('allowedName') test: string;\n      }\n    ",
+      "options": [
+        {
+          "allowedNames": ["allowedName"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 4,
+          "column": 16,
+          "endLine": 4,
+          "endColumn": 30,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component()\n      class Test {\n        @Input() set setter(setter: string) {}\n               \n\n        @Input('allowedName') test: string;\n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component()\n      class Test {\n        @Input() set devicechange(setter: string) {}\n               \n\n        @Input('allowedName') test: string;\n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if an input decorator 'aria-*' alias name does not match the property name",
+      "code": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        @Input('aria-invalid') ariaBusy: string;\n               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 16,
+          "endLine": 6,
+          "endColumn": 30,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        @Input() ariaBusy: string;\n               \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        @Input() 'aria-invalid': string;\n               \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if an input function 'aria-*' alias name does not match the property name",
+      "code": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        ariaBusy = input(1, { alias: 'aria-invalid' });\n                                     \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 38,
+          "endLine": 6,
+          "endColumn": 52,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        ariaBusy = input(1);\n                                     \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        'aria-invalid' = input(1);\n                                     \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if a required input function 'aria-*' alias name does not match the property name",
+      "code": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        ariaBusy = input.required<number>({ alias: 'aria-invalid' });\n                                                   \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 52,
+          "endLine": 6,
+          "endColumn": 66,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        ariaBusy = input.required<number>();\n                                                   \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        selector: 'foo'\n      })\n      class Test {\n        'aria-invalid' = input.required<number>();\n                                                   \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input decorator alias is prefixed by component's selector, but the suffix does not match the property name",
+      "code": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        @Input('fooColor') colors: string;\n               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 16,
+          "endLine": 6,
+          "endColumn": 26,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        @Input() colors: string;\n               \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        @Input() fooColor: string;\n               \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function alias is prefixed by component's selector, but the suffix does not match the property name",
+      "code": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        colors = input(1, { alias: 'fooColor' });\n                                   \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 36,
+          "endLine": 6,
+          "endColumn": 46,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        colors = input(1);\n                                   \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        fooColor = input(1);\n                                   \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function alias is prefixed by component's selector, but the suffix does not match the property name",
+      "code": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        colors = input.required<number>({ alias: 'fooColor' });\n                                                 \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 50,
+          "endLine": 6,
+          "endColumn": 60,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        colors = input.required<number>();\n                                                 \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        selector: 'foo'\n      })\n      class Test {\n        fooColor = input.required<number>();\n                                                 \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input decorator alias is not strictly equal to the selector plus the property name in `camelCase` form",
+      "code": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        @Input('foocolor') color: string;\n               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 16,
+          "endLine": 6,
+          "endColumn": 26,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        @Input() color: string;\n               \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        @Input() foocolor: string;\n               \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function alias is not strictly equal to the selector plus the property name in `camelCase` form",
+      "code": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        color = input(1, { alias: 'foocolor' });\n                                  \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 35,
+          "endLine": 6,
+          "endColumn": 45,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        color = input(1);\n                                  \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        foocolor = input(1);\n                                  \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function alias is not strictly equal to the selector plus the property name in `camelCase` form",
+      "code": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        color = input.required<number>({ alias: 'foocolor' });\n                                                \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 49,
+          "endLine": 6,
+          "endColumn": 59,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        color = input.required<number>();\n                                                \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        'selector': 'foo'\n      })\n      class Test {\n        foocolor = input.required<number>();\n                                                \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input decorator property is aliased without `@Component` or `@Directive` decorator",
+      "code": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        @Input('click') blur = this.getInput();\n               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 9,
+          "column": 16,
+          "endLine": 9,
+          "endColumn": 23,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        @Input() blur = this.getInput();\n               \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        @Input() click = this.getInput();\n               \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property is aliased without `@Component` or `@Directive` decorator",
+      "code": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        blur = input(1, { alias: 'click' });\n                                 \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 9,
+          "column": 34,
+          "endLine": 9,
+          "endColumn": 41,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        blur = input(1);\n                                 \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        click = input(1);\n                                 \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property is aliased without `@Component` or `@Directive` decorator",
+      "code": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        blur = input.required<number>({ alias: 'click' });\n                                               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 9,
+          "column": 48,
+          "endLine": 9,
+          "endColumn": 55,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        blur = input.required<number>();\n                                               \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Component({\n        selector: 'click',\n      })\n      class Test {}\n\n      @Injectable()\n      class Test {\n        click = input.required<number>();\n                                               \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input decorator property alias does not match the directive name when applied to an element in the selector",
+      "code": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        @Input('notFooDirective') foo: Foo;\n               \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 16,
+          "endLine": 6,
+          "endColumn": 33,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        @Input() foo: Foo;\n               \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        @Input() notFooDirective: Foo;\n               \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property alias does not match the directive name when applied to an element in the selector",
+      "code": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        foo = input({ alias: 'notFooDirective' });\n                             \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 30,
+          "endLine": 6,
+          "endColumn": 47,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        foo = input();\n                             \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        notFooDirective = input();\n                             \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property alias does not match the directive name when applied to an element in the selector",
+      "code": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        foo = input.required<number>({ alias: 'notFooDirective' });\n                                              \n      }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 47,
+          "endLine": 6,
+          "endColumn": 64,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        foo = input.required<number>();\n                                              \n      }\n    "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n      @Directive({\n        selector: 'img[fooDirective]',\n      })\n      class Test {\n        notFooDirective = input.required<number>();\n                                              \n      }\n    "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property is aliased and alias has properties after it",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { alias: 'test', after: 'it' });\n                                    \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 37,
+          "endLine": 6,
+          "endColumn": 43,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { after: 'it' });\n                                    \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input(1, { after: 'it' });\n                                    \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property is aliased and alias has properties after it",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ alias: 'test', after: 'it' });\n                                                  \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 51,
+          "endLine": 6,
+          "endColumn": 57,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ after: 'it' });\n                                                  \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input.required<number>({ after: 'it' });\n                                                  \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property is aliased and alias has properties before it with trailing comma",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { before: 'it', alias: 'test', });\n                                                  \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 51,
+          "endLine": 6,
+          "endColumn": 57,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { before: 'it', });\n                                                  \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input(1, { before: 'it', });\n                                                  \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property is aliased and alias has properties before it with trailing comma",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ before: 'it', alias: 'test', });\n                                                                \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 65,
+          "endLine": 6,
+          "endColumn": 71,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ before: 'it', });\n                                                                \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input.required<number>({ before: 'it', });\n                                                                \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property is aliased and alias has properties before it without trailing comma",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { before: 'it', alias: 'test' });\n                                                  \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 51,
+          "endLine": 6,
+          "endColumn": 57,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { before: 'it' });\n                                                  \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input(1, { before: 'it' });\n                                                  \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property is aliased and alias has properties before it without trailing comma",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ before: 'it', alias: 'test' });\n                                                                \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 65,
+          "endLine": 6,
+          "endColumn": 71,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ before: 'it' });\n                                                                \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input.required<number>({ before: 'it' });\n                                                                \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if input function property is aliased and alias has properties before and after it",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { before: 'it', alias: 'test', after: 'it' });\n                                                  \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 51,
+          "endLine": 6,
+          "endColumn": 57,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input(1, { before: 'it', after: 'it' });\n                                                  \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input(1, { before: 'it', after: 'it' });\n                                                  \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if required input function property is aliased and alias has properties before and after it",
+      "code": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ before: 'it', alias: 'test', after: 'it' });\n                                                                \n        }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "noInputRename",
+          "line": 6,
+          "column": 65,
+          "endLine": 6,
+          "endColumn": 71,
+          "suggestions": [
+            {
+              "messageId": "suggestRemoveAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          color = input.required<number>({ before: 'it', after: 'it' });\n                                                                \n        }\n      "
+            },
+            {
+              "messageId": "suggestReplaceOriginalNameWithAliasName",
+              "output": "\n        @Component({\n          'selector': 'foo'\n        })\n        class Test {\n          test = input.required<number>({ before: 'it', after: 'it' });\n                                                                \n        }\n      "
+            }
+          ]
+        }
+      ],
+      "output": null
+    }
+  ]
+}

--- a/npm/angular-eslint/test/plugin.test.mjs
+++ b/npm/angular-eslint/test/plugin.test.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -10,6 +10,9 @@ import plugin from '../index.js';
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = resolve(packageRoot, '../..');
+const noInputRenameFixture = JSON.parse(
+  readFileSync(new URL('./fixtures/no-input-rename-v22.0.0.json', import.meta.url), 'utf8'),
+);
 
 const expectedRuleNames = [
   'component-class-suffix',
@@ -185,6 +188,8 @@ describe('angular-eslint plugin adapter', () => {
         '`{{propertyType}}` has too many lines ({{lineCount}}). Maximum allowed is {{max}}',
       'directive-class-suffix':
         'Directive class names should end with one of these suffixes: {{suffixes}}',
+      'no-input-rename':
+        'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
     };
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
       expectedMessages[ruleName] || 'Unexpected Angular pattern.',
@@ -230,6 +235,32 @@ describe('angular-eslint plugin adapter', () => {
     expect(plugin.rules['no-input-prefix'].meta.schema[0].properties.prefixes.uniqueItems).toBe(
       undefined,
     );
+  });
+
+  it('exposes the exact upstream no-input-rename contract', () => {
+    const { meta } = plugin.rules['no-input-rename'];
+    expect(meta.schema).toEqual([
+      {
+        type: 'object',
+        properties: {
+          allowedNames: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'A list with allowed input names',
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ]);
+    expect(meta.messages).toEqual({
+      noInputRename:
+        'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
+      suggestRemoveAliasName: 'Remove alias name',
+      suggestReplaceOriginalNameWithAliasName: 'Remove alias name and use it as the original name',
+    });
+    expect(meta.fixable).toBe('code');
+    expect(meta.hasSuggestions).toBe(true);
   });
 
   it('exposes the complete component inline declaration contract', () => {
@@ -346,6 +377,59 @@ describe('angular-eslint plugin adapter', () => {
     ['pipe-prefix', '@Pipe({ name: "ngTitle" }) class Test {}', [{ prefixes: ['ng'] }], []],
   ])('honors configured %s prefixes through createOnce', (ruleName, code, options, expected) => {
     expect(runRule(ruleName, code, options)).toMatchObject(expected);
+  });
+
+  it.each(noInputRenameFixture.valid)(
+    'accepts upstream no-input-rename valid case through createOnce: $name',
+    ({ code, options }) => {
+      expect(runRule('no-input-rename', code, options)).toEqual([]);
+    },
+  );
+
+  it.each(noInputRenameFixture.invalid)(
+    'matches upstream no-input-rename invalid location through createOnce: $name',
+    ({ code, errors, options }) => {
+      expect(runRule('no-input-rename', code, options)).toEqual(
+        errors.map((error) => ({
+          messageId: 'noInputRename',
+          data: {},
+          loc: {
+            start: {
+              line: error.line,
+              column: error.column - 1,
+            },
+            end: {
+              line: error.endLine,
+              column: error.endColumn - 1,
+            },
+          },
+        })),
+      );
+    },
+  );
+
+  it('forwards allowedNames independently for metadata, decorators, and signal inputs', () => {
+    const code = `
+@Component({ inputs: ['metadata: allowed'] })
+class Test {
+  @Input('allowed') decorated: string;
+  signal = input(0, { alias: 'allowed' });
+  required = input.required<string>({ alias: 'blocked' });
+}
+`;
+    expect(runRule('no-input-rename', code, [{ allowedNames: ['allowed'] }])).toMatchObject([
+      { messageId: 'noInputRename' },
+    ]);
+  });
+
+  it('documents the adapter payload boundary without inventing fixes or suggestions', () => {
+    const reports = runRule(
+      'no-input-rename',
+      `class Test { @Input('external') internal: string; }`,
+    );
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).not.toHaveProperty('fix');
+    expect(reports[0]).not.toHaveProperty('suggest');
   });
 
   it.each([
@@ -706,6 +790,60 @@ describe('angular-eslint plugin adapter', () => {
           '@Pipes should be prefixed with "app"',
         ]),
       );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors no-input-rename allowedNames through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-no-input-rename-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.ts'),
+        '@Component({ inputs: ["metadata: allowed"] })\n' +
+          'class Test {\n' +
+          '  @Input("allowed") decorated: string;\n' +
+          '  signal = input(0, { alias: "blockedSignal" });\n' +
+          '  required = input.required<string>({ alias: "blockedRequired" });\n' +
+          '}\n',
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: '@angular-eslint',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            '@angular-eslint/no-input-rename': ['error', { allowedNames: ['allowed'] }],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(2);
+      expect(payload.diagnostics.map(({ code }) => code)).toEqual([
+        '@angular-eslint(no-input-rename)',
+        '@angular-eslint(no-input-rename)',
+      ]);
+      expect(payload.diagnostics.map(({ message }) => message)).toEqual([
+        'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
+        'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
+      ]);
+      expect(payload.diagnostics.map(({ labels }) => labels[0].span.line)).toEqual([4, 5]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "port:rules": "node tools/tasks/enumerate-port-rules.ts",
     "port:status": "node tools/tasks/sync-status-from-port-targets.ts",
     "port:tests:astro": "node tools/tasks/sync-astro-tests.ts",
+    "port:tests:angular:no-input-rename": "node tools/tasks/sync-angular-no-input-rename-tests.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
     "port:tests:eslint-json": "node tools/tasks/sync-eslint-json-tests.ts",
     "port:tests:eslint-markdown": "node tools/tasks/sync-eslint-markdown-tests.ts",

--- a/status.json
+++ b/status.json
@@ -316,7 +316,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of @angular-eslint/eslint-plugin/no-input-rename; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Oxc AST port of @angular-eslint/eslint-plugin v22.0.0 no-input-rename. Covers decorator, input()/input.required(), and metadata aliases with allowedNames forwarding plus selector/composed-name, ARIA, and hostDirectives semantics. All 46 authored valid and 35 authored invalid upstream cases are pinned and replayed through Rust/NAPI/adapter tests, with real Oxlint option coverage. The current diagnostic ABI does not transport fix/suggestion edits, so upstream fix/suggestion metadata is exposed but reports remain location-only."
       },
       {
         "name": "no-inputs-metadata-property",

--- a/tools/tasks/sync-angular-no-input-rename-tests.ts
+++ b/tools/tasks/sync-angular-no-input-rename-tests.ts
@@ -1,0 +1,204 @@
+// Snapshot every authored angular-eslint v22.0.0 no-input-rename RuleTester
+// case. The upstream source uses a TypeScript-only helper, so this script
+// supplies the small annotation parser locally and lets Node strip the
+// remaining type syntax before evaluating the case module.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SOURCE_COMMIT = '7ee4556badebf8c140ffdefdd0b07b02820d5e96';
+const sourcePath = resolve(
+  ROOT,
+  'upstream/angular-eslint/packages/eslint-plugin/tests/rules/no-input-rename/cases.ts',
+);
+const outputPath = resolve(ROOT, 'npm/angular-eslint/test/fixtures/no-input-rename-v22.0.0.json');
+const helperImport =
+  "import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/test-utils';";
+
+type AuthoredSuggestion = {
+  messageId: string;
+  output: string;
+};
+
+type AuthoredError = {
+  messageId: string;
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+  suggestions?: AuthoredSuggestion[];
+};
+
+type AuthoredCase = {
+  name?: string;
+  code: string;
+  options?: unknown[];
+};
+
+type AuthoredInvalidCase = AuthoredCase & {
+  errors: AuthoredError[];
+  output: null | string | string[];
+};
+
+const actualCommit = execFileSync(
+  'git',
+  ['-C', resolve(ROOT, 'upstream/angular-eslint'), 'rev-parse', 'HEAD'],
+  { encoding: 'utf8' },
+).trim();
+if (actualCommit !== SOURCE_COMMIT) {
+  throw new Error(`Expected angular-eslint ${SOURCE_COMMIT}, received ${actualCommit}.`);
+}
+
+const source = readFileSync(sourcePath, 'utf8');
+if (!source.includes(helperImport)) {
+  throw new Error('The upstream no-input-rename case harness changed shape.');
+}
+
+const executableSource = source.replace(helperImport, () => annotatedCaseHelper());
+const javascript = stripTypeScriptTypes(executableSource, { mode: 'strip' });
+const cases = (await import(
+  `data:text/javascript;base64,${Buffer.from(javascript).toString('base64')}`
+)) as {
+  valid: Array<AuthoredCase | string>;
+  invalid: AuthoredInvalidCase[];
+};
+
+const fixture = {
+  metadata: {
+    package: '@angular-eslint/eslint-plugin',
+    version: '22.0.0',
+    sourceCommit: SOURCE_COMMIT,
+    sourcePath: 'packages/eslint-plugin/tests/rules/no-input-rename/cases.ts',
+    sourceSha256: createHash('sha256').update(source).digest('hex'),
+    capture: 'every authored valid and invalid semantic case exactly once',
+    counts: {
+      valid: cases.valid.length,
+      invalid: cases.invalid.length,
+      diagnostics: cases.invalid.reduce((count, testCase) => count + testCase.errors.length, 0),
+    },
+  },
+  valid: cases.valid.map((testCase, index) => normalizeValidCase(testCase, index)),
+  invalid: cases.invalid.map((testCase, index) => normalizeInvalidCase(testCase, index)),
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { cwd: ROOT, stdio: 'ignore' });
+console.log(
+  `Captured ${fixture.metadata.counts.valid} valid and ${fixture.metadata.counts.invalid} invalid no-input-rename cases.`,
+);
+
+function normalizeValidCase(testCase: AuthoredCase | string, index: number) {
+  if (typeof testCase === 'string') {
+    return { name: `valid-${index + 1}`, code: testCase, options: [] };
+  }
+  return {
+    name: testCase.name ?? `valid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+  };
+}
+
+function normalizeInvalidCase(testCase: AuthoredInvalidCase, index: number) {
+  return {
+    name: testCase.name ?? `invalid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+    errors: testCase.errors.map((error) => ({
+      messageId: error.messageId,
+      line: error.line,
+      column: error.column,
+      endLine: error.endLine,
+      endColumn: error.endColumn,
+      suggestions: error.suggestions?.map((suggestion) => ({
+        messageId: suggestion.messageId,
+        output: suggestion.output,
+      })),
+    })),
+    output: testCase.output,
+  };
+}
+
+function annotatedCaseHelper() {
+  return String.raw`
+const SPECIAL_UNDERLINE_CHARS = ['~', '^', '#', '%', '¶', '*', '¨', '@'];
+
+function convertAnnotatedSourceToFailureCase(errorOptions) {
+  const messages =
+    'messageId' in errorOptions
+      ? [{ ...errorOptions, char: '~' }]
+      : errorOptions.messages;
+  let parsedSource = '';
+  const errors = messages.map(({ char, data, messageId, suggestions }) => {
+    const otherChars = messages
+      .map((message) => message.char)
+      .filter((candidate) => candidate !== char);
+    const parsed = parseInvalidSource(errorOptions.annotatedSource, char, otherChars);
+    parsedSource = parsed.source;
+    return {
+      data,
+      messageId,
+      line: parsed.start.line + 1,
+      column: parsed.start.character + 1,
+      endLine: parsed.end.line + 1,
+      endColumn: parsed.end.character + 1,
+      suggestions,
+    };
+  });
+  return {
+    name: errorOptions.description,
+    code: parsedSource,
+    options: errorOptions.options ?? [],
+    errors,
+    output: errorOptions.annotatedOutputs
+      ? errorOptions.annotatedOutputs.map((output) => parseInvalidSource(output).source)
+      : errorOptions.annotatedOutput
+        ? parseInvalidSource(errorOptions.annotatedOutput).source
+        : null,
+  };
+}
+
+function parseInvalidSource(source, specialChar = '~', otherChars = []) {
+  const ignored = new Set(otherChars);
+  let column = 0;
+  let line = 0;
+  let sourceLine = 0;
+  let annotationLine = false;
+  let start;
+  let end;
+  for (const character of source) {
+    if (character === '\n') {
+      if (annotationLine) annotationLine = false;
+      else sourceLine = line;
+      column = 0;
+      line += 1;
+      continue;
+    }
+    column += 1;
+    if (ignored.has(character)) annotationLine = true;
+    if (character !== specialChar) continue;
+    annotationLine = true;
+    start ??= { character: column - 1, line: sourceLine };
+    end = { character: column, line: sourceLine };
+  }
+  const ignoredPattern =
+    otherChars.length === 0
+      ? null
+      : new RegExp(
+          '[' + otherChars.map((value) => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('') + ']',
+          'g',
+        );
+  const withoutOtherAnnotations = ignoredPattern ? source.replace(ignoredPattern, ' ') : source;
+  return {
+    source: withoutOtherAnnotations.replaceAll(specialChar, ''),
+    start,
+    end,
+  };
+}
+`;
+}


### PR DESCRIPTION
## Summary
- port `@angular-eslint/no-input-rename` to the native Oxc implementation
- support decorator aliases, setter inputs, signal `input`/`input.required`, component metadata, selector and composed ARIA semantics, host directives, and `allowedNames`
- expose the rule through NAPI, plugin metadata, docs, status, and deterministic upstream-fixture synchronization

## Tests
- pin all 46 upstream valid cases and 35 invalid cases with 35 exact diagnostics
- add focused Rust coverage for comments, strings, malformed syntax, computed keys, host directives, UTF-16 locations, rule isolation, and every supported alias shape
- full workspace: 17,047 JS tests and all Rust/doc tests
- full benchmark build, security audit, license, status, and publish-readiness gates
- latest-main rebase: 291 targeted JS tests and 10 targeted Rust tests

Refs #419