### PR TITLE
feat(angular-eslint): port consistent-component-styles

### DIFF
--- a/crates/angular_eslint/src/consistent_component_styles.rs
+++ b/crates/angular_eslint/src/consistent_component_styles.rs
@@ -1,0 +1,532 @@
+use oxc_ast::ast::{
+    ArrayExpression, BigIntLiteral, BooleanLiteral, Class, ClassType, Decorator, Expression,
+    NullLiteral, NumericLiteral, ObjectProperty, PropertyKey, RegExpLiteral, StringLiteral,
+    TemplateLiteral,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::SmallVec;
+use serde_json::Value;
+
+use crate::scanner::Scanner;
+use crate::types::Diagnostic;
+
+const CONSISTENT_COMPONENT_STYLES: &str = "consistent-component-styles";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Mode {
+    Array,
+    String,
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_consistent_component_styles(&mut self, class: &Class<'_>) {
+        if !self.options.is_enabled(CONSISTENT_COMPONENT_STYLES)
+            || class.r#type != ClassType::ClassDeclaration
+        {
+            return;
+        }
+
+        let mode = configured_mode(&self.options.options);
+        for decorator in &class.decorators {
+            let Some(component) = component_decorator(decorator) else {
+                continue;
+            };
+            let mut collector = MetadataDiagnosticCollector {
+                mode,
+                diagnostics: SmallVec::new(),
+            };
+            collector.visit_call_expression(component);
+            for (message_id, span) in collector.diagnostics {
+                self.diagnostics.push(Diagnostic {
+                    rule_name: CONSISTENT_COMPONENT_STYLES,
+                    message_id,
+                    data: SmallVec::new(),
+                    loc: self.line_index.loc_for_span(self.source_text, span),
+                });
+            }
+        }
+    }
+}
+
+fn configured_mode(options: &Value) -> Mode {
+    match options
+        .as_array()
+        .and_then(|options| options.first())
+        .and_then(Value::as_str)
+    {
+        Some("array") => Mode::Array,
+        _ => Mode::String,
+    }
+}
+
+fn component_decorator<'a>(
+    decorator: &'a Decorator<'a>,
+) -> Option<&'a oxc_ast::ast::CallExpression<'a>> {
+    let Expression::CallExpression(call) = decorator.expression.get_inner_expression() else {
+        return None;
+    };
+    matches!(
+        call.callee.get_inner_expression(),
+        Expression::Identifier(identifier) if identifier.name == "Component"
+    )
+    .then_some(call.as_ref())
+}
+
+struct MetadataDiagnosticCollector {
+    mode: Mode,
+    diagnostics: SmallVec<[(&'static str, Span); 8]>,
+}
+
+impl<'a> Visit<'a> for MetadataDiagnosticCollector {
+    fn visit_object_property(&mut self, property: &ObjectProperty<'a>) {
+        let diagnostic = match (self.mode, metadata_property_name(property)) {
+            (Mode::Array, Some(MetadataPropertyName::Styles))
+                if is_literal_or_template(&property.value) =>
+            {
+                Some(("useStylesArray", property.value.span()))
+            }
+            (Mode::Array, Some(MetadataPropertyName::StyleUrl))
+                if property_contains_literal(property) =>
+            {
+                Some(("useStyleUrls", property.span))
+            }
+            (Mode::String, Some(MetadataPropertyName::Styles)) => {
+                let Expression::ArrayExpression(array) = &property.value else {
+                    walk::walk_object_property(self, property);
+                    return;
+                };
+                is_single_array_with_literal(array).then_some(("useStylesString", array.span))
+            }
+            (Mode::String, Some(MetadataPropertyName::StyleUrls))
+                if property_contains_single_array_with_literal(property) =>
+            {
+                Some(("useStyleUrl", property.span))
+            }
+            _ => None,
+        };
+        if let Some(diagnostic) = diagnostic {
+            self.diagnostics.push(diagnostic);
+        }
+        walk::walk_object_property(self, property);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MetadataPropertyName {
+    Styles,
+    StyleUrl,
+    StyleUrls,
+}
+
+fn metadata_property_name(property: &ObjectProperty<'_>) -> Option<MetadataPropertyName> {
+    let name = match &property.key {
+        PropertyKey::StaticIdentifier(identifier) if !property.computed => identifier.name.as_str(),
+        PropertyKey::StringLiteral(literal) => literal.value.as_str(),
+        PropertyKey::TemplateLiteral(template) => template.quasis.first()?.value.raw.as_str(),
+        _ => return None,
+    };
+    match name {
+        "styles" => Some(MetadataPropertyName::Styles),
+        "styleUrl" => Some(MetadataPropertyName::StyleUrl),
+        "styleUrls" => Some(MetadataPropertyName::StyleUrls),
+        _ => None,
+    }
+}
+
+fn is_literal_or_template(expression: &Expression<'_>) -> bool {
+    matches!(
+        expression,
+        Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::TemplateLiteral(_)
+    )
+}
+
+fn is_single_array_with_literal(array: &ArrayExpression<'_>) -> bool {
+    if array.elements.len() != 1 {
+        return false;
+    }
+    let mut finder = LiteralFinder::default();
+    finder.visit_array_expression(array);
+    finder.found
+}
+
+fn property_contains_literal(property: &ObjectProperty<'_>) -> bool {
+    let mut finder = LiteralFinder::default();
+    finder.visit_object_property(property);
+    finder.found
+}
+
+#[derive(Default)]
+struct LiteralFinder {
+    found: bool,
+}
+
+impl<'a> Visit<'a> for LiteralFinder {
+    fn visit_boolean_literal(&mut self, _literal: &BooleanLiteral) {
+        self.found = true;
+    }
+
+    fn visit_null_literal(&mut self, _literal: &NullLiteral) {
+        self.found = true;
+    }
+
+    fn visit_numeric_literal(&mut self, _literal: &NumericLiteral<'a>) {
+        self.found = true;
+    }
+
+    fn visit_string_literal(&mut self, _literal: &StringLiteral<'a>) {
+        self.found = true;
+    }
+
+    fn visit_big_int_literal(&mut self, _literal: &BigIntLiteral<'a>) {
+        self.found = true;
+    }
+
+    fn visit_reg_exp_literal(&mut self, _literal: &RegExpLiteral<'a>) {
+        self.found = true;
+    }
+
+    fn visit_template_literal(&mut self, _template: &TemplateLiteral<'a>) {
+        self.found = true;
+    }
+}
+
+fn property_contains_single_array_with_literal(property: &ObjectProperty<'_>) -> bool {
+    let mut finder = SingleArrayLiteralFinder::default();
+    finder.visit_object_property(property);
+    finder.found
+}
+
+#[derive(Default)]
+struct SingleArrayLiteralFinder {
+    found: bool,
+}
+
+impl<'a> Visit<'a> for SingleArrayLiteralFinder {
+    fn visit_array_expression(&mut self, array: &ArrayExpression<'a>) {
+        if is_single_array_with_literal(array) {
+            self.found = true;
+            return;
+        }
+        walk::walk_array_expression(self, array);
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "Pinned upstream fixtures use serde_json values and Vec assertions to mirror the JavaScript ABI."
+)]
+mod tests {
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use serde_json::{Value, json};
+
+    use super::CONSISTENT_COMPONENT_STYLES;
+    use crate::{Diagnostic, ScanOptions, scan_angular_eslint_with_options};
+
+    const UPSTREAM_FIXTURE: &str = include_str!(
+        "../../../npm/angular-eslint/test/fixtures/consistent-component-styles-v22.0.0.json"
+    );
+
+    fn scan(source: &str, options: Value) -> Vec<Diagnostic> {
+        scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from(
+                    CONSISTENT_COMPONENT_STYLES,
+                )]),
+                options,
+            },
+        )
+        .into_vec()
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_valid_case() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid consistent styles fixture");
+        let valid = fixture["valid"]
+            .as_array()
+            .expect("fixture has valid cases");
+        assert_eq!(valid.len(), 21);
+        for test_case in valid {
+            let source = test_case["code"]
+                .as_str()
+                .expect("valid fixture case has source");
+            let diagnostics = scan(source, test_case["options"].clone());
+            assert!(
+                diagnostics.is_empty(),
+                "{}: {diagnostics:#?}",
+                test_case["name"]
+                    .as_str()
+                    .expect("valid fixture case has name")
+            );
+        }
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_invalid_location_and_message() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid consistent styles fixture");
+        let invalid = fixture["invalid"]
+            .as_array()
+            .expect("fixture has invalid cases");
+        assert_eq!(invalid.len(), 20);
+        for test_case in invalid {
+            let source = test_case["code"]
+                .as_str()
+                .expect("invalid fixture case has source");
+            let diagnostics = scan(source, test_case["options"].clone());
+            let errors = test_case["errors"]
+                .as_array()
+                .expect("invalid fixture case has errors");
+            assert_eq!(
+                diagnostics.len(),
+                errors.len(),
+                "{}: {diagnostics:#?}",
+                test_case["name"]
+                    .as_str()
+                    .expect("invalid fixture case has name")
+            );
+            for (diagnostic, error) in diagnostics.iter().zip(errors) {
+                assert_eq!(
+                    diagnostic.message_id,
+                    error["messageId"].as_str().expect("error has a message id")
+                );
+                assert!(diagnostic.data.is_empty());
+                assert_eq!(
+                    diagnostic.loc.start_line,
+                    error["line"].as_u64().expect("error has line") as u32
+                );
+                assert_eq!(
+                    diagnostic.loc.start_column + 1,
+                    error["column"].as_u64().expect("error has column") as u32
+                );
+                assert_eq!(
+                    diagnostic.loc.end_line,
+                    error["endLine"].as_u64().expect("error has end line") as u32
+                );
+                assert_eq!(
+                    diagnostic.loc.end_column + 1,
+                    error["endColumn"].as_u64().expect("error has end column") as u32
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reports_all_four_messages_in_source_order() {
+        let source = r#"
+            @Component({
+                styles: ['first'],
+                styleUrls: [`first.css`],
+            })
+            class StringMode {}
+            @Component({
+                styles: `second`,
+                styleUrl: 'second.css',
+            })
+            class ArrayMode {}
+        "#;
+        let string_diagnostics = scan(source, json!(["string"]));
+        assert_eq!(
+            string_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            ["useStylesString", "useStyleUrl"]
+        );
+
+        let array_diagnostics = scan(source, json!(["array"]));
+        assert_eq!(
+            array_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            ["useStylesArray", "useStyleUrls"]
+        );
+        assert!(array_diagnostics.windows(2).all(|pair| {
+            (pair[0].loc.start_line, pair[0].loc.start_column)
+                < (pair[1].loc.start_line, pair[1].loc.start_column)
+        }));
+    }
+
+    #[test]
+    fn defaults_unknown_or_missing_modes_to_string() {
+        let source = "@Component({ styles: ['x'] }) class Test {}";
+        for options in [
+            json!([]),
+            json!(["string"]),
+            json!(["invalid"]),
+            json!([{}]),
+        ] {
+            let diagnostics = scan(source, options);
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].message_id, "useStylesString");
+        }
+    }
+
+    #[test]
+    fn matches_upstream_literal_and_descendant_selector_semantics() {
+        let array_source = r#"
+            @Component({
+                styles: 1,
+                styleUrl: choose(url, 'fallback.css'),
+            })
+            class Test {}
+        "#;
+        assert_eq!(
+            scan(array_source, json!(["array"]))
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            ["useStylesArray", "useStyleUrls"]
+        );
+
+        let string_source = r#"
+            @Component({
+                styles: [resolve('inline')],
+                styleUrls: select(['nested.css']),
+            })
+            class Test {}
+        "#;
+        assert_eq!(
+            scan(string_source, json!(["string"]))
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            ["useStylesString", "useStyleUrl"]
+        );
+    }
+
+    #[test]
+    fn supports_upstream_static_and_template_metadata_key_shapes() {
+        let source = r#"
+            const suffix = 'ignored-by-upstream-selector';
+            @Component({
+                'styles': ['one'],
+                ['styleUrls']: ['two.css'],
+                [`styles${suffix}`]: ['three'],
+                [styleUrls]: ['ignored.css'],
+            })
+            class Test {}
+        "#;
+        let diagnostics = scan(source, json!(["string"]));
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            ["useStylesString", "useStyleUrl", "useStylesString"]
+        );
+    }
+
+    #[test]
+    fn ignores_non_component_and_non_declaration_contexts() {
+        let source = r#"
+            const text = "@Component({ styleUrls: ['fake.css'] })";
+            const metadata = { styleUrls: ['plain.css'] };
+            @Directive({ styleUrls: ['directive.css'] })
+            class DirectiveTest {}
+            @Other({ styleUrls: ['other.css'] })
+            class OtherTest {}
+            const Expression = @Component({ styleUrls: ['expression.css'] }) class {};
+        "#;
+        assert!(scan(source, json!([])).is_empty());
+    }
+
+    #[test]
+    fn traverses_component_decorator_metadata_without_regex_false_positives() {
+        let source = r#"
+            @Component(factory({
+                styles: ['nested'],
+                styleUrls: ['nested.css'],
+            }))
+            class Test {}
+        "#;
+        assert_eq!(scan(source, json!([])).len(), 2);
+    }
+
+    #[test]
+    fn handles_empty_sparse_spread_and_multiple_arrays_like_upstream() {
+        let source = r#"
+            @Component({
+                empty: [],
+                styles: [],
+                styleUrls: [],
+                otherStyles: ['x'],
+            })
+            class Empty {}
+            @Component({
+                styles: ['one', 'two'],
+                styleUrls: ['one.css', 'two.css'],
+            })
+            class Multiple {}
+            @Component({
+                styles: [...['spread']],
+                styleUrls: [[`nested.css`]],
+            })
+            class Descendants {}
+        "#;
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            ["useStylesString", "useStyleUrl"]
+        );
+    }
+
+    #[test]
+    fn preserves_utf16_columns_and_exact_report_spans() {
+        let diagnostics = scan(
+            "@Component({ marker: '😀', styles: ['x'], styleUrls: ['x.css'] }) class Test {}",
+            json!([]),
+        );
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            (
+                diagnostics[0].loc.start_column,
+                diagnostics[0].loc.end_column
+            ),
+            (35, 40)
+        );
+        assert_eq!(
+            (
+                diagnostics[1].loc.start_column,
+                diagnostics[1].loc.end_column
+            ),
+            (42, 62)
+        );
+    }
+
+    #[test]
+    fn is_rule_isolated_and_parse_errors_fail_closed() {
+        let source = "@Component({ styleUrls: ['x.css'] }) class Test {}";
+        let diagnostics = scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from("no-output-rename")]),
+                options: json!([]),
+            },
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule_name != CONSISTENT_COMPONENT_STYLES)
+        );
+        assert!(scan("@Component({ styleUrls: ['x.css']", json!([])).is_empty());
+    }
+}

--- a/crates/angular_eslint/src/lib.rs
+++ b/crates/angular_eslint/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = "Rust implementation of @angular-eslint/eslint-plugin rule logic."]
 
 mod class_suffix;
+mod consistent_component_styles;
 mod inline_declarations;
 mod input_rename;
 mod prefix;

--- a/crates/angular_eslint/src/scanner.rs
+++ b/crates/angular_eslint/src/scanner.rs
@@ -22,7 +22,6 @@ impl<'a> Scanner<'a> {
             "computed-must-return",
             r#"computed\s*\(\s*\(\s*\)\s*=>\s*\{"#,
         );
-        self.check_regex("consistent-component-styles", r#"\bstyleUrls\s*:"#);
         self.check_regex(
             "contextual-decorator",
             r#"@Input\s*\([^)]*\)\s*class\s+\w+"#,

--- a/crates/angular_eslint/src/selector.rs
+++ b/crates/angular_eslint/src/selector.rs
@@ -74,6 +74,7 @@ impl Visit<'_> for Scanner<'_> {
     fn visit_class(&mut self, class: &Class<'_>) {
         self.check_class_suffix_decorators(class);
         self.check_component_inline_declarations(class);
+        self.check_consistent_component_styles(class);
         self.check_input_rename(class);
         self.check_prefix_rules(class);
         self.check_selector_decorators(class);

--- a/npm/angular-eslint/README.md
+++ b/npm/angular-eslint/README.md
@@ -5,6 +5,16 @@ Rust-backed Oxlint plugin port of `@angular-eslint/eslint-plugin` v22.0.0.
 This package exposes the `@angular-eslint` plugin and a native API for scanning
 Angular TypeScript source through the Rust implementation.
 
+`consistent-component-styles` is an Oxc AST port of the upstream `string`
+(default) and `array` modes. It distinguishes Component decorator metadata
+from comments, strings, directives, and unrelated object properties, preserves
+the four upstream diagnostic IDs and exact report spans, and exposes the
+upstream schema, messages, and fixability metadata. The checked-in fixture
+replays all 21 authored valid and 20 authored invalid cases from commit
+`7ee4556badebf8c140ffdefdd0b07b02820d5e96`. An audit of v22.1.0 found no
+semantic, fixture, or documentation drift; its only rule-source change is
+formatting.
+
 `no-input-rename` is an Oxc AST port covering `@Input()` aliases, `input()` and
 `input.required()` signal aliases, and `inputs` metadata. It forwards the
 upstream `allowedNames` option and preserves the selector-composition,
@@ -13,7 +23,7 @@ checked-in fixture replays all 46 authored valid and 35 authored invalid cases
 from commit `7ee4556badebf8c140ffdefdd0b07b02820d5e96`.
 
 The current native diagnostic ABI contains message data and locations, but not
-fix or suggestion edit payloads. The plugin therefore exposes the upstream
-`fixable`, `hasSuggestions`, schema, and message metadata while reporting
-`noInputRename` diagnostics without edits. Fix/suggestion transport can be
-added separately without changing this rule's detection semantics.
+fix or suggestion edit payloads. The plugin therefore exposes upstream
+fixability and suggestion metadata where applicable, plus exact schemas and
+messages, while reports remain location-only. Edit transport can be added
+separately without changing these rules' detection semantics.

--- a/npm/angular-eslint/api.d.ts
+++ b/npm/angular-eslint/api.d.ts
@@ -18,6 +18,8 @@ export type NoInputRenameOptions = [
   }?,
 ];
 
+export type ConsistentComponentStylesOptions = [mode: 'array' | 'string'];
+
 export function implementedAngularEslintRuleNames(): string[];
 export function scanAngularEslint(
   sourceText: string,

--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -16,14 +16,30 @@ const selectorRuleNames = new Set(['component-selector', 'directive-selector']);
 const classSuffixRuleNames = new Set(['component-class-suffix', 'directive-class-suffix']);
 const prefixRuleNames = new Set(['no-input-prefix', 'pipe-prefix']);
 const inlineDeclarationRuleName = 'component-max-inline-declarations';
+const consistentComponentStylesRuleName = 'consistent-component-styles';
 const inputRenameRuleName = 'no-input-rename';
 const optionAwareRuleNames = new Set([
   ...selectorRuleNames,
   ...classSuffixRuleNames,
   ...prefixRuleNames,
   inlineDeclarationRuleName,
+  consistentComponentStylesRuleName,
   inputRenameRuleName,
 ]);
+
+const consistentComponentStylesSchema = [
+  {
+    type: 'string',
+    enum: ['array', 'string'],
+  },
+];
+
+const consistentComponentStylesMessages = {
+  useStyleUrl: 'Use `styleUrl` instead of `styleUrls` for a single stylesheet',
+  useStyleUrls: 'Use `styleUrls` instead of `styleUrl`',
+  useStylesArray: 'Use a `string[]` instead of a `string` for the `styles` property',
+  useStylesString: 'Use a `string` instead of a `string[]` for the `styles` property',
+};
 
 const inlineDeclarationSchema = [
   {
@@ -240,12 +256,15 @@ function createAngularEslintRule(ruleName) {
   const isClassSuffixRule = classSuffixRuleNames.has(ruleName);
   const isPrefixRule = prefixRuleNames.has(ruleName);
   const isInlineDeclarationRule = ruleName === inlineDeclarationRuleName;
+  const isConsistentComponentStylesRule = ruleName === consistentComponentStylesRuleName;
   const isInputRenameRule = ruleName === inputRenameRuleName;
   return {
     meta: {
       type: problemRules.has(ruleName) ? 'problem' : 'suggestion',
       docs: {
-        description: `enforce angular eslint ${ruleName.replaceAll('-', ' ')}`,
+        description: isConsistentComponentStylesRule
+          ? 'Ensures consistent usage of `styles`/`styleUrls`/`styleUrl` within Component metadata'
+          : `enforce angular eslint ${ruleName.replaceAll('-', ' ')}`,
         category: 'Best Practices',
         recommended: false,
         url: `${DOCS_BASE}/${ruleName}.md`,
@@ -258,11 +277,13 @@ function createAngularEslintRule(ruleName) {
             ? prefixMessages[ruleName]
             : isInlineDeclarationRule
               ? inlineDeclarationMessages
-              : isInputRenameRule
-                ? inputRenameMessages
-                : {
-                    unexpected: 'Unexpected Angular pattern.',
-                  },
+              : isConsistentComponentStylesRule
+                ? consistentComponentStylesMessages
+                : isInputRenameRule
+                  ? inputRenameMessages
+                  : {
+                      unexpected: 'Unexpected Angular pattern.',
+                    },
       schema: isSelectorRule
         ? selectorSchema
         : isClassSuffixRule
@@ -271,9 +292,12 @@ function createAngularEslintRule(ruleName) {
             ? prefixSchemas[ruleName]
             : isInlineDeclarationRule
               ? inlineDeclarationSchema
-              : isInputRenameRule
-                ? inputRenameSchema
-                : [],
+              : isConsistentComponentStylesRule
+                ? consistentComponentStylesSchema
+                : isInputRenameRule
+                  ? inputRenameSchema
+                  : [],
+      ...(isConsistentComponentStylesRule ? { fixable: 'code' } : {}),
       ...(isInputRenameRule ? { fixable: 'code', hasSuggestions: true } : {}),
     },
     createOnce(context) {

--- a/npm/angular-eslint/test/api.test.mjs
+++ b/npm/angular-eslint/test/api.test.mjs
@@ -4,6 +4,12 @@ import { describe, expect, it } from 'vitest';
 
 import { implementedAngularEslintRuleNames, scanAngularEslint } from '../api.js';
 
+const consistentComponentStylesFixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/consistent-component-styles-v22.0.0.json', import.meta.url),
+    'utf8',
+  ),
+);
 const noInputRenameFixture = JSON.parse(
   readFileSync(new URL('./fixtures/no-input-rename-v22.0.0.json', import.meta.url), 'utf8'),
 );
@@ -327,6 +333,129 @@ describe('angular-eslint native API', () => {
         options,
       }),
     ).toMatchObject(expected);
+  });
+
+  it('pins every authored consistent-component-styles case from angular-eslint v22.0.0', () => {
+    expect(consistentComponentStylesFixture.metadata).toEqual({
+      package: '@angular-eslint/eslint-plugin',
+      version: '22.0.0',
+      sourceCommit: '7ee4556badebf8c140ffdefdd0b07b02820d5e96',
+      sourcePath: 'packages/eslint-plugin/tests/rules/consistent-component-styles/cases.ts',
+      sourceSha256: '440ee39c6dd952eaac1f732c8d7f5428ea12ec65e85c617980523db6eb5d410e',
+      capture: 'every authored valid and invalid semantic case exactly once',
+      counts: {
+        valid: 21,
+        invalid: 20,
+        diagnostics: 20,
+      },
+    });
+  });
+
+  it.each(consistentComponentStylesFixture.valid)(
+    'accepts upstream consistent-component-styles valid case: $name',
+    ({ code, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['consistent-component-styles'],
+          options,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it.each(consistentComponentStylesFixture.invalid)(
+    'matches upstream consistent-component-styles invalid diagnostic: $name',
+    ({ code, errors, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['consistent-component-styles'],
+          options,
+        }),
+      ).toEqual(
+        errors.map((error) => ({
+          ruleName: 'consistent-component-styles',
+          messageId: error.messageId,
+          data: [],
+          loc: {
+            startLine: error.line,
+            startColumn: error.column - 1,
+            endLine: error.endLine,
+            endColumn: error.endColumn - 1,
+          },
+        })),
+      );
+    },
+  );
+
+  it('reports all consistent-component-styles shapes in metadata source order', () => {
+    const source = `
+@Component({
+  styles: ['inline'],
+  styleUrls: ['one.css'],
+  nested: { styles: ['nested'], styleUrls: ['nested.css'] },
+})
+class StringMode {}
+`;
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['consistent-component-styles'],
+        options: ['string'],
+      }).map(({ messageId, loc }) => ({ messageId, line: loc.startLine })),
+    ).toEqual([
+      { messageId: 'useStylesString', line: 3 },
+      { messageId: 'useStyleUrl', line: 4 },
+      { messageId: 'useStylesString', line: 5 },
+      { messageId: 'useStyleUrl', line: 5 },
+    ]);
+
+    expect(
+      scanAngularEslint(
+        `@Component({ styles: \`inline\`, styleUrl: choose('one.css') }) class ArrayMode {}`,
+        'fixture.ts',
+        {
+          ruleNames: ['consistent-component-styles'],
+          options: ['array'],
+        },
+      ).map(({ messageId }) => messageId),
+    ).toEqual(['useStylesArray', 'useStyleUrls']);
+  });
+
+  it('keeps consistent-component-styles isolated and fails closed on malformed TypeScript', () => {
+    const source = `@Component({ styleUrls: ['one.css'] }) class Test {}`;
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['no-output-rename'],
+        options: [],
+      }).some(({ ruleName }) => ruleName === 'consistent-component-styles'),
+    ).toBe(false);
+    expect(
+      scanAngularEslint(`@Component({ styleUrls: ['one.css']`, 'fixture.ts', {
+        ruleNames: ['consistent-component-styles'],
+        options: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it('preserves UTF-16 columns for consistent-component-styles reports', () => {
+    expect(
+      scanAngularEslint(
+        `@Component({ marker: '😀', styles: ['x'], styleUrls: ['x.css'] }) class Test {}`,
+        'fixture.ts',
+        {
+          ruleNames: ['consistent-component-styles'],
+          options: [],
+        },
+      ),
+    ).toMatchObject([
+      {
+        messageId: 'useStylesString',
+        loc: { startLine: 1, startColumn: 35, endLine: 1, endColumn: 40 },
+      },
+      {
+        messageId: 'useStyleUrl',
+        loc: { startLine: 1, startColumn: 42, endLine: 1, endColumn: 62 },
+      },
+    ]);
   });
 
   it('pins every authored no-input-rename case from angular-eslint v22.0.0', () => {

--- a/npm/angular-eslint/test/fixtures/consistent-component-styles-v22.0.0.json
+++ b/npm/angular-eslint/test/fixtures/consistent-component-styles-v22.0.0.json
@@ -1,0 +1,424 @@
+{
+  "metadata": {
+    "package": "@angular-eslint/eslint-plugin",
+    "version": "22.0.0",
+    "sourceCommit": "7ee4556badebf8c140ffdefdd0b07b02820d5e96",
+    "sourcePath": "packages/eslint-plugin/tests/rules/consistent-component-styles/cases.ts",
+    "sourceSha256": "440ee39c6dd952eaac1f732c8d7f5428ea12ec65e85c617980523db6eb5d410e",
+    "capture": "every authored valid and invalid semantic case exactly once",
+    "counts": {
+      "valid": 21,
+      "invalid": 20,
+      "diagnostics": 20
+    }
+  },
+  "valid": [
+    {
+      "name": "valid-1",
+      "code": "\n    @Component({\n      styles: ':host { display: block; }',\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-2",
+      "code": "\n    @Component({\n      styles: `\n        :host { display: block; }\n      `,\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-3",
+      "code": "\n    @Component({\n      selector: 'my-test',\n      standalone: true,\n      imports: [CommonModule],\n      styles: `\n        :host { display: block; }\n      `,\n      providers: [FooService]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-4",
+      "code": "\n    @Component({\n      styles: [\n        ':host { display: block; }',\n        `.foo { color: red; }`\n      ],\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-5",
+      "code": "\n    @Component({\n      styleUrl: `./test.component.css`,\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-6",
+      "code": "\n    @Component({\n      styleUrls: [\n        '../shared.css',\n        `./test.component.css`\n      ],\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-7",
+      "code": "\n    @Component({\n      selector: 'my-test',\n      standalone: true,\n      imports: [CommonModule],\n      styleUrls: [\n        '../shared.css',\n        `./test.component.css`\n      ],\n      providers: [FooService]\n    })\n    class Test {}\n  ",
+      "options": []
+    },
+    {
+      "name": "valid-8",
+      "code": "\n      @Component({\n        styles: ':host { display: block; }',\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-9",
+      "code": "\n      @Component({\n        styles: `\n          :host { display: block; }\n        `,\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-10",
+      "code": "\n      @Component({\n        selector: 'my-test',\n        standalone: true,\n        imports: [CommonModule],\n        styles: `\n          :host { display: block; }\n        `,\n        providers: [FooService]\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-11",
+      "code": "\n      @Component({\n        styles: [\n          ':host { display: block; }',\n          `.foo { color: red; }`\n        ],\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-12",
+      "code": "\n      @Component({\n        styleUrl: `./test.component.css`,\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-13",
+      "code": "\n      @Component({\n        styleUrls: [\n          '../shared.css',\n          `./test.component.css`\n        ],\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-14",
+      "code": "\n      @Component({\n        selector: 'my-test',\n        standalone: true,\n        imports: [CommonModule],\n        styleUrls: [\n          '../shared.css',\n          `./test.component.css`\n        ],\n        providers: [FooService]\n      })\n      class Test {}\n    ",
+      "options": ["string"]
+    },
+    {
+      "name": "valid-15",
+      "code": "\n      @Component({\n        styles: [':host { display: block; }'],\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    },
+    {
+      "name": "valid-16",
+      "code": "\n      @Component({\n        styles: [\n          `\n            :host { display: block; }\n          `\n        ],\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    },
+    {
+      "name": "valid-17",
+      "code": "\n      @Component({\n        selector: 'my-test',\n        standalone: true,\n        imports: [CommonModule],\n        styles: [\n          `\n            :host { display: block; }\n          `\n        ],\n        providers: [FooService]\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    },
+    {
+      "name": "valid-18",
+      "code": "\n      @Component({\n        styles: [\n          ':host { display: block; }',\n          `.foo { color: red; }`\n        ],\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    },
+    {
+      "name": "valid-19",
+      "code": "\n      @Component({\n        styleUrls: [`./test.component.css`],\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    },
+    {
+      "name": "valid-20",
+      "code": "\n      @Component({\n        styleUrls: [\n          '../shared.css',\n          `./test.component.css`\n        ],\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    },
+    {
+      "name": "valid-21",
+      "code": "\n      @Component({\n        selector: 'my-test',\n        standalone: true,\n        imports: [CommonModule],\n        styleUrls: [\n          '../shared.css',\n          `./test.component.css`\n        ],\n        providers: [FooService]\n      })\n      class Test {}\n    ",
+      "options": ["array"]
+    }
+  ],
+  "invalid": [
+    {
+      "name": "should fail when a component has a single style array value",
+      "code": "\n    @Component({\n      styles: [':host { display: block; }']\n              \n    })\n    class Test {}\n  ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 44
+        }
+      ],
+      "output": "\n    @Component({\n      styles: ':host { display: block; }'\n              \n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a single styles array value with multiple decorator properties",
+      "code": "\n    @Component({\n      standalone: true,\n      imports: [MatButtonModule],\n      styles: [':host { display: block; }'],\n              \n      providers: []\n    })\n    class Test {}\n  ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 5,
+          "column": 15,
+          "endLine": 5,
+          "endColumn": 44
+        }
+      ],
+      "output": "\n    @Component({\n      standalone: true,\n      imports: [MatButtonModule],\n      styles: ':host { display: block; }',\n              \n      providers: []\n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a single styleUrls array value",
+      "code": "\n    @Component({\n      styleUrls: ['./test.component.css']\n      \n    })\n    class Test {}\n  ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStyleUrl",
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 42
+        }
+      ],
+      "output": "\n    @Component({\n      styleUrl: './test.component.css'\n      \n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a single styleUrls array value with multiple decorator properties",
+      "code": "\n    @Component({\n      standalone: true,\n      imports: [MatButtonModule],\n      styleUrls: ['./test.component.css'],\n      \n      providers: []\n    })\n    class Test {}\n  ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStyleUrl",
+          "line": 5,
+          "column": 7,
+          "endLine": 5,
+          "endColumn": 42
+        }
+      ],
+      "output": "\n    @Component({\n      standalone: true,\n      imports: [MatButtonModule],\n      styleUrl: './test.component.css',\n      \n      providers: []\n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should keep template strings when fixing styles array to string",
+      "code": "\n    const type = 'block';\n    @Component({\n      styles: [`:host\\t{ display: ${type}; }`]\n              \n    })\n    class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 4,
+          "column": 15,
+          "endLine": 4,
+          "endColumn": 47
+        }
+      ],
+      "output": "\n    const type = 'block';\n    @Component({\n      styles: `:host\\t{ display: ${type}; }`\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep escaped characters when fixing styles array to string",
+      "code": "\n    @Component({\n      styles: [':host\\t{ display: block; }']\n              \n    })\n    class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 45
+        }
+      ],
+      "output": "\n    @Component({\n      styles: ':host\\t{ display: block; }'\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep single quotes when fixing styles array to string",
+      "code": "\n    @Component({\n      styles: [':host{ display: block; }']\n              \n    })\n    class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 43
+        }
+      ],
+      "output": "\n    @Component({\n      styles: ':host{ display: block; }'\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep double quotes when fixing styles array to string",
+      "code": "\n    @Component({\n      styles: [\":host{ display: block; }\"]\n              \n    })\n    class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 43
+        }
+      ],
+      "output": "\n    @Component({\n      styles: \":host{ display: block; }\"\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep backtick quotes when fixing styles array to string",
+      "code": "\n    @Component({\n      styles: [`:host{ display: block; }`]\n              \n    })\n    class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 43
+        }
+      ],
+      "output": "\n    @Component({\n      styles: `:host{ display: block; }`\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep backtick quotes when fixing styleUrls array to styleUrl string",
+      "code": "\n    @Component({\n      styleUrls: [`./test.component.css`]\n      \n    })\n    class Test {}\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "useStyleUrl",
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 42
+        }
+      ],
+      "output": "\n    @Component({\n      styleUrl: `./test.component.css`\n      \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should fail when a component has a single style array value when string is preferred",
+      "code": "\n    @Component({\n      styles: [':host { display: block; }']\n              \n    })\n    class Test {}\n  ",
+      "options": ["string"],
+      "errors": [
+        {
+          "messageId": "useStylesString",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 44
+        }
+      ],
+      "output": "\n    @Component({\n      styles: ':host { display: block; }'\n              \n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a single styleUrls array value when string is preferred",
+      "code": "\n    @Component({\n      styleUrls: ['./test.component.css']\n      \n    })\n    class Test {}\n  ",
+      "options": ["string"],
+      "errors": [
+        {
+          "messageId": "useStyleUrl",
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 42
+        }
+      ],
+      "output": "\n    @Component({\n      styleUrl: './test.component.css'\n      \n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a styles string when an array is preferred",
+      "code": "\n    @Component({\n      styles: ':host { display: block; }'\n              \n    })\n    class Test {}\n  ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 42
+        }
+      ],
+      "output": "\n    @Component({\n      styles: [':host { display: block; }']\n              \n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a styles string with multiple decorator properties when an array is preferred",
+      "code": "\n    @Component({\n      standalone: true,\n      imports: [MatButtonModule],\n      styles: ':host { display: block; }',\n              \n      providers: []\n    })\n    class Test {}\n  ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 5,
+          "column": 15,
+          "endLine": 5,
+          "endColumn": 42
+        }
+      ],
+      "output": "\n    @Component({\n      standalone: true,\n      imports: [MatButtonModule],\n      styles: [':host { display: block; }'],\n              \n      providers: []\n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should fail when a component has a styleUrl string value when an array is preferred",
+      "code": "\n    @Component({\n      styleUrl: './test.component.css',\n      \n    })\n    class Test {}\n  ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStyleUrls",
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 39
+        }
+      ],
+      "output": "\n    @Component({\n      styleUrls: ['./test.component.css'],\n      \n    })\n    class Test {}\n  "
+    },
+    {
+      "name": "should keep template strings when fixing styles string to array",
+      "code": "\n    const type = 'block';\n    @Component({\n      styles: `:host\\t{ display: ${type}; }`\n              \n    })\n    class Test {}\n    ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 4,
+          "column": 15,
+          "endLine": 4,
+          "endColumn": 45
+        }
+      ],
+      "output": "\n    const type = 'block';\n    @Component({\n      styles: [`:host\\t{ display: ${type}; }`]\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep escaped characters when fixing styles string to array",
+      "code": "\n    @Component({\n      styles: ':host\\t{ display: block; }'\n              \n    })\n    class Test {}\n    ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 43
+        }
+      ],
+      "output": "\n    @Component({\n      styles: [':host\\t{ display: block; }']\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep single quotes when fixing styles string to array",
+      "code": "\n    @Component({\n      styles: ':host{ display: block; }'\n              \n    })\n    class Test {}\n    ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 41
+        }
+      ],
+      "output": "\n    @Component({\n      styles: [':host{ display: block; }']\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep double quotes when fixing styles string to array",
+      "code": "\n    @Component({\n      styles: \":host{ display: block; }\"\n              \n    })\n    class Test {}\n    ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 41
+        }
+      ],
+      "output": "\n    @Component({\n      styles: [\":host{ display: block; }\"]\n              \n    })\n    class Test {}\n    "
+    },
+    {
+      "name": "should keep backtick quotes when fixing styles string to array",
+      "code": "\n    @Component({\n      styles: `:host{ display: block; }`\n              \n    })\n    class Test {}\n    ",
+      "options": ["array"],
+      "errors": [
+        {
+          "messageId": "useStylesArray",
+          "line": 3,
+          "column": 15,
+          "endLine": 3,
+          "endColumn": 41
+        }
+      ],
+      "output": "\n    @Component({\n      styles: [`:host{ display: block; }`]\n              \n    })\n    class Test {}\n    "
+    }
+  ]
+}

--- a/npm/angular-eslint/test/plugin.test.mjs
+++ b/npm/angular-eslint/test/plugin.test.mjs
@@ -10,8 +10,17 @@ import plugin from '../index.js';
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = resolve(packageRoot, '../..');
+const consistentComponentStylesFixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/consistent-component-styles-v22.0.0.json', import.meta.url),
+    'utf8',
+  ),
+);
 const noInputRenameFixture = JSON.parse(
   readFileSync(new URL('./fixtures/no-input-rename-v22.0.0.json', import.meta.url), 'utf8'),
+);
+const playgroundCatalog = JSON.parse(
+  readFileSync(resolve(workspaceRoot, 'playground/src/catalog.json'), 'utf8'),
 );
 
 const expectedRuleNames = [
@@ -186,6 +195,8 @@ describe('angular-eslint plugin adapter', () => {
         'Component class names should end with one of these suffixes: {{suffixes}}',
       'component-max-inline-declarations':
         '`{{propertyType}}` has too many lines ({{lineCount}}). Maximum allowed is {{max}}',
+      'consistent-component-styles':
+        'Use `styleUrl` instead of `styleUrls` for a single stylesheet',
       'directive-class-suffix':
         'Directive class names should end with one of these suffixes: {{suffixes}}',
       'no-input-rename':
@@ -235,6 +246,36 @@ describe('angular-eslint plugin adapter', () => {
     expect(plugin.rules['no-input-prefix'].meta.schema[0].properties.prefixes.uniqueItems).toBe(
       undefined,
     );
+  });
+
+  it('exposes the exact upstream consistent-component-styles contract', () => {
+    const { meta } = plugin.rules['consistent-component-styles'];
+    expect(meta.type).toBe('suggestion');
+    expect(meta.docs.description).toBe(
+      'Ensures consistent usage of `styles`/`styleUrls`/`styleUrl` within Component metadata',
+    );
+    expect(meta.schema).toEqual([
+      {
+        type: 'string',
+        enum: ['array', 'string'],
+      },
+    ]);
+    expect(meta.messages).toEqual({
+      useStyleUrl: 'Use `styleUrl` instead of `styleUrls` for a single stylesheet',
+      useStyleUrls: 'Use `styleUrls` instead of `styleUrl`',
+      useStylesArray: 'Use a `string[]` instead of a `string` for the `styles` property',
+      useStylesString: 'Use a `string` instead of a `string[]` for the `styles` property',
+    });
+    expect(meta.fixable).toBe('code');
+    expect(meta.hasSuggestions).toBeUndefined();
+
+    const playgroundRule = playgroundCatalog.plugins
+      .find(({ plugin: pluginName }) => pluginName === '@angular-eslint')
+      .rules.find(({ name }) => name === 'consistent-component-styles');
+    expect(playgroundRule).toMatchObject({
+      description: meta.docs.description,
+      messages: meta.messages,
+    });
   });
 
   it('exposes the exact upstream no-input-rename contract', () => {
@@ -377,6 +418,63 @@ describe('angular-eslint plugin adapter', () => {
     ['pipe-prefix', '@Pipe({ name: "ngTitle" }) class Test {}', [{ prefixes: ['ng'] }], []],
   ])('honors configured %s prefixes through createOnce', (ruleName, code, options, expected) => {
     expect(runRule(ruleName, code, options)).toMatchObject(expected);
+  });
+
+  it.each(consistentComponentStylesFixture.valid)(
+    'accepts upstream consistent-component-styles valid case through createOnce: $name',
+    ({ code, options }) => {
+      expect(runRule('consistent-component-styles', code, options)).toEqual([]);
+    },
+  );
+
+  it.each(consistentComponentStylesFixture.invalid)(
+    'matches upstream consistent-component-styles invalid location through createOnce: $name',
+    ({ code, errors, options }) => {
+      expect(runRule('consistent-component-styles', code, options)).toEqual(
+        errors.map((error) => ({
+          messageId: error.messageId,
+          data: {},
+          loc: {
+            start: {
+              line: error.line,
+              column: error.column - 1,
+            },
+            end: {
+              line: error.endLine,
+              column: error.endColumn - 1,
+            },
+          },
+        })),
+      );
+    },
+  );
+
+  it('forwards consistent-component-styles modes independently through createOnce', () => {
+    const code = `
+@Component({
+  styles: 'inline',
+  styleUrl: 'one.css',
+  styleUrls: ['two.css'],
+})
+class Test {}
+`;
+    expect(runRule('consistent-component-styles', code)).toMatchObject([
+      { messageId: 'useStyleUrl' },
+    ]);
+    expect(runRule('consistent-component-styles', code, ['array'])).toMatchObject([
+      { messageId: 'useStylesArray' },
+      { messageId: 'useStyleUrls' },
+    ]);
+  });
+
+  it('does not invent consistent-component-styles fixes outside the diagnostic ABI', () => {
+    const reports = runRule(
+      'consistent-component-styles',
+      `@Component({ styles: ['inline'] }) class Test {}`,
+    );
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).not.toHaveProperty('fix');
+    expect(reports[0]).not.toHaveProperty('suggest');
   });
 
   it.each(noInputRenameFixture.valid)(
@@ -790,6 +888,59 @@ class Test {
           '@Pipes should be prefixed with "app"',
         ]),
       );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors consistent-component-styles mode through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-consistent-styles-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.ts'),
+        '@Component({\n' +
+          '  styles: "inline",\n' +
+          '  styleUrl: `one.css`,\n' +
+          '  styleUrls: ["already-array.css"],\n' +
+          '}) class Test {}\n',
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: '@angular-eslint',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            '@angular-eslint/consistent-component-styles': ['error', 'array'],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(2);
+      expect(payload.diagnostics.map(({ code }) => code)).toEqual([
+        '@angular-eslint(consistent-component-styles)',
+        '@angular-eslint(consistent-component-styles)',
+      ]);
+      expect(payload.diagnostics.map(({ message }) => message)).toEqual([
+        'Use a `string[]` instead of a `string` for the `styles` property',
+        'Use `styleUrls` instead of `styleUrl`',
+      ]);
+      expect(payload.diagnostics.map(({ labels }) => labels[0].span.line)).toEqual([2, 3]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "port:rules": "node tools/tasks/enumerate-port-rules.ts",
     "port:status": "node tools/tasks/sync-status-from-port-targets.ts",
     "port:tests:astro": "node tools/tasks/sync-astro-tests.ts",
+    "port:tests:angular:consistent-component-styles": "node tools/tasks/sync-angular-consistent-component-styles-tests.ts",
     "port:tests:angular:no-input-rename": "node tools/tasks/sync-angular-no-input-rename-tests.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
     "port:tests:eslint-json": "node tools/tasks/sync-eslint-json-tests.ts",

--- a/playground/src/catalog.json
+++ b/playground/src/catalog.json
@@ -40,10 +40,13 @@
         },
         {
           "name": "consistent-component-styles",
-          "description": "enforce angular eslint consistent component styles",
+          "description": "Ensures consistent usage of `styles`/`styleUrls`/`styleUrl` within Component metadata",
           "docsUrl": "https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-component-styles.md",
           "messages": {
-            "unexpected": "Unexpected Angular pattern."
+            "useStyleUrl": "Use `styleUrl` instead of `styleUrls` for a single stylesheet",
+            "useStyleUrls": "Use `styleUrls` instead of `styleUrl`",
+            "useStylesArray": "Use a `string[]` instead of a `string` for the `styles` property",
+            "useStylesString": "Use a `string` instead of a `string[]` for the `styles` property"
           }
         },
         {

--- a/status.json
+++ b/status.json
@@ -92,7 +92,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of @angular-eslint/eslint-plugin/consistent-component-styles; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Oxc AST port of @angular-eslint/eslint-plugin v22.0.0 consistent-component-styles. Covers the string default and array option, all four upstream diagnostic IDs, Component decorator metadata key/value selector semantics, exact UTF-16 locations, and source-order reporting. All 21 authored valid and 20 authored invalid upstream cases are pinned and replayed through Rust/NAPI/adapter tests, with real Oxlint option coverage. v22.1.0 source/tests/docs were audited with no semantic drift. The current diagnostic ABI does not transport fix edits, so upstream fixable metadata is exposed but reports remain location-only."
       },
       {
         "name": "contextual-decorator",

--- a/tools/tasks/sync-angular-consistent-component-styles-tests.ts
+++ b/tools/tasks/sync-angular-consistent-component-styles-tests.ts
@@ -1,0 +1,195 @@
+// Snapshot every authored angular-eslint v22.0.0 consistent-component-styles
+// RuleTester case. The upstream source uses a TypeScript-only helper, so this
+// script supplies the small annotation parser locally and lets Node strip the
+// remaining type syntax before evaluating the case module.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SOURCE_COMMIT = '7ee4556badebf8c140ffdefdd0b07b02820d5e96';
+const sourcePath = resolve(
+  ROOT,
+  'upstream/angular-eslint/packages/eslint-plugin/tests/rules/consistent-component-styles/cases.ts',
+);
+const outputPath = resolve(
+  ROOT,
+  'npm/angular-eslint/test/fixtures/consistent-component-styles-v22.0.0.json',
+);
+const helperImport =
+  "import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/test-utils';";
+
+type AuthoredError = {
+  messageId: string;
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+};
+
+type AuthoredCase = {
+  name?: string;
+  code: string;
+  options?: unknown[];
+};
+
+type AuthoredInvalidCase = AuthoredCase & {
+  errors: AuthoredError[];
+  output: null | string | string[];
+};
+
+const actualCommit = execFileSync(
+  'git',
+  ['-C', resolve(ROOT, 'upstream/angular-eslint'), 'rev-parse', 'HEAD'],
+  { encoding: 'utf8' },
+).trim();
+if (actualCommit !== SOURCE_COMMIT) {
+  throw new Error(`Expected angular-eslint ${SOURCE_COMMIT}, received ${actualCommit}.`);
+}
+
+const source = readFileSync(sourcePath, 'utf8');
+if (!source.includes(helperImport)) {
+  throw new Error('The upstream consistent-component-styles case harness changed shape.');
+}
+
+const executableSource = source.replace(helperImport, () => annotatedCaseHelper());
+const javascript = stripTypeScriptTypes(executableSource, { mode: 'strip' });
+const cases = (await import(
+  `data:text/javascript;base64,${Buffer.from(javascript).toString('base64')}`
+)) as {
+  valid: Array<AuthoredCase | string>;
+  invalid: AuthoredInvalidCase[];
+};
+
+const fixture = {
+  metadata: {
+    package: '@angular-eslint/eslint-plugin',
+    version: '22.0.0',
+    sourceCommit: SOURCE_COMMIT,
+    sourcePath: 'packages/eslint-plugin/tests/rules/consistent-component-styles/cases.ts',
+    sourceSha256: createHash('sha256').update(source).digest('hex'),
+    capture: 'every authored valid and invalid semantic case exactly once',
+    counts: {
+      valid: cases.valid.length,
+      invalid: cases.invalid.length,
+      diagnostics: cases.invalid.reduce((count, testCase) => count + testCase.errors.length, 0),
+    },
+  },
+  valid: cases.valid.map((testCase, index) => normalizeValidCase(testCase, index)),
+  invalid: cases.invalid.map((testCase, index) => normalizeInvalidCase(testCase, index)),
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { cwd: ROOT, stdio: 'ignore' });
+console.log(
+  `Captured ${fixture.metadata.counts.valid} valid and ${fixture.metadata.counts.invalid} invalid consistent-component-styles cases.`,
+);
+
+function normalizeValidCase(testCase: AuthoredCase | string, index: number) {
+  if (typeof testCase === 'string') {
+    return { name: `valid-${index + 1}`, code: testCase, options: [] };
+  }
+  return {
+    name: testCase.name ?? `valid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+  };
+}
+
+function normalizeInvalidCase(testCase: AuthoredInvalidCase, index: number) {
+  return {
+    name: testCase.name ?? `invalid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+    errors: testCase.errors.map((error) => ({
+      messageId: error.messageId,
+      line: error.line,
+      column: error.column,
+      endLine: error.endLine,
+      endColumn: error.endColumn,
+    })),
+    output: testCase.output,
+  };
+}
+
+function annotatedCaseHelper() {
+  return String.raw`
+function convertAnnotatedSourceToFailureCase(errorOptions) {
+  const messages =
+    'messageId' in errorOptions
+      ? [{ ...errorOptions, char: '~' }]
+      : errorOptions.messages;
+  let parsedSource = '';
+  const errors = messages.map(({ char, data, messageId, suggestions }) => {
+    const otherChars = messages
+      .map((message) => message.char)
+      .filter((candidate) => candidate !== char);
+    const parsed = parseInvalidSource(errorOptions.annotatedSource, char, otherChars);
+    parsedSource = parsed.source;
+    return {
+      data,
+      messageId,
+      line: parsed.start.line + 1,
+      column: parsed.start.character + 1,
+      endLine: parsed.end.line + 1,
+      endColumn: parsed.end.character + 1,
+      suggestions,
+    };
+  });
+  return {
+    name: errorOptions.description,
+    code: parsedSource,
+    options: errorOptions.options ?? [],
+    errors,
+    output: errorOptions.annotatedOutputs
+      ? errorOptions.annotatedOutputs.map((output) => parseInvalidSource(output).source)
+      : errorOptions.annotatedOutput
+        ? parseInvalidSource(errorOptions.annotatedOutput).source
+        : null,
+  };
+}
+
+function parseInvalidSource(source, specialChar = '~', otherChars = []) {
+  const ignored = new Set(otherChars);
+  let column = 0;
+  let line = 0;
+  let sourceLine = 0;
+  let annotationLine = false;
+  let start;
+  let end;
+  for (const character of source) {
+    if (character === '\n') {
+      if (annotationLine) annotationLine = false;
+      else sourceLine = line;
+      column = 0;
+      line += 1;
+      continue;
+    }
+    column += 1;
+    if (ignored.has(character)) annotationLine = true;
+    if (character !== specialChar) continue;
+    annotationLine = true;
+    start ??= { character: column - 1, line: sourceLine };
+    end = { character: column, line: sourceLine };
+  }
+  const ignoredPattern =
+    otherChars.length === 0
+      ? null
+      : new RegExp(
+          '[' + otherChars.map((value) => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('') + ']',
+          'g',
+        );
+  const withoutOtherAnnotations = ignoredPattern ? source.replace(ignoredPattern, ' ') : source;
+  return {
+    source: withoutOtherAnnotations.replaceAll(specialChar, ''),
+    start,
+    end,
+  };
+}
+`;
+}


### PR DESCRIPTION
## Summary
- port `@angular-eslint/consistent-component-styles` to the native Oxc implementation
- support the default string mode and array mode across static/template metadata keys, multiple arrays, sparse entries, spreads, and component decorator traversal
- preserve all four upstream messages, exact source ordering, UTF-16 locations, metadata, NAPI/API/plugin behavior, docs, status, playground catalog, and deterministic fixture synchronization

## Tests
- pin all 21 upstream valid cases and 20 invalid cases with 20 exact diagnostics
- add focused regressions for selector semantics, computed/static/template keys, nested metadata, malformed input, rule isolation, sparse/spread arrays, Unicode, and every message shape
- full workspace: 16,551 JS tests plus all Rust/doc tests and full fmt/typecheck/lint/build/benchmark/security/license/status/publish-readiness gates
- latest-main rebase: 381 targeted JS tests and 44 Angular Rust tests

Refs #419