### PR TITLE
feat(playwright): support expect-expect options

### DIFF
--- a/crates/playground_wasm/src/plugins/playwright.rs
+++ b/crates/playground_wasm/src/plugins/playwright.rs
@@ -157,4 +157,30 @@ mod tests {
             (4, 40, 4, 57)
         );
     }
+
+    #[test]
+    fn preserves_expect_expect_message_location_and_empty_data() {
+        let filter = EnabledFilter::parse(r#"{"playwright":["expect-expect"]}"#);
+        let mut diagnostics = Vec::new();
+        scan(
+            "\"🧪\"; test(\"empty\", () => {});\n",
+            "fixture.ts",
+            &filter,
+            &mut diagnostics,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "expect-expect");
+        assert_eq!(diagnostics[0].message_id, "noAssertions");
+        assert!(diagnostics[0].data.is_empty());
+        assert_eq!(
+            (
+                diagnostics[0].start_line,
+                diagnostics[0].start_column,
+                diagnostics[0].end_line,
+                diagnostics[0].end_column,
+            ),
+            (1, 6, 1, 10)
+        );
+    }
 }

--- a/crates/playwright/src/expect_expect.rs
+++ b/crates/playwright/src/expect_expect.rs
@@ -1,0 +1,263 @@
+//! AST-backed port of Playwright's `expect-expect` rule.
+
+use oxc_ast::ast::{
+    BindingPattern, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
+    MemberExpression, ModuleExportName, Program, VariableDeclarator, match_member_expression,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use regress::Regex;
+
+use crate::{
+    thresholds::{PlaywrightCall, classify_call, is_expect_assertion},
+    types::{Diagnostic, DiagnosticData, LineIndex, PlaywrightOptions},
+};
+
+const RULE_NAME: &str = "expect-expect";
+
+pub(crate) fn scan_expect_expect<'ast>(
+    program: &Program<'ast>,
+    source_text: &str,
+    line_index: &LineIndex,
+    options: &PlaywrightOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 64]>,
+) {
+    let mut test_names = SmallVec::<[CompactString; 8]>::new();
+    test_names.push(CompactString::from("test"));
+    for alias in &options.test_aliases {
+        push_unique(&mut test_names, alias.as_str());
+    }
+
+    let mut expect_names = SmallVec::<[CompactString; 8]>::new();
+    expect_names.push(CompactString::from("expect"));
+    for alias in &options.expect_aliases {
+        push_unique(&mut expect_names, alias.as_str());
+    }
+
+    let mut extend_declarations = SmallVec::<[(CompactString, CompactString); 16]>::new();
+    NameCollector {
+        expect_names: &mut expect_names,
+        extend_declarations: &mut extend_declarations,
+        test_names: &mut test_names,
+    }
+    .visit_program(program);
+    resolve_extend_aliases(&mut test_names, &extend_declarations);
+
+    let patterns = options
+        .assert_function_patterns
+        .iter()
+        .filter_map(|pattern| Regex::new(pattern.as_str()).ok())
+        .collect();
+    let mut visitor = ExpectExpectVisitor {
+        active_tests: SmallVec::new(),
+        assert_function_names: &options.assert_function_names,
+        assert_function_patterns: patterns,
+        expect_names: &expect_names,
+        pending_tests: SmallVec::new(),
+        test_names: &test_names,
+    };
+    visitor.visit_program(program);
+
+    for test in visitor.pending_tests {
+        if !test.asserted {
+            diagnostics.push(Diagnostic {
+                rule_name: RULE_NAME,
+                message_id: "noAssertions",
+                data: DiagnosticData::default(),
+                loc: line_index.loc_for_span(source_text, test.callee_span),
+                fix: None,
+            });
+        }
+    }
+}
+
+struct NameCollector<'storage> {
+    expect_names: &'storage mut SmallVec<[CompactString; 8]>,
+    extend_declarations: &'storage mut SmallVec<[(CompactString, CompactString); 16]>,
+    test_names: &'storage mut SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for NameCollector<'_> {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
+        let Some(specifiers) = &declaration.specifiers else {
+            return;
+        };
+        for specifier in specifiers {
+            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                continue;
+            };
+            match module_export_name(&specifier.imported) {
+                Some("test") => push_unique(self.test_names, specifier.local.name.as_str()),
+                Some("expect") => push_unique(self.expect_names, specifier.local.name.as_str()),
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_variable_declarator(&mut self, declaration: &VariableDeclarator<'ast>) {
+        if let (BindingPattern::BindingIdentifier(identifier), Some(initializer)) =
+            (&declaration.id, &declaration.init)
+            && let Some(root) = test_extend_root(initializer)
+        {
+            self.extend_declarations.push((
+                CompactString::from(identifier.name.as_str()),
+                CompactString::from(root),
+            ));
+        }
+        walk::walk_variable_declarator(self, declaration);
+    }
+}
+
+struct PendingTest {
+    asserted: bool,
+    callee_span: Span,
+}
+
+struct ExpectExpectVisitor<'options, 'names> {
+    active_tests: SmallVec<[usize; 8]>,
+    assert_function_names: &'options [CompactString],
+    assert_function_patterns: SmallVec<[Regex; 4]>,
+    expect_names: &'names [CompactString],
+    pending_tests: SmallVec<[PendingTest; 16]>,
+    test_names: &'names [CompactString],
+}
+
+impl<'ast> Visit<'ast> for ExpectExpectVisitor<'_, '_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        if matches!(
+            classify_call(call, self.test_names),
+            Some(PlaywrightCall::Test)
+        ) {
+            let index = self.pending_tests.len();
+            self.pending_tests.push(PendingTest {
+                asserted: false,
+                callee_span: call.callee.span(),
+            });
+            self.active_tests.push(index);
+            walk::walk_call_expression(self, call);
+            self.active_tests.pop();
+            return;
+        }
+
+        if (is_expect_assertion(call, self.expect_names, self.test_names)
+            || self.is_custom_assertion(call))
+            && let Some(index) = self.active_tests.first().copied()
+        {
+            self.pending_tests[index].asserted = true;
+        }
+        walk::walk_call_expression(self, call);
+    }
+}
+
+impl ExpectExpectVisitor<'_, '_> {
+    fn is_custom_assertion(&self, call: &CallExpression<'_>) -> bool {
+        let Some(name) = terminal_callee_identifier(&call.callee) else {
+            return false;
+        };
+        self.assert_function_names
+            .iter()
+            .any(|configured| configured == name)
+            || self
+                .assert_function_patterns
+                .iter()
+                .any(|pattern| pattern.find(name).is_some())
+    }
+}
+
+fn terminal_callee_identifier<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
+    match expression.get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => terminal_callee_identifier(&call.callee),
+        member @ match_member_expression!(Expression) => {
+            terminal_member_identifier(member.to_member_expression())
+        }
+        _ => None,
+    }
+}
+
+fn terminal_member_identifier<'ast>(member: &'ast MemberExpression<'ast>) -> Option<&'ast str> {
+    match member {
+        MemberExpression::StaticMemberExpression(member) => Some(member.property.name.as_str()),
+        MemberExpression::ComputedMemberExpression(member) => {
+            match member.expression.get_inner_expression() {
+                Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+                _ => None,
+            }
+        }
+        MemberExpression::PrivateFieldExpression(_) => None,
+    }
+}
+
+fn resolve_extend_aliases(
+    test_names: &mut SmallVec<[CompactString; 8]>,
+    declarations: &[(CompactString, CompactString)],
+) {
+    loop {
+        let mut changed = false;
+        for (name, root) in declarations {
+            if contains_name(test_names, root.as_str()) && !contains_name(test_names, name.as_str())
+            {
+                test_names.push(name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn test_extend_root<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return None;
+    };
+    let member = member_from_expression(&call.callee)?;
+    if member.static_property_name() != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn test_extend_root_from_call<'ast>(call: &'ast CallExpression<'ast>) -> Option<&'ast str> {
+    let member = member_from_expression(&call.callee)?;
+    if member.static_property_name() != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn member_from_expression<'ast>(
+    expression: &'ast Expression<'ast>,
+) -> Option<&'ast MemberExpression<'ast>> {
+    match expression.get_inner_expression() {
+        member @ match_member_expression!(Expression) => Some(member.to_member_expression()),
+        _ => None,
+    }
+}
+
+fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn contains_name(names: &[CompactString], value: &str) -> bool {
+    names.iter().any(|name| name == value)
+}
+
+fn push_unique(names: &mut SmallVec<[CompactString; 8]>, value: &str) {
+    if !contains_name(names, value) {
+        names.push(CompactString::from(value));
+    }
+}

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = "Rust implementation of eslint-plugin-playwright rule logic."]
 
+mod expect_expect;
 mod patterns;
 mod restricted;
 mod scanner;
@@ -14,6 +15,7 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxlint_plugins_carton::SmallVec;
 
+use crate::expect_expect::scan_expect_expect;
 use crate::patterns::scan_pattern_rules;
 use crate::restricted::scan_restricted_rules;
 use crate::scanner::Scanner;
@@ -113,6 +115,13 @@ pub fn scan_playwright_with_options(
         line_index: LineIndex::new(source_text),
         diagnostics: SmallVec::new(),
     };
+    scan_expect_expect(
+        &parser_return.program,
+        source_text,
+        &scanner.line_index,
+        options,
+        &mut scanner.diagnostics,
+    );
     scanner.scan();
     scan_pattern_rules(
         &parser_return.program,

--- a/crates/playwright/src/scanner.rs
+++ b/crates/playwright/src/scanner.rs
@@ -18,10 +18,6 @@ impl<'a> Scanner<'a> {
             "consistent-spacing-between-blocks",
             r#"(?s)test\s*\(\s*['"]one['"].*?\);\s*\n\s*test\s*\(\s*['"]two['"]"#,
         );
-        self.check_regex("expect-expect", r#"test\s*\(\s*['"]without assertions['"]"#);
-        if self.source_text.contains("test(") && !self.source_text.contains("expect(") {
-            self.report_at_first("expect-expect", "test(");
-        }
         self.check_regex(
             "missing-playwright-await",
             r#"(?m)(^|[^\w.])page\.(click|dblclick|fill|goto|locator|press|selectOption|setInputFiles|tap|type|uncheck|waitForLoadState)\s*\("#,
@@ -166,18 +162,6 @@ impl<'a> Scanner<'a> {
         let first = self.source_text.find(needle);
         let second = first.and_then(|index| self.source_text[index + needle.len()..].find(needle));
         if let (Some(index), Some(_)) = (first, second) {
-            self.report(
-                rule_name,
-                Span::new(index as u32, (index + needle.len()) as u32),
-            );
-        }
-    }
-
-    fn report_at_first(&mut self, rule_name: &'static str, needle: &str) {
-        if self.has_reported(rule_name) {
-            return;
-        }
-        if let Some(index) = self.source_text.find(needle) {
             self.report(
                 rule_name,
                 Span::new(index as u32, (index + needle.len()) as u32),

--- a/crates/playwright/src/tests.rs
+++ b/crates/playwright/src/tests.rs
@@ -585,6 +585,156 @@ fn threshold_locations_use_utf16_and_malformed_sources_fail_closed() {
     assert!(scan_playwright_with_options("test(\"broken", "fixture.spec.ts", &options).is_empty());
 }
 
+#[test]
+fn expect_expect_reports_each_unasserted_test_at_the_exact_callee() {
+    let source = concat!(
+        "test(\"plain\", () => {});\n",
+        "test.skip(\"skipped\", () => {});\n",
+        "test(\"asserted\", () => expect(true).toBeDefined());\n",
+        "test.slow(\"asserted\", () => test.expect(true).toBeDefined());\n",
+    );
+    let diagnostics = expect_expect_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].message_id, "noAssertions");
+    assert_eq!(
+        (
+            diagnostics[0].loc.start_line,
+            diagnostics[0].loc.start_column,
+            diagnostics[0].loc.end_column,
+        ),
+        (1, 0, 4)
+    );
+    assert_eq!(
+        (
+            diagnostics[1].loc.start_line,
+            diagnostics[1].loc.start_column,
+            diagnostics[1].loc.end_column,
+        ),
+        (2, 0, 9)
+    );
+    assert_eq!(diagnostics[0].data, crate::DiagnosticData::default());
+}
+
+#[test]
+fn expect_expect_matches_custom_terminal_names_and_patterns() {
+    let source = concat!(
+        "test(\"direct\", () => assertCustomCondition());\n",
+        "test(\"member\", () => page.assertCustomCondition());\n",
+        "test(\"computed identifier\", () => page[assertCustomCondition]());\n",
+        "test(\"computed string\", () => page[\"assertCustomCondition\"]());\n",
+        "test(\"nonterminal\", () => page.assertCustomCondition.factory());\n",
+        "test(\"pattern\", () => verifyElementVisible());\n",
+        "test(\"suffix\", () => anotherAssertion());\n",
+        "test(\"lookahead\", () => ensureElement());\n",
+        "test(\"backreference\", () => checkcheck());\n",
+    );
+    let options = PlaywrightOptions {
+        assert_function_names: [CompactString::from("assertCustomCondition")]
+            .into_iter()
+            .collect(),
+        assert_function_patterns: [
+            CompactString::from("^verify.*"),
+            CompactString::from(".*Assertion$"),
+            CompactString::from("^ensure(?=Element)"),
+            CompactString::from(r"^(check)\1$"),
+        ]
+        .into_iter()
+        .collect(),
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = expect_expect_diagnostics(source, &options);
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].loc.start_line, 4);
+    assert_eq!(diagnostics[1].loc.start_line, 5);
+}
+
+#[test]
+fn expect_expect_supports_global_import_and_chained_extend_aliases() {
+    let source = concat!(
+        "import { test as scenario, expect as assuming } from \"another-runner\";\n",
+        "const later = custom.extend({});\n",
+        "const custom = scenario.extend({}).extend({});\n",
+        "scenario(\"import\", () => assuming(true).toBeDefined());\n",
+        "later(\"extended\", () => expect(true).toBeDefined());\n",
+        "it(\"global\", () => verify(true).toBeDefined());\n",
+    );
+    let options = PlaywrightOptions {
+        expect_aliases: [CompactString::from("verify")].into_iter().collect(),
+        test_aliases: [CompactString::from("it")].into_iter().collect(),
+        ..PlaywrightOptions::default()
+    };
+
+    assert!(expect_expect_diagnostics(source, &options).is_empty());
+}
+
+#[test]
+fn expect_expect_preserves_upstream_outermost_nested_test_behavior() {
+    let source = concat!(
+        "test(\"outer\", () => {\n",
+        "  test(\"inner\", () => {\n",
+        "    expect(true).toBeDefined();\n",
+        "  });\n",
+        "});\n",
+    );
+    let diagnostics = expect_expect_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+    assert_eq!(diagnostics[0].loc.start_column, 2);
+    assert_eq!(diagnostics[0].loc.end_column, 6);
+}
+
+#[test]
+fn expect_expect_counts_step_and_nested_callback_assertions_but_isolates_siblings() {
+    let source = concat!(
+        "test.describe.configure({ mode: \"parallel\" });\n",
+        "test.skip(true);\n",
+        "test(\"step\", async () => {\n",
+        "  await test.step(\"inside\", async () => expect(true).toBeDefined());\n",
+        "});\n",
+        "test(\"callback\", () => Promise.resolve().then(() => expect(true).toBeDefined()));\n",
+        "test(\"empty sibling\", () => {});\n",
+    );
+    let diagnostics = expect_expect_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].loc.start_line, 7);
+}
+
+#[test]
+fn expect_expect_uses_utf16_locations_and_malformed_sources_fail_closed() {
+    let source = concat!(
+        "const marker = \"🧪\";\n",
+        "test(\"empty 🧪\", () => {});\n",
+    );
+    let diagnostics = expect_expect_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].loc.start_line, 2);
+    assert_eq!(diagnostics[0].loc.start_column, 0);
+    assert_eq!(diagnostics[0].loc.end_column, 4);
+    assert!(
+        scan_playwright_with_options(
+            "test(\"broken",
+            "fixture.spec.ts",
+            &PlaywrightOptions::default(),
+        )
+        .is_empty()
+    );
+}
+
+fn expect_expect_diagnostics(
+    source: &str,
+    options: &PlaywrightOptions,
+) -> SmallVec<[crate::Diagnostic; 8]> {
+    scan_playwright_with_options(source, "fixture.spec.ts", options)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.rule_name == "expect-expect")
+        .collect()
+}
+
 fn threshold_diagnostics(
     source: &str,
     options: &PlaywrightOptions,

--- a/crates/playwright/src/thresholds.rs
+++ b/crates/playwright/src/thresholds.rs
@@ -266,13 +266,13 @@ impl ThresholdVisitor<'_, '_, '_, '_> {
 }
 
 #[derive(Clone, Copy)]
-enum PlaywrightCall {
+pub(crate) enum PlaywrightCall {
     Describe,
     Hook,
     Test,
 }
 
-fn classify_call(
+pub(crate) fn classify_call(
     call: &CallExpression<'_>,
     test_names: &[CompactString],
 ) -> Option<PlaywrightCall> {
@@ -335,7 +335,7 @@ fn valid_describe_tail(tail: &[&str]) -> bool {
     )
 }
 
-fn is_expect_assertion(
+pub(crate) fn is_expect_assertion(
     call: &CallExpression<'_>,
     expect_names: &[CompactString],
     test_names: &[CompactString],

--- a/crates/playwright/src/types.rs
+++ b/crates/playwright/src/types.rs
@@ -11,6 +11,8 @@ pub struct Restriction {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaywrightOptions {
+    pub assert_function_names: SmallVec<[CompactString; 4]>,
+    pub assert_function_patterns: SmallVec<[CompactString; 4]>,
     pub restricted_locators: SmallVec<[Restriction; 8]>,
     pub restricted_matchers: SmallVec<[Restriction; 8]>,
     pub restricted_roles: SmallVec<[Restriction; 8]>,
@@ -77,6 +79,8 @@ pub struct TagPattern {
 impl Default for PlaywrightOptions {
     fn default() -> Self {
         Self {
+            assert_function_names: SmallVec::new(),
+            assert_function_patterns: SmallVec::new(),
             restricted_locators: SmallVec::new(),
             restricted_matchers: SmallVec::new(),
             restricted_roles: SmallVec::new(),

--- a/npm/playwright/README.md
+++ b/npm/playwright/README.md
@@ -5,6 +5,30 @@ Rust-backed Oxlint plugin port of `eslint-plugin-playwright` v2.10.4.
 This package exposes the `playwright` plugin, recommended configs, and a native
 API for scanning Playwright test source through the Rust implementation.
 
+## Assertion function options
+
+`expect-expect` accepts the complete upstream v2.10.4 assertion-function
+contract:
+
+```json
+{
+  "rules": {
+    "playwright/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": ["assertCustomCondition"],
+        "assertFunctionPatterns": ["^assert.*", "^verify.*"]
+      }
+    ]
+  }
+}
+```
+
+Exact names match direct calls and terminal member identifiers such as
+`page.assertCustomCondition()`. Patterns use JavaScript regular-expression
+syntax. Assertions inside nested callbacks and `test.step()` count toward their
+containing test, matching upstream ancestry behavior.
+
 ## Numeric threshold options
 
 The numeric threshold rules implement the complete upstream v2.10.4 option
@@ -72,6 +96,8 @@ The direct API accepts the same option values:
 const { scanPlaywright } = require('@oxlint-plugins/oxlint-plugin-playwright/api');
 
 scanPlaywright('page.getByTestId("submit")', 'fixture.spec.ts', {
+  assertFunctionNames: ['assertCustomCondition'],
+  assertFunctionPatterns: ['^verify.*'],
   maxExpects: 5,
   maxNestedDescribe: 5,
   maxTopLevelDescribes: 2,

--- a/npm/playwright/api.d.ts
+++ b/npm/playwright/api.d.ts
@@ -46,6 +46,8 @@ export type PlaywrightRestrictedRole =
     };
 
 export type PlaywrightScanOptions = {
+  assertFunctionNames?: string[];
+  assertFunctionPatterns?: string[];
   noRestrictedLocators?: PlaywrightRestrictedLocator[];
   noRestrictedMatchers?: Record<string, string | null>;
   noRestrictedRoles?: PlaywrightRestrictedRole[];

--- a/npm/playwright/api.js
+++ b/npm/playwright/api.js
@@ -18,6 +18,8 @@ function scanPlaywright(sourceText, filename = 'file.spec.ts', options = {}) {
   }
 
   const diagnostics = native.scanPlaywright(sourceText, filename, {
+    assertFunctionNames: stringList(options.assertFunctionNames),
+    assertFunctionPatterns: regexList(options.assertFunctionPatterns),
     expectAliases: stringList(options.expectAliases),
     testAliases: stringList(options.testAliases),
     maxExpects: integerOption(options.maxExpects, 'maxExpects', 1),
@@ -119,6 +121,13 @@ function tagPatterns(values) {
       ];
     }
     return [];
+  });
+}
+
+function regexList(values) {
+  return stringList(values).map((value) => {
+    new RegExp(value);
+    return value;
   });
 }
 

--- a/npm/playwright/index.js
+++ b/npm/playwright/index.js
@@ -140,7 +140,10 @@ function createLegacyRecommendedConfig() {
 
 function createPlaywrightRule(ruleName) {
   const specializedMeta =
-    restrictedRuleMeta(ruleName) ?? patternRuleMeta(ruleName) ?? thresholdRuleMeta(ruleName);
+    expectExpectRuleMeta(ruleName) ??
+    restrictedRuleMeta(ruleName) ??
+    patternRuleMeta(ruleName) ??
+    thresholdRuleMeta(ruleName);
   return {
     meta: {
       type: ruleType(ruleName),
@@ -149,7 +152,7 @@ function createPlaywrightRule(ruleName) {
           specializedMeta?.description ?? `enforce playwright ${ruleName.replaceAll('-', ' ')}`,
         category: 'Best Practices',
         recommended: recommendedRuleConfig[`playwright/${ruleName}`] !== undefined,
-        url: `${DOCS_BASE}/${ruleName}.md`,
+        url: specializedMeta?.url ?? `${DOCS_BASE}/${ruleName}.md`,
       },
       fixable: fixableRule(ruleName) ? 'code' : undefined,
       messages: specializedMeta?.messages ?? {
@@ -189,11 +192,13 @@ function fixableRule(ruleName) {
 
 function diagnosticsForRule(context, ruleName) {
   const options =
-    restrictedRules.has(ruleName) || patternRules.has(ruleName)
-      ? ruleScanOptions(context, ruleName)
-      : thresholdRules.has(ruleName)
-        ? thresholdScanOptions(context, ruleName)
-        : undefined;
+    ruleName === 'expect-expect'
+      ? expectExpectScanOptions(context)
+      : restrictedRules.has(ruleName) || patternRules.has(ruleName)
+        ? ruleScanOptions(context, ruleName)
+        : thresholdRules.has(ruleName)
+          ? thresholdScanOptions(context, ruleName)
+          : undefined;
   return diagnosticsForContext(context, options).filter(
     (diagnostic) => diagnostic.ruleName === ruleName,
   );
@@ -256,6 +261,19 @@ function sourceTextForContext(context) {
     return sourceCode.text;
   }
   return '';
+}
+
+function expectExpectScanOptions(context) {
+  const options = Array.isArray(context.options) ? context.options : [];
+  const configured = options[0] && typeof options[0] === 'object' ? options[0] : {};
+  const expectAliases = context.settings?.playwright?.globalAliases?.expect;
+  const testAliases = context.settings?.playwright?.globalAliases?.test;
+  return {
+    assertFunctionNames: configured.assertFunctionNames,
+    assertFunctionPatterns: configured.assertFunctionPatterns,
+    ...(Array.isArray(expectAliases) ? { expectAliases } : {}),
+    ...(Array.isArray(testAliases) ? { testAliases } : {}),
+  };
 }
 
 function thresholdScanOptions(context, ruleName) {
@@ -378,6 +396,35 @@ function tagListSchema() {
       ],
     },
     type: 'array',
+  };
+}
+
+function expectExpectRuleMeta(ruleName) {
+  if (ruleName !== 'expect-expect') {
+    return null;
+  }
+  return {
+    description: 'Enforce assertion to be made in a test body',
+    messages: {
+      noAssertions: 'Test has no assertions',
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          assertFunctionNames: {
+            items: [{ type: 'string' }],
+            type: 'array',
+          },
+          assertFunctionPatterns: {
+            items: [{ type: 'string' }],
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/expect-expect.md',
   };
 }
 

--- a/npm/playwright/src/lib.rs
+++ b/npm/playwright/src/lib.rs
@@ -27,6 +27,8 @@ mod napi_abi {
     #[napi(object)]
     #[derive(Clone, Debug, Default)]
     pub struct PlaywrightScanOptions {
+        pub assert_function_names: Option<Vec<String>>,
+        pub assert_function_patterns: Option<Vec<String>>,
         pub restricted_locators: Option<Vec<PlaywrightRestriction>>,
         pub restricted_matchers: Option<Vec<PlaywrightRestriction>>,
         pub restricted_roles: Option<Vec<PlaywrightRestriction>>,
@@ -144,6 +146,8 @@ mod napi_abi {
         let valid_title = compact_valid_title(options.valid_title);
         let valid_test_tags = compact_valid_test_tags(options.valid_test_tags);
         let core_options = core::PlaywrightOptions {
+            assert_function_names: compact_strings(options.assert_function_names),
+            assert_function_patterns: compact_strings(options.assert_function_patterns),
             restricted_locators: compact_restrictions(options.restricted_locators),
             restricted_matchers: compact_restrictions(options.restricted_matchers),
             restricted_roles: compact_restrictions(options.restricted_roles),
@@ -283,6 +287,14 @@ mod napi_abi {
                 flags: CompactString::from(pattern.flags),
                 is_regex: pattern.is_regex,
             })
+            .collect()
+    }
+
+    fn compact_strings(values: Option<Vec<String>>) -> SmallVec<[CompactString; 4]> {
+        values
+            .unwrap_or_default()
+            .into_iter()
+            .map(CompactString::from)
             .collect()
     }
 }

--- a/npm/playwright/test/api.test.mjs
+++ b/npm/playwright/test/api.test.mjs
@@ -155,7 +155,7 @@ describe('playwright native API', () => {
 
     expect(diagnostic).toMatchObject({
       ruleName: 'expect-expect',
-      messageId: 'unexpected',
+      messageId: 'noAssertions',
       loc: {
         startLine: 1,
         startColumn: 0,

--- a/npm/playwright/test/expect-expect-upstream.test.mjs
+++ b/npm/playwright/test/expect-expect-upstream.test.mjs
@@ -1,0 +1,360 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanPlaywright } from '../api.js';
+import plugin from '../index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = dirname(here);
+const workspaceRoot = resolve(packageRoot, '../..');
+const fixture = JSON.parse(
+  readFileSync(join(here, 'fixtures', 'expect-expect-v2.10.4.json'), 'utf8'),
+);
+
+describe('eslint-plugin-playwright v2.10.4 expect-expect replay', () => {
+  it('pins the complete authored inventory and exact source hashes', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-playwright',
+      version: '2.10.4',
+      sourceCommit: '894c0ec261763bb1e073b276c70bbf88b4ebad39',
+      license: 'MIT',
+      tool: 'tools/tasks/sync-playwright-expect-expect-tests.ts',
+      sourceFiles: [
+        'src/rules/expect-expect.ts',
+        'src/rules/expect-expect.test.ts',
+        'docs/rules/expect-expect.md',
+      ],
+      sourceHashes: {
+        'src/rules/expect-expect.ts':
+          '110a10377a4185fd95330efd0c098e9475ddfed98f7da9ef276b5654e3958112',
+        'src/rules/expect-expect.test.ts':
+          '2515bb44c8c914a229d34bed3dff38669361dc8f1c6332a82598f4a32f0df092',
+        'docs/rules/expect-expect.md':
+          '7b4613f0c991066aab1a861a06b475d15686f8a0ec1ee068264ec7c4bc2de97e',
+      },
+      inventory: {
+        valid: 32,
+        invalid: 8,
+        diagnostics: 8,
+      },
+    });
+  });
+
+  it.each(fixture.suite.valid)(
+    'accepts authored valid case %# through native and adapter entry points',
+    (testCase) => {
+      expect(nativeDiagnostics(testCase)).toEqual([]);
+      expect(adapterReports(testCase)).toEqual([]);
+    },
+  );
+
+  it.each(fixture.suite.invalid)(
+    'reproduces authored invalid case %# with exact contract',
+    (testCase) => {
+      const native = nativeDiagnostics(testCase);
+      const adapter = adapterReports(testCase);
+      expect(native.map(({ messageId }) => messageId)).toEqual(
+        testCase.expectedDiagnostics.map(({ messageId }) => messageId),
+      );
+      expect(adapter).toEqual(
+        native.map(({ messageId, data, loc }) => ({
+          messageId,
+          data,
+          loc: {
+            start: {
+              line: loc.startLine,
+              column: loc.startColumn,
+            },
+            end: {
+              line: loc.endLine,
+              column: loc.endColumn,
+            },
+          },
+        })),
+      );
+      for (const [index, expected] of testCase.expectedDiagnostics.entries()) {
+        expect(native[index]).toMatchObject({
+          messageId: expected.messageId,
+          data: { message: '' },
+          ...(expected.loc ? { loc: expected.loc } : {}),
+        });
+      }
+    },
+  );
+
+  it('exposes the exact upstream metadata and no fixer', () => {
+    expect(plugin.rules['expect-expect'].meta).toMatchObject({
+      type: 'problem',
+      docs: {
+        description: 'Enforce assertion to be made in a test body',
+        recommended: true,
+        url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/expect-expect.md',
+      },
+      messages: {
+        noAssertions: 'Test has no assertions',
+      },
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            assertFunctionNames: {
+              items: [{ type: 'string' }],
+              type: 'array',
+            },
+            assertFunctionPatterns: {
+              items: [{ type: 'string' }],
+              type: 'array',
+            },
+          },
+          type: 'object',
+        },
+      ],
+    });
+    expect(plugin.rules['expect-expect'].meta.fixable).toBeUndefined();
+  });
+
+  it('matches only terminal identifier names like upstream dig()', () => {
+    const source = [
+      'test("direct", () => assertCustomCondition());',
+      'test("member", () => page.assertCustomCondition());',
+      'test("computed identifier", () => page[assertCustomCondition]());',
+      'test("computed string", () => page["assertCustomCondition"]());',
+      'test("nonterminal", () => page.assertCustomCondition.factory());',
+    ].join('\n');
+    expect(
+      scanPlaywright(source, 'fixture.spec.ts', {
+        assertFunctionNames: ['assertCustomCondition'],
+      })
+        .filter(({ ruleName }) => ruleName === 'expect-expect')
+        .map(({ loc }) => loc.startLine),
+    ).toEqual([4, 5]);
+  });
+
+  it('supports multiple exact names and regular-expression patterns together', () => {
+    const source = [
+      'test("exact", () => myCustomAssert());',
+      'test("prefix", () => verifyElementVisible());',
+      'test("suffix", () => anotherAssertion());',
+      'test("lookahead", () => ensureElement());',
+      'test("backreference", () => checkcheck());',
+      'test("missing", () => checkNothing());',
+    ].join('\n');
+    expect(
+      scanPlaywright(source, 'fixture.spec.ts', {
+        assertFunctionNames: ['myCustomAssert'],
+        assertFunctionPatterns: ['^verify.*', '.*Assertion$', '^ensure(?=Element)', '^(check)\\1$'],
+      })
+        .filter(({ ruleName }) => ruleName === 'expect-expect')
+        .map(({ loc }) => loc.startLine),
+    ).toEqual([6]);
+  });
+
+  it('validates pattern syntax at the direct and plugin adapter boundaries', () => {
+    const source = 'test("case", () => {});';
+    expect(() =>
+      scanPlaywright(source, 'fixture.spec.ts', {
+        assertFunctionPatterns: ['(?<unterminated'],
+      }),
+    ).toThrow(SyntaxError);
+    expect(() => runRule(source, [{ assertFunctionPatterns: ['(?<unterminated'] }])).toThrow(
+      SyntaxError,
+    );
+  });
+
+  it('supports global aliases, arbitrary named import aliases, and chained extends', () => {
+    const source = [
+      'import { test as scenario, expect as assuming } from "another-runner";',
+      'const custom = scenario.extend({}).extend({});',
+      'const chained = custom.extend({});',
+      'scenario("import", () => assuming(true).toBeDefined());',
+      'chained("extended", () => expect(true).toBeDefined());',
+      'it("global", () => verify(true).toBeDefined());',
+    ].join('\n');
+    expect(
+      runRule(source, [], {
+        playwright: {
+          globalAliases: {
+            expect: ['verify'],
+            test: ['it'],
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it('preserves upstream outermost-test ancestry semantics for nested tests', () => {
+    const source = [
+      'test("outer", () => {',
+      '  test("inner", () => {',
+      '    expect(true).toBeDefined();',
+      '  });',
+      '});',
+    ].join('\n');
+    expect(runRule(source)).toMatchObject([
+      {
+        messageId: 'noAssertions',
+        loc: {
+          start: { line: 2, column: 2 },
+          end: { line: 2, column: 6 },
+        },
+      },
+    ]);
+  });
+
+  it('counts assertions in steps and nested callbacks while isolating sibling tests', () => {
+    const source = [
+      'test.describe.configure({ mode: "parallel" });',
+      'test.skip(true);',
+      'test("step", async () => {',
+      '  await test.step("inside", async () => expect(true).toBeDefined());',
+      '});',
+      'test("callback", () => Promise.resolve().then(() => expect(true).toBeDefined()));',
+      'test("empty sibling", () => {});',
+    ].join('\n');
+    expect(
+      nativeDiagnostics({ code: source, options: [], settings: null }).map(({ messageId, loc }) => [
+        messageId,
+        loc.startLine,
+      ]),
+    ).toEqual([['noAssertions', 7]]);
+  });
+
+  it('uses UTF-16 columns, fails closed on malformed input, and keeps rule selection isolated', () => {
+    expect(
+      nativeDiagnostics({
+        code: '"🧪"; test("empty", () => {});',
+        options: [],
+        settings: null,
+      }),
+    ).toMatchObject([
+      {
+        messageId: 'noAssertions',
+        loc: {
+          startLine: 1,
+          startColumn: 6,
+          endLine: 1,
+          endColumn: 10,
+        },
+      },
+    ]);
+    expect(
+      scanPlaywright('test("broken', 'fixture.spec.ts').filter(
+        ({ ruleName }) => ruleName === 'expect-expect',
+      ),
+    ).toEqual([]);
+    expect(runNamedRule('max-expects', 'test("empty", () => {});')).toEqual([]);
+  });
+
+  it('runs options and exact diagnostics through real Oxlint on TypeScript', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-playwright-expect-expect-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.spec.ts'),
+        [
+          'const label: string = "case";',
+          'test("empty", () => console.log(label));',
+          'test("named", () => assertCustomCondition());',
+          'test("pattern", () => verifyElementVisible());',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [{ name: 'playwright', specifier: join(packageRoot, 'index.js') }],
+          rules: {
+            'playwright/expect-expect': [
+              'error',
+              {
+                assertFunctionNames: ['assertCustomCondition'],
+                assertFunctionPatterns: ['^verify.*'],
+              },
+            ],
+          },
+        }),
+      );
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.spec.ts'],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(
+        payload.diagnostics.map(({ code, message, labels }) => [
+          code,
+          message,
+          labels[0].span.line,
+          labels[0].span.column,
+        ]),
+      ).toEqual([['playwright(expect-expect)', 'Test has no assertions', 2, 1]]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function nativeDiagnostics(testCase) {
+  return scanPlaywright(testCase.code, 'fixture.spec.ts', scanOptions(testCase)).filter(
+    ({ ruleName }) => ruleName === 'expect-expect',
+  );
+}
+
+function adapterReports(testCase) {
+  return runRule(testCase.code, testCase.options, testCase.settings);
+}
+
+function runRule(sourceText, options = [], settings = null) {
+  return runNamedRule('expect-expect', sourceText, options, settings);
+}
+
+function runNamedRule(ruleName, sourceText, options = [], settings = null) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[ruleName].createOnce({
+    filename: 'fixture.spec.ts',
+    options,
+    settings: settings ?? {},
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function scanOptions(testCase) {
+  const configured = testCase.options[0] ?? {};
+  const globalAliases = testCase.settings?.playwright?.globalAliases ?? {};
+  return {
+    assertFunctionNames: configured.assertFunctionNames,
+    assertFunctionPatterns: configured.assertFunctionPatterns,
+    ...(Array.isArray(globalAliases.expect) ? { expectAliases: globalAliases.expect } : {}),
+    ...(Array.isArray(globalAliases.test) ? { testAliases: globalAliases.test } : {}),
+  };
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((a, b) => a.localeCompare(b));
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+  return candidates[candidates.length - 1];
+}

--- a/npm/playwright/test/fixtures/expect-expect-v2.10.4.json
+++ b/npm/playwright/test/fixtures/expect-expect-v2.10.4.json
@@ -1,0 +1,406 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-playwright",
+    "version": "2.10.4",
+    "sourceCommit": "894c0ec261763bb1e073b276c70bbf88b4ebad39",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-playwright-expect-expect-tests.ts",
+    "sourceFiles": [
+      "src/rules/expect-expect.ts",
+      "src/rules/expect-expect.test.ts",
+      "docs/rules/expect-expect.md"
+    ],
+    "sourceHashes": {
+      "src/rules/expect-expect.ts": "110a10377a4185fd95330efd0c098e9475ddfed98f7da9ef276b5654e3958112",
+      "src/rules/expect-expect.test.ts": "2515bb44c8c914a229d34bed3dff38669361dc8f1c6332a82598f4a32f0df092",
+      "docs/rules/expect-expect.md": "7b4613f0c991066aab1a861a06b475d15686f8a0ec1ee068264ec7c4bc2de97e"
+    },
+    "inventory": {
+      "valid": 32,
+      "invalid": 8,
+      "diagnostics": 8
+    }
+  },
+  "suite": {
+    "rule": "expect-expect",
+    "valid": [
+      {
+        "code": "foo();",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "[\"bar\"]();",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "testing(\"will test something eventually\", () => {})",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test(\"should pass\", () => expect(true).toBeDefined())",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test(\"should pass\", () => test.expect(true).toBeDefined())",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.slow(\"should pass\", () => expect(true).toBeDefined())",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.skip(\"should pass\", () => expect(true).toBeDefined())",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.describe.configure({ mode: \"parallel\" })",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.info()",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.use({ locale: \"en-US\" })",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.skip();",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.skip(true);",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.skip(browserName === \"Chrome\", \"This feature is skipped on Chrome\")",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.skip(({ browserName }) => browserName === \"Chrome\");",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.skip(\"foo\", () => { expect(true).toBeDefined(); })",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.slow();",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.slow(true);",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.slow(browserName === \"webkit\", \"This feature is slow on Mac\")",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.slow(({ browserName }) => browserName === \"Chrome\");",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.slow(\"foo\", () => { expect(true).toBeDefined(); })",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test('steps', async ({ page }) => {\n  await test.step('first tab', async () => {\n    await expect(page.getByText('Hello')).toBeVisible();\n  });\n});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.only('steps', async ({ page }) => {\n  await test.step('first tab', async () => {\n    await expect(page.getByText('Hello')).toBeVisible();\n  });\n});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test.only('steps', async ({ page }) => {\n  await test.step.skip('first tab', async () => {\n    await expect(page.getByText('Hello')).toBeVisible();\n  });\n});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test('should fail', async ({ page }) => {\n  await assertCustomCondition(page)\n})",
+        "options": [
+          {
+            "assertFunctionNames": ["assertCustomCondition"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test('should fail', async ({ myPage, page }) => {\n  await myPage.assertCustomCondition(page)\n})",
+        "options": [
+          {
+            "assertFunctionNames": ["assertCustomCondition"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test('should pass', async ({ page }) => {\n  await verifyElementVisible(page.locator('button'))\n})",
+        "options": [
+          {
+            "assertFunctionPatterns": ["^verify.*"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test('should pass', async ({ page }) => {\n  await page.checkTextContent('Hello')\n  await validateUserLoggedIn(page)\n})",
+        "options": [
+          {
+            "assertFunctionPatterns": ["^check.*", "^validate.*"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test('should pass', async ({ page }) => {\n  await myCustomAssert(page)\n  await anotherAssertion(true)\n})",
+        "options": [
+          {
+            "assertFunctionNames": ["myCustomAssert"],
+            "assertFunctionPatterns": [".*Assertion$"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "it(\"should pass\", () => expect(true).toBeDefined())",
+        "options": [],
+        "settings": {
+          "playwright": {
+            "globalAliases": {
+              "test": ["it"]
+            }
+          }
+        },
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "const custom = test.extend({});\ncustom(\"should pass\", () => expect(true).toBeDefined());",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "test(\"should pass\", () => assert(true).toBeDefined())",
+        "options": [],
+        "settings": {
+          "playwright": {
+            "globalAliases": {
+              "expect": ["assert"]
+            }
+          }
+        },
+        "expectedDiagnostics": []
+      },
+      {
+        "code": "import { test as custom } from '@playwright/test';\ncustom(\"should pass\", () => expect(true).toBeDefined());",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": []
+      }
+    ],
+    "invalid": [
+      {
+        "code": "test(\"should fail\", () => {});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 1,
+              "startColumn": 0,
+              "endLine": 1,
+              "endColumn": 4
+            }
+          }
+        ]
+      },
+      {
+        "code": "test.skip(\"should fail\", () => {});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 1,
+              "startColumn": 0,
+              "endLine": 1,
+              "endColumn": 9
+            }
+          }
+        ]
+      },
+      {
+        "code": "test('should fail', async ({ page }) => {\n  await assertCustomCondition(page)\n})",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 1,
+              "startColumn": 0,
+              "endLine": 1,
+              "endColumn": 4
+            }
+          }
+        ]
+      },
+      {
+        "code": "test('should fail', async ({ page }) => {\n  await assertCustomCondition(page)\n})",
+        "options": [
+          {
+            "assertFunctionNames": ["wayComplexCustomCondition"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 1,
+              "startColumn": 0,
+              "endLine": 1,
+              "endColumn": 4
+            }
+          }
+        ]
+      },
+      {
+        "code": "test('should fail', async ({ page }) => {\n  await assertCustomCondition(page)\n})",
+        "options": [
+          {
+            "assertFunctionPatterns": ["^verify.*", "^check.*"]
+          }
+        ],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 1,
+              "startColumn": 0,
+              "endLine": 1,
+              "endColumn": 4
+            }
+          }
+        ]
+      },
+      {
+        "code": "it(\"should pass\", () => hi(true).toBeDefined())",
+        "options": [],
+        "settings": {
+          "playwright": {
+            "globalAliases": {
+              "test": ["it"]
+            }
+          }
+        },
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 1,
+              "startColumn": 0,
+              "endLine": 1,
+              "endColumn": 2
+            }
+          }
+        ]
+      },
+      {
+        "code": "const custom = test.extend({});\ncustom(\"should fail\", () => {});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 2,
+              "startColumn": 0,
+              "endLine": 2,
+              "endColumn": 6
+            }
+          }
+        ]
+      },
+      {
+        "code": "import { test as custom } from '@playwright/test';\ncustom(\"should fail\", () => {});",
+        "options": [],
+        "settings": null,
+        "expectedDiagnostics": [
+          {
+            "messageId": "noAssertions",
+            "data": {},
+            "loc": {
+              "startLine": 2,
+              "startColumn": 0,
+              "endLine": 2,
+              "endColumn": 6
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/npm/playwright/test/plugin.test.mjs
+++ b/npm/playwright/test/plugin.test.mjs
@@ -153,6 +153,7 @@ const expectedRestrictedMessages = {
   'valid-title': '{{ functionName }} should not have an empty title',
 };
 const expectedThresholdMessages = {
+  'expect-expect': 'Test has no assertions',
   'max-expects': 'Too many assertion calls ({{ count }}) - maximum allowed is {{ max }}',
   'max-nested-describe':
     'Maximum describe call depth exceeded ({{ depth }}). Maximum allowed is {{ max }}.',

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "port:tests:perfectionist:sort-named-exports": "node tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
     "port:tests:perfectionist:sort-imports": "node tools/tasks/sync-perfectionist-sort-imports-options-tests.ts",
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
+    "port:tests:playwright:expect-expect": "node tools/tasks/sync-playwright-expect-expect-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:playwright:patterns": "node tools/tasks/sync-playwright-pattern-tests.ts",
     "port:tests:playwright:thresholds": "node tools/tasks/sync-playwright-threshold-tests.ts",

--- a/status.json
+++ b/status.json
@@ -4259,7 +4259,7 @@
           "lsp": true,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-playwright/expect-expect; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Rust/Oxc AST port of eslint-plugin-playwright/expect-expect with complete v2.10.4 assertFunctionNames and assertFunctionPatterns options, pinned authored fixtures, exact locations, direct API coverage, and Oxlint jsPlugins integration."
       },
       {
         "name": "max-expects",

--- a/tools/tasks/sync-playwright-expect-expect-tests.ts
+++ b/tools/tasks/sync-playwright-expect-expect-tests.ts
@@ -1,0 +1,206 @@
+// Captures every authored eslint-plugin-playwright v2.10.4 RuleTester case for
+// `expect-expect` from the exact vendored commit.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type RawCase =
+  | string
+  | {
+      code: string;
+      errors?: RawError[];
+      options?: unknown[];
+      settings?: unknown;
+    };
+type RawError = {
+  column?: number;
+  data?: Record<string, unknown>;
+  endColumn?: number;
+  endLine?: number;
+  line?: number;
+  messageId?: string;
+};
+type CapturedSuite = {
+  invalid: RawCase[];
+  valid: RawCase[];
+};
+type Manifest = {
+  plugins: Array<{
+    baselineVersion: string;
+    id: string;
+    license: string;
+    pinnedRef?: string;
+    submodule: string;
+  }>;
+};
+
+const ROOT = process.cwd();
+const VERSION = '2.10.4';
+const PINNED_COMMIT = '894c0ec261763bb1e073b276c70bbf88b4ebad39';
+const RULE = 'expect-expect';
+const SOURCE_FILES = [`src/rules/${RULE}.ts`, `src/rules/${RULE}.test.ts`, `docs/rules/${RULE}.md`];
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-playwright');
+if (!plugin) throw new Error('eslint-plugin-playwright is not registered');
+if (plugin.baselineVersion !== VERSION || plugin.pinnedRef !== `v${VERSION}`) {
+  throw new Error(`Expected eslint-plugin-playwright v${VERSION}`);
+}
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Run \`git submodule update --init ${plugin.submodule}\` first.`);
+}
+const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}.`);
+}
+
+const sourceHashes = Object.fromEntries(
+  SOURCE_FILES.map((sourceFile) => [
+    sourceFile,
+    createHash('sha256').update(upstreamSource(sourceFile)).digest('hex'),
+  ]),
+);
+const captured = captureSuite(upstreamSource(`src/rules/${RULE}.test.ts`));
+const suite = {
+  rule: RULE,
+  valid: captured.valid.map((testCase, index) =>
+    normalizeCase(testCase, false, `${RULE} valid ${index}`),
+  ),
+  invalid: captured.invalid.map((testCase, index) =>
+    normalizeCase(testCase, true, `${RULE} invalid ${index}`),
+  ),
+};
+const inventory = {
+  valid: suite.valid.length,
+  invalid: suite.invalid.length,
+  diagnostics: suite.invalid.reduce(
+    (total, testCase) => total + testCase.expectedDiagnostics.length,
+    0,
+  ),
+};
+const fixture = {
+  __generated: {
+    source: 'eslint-plugin-playwright',
+    version: VERSION,
+    sourceCommit: PINNED_COMMIT,
+    license: plugin.license,
+    tool: 'tools/tasks/sync-playwright-expect-expect-tests.ts',
+    sourceFiles: SOURCE_FILES,
+    sourceHashes,
+    inventory,
+  },
+  suite,
+};
+
+const outputDirectory = join(ROOT, 'npm', 'playwright', 'test', 'fixtures');
+mkdirSync(outputDirectory, { recursive: true });
+const outputPath = join(outputDirectory, `expect-expect-v${VERSION}.json`);
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { stdio: 'ignore' });
+console.log(
+  `Captured ${inventory.valid} valid, ${inventory.invalid} invalid, and ` +
+    `${inventory.diagnostics} diagnostics for ${RULE}.`,
+);
+
+function captureSuite(source: string): CapturedSuite {
+  const executable = source.replace(/^import .*$/gmu, '');
+  const sandbox: {
+    captured?: CapturedSuite;
+    dedent: typeof dedent;
+    rule: object;
+    runRuleTester: (
+      capturedRule: string,
+      capturedRuleModule: unknown,
+      suite: CapturedSuite,
+    ) => void;
+  } = {
+    dedent,
+    rule: {},
+    runRuleTester(capturedRule, _capturedRuleModule, suite) {
+      if (capturedRule !== RULE) {
+        throw new Error(`Expected ${RULE}, captured ${capturedRule}.`);
+      }
+      sandbox.captured = suite;
+    },
+  };
+  runInNewContext(`"use strict";\n${executable}`, sandbox);
+  if (!sandbox.captured) throw new Error(`Failed to capture ${RULE}.`);
+  return sandbox.captured;
+}
+
+function normalizeCase(testCase: RawCase, invalid: boolean, label: string) {
+  const normalized = typeof testCase === 'string' ? { code: testCase } : testCase;
+  if (typeof normalized.code !== 'string') throw new Error(`${label} is missing source code.`);
+  const errors = invalid ? normalized.errors : [];
+  if (invalid && (!Array.isArray(errors) || errors.length === 0)) {
+    throw new Error(`${label} is missing expected errors.`);
+  }
+  return {
+    code: normalized.code,
+    options: normalized.options ?? [],
+    settings: normalized.settings ?? null,
+    expectedDiagnostics: (errors ?? []).map((error, index) =>
+      normalizeError(error, `${label} error ${index}`),
+    ),
+  };
+}
+
+function normalizeError(error: RawError, label: string) {
+  if (typeof error.messageId !== 'string') throw new Error(`${label} is missing messageId.`);
+  const line = error.line ?? 1;
+  return {
+    messageId: error.messageId,
+    data: error.data ?? {},
+    ...(typeof error.column === 'number'
+      ? {
+          loc: {
+            startLine: line,
+            startColumn: error.column - 1,
+            ...(typeof error.endColumn === 'number'
+              ? {
+                  endLine: error.endLine ?? line,
+                  endColumn: error.endColumn - 1,
+                }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function upstreamSource(sourceFile: string): string {
+  return execFileSync('git', ['-C', submodule, 'show', `${PINNED_COMMIT}:${sourceFile}`], {
+    encoding: 'utf8',
+  });
+}
+
+function dedent(
+  strings: TemplateStringsArray | string,
+  ...values: Array<string | number | bigint | boolean | null | undefined>
+): string {
+  const value =
+    typeof strings === 'string'
+      ? strings
+      : strings.reduce(
+          (output, segment, index) => output + segment + String(values[index] ?? ''),
+          '',
+        );
+  const lines = value
+    .replace(/^\n/u, '')
+    .replace(/\n\s*$/u, '')
+    .split('\n');
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^\s*/u)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join('\n');
+}


### PR DESCRIPTION
## Summary
- replace the placeholder `expect-expect` scan with an Oxc AST implementation
- support the full upstream `assertFunctionNames` and `assertFunctionPatterns` option surface with ECMAScript regular-expression behavior
- resolve global/import aliases, `test.extend` ancestry, nested callbacks, steps, and assertion isolation
- expose exact metadata, messages, schema, NAPI/API/plugin behavior, playground support, docs, status, and deterministic fixture synchronization

## Tests
- pin all 32 upstream valid cases and 8 invalid cases with 8 exact diagnostics
- add focused regressions for aliases, imports, chained extends, patterns, nested tests, siblings, malformed syntax, and UTF-16 locations
- full workspace: 17,606 JS tests; all Rust/doc tests; clippy, fmt, typecheck, lint, build, benchmark, security, license, status, and publish-readiness gates
- latest-main rebase: 114 targeted JS tests, 21 Playwright Rust tests, and 4 playground Playwright tests

Refs #420