### PR TITLE
feat(angular-eslint): port prefer-signals

### DIFF
--- a/crates/angular_eslint/src/lib.rs
+++ b/crates/angular_eslint/src/lib.rs
@@ -4,6 +4,7 @@ mod class_suffix;
 mod consistent_component_styles;
 mod inline_declarations;
 mod input_rename;
+mod prefer_signals;
 mod prefix;
 mod scanner;
 mod selector;
@@ -112,6 +113,7 @@ pub fn scan_angular_eslint_with_options(
         source_text,
         line_index: LineIndex::new(source_text),
         options,
+        signal_returning_functions: SmallVec::new(),
         diagnostics: SmallVec::new(),
     };
     scanner.scan(&parser_return.program);

--- a/crates/angular_eslint/src/prefer_signals.rs
+++ b/crates/angular_eslint/src/prefer_signals.rs
@@ -1,0 +1,620 @@
+use oxc_ast::ast::{
+    Decorator, Expression, Program, PropertyDefinition, Statement, TSType, TSTypeName,
+};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::Value;
+
+use crate::scanner::Scanner;
+use crate::types::{Diagnostic, DiagnosticDatum};
+
+const PREFER_SIGNALS: &str = "prefer-signals";
+
+const KNOWN_SIGNAL_TYPES: [&str; 5] = [
+    "InputSignal",
+    "ModelSignal",
+    "Signal",
+    "WritableSignal",
+    "InputSignalWithTransform",
+];
+
+const KNOWN_SIGNAL_CREATION_FUNCTIONS: [&str; 10] = [
+    "computed",
+    "contentChild",
+    "contentChildren",
+    "input",
+    "linkedSignal",
+    "model",
+    "signal",
+    "toSignal",
+    "viewChild",
+    "viewChildren",
+];
+
+#[derive(Debug)]
+struct PreferSignalsOptions<'a> {
+    prefer_readonly_signal_properties: bool,
+    prefer_input_signals: bool,
+    prefer_query_signals: bool,
+    use_type_checking: bool,
+    additional_signal_creation_functions: SmallVec<[&'a str; 4]>,
+}
+
+impl Default for PreferSignalsOptions<'_> {
+    fn default() -> Self {
+        Self {
+            prefer_readonly_signal_properties: true,
+            prefer_input_signals: true,
+            prefer_query_signals: true,
+            use_type_checking: false,
+            additional_signal_creation_functions: SmallVec::new(),
+        }
+    }
+}
+
+impl Scanner<'_> {
+    pub(crate) fn collect_signal_returning_functions(&mut self, program: &Program<'_>) {
+        if !self.options.is_enabled(PREFER_SIGNALS)
+            || !configured_options(self.options).use_type_checking
+        {
+            return;
+        }
+
+        for statement in &program.body {
+            let Statement::FunctionDeclaration(function) = statement else {
+                continue;
+            };
+            let (Some(identifier), Some(return_type)) = (&function.id, &function.return_type)
+            else {
+                continue;
+            };
+            if type_annotation_is_known_signal(&return_type.type_annotation) {
+                self.signal_returning_functions
+                    .push(CompactString::from(identifier.name.as_str()));
+            }
+        }
+    }
+
+    pub(crate) fn check_prefer_signals_property(&mut self, property: &PropertyDefinition<'_>) {
+        if !self.options.is_enabled(PREFER_SIGNALS) || property.readonly {
+            return;
+        }
+        let options = configured_options(self.options);
+        if !options.prefer_readonly_signal_properties
+            || !property_is_signal(property, &options, &self.signal_returning_functions)
+        {
+            return;
+        }
+        self.report_prefer_signals(
+            "preferReadonlySignalProperties",
+            SmallVec::new(),
+            property.key.span(),
+        );
+    }
+
+    pub(crate) fn check_prefer_signals_decorator(&mut self, decorator: &Decorator<'_>) {
+        if !self.options.is_enabled(PREFER_SIGNALS) {
+            return;
+        }
+        let options = configured_options(self.options);
+        let Expression::CallExpression(call) = &decorator.expression else {
+            return;
+        };
+        let Expression::Identifier(identifier) = &call.callee else {
+            return;
+        };
+
+        match identifier.name.as_str() {
+            "Input" if options.prefer_input_signals => {
+                self.report_prefer_signals("preferInputSignals", SmallVec::new(), decorator.span);
+            }
+            decorator_name
+            @ ("ContentChild" | "ContentChildren" | "ViewChild" | "ViewChildren")
+                if options.prefer_query_signals =>
+            {
+                let function_name = match decorator_name {
+                    "ContentChild" => "contentChild",
+                    "ContentChildren" => "contentChildren",
+                    "ViewChild" => "viewChild",
+                    "ViewChildren" => "viewChildren",
+                    _ => unreachable!("guarded query decorator"),
+                };
+                let mut data = SmallVec::new();
+                data.push(DiagnosticDatum {
+                    key: CompactString::from("function"),
+                    value: CompactString::from(function_name),
+                });
+                data.push(DiagnosticDatum {
+                    key: CompactString::from("decorator"),
+                    value: CompactString::from(decorator_name),
+                });
+                self.report_prefer_signals("preferQuerySignals", data, decorator.span);
+            }
+            _ => {}
+        }
+    }
+
+    fn report_prefer_signals(
+        &mut self,
+        message_id: &'static str,
+        data: SmallVec<[DiagnosticDatum; 2]>,
+        span: Span,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name: PREFER_SIGNALS,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+fn configured_options(scan_options: &crate::ScanOptions) -> PreferSignalsOptions<'_> {
+    let Some(option) = scan_options
+        .options
+        .as_array()
+        .and_then(|options| options.first())
+    else {
+        return PreferSignalsOptions::default();
+    };
+
+    PreferSignalsOptions {
+        prefer_readonly_signal_properties: boolean_option(
+            option,
+            "preferReadonlySignalProperties",
+            true,
+        ),
+        prefer_input_signals: boolean_option(option, "preferInputSignals", true),
+        prefer_query_signals: boolean_option(option, "preferQuerySignals", true),
+        use_type_checking: boolean_option(option, "useTypeChecking", false),
+        additional_signal_creation_functions: option
+            .get("additionalSignalCreationFunctions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .collect(),
+    }
+}
+
+fn boolean_option(options: &Value, name: &str, default: bool) -> bool {
+    options
+        .get(name)
+        .and_then(Value::as_bool)
+        .unwrap_or(default)
+}
+
+fn property_is_signal(
+    property: &PropertyDefinition<'_>,
+    options: &PreferSignalsOptions<'_>,
+    signal_returning_functions: &[CompactString],
+) -> bool {
+    if let Some(type_annotation) = &property.type_annotation {
+        return type_annotation_is_known_signal(&type_annotation.type_annotation);
+    }
+
+    let Some(value) = &property.value else {
+        return false;
+    };
+    if initializer_is_known_signal(value, &options.additional_signal_creation_functions) {
+        return true;
+    }
+    options.use_type_checking && expression_has_known_signal_type(value, signal_returning_functions)
+}
+
+fn type_annotation_is_known_signal(annotation: &TSType<'_>) -> bool {
+    let TSType::TSTypeReference(reference) = annotation else {
+        return false;
+    };
+    if reference.type_arguments.is_none() {
+        return false;
+    }
+    let TSTypeName::IdentifierReference(identifier) = &reference.type_name else {
+        return false;
+    };
+    KNOWN_SIGNAL_TYPES.contains(&identifier.name.as_str())
+}
+
+fn initializer_is_known_signal(
+    value: &Expression<'_>,
+    additional_signal_creation_functions: &[&str],
+) -> bool {
+    let Expression::CallExpression(call) = value else {
+        return false;
+    };
+    let mut call = call.as_ref();
+
+    if member_identifier_name(&call.callee) == Some("asReadonly") {
+        let Some(object) = member_object(&call.callee) else {
+            return false;
+        };
+        let Expression::CallExpression(inner_call) = object else {
+            return false;
+        };
+        call = inner_call.as_ref();
+    }
+
+    let callee = match &call.callee {
+        Expression::StaticMemberExpression(member) => {
+            if member.property.name != "required" {
+                return false;
+            }
+            &member.object
+        }
+        Expression::ComputedMemberExpression(member) => {
+            if matches!(
+                &member.expression,
+                Expression::Identifier(identifier) if identifier.name != "required"
+            ) {
+                return false;
+            }
+            &member.object
+        }
+        Expression::PrivateFieldExpression(member) => &member.object,
+        callee => callee,
+    };
+
+    let Expression::Identifier(identifier) = callee else {
+        return false;
+    };
+    KNOWN_SIGNAL_CREATION_FUNCTIONS.contains(&identifier.name.as_str())
+        || additional_signal_creation_functions.contains(&identifier.name.as_str())
+}
+
+fn expression_has_known_signal_type(
+    value: &Expression<'_>,
+    signal_returning_functions: &[CompactString],
+) -> bool {
+    let Expression::CallExpression(call) = value else {
+        return false;
+    };
+    let Expression::Identifier(identifier) = &call.callee else {
+        return false;
+    };
+    signal_returning_functions
+        .iter()
+        .any(|name| name == identifier.name.as_str())
+}
+
+fn member_identifier_name<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    match expression {
+        Expression::StaticMemberExpression(member) => Some(member.property.name.as_str()),
+        Expression::ComputedMemberExpression(member) => {
+            let Expression::Identifier(identifier) = &member.expression else {
+                return None;
+            };
+            Some(identifier.name.as_str())
+        }
+        Expression::PrivateFieldExpression(_) => None,
+        _ => None,
+    }
+}
+
+fn member_object<'a>(expression: &'a Expression<'a>) -> Option<&'a Expression<'a>> {
+    match expression {
+        Expression::StaticMemberExpression(member) => Some(&member.object),
+        Expression::ComputedMemberExpression(member) => Some(&member.object),
+        Expression::PrivateFieldExpression(member) => Some(&member.object),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "Pinned upstream fixtures use serde_json values and Vec assertions to mirror the JavaScript ABI."
+)]
+mod tests {
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use serde_json::{Value, json};
+
+    use super::PREFER_SIGNALS;
+    use crate::{Diagnostic, ScanOptions, scan_angular_eslint_with_options};
+
+    const UPSTREAM_FIXTURE: &str =
+        include_str!("../../../npm/angular-eslint/test/fixtures/prefer-signals-v22.1.0.json");
+
+    fn scan(source: &str, options: Value) -> Vec<Diagnostic> {
+        scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from(PREFER_SIGNALS)]),
+                options,
+            },
+        )
+        .into_vec()
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_valid_case() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid prefer-signals fixture");
+        let valid = fixture["valid"]
+            .as_array()
+            .expect("fixture has valid cases");
+        assert_eq!(valid.len(), 39);
+        for test_case in valid {
+            let diagnostics = scan(
+                test_case["code"].as_str().expect("valid case has source"),
+                test_case["options"].clone(),
+            );
+            assert!(
+                diagnostics.is_empty(),
+                "{}: {diagnostics:#?}",
+                test_case["name"].as_str().expect("valid case has name"),
+            );
+        }
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_invalid_location_message_and_data() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid prefer-signals fixture");
+        let invalid = fixture["invalid"]
+            .as_array()
+            .expect("fixture has invalid cases");
+        assert_eq!(invalid.len(), 26);
+        for test_case in invalid {
+            let diagnostics = scan(
+                test_case["code"].as_str().expect("invalid case has source"),
+                test_case["options"].clone(),
+            );
+            let errors = test_case["errors"]
+                .as_array()
+                .expect("invalid case has errors");
+            assert_eq!(
+                diagnostics.len(),
+                errors.len(),
+                "{}: {diagnostics:#?}",
+                test_case["name"].as_str().expect("invalid case has name"),
+            );
+            for (diagnostic, error) in diagnostics.iter().zip(errors) {
+                assert_eq!(diagnostic.message_id, error["messageId"]);
+                assert_eq!(
+                    diagnostic.loc,
+                    crate::DiagnosticLoc {
+                        start_line: error["line"].as_u64().expect("line") as u32,
+                        start_column: error["column"].as_u64().expect("column") as u32 - 1,
+                        end_line: error["endLine"].as_u64().expect("end line") as u32,
+                        end_column: error["endColumn"].as_u64().expect("end column") as u32 - 1,
+                    },
+                    "{}",
+                    test_case["name"].as_str().expect("invalid case has name"),
+                );
+                let actual_data = diagnostic
+                    .data
+                    .iter()
+                    .map(|datum| (datum.key.as_str(), datum.value.as_str()))
+                    .collect::<Vec<_>>();
+                let expected_data = error["data"]
+                    .as_object()
+                    .expect("error data is an object")
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.as_str().expect("string data")))
+                    .collect::<Vec<_>>();
+                assert_eq!(actual_data, expected_data);
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_upstream_member_expression_edges() {
+        let source = r#"
+class Test {
+  computedLiteral = input["anything"]();
+  computedRequired = input[required]();
+  rejectedComputedIdentifier = input[anything]();
+  rejectedStaticMember = input.optional();
+  asReadonly = signal(1)[asReadonly]();
+}
+"#;
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.loc.start_line)
+                .collect::<Vec<_>>(),
+            vec![3, 4, 7],
+        );
+    }
+
+    #[test]
+    fn recognizes_every_known_signal_type_and_requires_upstream_type_shape() {
+        let source = r#"
+class Test {
+  input: InputSignal<number>;
+  model: ModelSignal<number>;
+  signal: Signal<number>;
+  writable: WritableSignal<number>;
+  transformed: InputSignalWithTransform<string, number>;
+  missingArguments: Signal;
+  qualified: core.Signal<number>;
+  unrelated: ReadonlySignal<number>;
+  readonly alreadySafe: Signal<number>;
+}
+"#;
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(diagnostics.len(), 5);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.loc.start_line)
+                .collect::<Vec<_>>(),
+            vec![3, 4, 5, 6, 7],
+        );
+    }
+
+    #[test]
+    fn recognizes_every_known_factory_required_readonly_and_custom_form() {
+        let source = r#"
+class Test {
+  a = computed(() => 1);
+  b = contentChild("x");
+  c = contentChildren("x");
+  d = input();
+  e = linkedSignal(() => source);
+  f = model();
+  g = signal(1);
+  h = toSignal(source);
+  i = viewChild("x");
+  j = viewChildren("x");
+  k = input.required();
+  l = signal(1).asReadonly();
+  m = createSignal();
+}
+"#;
+        let diagnostics = scan(
+            source,
+            json!([{ "additionalSignalCreationFunctions": ["createSignal"] }]),
+        );
+        assert_eq!(diagnostics.len(), 13);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.message_id == "preferReadonlySignalProperties"),
+        );
+    }
+
+    #[test]
+    fn reports_all_legacy_decorators_with_exact_query_data() {
+        let source = r#"
+class Test {
+  @Input() input: string;
+  @ContentChild("x") contentChild: Widget;
+  @ContentChildren("x") contentChildren: QueryList<Widget>;
+  @ViewChild("x") viewChild: Widget;
+  @ViewChildren("x") viewChildren: QueryList<Widget>;
+}
+"#;
+        let diagnostics = scan(source, json!([]));
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            vec![
+                "preferInputSignals",
+                "preferQuerySignals",
+                "preferQuerySignals",
+                "preferQuerySignals",
+                "preferQuerySignals",
+            ],
+        );
+        assert_eq!(
+            diagnostics[4]
+                .data
+                .iter()
+                .map(|datum| (datum.key.as_str(), datum.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("function", "viewChildren"), ("decorator", "ViewChildren"),],
+        );
+    }
+
+    #[test]
+    fn rejects_strings_comments_namespaced_and_bare_decorator_near_misses() {
+        let source = r#"
+const text = "@Input() value = signal(1)";
+// @ViewChild("x")
+class Test {
+  @angular.Input() namespaced: string;
+  @Input bare: string;
+  member = angular.signal(1);
+  constructed = new Signal<number>();
+  state = useState(0);
+}
+"#;
+        assert!(scan(source, json!([])).is_empty());
+    }
+
+    #[test]
+    fn uses_defaults_for_partial_and_non_boolean_options() {
+        let source = "class Test { @Input() value = signal(1); }";
+        assert_eq!(
+            scan(
+                source,
+                json!([{
+                    "preferInputSignals": "invalid",
+                    "preferQuerySignals": null,
+                    "additionalSignalCreationFunctions": [false, 1],
+                }]),
+            )
+            .len(),
+            2,
+        );
+        assert_eq!(scan(source, json!(["invalid"])).len(), 2);
+    }
+
+    #[test]
+    fn preserves_utf16_columns_for_property_and_decorator_reports() {
+        let diagnostics = scan(
+            "class Test { emoji = '😀'; @Input() signalValue = signal(1); }",
+            json!([]),
+        );
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (
+                    diagnostic.message_id,
+                    diagnostic.loc.start_column,
+                    diagnostic.loc.end_column,
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("preferReadonlySignalProperties", 36, 47),
+                ("preferInputSignals", 27, 35),
+            ],
+        );
+    }
+
+    #[test]
+    fn options_disable_independent_rule_branches() {
+        let source = r#"
+class Test {
+  @Input() signal = signal(1);
+  @ViewChild("child") child: Widget;
+}
+"#;
+        let diagnostics = scan(
+            source,
+            json!([{
+                "preferReadonlySignalProperties": false,
+                "preferInputSignals": false,
+                "preferQuerySignals": false,
+            }]),
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_property_before_its_decorator_like_upstream_traversal() {
+        let diagnostics = scan("class Test { @Input() value = signal(1); }", json!([]));
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            vec!["preferReadonlySignalProperties", "preferInputSignals"],
+        );
+    }
+
+    #[test]
+    fn stays_isolated_and_fails_closed_on_parse_errors() {
+        let other_rule = scan_angular_eslint_with_options(
+            "class Test { value = signal(1); }",
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from("no-output-rename")]),
+                options: json!([]),
+            },
+        );
+        assert!(
+            other_rule
+                .iter()
+                .all(|diagnostic| diagnostic.rule_name != PREFER_SIGNALS)
+        );
+        assert!(scan("class Test { value = signal(", json!([])).is_empty());
+    }
+}

--- a/crates/angular_eslint/src/scanner.rs
+++ b/crates/angular_eslint/src/scanner.rs
@@ -3,7 +3,7 @@
 use oxc_ast::ast::Program;
 use oxc_ast_visit::Visit;
 use oxc_span::Span;
-use oxlint_plugins_carton::SmallVec;
+use oxlint_plugins_carton::{CompactString, SmallVec};
 use regex::Regex;
 
 use crate::ScanOptions;
@@ -13,11 +13,13 @@ pub(crate) struct Scanner<'a> {
     pub(crate) source_text: &'a str,
     pub(crate) line_index: LineIndex,
     pub(crate) options: &'a ScanOptions,
+    pub(crate) signal_returning_functions: SmallVec<[CompactString; 4]>,
     pub(crate) diagnostics: SmallVec<[Diagnostic; 64]>,
 }
 
 impl<'a> Scanner<'a> {
     pub(crate) fn scan(&mut self, program: &Program<'a>) {
+        self.collect_signal_returning_functions(program);
         self.check_regex(
             "computed-must-return",
             r#"computed\s*\(\s*\(\s*\)\s*=>\s*\{"#,
@@ -83,7 +85,6 @@ impl<'a> Scanner<'a> {
             "prefer-signal-model",
             r#"@Input\s*\([^)]*\)\s+value\b[\s\S]*@Output\s*\([^)]*\)\s+valueChange\b"#,
         );
-        self.check_regex("prefer-signals", r#"@Input\s*\([^)]*\)\s+\w+"#);
         self.check_regex("prefer-standalone", r#"standalone\s*:\s*false"#);
         self.check_regex(
             "relative-url-prefix",

--- a/crates/angular_eslint/src/selector.rs
+++ b/crates/angular_eslint/src/selector.rs
@@ -1,4 +1,7 @@
-use oxc_ast::ast::{Class, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_ast::ast::{
+    Class, Decorator, Expression, ObjectExpression, ObjectPropertyKind, PropertyDefinition,
+    PropertyKey,
+};
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
 use oxlint_plugins_carton::{CompactString, SmallVec};
@@ -79,6 +82,16 @@ impl Visit<'_> for Scanner<'_> {
         self.check_prefix_rules(class);
         self.check_selector_decorators(class);
         walk::walk_class(self, class);
+    }
+
+    fn visit_property_definition(&mut self, property: &PropertyDefinition<'_>) {
+        self.check_prefer_signals_property(property);
+        walk::walk_property_definition(self, property);
+    }
+
+    fn visit_decorator(&mut self, decorator: &Decorator<'_>) {
+        self.check_prefer_signals_decorator(decorator);
+        walk::walk_decorator(self, decorator);
     }
 }
 

--- a/crates/angular_eslint/src/tests.rs
+++ b/crates/angular_eslint/src/tests.rs
@@ -70,6 +70,7 @@ fn scans_representative_rules() {
         })
         .collect();
     actual.sort_unstable();
+    actual.dedup();
     expected.sort_unstable();
     assert_eq!(actual, expected);
 }

--- a/npm/angular-eslint/README.md
+++ b/npm/angular-eslint/README.md
@@ -1,6 +1,6 @@
 # @oxlint-plugins/oxlint-plugin-angular-eslint
 
-Rust-backed Oxlint plugin port of `@angular-eslint/eslint-plugin` v22.0.0.
+Rust-backed Oxlint plugin port of `@angular-eslint/eslint-plugin`.
 
 This package exposes the `@angular-eslint` plugin and a native API for scanning
 Angular TypeScript source through the Rust implementation.
@@ -21,6 +21,16 @@ upstream `allowedNames` option and preserves the selector-composition,
 `aria-*`, and `hostDirectives` exceptions from angular-eslint v22.0.0. The
 checked-in fixture replays all 46 authored valid and 35 authored invalid cases
 from commit `7ee4556badebf8c140ffdefdd0b07b02820d5e96`.
+
+`prefer-signals` is an Oxc AST port of the current angular-eslint v22.1.0
+contract. It covers the five known signal types, ten signal creation
+functions, `.required()` and `.asReadonly()` forms, `@Input()`, and all four
+legacy query decorators. Its five options are forwarded independently,
+including custom signal factories and source-local TypeScript return-type
+recovery for `useTypeChecking`. The checked-in deterministic fixture replays
+all 39 authored valid and 26 authored invalid cases from tag `v22.1.0`
+(`a666e1b45c9782d1ac2066fd55ec0127d0580950`) with exact message IDs, data,
+and UTF-16 locations.
 
 The current native diagnostic ABI contains message data and locations, but not
 fix or suggestion edit payloads. The plugin therefore exposes upstream

--- a/npm/angular-eslint/api.d.ts
+++ b/npm/angular-eslint/api.d.ts
@@ -20,6 +20,16 @@ export type NoInputRenameOptions = [
 
 export type ConsistentComponentStylesOptions = [mode: 'array' | 'string'];
 
+export type PreferSignalsOptions = [
+  {
+    readonly preferReadonlySignalProperties?: boolean;
+    readonly preferInputSignals?: boolean;
+    readonly preferQuerySignals?: boolean;
+    readonly useTypeChecking?: boolean;
+    readonly additionalSignalCreationFunctions?: readonly string[];
+  }?,
+];
+
 export function implementedAngularEslintRuleNames(): string[];
 export function scanAngularEslint(
   sourceText: string,

--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -18,6 +18,7 @@ const prefixRuleNames = new Set(['no-input-prefix', 'pipe-prefix']);
 const inlineDeclarationRuleName = 'component-max-inline-declarations';
 const consistentComponentStylesRuleName = 'consistent-component-styles';
 const inputRenameRuleName = 'no-input-rename';
+const preferSignalsRuleName = 'prefer-signals';
 const optionAwareRuleNames = new Set([
   ...selectorRuleNames,
   ...classSuffixRuleNames,
@@ -25,6 +26,7 @@ const optionAwareRuleNames = new Set([
   inlineDeclarationRuleName,
   consistentComponentStylesRuleName,
   inputRenameRuleName,
+  preferSignalsRuleName,
 ]);
 
 const consistentComponentStylesSchema = [
@@ -143,6 +145,44 @@ const inputRenameMessages = {
   suggestReplaceOriginalNameWithAliasName: 'Remove alias name and use it as the original name',
 };
 
+const preferSignalsSchema = [
+  {
+    type: 'object',
+    properties: {
+      preferReadonlySignalProperties: {
+        type: 'boolean',
+        default: true,
+      },
+      preferInputSignals: {
+        type: 'boolean',
+        default: true,
+      },
+      preferQuerySignals: {
+        type: 'boolean',
+        default: true,
+      },
+      useTypeChecking: {
+        type: 'boolean',
+        default: false,
+      },
+      additionalSignalCreationFunctions: {
+        type: 'array',
+        items: { type: 'string' },
+        default: [],
+      },
+    },
+    additionalProperties: false,
+  },
+];
+
+const preferSignalsMessages = {
+  preferInputSignals:
+    'Use `InputSignal`s (e.g. via `input()`) for Component input properties rather than the legacy `@Input()` decorator',
+  preferQuerySignals: 'Use the `{{function}}` function instead of the `{{decorator}}` decorator',
+  preferReadonlySignalProperties:
+    'Properties declared using signals should be marked as `readonly` since they should not be reassigned',
+};
+
 const selectorConfigSchema = {
   type: 'object',
   properties: {
@@ -258,13 +298,16 @@ function createAngularEslintRule(ruleName) {
   const isInlineDeclarationRule = ruleName === inlineDeclarationRuleName;
   const isConsistentComponentStylesRule = ruleName === consistentComponentStylesRuleName;
   const isInputRenameRule = ruleName === inputRenameRuleName;
+  const isPreferSignalsRule = ruleName === preferSignalsRuleName;
   return {
     meta: {
       type: problemRules.has(ruleName) ? 'problem' : 'suggestion',
       docs: {
         description: isConsistentComponentStylesRule
           ? 'Ensures consistent usage of `styles`/`styleUrls`/`styleUrl` within Component metadata'
-          : `enforce angular eslint ${ruleName.replaceAll('-', ' ')}`,
+          : isPreferSignalsRule
+            ? 'Use readonly signals instead of `@Input()`, `@ViewChild()` and other legacy decorators'
+            : `enforce angular eslint ${ruleName.replaceAll('-', ' ')}`,
         category: 'Best Practices',
         recommended: false,
         url: `${DOCS_BASE}/${ruleName}.md`,
@@ -281,9 +324,11 @@ function createAngularEslintRule(ruleName) {
                 ? consistentComponentStylesMessages
                 : isInputRenameRule
                   ? inputRenameMessages
-                  : {
-                      unexpected: 'Unexpected Angular pattern.',
-                    },
+                  : isPreferSignalsRule
+                    ? preferSignalsMessages
+                    : {
+                        unexpected: 'Unexpected Angular pattern.',
+                      },
       schema: isSelectorRule
         ? selectorSchema
         : isClassSuffixRule
@@ -296,9 +341,12 @@ function createAngularEslintRule(ruleName) {
                 ? consistentComponentStylesSchema
                 : isInputRenameRule
                   ? inputRenameSchema
-                  : [],
+                  : isPreferSignalsRule
+                    ? preferSignalsSchema
+                    : [],
       ...(isConsistentComponentStylesRule ? { fixable: 'code' } : {}),
       ...(isInputRenameRule ? { fixable: 'code', hasSuggestions: true } : {}),
+      ...(isPreferSignalsRule ? { fixable: 'code' } : {}),
     },
     createOnce(context) {
       return {

--- a/npm/angular-eslint/test/api.test.mjs
+++ b/npm/angular-eslint/test/api.test.mjs
@@ -13,6 +13,9 @@ const consistentComponentStylesFixture = JSON.parse(
 const noInputRenameFixture = JSON.parse(
   readFileSync(new URL('./fixtures/no-input-rename-v22.0.0.json', import.meta.url), 'utf8'),
 );
+const preferSignalsFixture = JSON.parse(
+  readFileSync(new URL('./fixtures/prefer-signals-v22.1.0.json', import.meta.url), 'utf8'),
+);
 
 const expectedRuleNames = [
   'component-class-suffix',
@@ -111,7 +114,7 @@ describe('angular-eslint native API', () => {
   it('scans representative Angular patterns for every rule', () => {
     const diagnostics = scanAngularEslint(representativeSource, 'fixture.ts');
 
-    expect(diagnostics.map((diagnostic) => diagnostic.ruleName).sort()).toEqual(
+    expect([...new Set(diagnostics.map((diagnostic) => diagnostic.ruleName))].sort()).toEqual(
       expectedRuleNames
         .filter(
           (ruleName) =>
@@ -669,5 +672,170 @@ class Test { @Input('publicName') internal: string; }
         endLine: 1,
       },
     });
+  });
+
+  it('pins every authored prefer-signals case from angular-eslint v22.1.0', () => {
+    expect(preferSignalsFixture.metadata).toEqual({
+      package: '@angular-eslint/eslint-plugin',
+      version: '22.1.0',
+      sourceCommit: 'a666e1b45c9782d1ac2066fd55ec0127d0580950',
+      sourceTag: 'v22.1.0',
+      sourcePath: 'packages/eslint-plugin/tests/rules/prefer-signals/cases.ts',
+      sourceSha256: '33cae0732a9d9a41e1dd943ee8a19e282e240a06a247a31a0dac942fcec96cae',
+      capture: 'every authored valid and invalid semantic case exactly once',
+      counts: {
+        valid: 39,
+        invalid: 26,
+        diagnostics: 26,
+      },
+    });
+  });
+
+  it.each(preferSignalsFixture.valid)(
+    'accepts upstream prefer-signals valid case: $name',
+    ({ code, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['prefer-signals'],
+          options,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it.each(preferSignalsFixture.invalid)(
+    'matches upstream prefer-signals invalid diagnostic: $name',
+    ({ code, errors, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['prefer-signals'],
+          options,
+        }),
+      ).toEqual(
+        errors.map((error) => ({
+          ruleName: 'prefer-signals',
+          messageId: error.messageId,
+          data: Object.entries(error.data).map(([key, value]) => ({ key, value })),
+          loc: {
+            startLine: error.line,
+            startColumn: error.column - 1,
+            endLine: error.endLine,
+            endColumn: error.endColumn - 1,
+          },
+        })),
+      );
+    },
+  );
+
+  it('reports readonly, input, and query branches in upstream traversal order', () => {
+    const diagnostics = scanAngularEslint(
+      `class Test {
+  @Input() signalValue = signal(1);
+  @ViewChild('child') child: Widget;
+  plain = contentChildren('items');
+}`,
+      'fixture.ts',
+      { ruleNames: ['prefer-signals'], options: [] },
+    );
+
+    expect(
+      diagnostics.map(({ messageId, data, loc }) => ({
+        messageId,
+        data,
+        line: loc.startLine,
+      })),
+    ).toEqual([
+      { messageId: 'preferReadonlySignalProperties', data: [], line: 2 },
+      { messageId: 'preferInputSignals', data: [], line: 2 },
+      {
+        messageId: 'preferQuerySignals',
+        data: [
+          { key: 'function', value: 'viewChild' },
+          { key: 'decorator', value: 'ViewChild' },
+        ],
+        line: 3,
+      },
+      { messageId: 'preferReadonlySignalProperties', data: [], line: 4 },
+    ]);
+  });
+
+  it.each([
+    [[{ preferReadonlySignalProperties: false }], ['preferInputSignals', 'preferQuerySignals']],
+    [[{ preferInputSignals: false }], ['preferReadonlySignalProperties', 'preferQuerySignals']],
+    [[{ preferQuerySignals: false }], ['preferReadonlySignalProperties', 'preferInputSignals']],
+    [
+      [
+        {
+          preferReadonlySignalProperties: false,
+          preferInputSignals: false,
+          preferQuerySignals: false,
+        },
+      ],
+      [],
+    ],
+  ])('isolates prefer-signals option branches for %j', (options, messageIds) => {
+    const diagnostics = scanAngularEslint(
+      `class Test {
+  @Input() value = signal(1);
+  @ContentChild('child') child: Widget;
+}`,
+      'fixture.ts',
+      { ruleNames: ['prefer-signals'], options },
+    );
+    expect(diagnostics.map(({ messageId }) => messageId)).toEqual(messageIds);
+  });
+
+  it('supports additional factories and source-local type checking independently', () => {
+    const source = `
+class Test {
+  custom = createCustomSignal();
+  typed = createTypedSignal();
+}
+declare function createTypedSignal(): Signal<boolean>;
+`;
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['prefer-signals'],
+        options: [{ additionalSignalCreationFunctions: ['createCustomSignal'] }],
+      }).map(({ loc }) => loc.startLine),
+    ).toEqual([3]);
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['prefer-signals'],
+        options: [{ useTypeChecking: true }],
+      }).map(({ loc }) => loc.startLine),
+    ).toEqual([4]);
+  });
+
+  it('preserves UTF-16 columns and ignores non-Angular state factories', () => {
+    const [diagnostic] = scanAngularEslint(
+      `class Test { marker = '😀'; signalValue = signal(1); state = useState(0); }`,
+      'fixture.ts',
+      { ruleNames: ['prefer-signals'], options: [] },
+    );
+    expect(diagnostic).toMatchObject({
+      messageId: 'preferReadonlySignalProperties',
+      loc: {
+        startLine: 1,
+        startColumn: 28,
+        endLine: 1,
+        endColumn: 39,
+      },
+    });
+  });
+
+  it('keeps prefer-signals isolated and fails closed on malformed TypeScript', () => {
+    expect(
+      scanAngularEslint(`class Test { value = signal(1); }`, 'fixture.ts', {
+        ruleNames: ['no-output-rename'],
+        options: [],
+      }).some(({ ruleName }) => ruleName === 'prefer-signals'),
+    ).toBe(false);
+    expect(
+      scanAngularEslint(`class Test { value = signal(`, 'fixture.ts', {
+        ruleNames: ['prefer-signals'],
+        options: [],
+      }),
+    ).toEqual([]);
   });
 });

--- a/npm/angular-eslint/test/fixtures/prefer-signals-v22.1.0.json
+++ b/npm/angular-eslint/test/fixtures/prefer-signals-v22.1.0.json
@@ -1,0 +1,687 @@
+{
+  "metadata": {
+    "package": "@angular-eslint/eslint-plugin",
+    "version": "22.1.0",
+    "sourceCommit": "a666e1b45c9782d1ac2066fd55ec0127d0580950",
+    "sourceTag": "v22.1.0",
+    "sourcePath": "packages/eslint-plugin/tests/rules/prefer-signals/cases.ts",
+    "sourceSha256": "33cae0732a9d9a41e1dd943ee8a19e282e240a06a247a31a0dac942fcec96cae",
+    "capture": "every authored valid and invalid semantic case exactly once",
+    "counts": {
+      "valid": 39,
+      "invalid": 26,
+      "diagnostics": 26
+    }
+  },
+  "valid": [
+    {
+      "name": "valid-1",
+      "code": "\n    class Test {\n      testSubject = new Subject();\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-2",
+      "code": "\n    class Test {\n      testSubject = new ReplaySubject(1);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-3",
+      "code": "\n    class Test {\n      testValue = test();\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-4",
+      "code": "\n    class Test {\n      testValue: number;\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-5",
+      "code": "\n    class Test {\n      testValue: Widget<number>;\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-6",
+      "code": "\n    class Test {\n      readonly testSignal: Signal<number>;\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-7",
+      "code": "\n    class Test {\n      readonly testSignal: InputSignal<number>;\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-8",
+      "code": "\n    class Test {\n      readonly testSignal: ModelSignal<number>;\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-9",
+      "code": "\n    class Test {\n      readonly testSignal: WritableSignal<number>;\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-10",
+      "code": "\n    class Test {\n      readonly testSignal = computed(() => 0);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-11",
+      "code": "\n    class Test {\n      readonly testSignal = linkedSignal(() => source);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-12",
+      "code": "\n    class Test {\n      readonly testSignal = contentChild('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-13",
+      "code": "\n    class Test {\n      readonly testSignal = contentChild.required('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-14",
+      "code": "\n    class Test {\n      readonly testSignal = contentChildren('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-15",
+      "code": "\n    class Test {\n      readonly testSignal = input('');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-16",
+      "code": "\n    class Test {\n      readonly testSignal = input.required();\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-17",
+      "code": "\n    class Test {\n      readonly testSignal = model();\n      readonly testRequired = model.required(42);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-18",
+      "code": "\n    class Test {\n      readonly testSignal = signal(true);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-19",
+      "code": "\n    class Test {\n      readonly testSignal = signal(true).asReadonly();\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-20",
+      "code": "\n    class Test {\n      readonly testSignal = toSignal(source);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-21",
+      "code": "\n    class Test {\n      readonly testSignal = viewChild('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-22",
+      "code": "\n    class Test {\n      readonly testSignal = viewChild.required('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-23",
+      "code": "\n    class Test {\n      readonly testSignal = viewChildren('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-24",
+      "code": "\n    class Test {\n      testSignal = createSignal('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-25",
+      "code": "\n      class Test {\n        testSignal = signal('test');\n      }\n      ",
+      "options": [
+        {
+          "preferReadonlySignalProperties": false
+        }
+      ]
+    },
+    {
+      "name": "valid-26",
+      "code": "\n      class Test {\n        readonly testSignal = createSignal('test');\n      }\n      ",
+      "options": [
+        {
+          "additionalSignalCreationFunctions": ["createSignal"]
+        }
+      ]
+    },
+    {
+      "name": "valid-27",
+      "code": "\n    class Test {\n      testSignal = createSignal();\n    }\n    function createSignal(): Signal<boolean> {\n      return signal(true);\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-28",
+      "code": "\n      class Test {\n        readonly testSignal = createSignal();\n      }\n      function createSignal(): Signal<boolean> {\n        return signal(true);\n      }\n      ",
+      "options": [
+        {
+          "useTypeChecking": true
+        }
+      ]
+    },
+    {
+      "name": "valid-29",
+      "code": "\n      class Test {\n        testNotSignal = createNotSignal();\n      }\n      function createNotSignal(): NotSignal<boolean> {\n        return true;\n      }\n      ",
+      "options": [
+        {
+          "useTypeChecking": true
+        }
+      ]
+    },
+    {
+      "name": "valid-30",
+      "code": "\n    class Test {\n      readonly value = input();\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-31",
+      "code": "\n      class Test {\n        @Input()\n        readonly value = 1;\n      }\n      ",
+      "options": [
+        {
+          "preferInputSignals": false
+        }
+      ]
+    },
+    {
+      "name": "valid-32",
+      "code": "\n    class Test {\n      readonly query = viewChild('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-33",
+      "code": "\n      class Test {\n        @ViewChild('test')\n        value: Widget;\n      }\n      ",
+      "options": [
+        {
+          "preferQuerySignals": false
+        }
+      ]
+    },
+    {
+      "name": "valid-34",
+      "code": "\n    class Test {\n      readonly query = viewChildren('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-35",
+      "code": "\n      class Test {\n        @ViewChildren('test')\n        value: QueryList<Widget>;\n      }\n      ",
+      "options": [
+        {
+          "preferQuerySignals": false
+        }
+      ]
+    },
+    {
+      "name": "valid-36",
+      "code": "\n    class Test {\n      readonly query = contentChild('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-37",
+      "code": "\n      class Test {\n        @ContentChild('test')\n        value: Widget;\n      }\n      ",
+      "options": [
+        {
+          "preferQuerySignals": false
+        }
+      ]
+    },
+    {
+      "name": "valid-38",
+      "code": "\n    class Test {\n      readonly query = contentChildren('test');\n    }\n    ",
+      "options": []
+    },
+    {
+      "name": "valid-39",
+      "code": "\n      class Test {\n        @ContentChildren('test')\n        value: QueryList<Widget>;\n      }\n      ",
+      "options": [
+        {
+          "preferQuerySignals": false
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "name": "should fail when a Signal is not readonly",
+      "code": "\n      class Test {\n        testSignal: Signal<number>;\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal: Signal<number>;\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when an InputSignal is not readonly",
+      "code": "\n      class Test {\n        testSignal: InputSignal<number>;\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal: InputSignal<number>;\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a ModelSignal is not readonly",
+      "code": "\n      class Test {\n        testSignal: ModelSignal<number>;\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal: ModelSignal<number>;\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a WritableSignal is not readonly",
+      "code": "\n      class Test {\n        testSignal: WritableSignal<number>;\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal: WritableSignal<number>;\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a computed is not readonly",
+      "code": "\n      class Test {\n        testSignal = computed(() => 0);\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = computed(() => 0);\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a linkedSignal is not readonly",
+      "code": "\n      class Test {\n        testSignal = linkedSignal(() => source);\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = linkedSignal(() => source);\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a contentChild is not readonly",
+      "code": "\n      class Test {\n        testSignal = contentChild('test');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = contentChild('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a contentChild.required is not readonly",
+      "code": "\n      class Test {\n        testSignal = contentChild.required('test');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = contentChild.required('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a contentChildren is not readonly",
+      "code": "\n      class Test {\n        testSignal = contentChildren('test');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = contentChildren('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when an input is not readonly",
+      "code": "\n      class Test {\n        testSignal = input('');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = input('');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when an input.required is not readonly",
+      "code": "\n      class Test {\n        testSignal = input.required('');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = input.required('');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a model is not readonly",
+      "code": "\n      class Test {\n        testSignal = model(42);\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = model(42);\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a model.required is not readonly",
+      "code": "\n      class Test {\n        testSignal = model.required();\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = model.required();\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a signal is not readonly",
+      "code": "\n      class Test {\n        testSignal = signal(42);\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = signal(42);\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a signal.asReadonly() is not readonly",
+      "code": "\n      class Test {\n        testSignal = signal(42).asReadonly();\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = signal(42).asReadonly();\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a toSignal is not readonly",
+      "code": "\n      class Test {\n        testSignal = toSignal(source);\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = toSignal(source);\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a viewChild is not readonly",
+      "code": "\n      class Test {\n        testSignal = viewChild('test');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = viewChild('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a viewChild.required is not readonly",
+      "code": "\n      class Test {\n        testSignal = viewChild.required('test');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = viewChild.required('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a viewChildren is not readonly",
+      "code": "\n      class Test {\n        testSignal = viewChildren('test');\n        \n      }\n      ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = viewChildren('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a Signal assigned from a user-specified function is not readonly",
+      "code": "\n      class Test {\n        testSignal = createSignal('test');\n        \n      }\n      ",
+      "options": [
+        {
+          "additionalSignalCreationFunctions": ["createSignal"]
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = createSignal('test');\n        \n      }\n      "
+    },
+    {
+      "name": "should fail when a Signal calculated with type-checking is not readonly",
+      "code": "\n      class Test {\n        testSignal = createSignal();\n        \n      }\n      declare function createSignal(): Signal<boolean>;\n      interface Signal<T> {}\n      ",
+      "options": [
+        {
+          "useTypeChecking": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "preferReadonlySignalProperties",
+          "data": {},
+          "line": 3,
+          "column": 9,
+          "endLine": 3,
+          "endColumn": 19
+        }
+      ],
+      "output": "\n      class Test {\n        readonly testSignal = createSignal();\n        \n      }\n      declare function createSignal(): Signal<boolean>;\n      interface Signal<T> {}\n      "
+    },
+    {
+      "name": "should fail when @Input() is used",
+      "code": "\n    class Test {\n      @Input()\n      \n      value = 1;\n    }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferInputSignals",
+          "data": {},
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 15
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail when @ViewChild() is used",
+      "code": "\n    class Test {\n      @ViewChild('test')\n      \n      value: Widget;\n    }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferQuerySignals",
+          "data": {
+            "function": "viewChild",
+            "decorator": "ViewChild"
+          },
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 25
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail when @ViewChildren() is used",
+      "code": "\n    class Test {\n      @ViewChildren('test')\n      \n      value: QueryList<Widget>;\n    }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferQuerySignals",
+          "data": {
+            "function": "viewChildren",
+            "decorator": "ViewChildren"
+          },
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 28
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail when @ContentChild() is used",
+      "code": "\n    class Test {\n      @ContentChild('test')\n      \n      value: Widget;\n    }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferQuerySignals",
+          "data": {
+            "function": "contentChild",
+            "decorator": "ContentChild"
+          },
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 28
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail when @ContentChildren() is used",
+      "code": "\n    class Test {\n      @ContentChildren('test')\n      \n      value: QueryList<Widget>;\n    }\n    ",
+      "options": [],
+      "errors": [
+        {
+          "messageId": "preferQuerySignals",
+          "data": {
+            "function": "contentChildren",
+            "decorator": "ContentChildren"
+          },
+          "line": 3,
+          "column": 7,
+          "endLine": 3,
+          "endColumn": 31
+        }
+      ],
+      "output": null
+    }
+  ]
+}

--- a/npm/angular-eslint/test/plugin.test.mjs
+++ b/npm/angular-eslint/test/plugin.test.mjs
@@ -19,6 +19,9 @@ const consistentComponentStylesFixture = JSON.parse(
 const noInputRenameFixture = JSON.parse(
   readFileSync(new URL('./fixtures/no-input-rename-v22.0.0.json', import.meta.url), 'utf8'),
 );
+const preferSignalsFixture = JSON.parse(
+  readFileSync(new URL('./fixtures/prefer-signals-v22.1.0.json', import.meta.url), 'utf8'),
+);
 const playgroundCatalog = JSON.parse(
   readFileSync(resolve(workspaceRoot, 'playground/src/catalog.json'), 'utf8'),
 );
@@ -201,6 +204,8 @@ describe('angular-eslint plugin adapter', () => {
         'Directive class names should end with one of these suffixes: {{suffixes}}',
       'no-input-rename':
         'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
+      'prefer-signals':
+        'Use `InputSignal`s (e.g. via `input()`) for Component input properties rather than the legacy `@Input()` decorator',
     };
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
       expectedMessages[ruleName] || 'Unexpected Angular pattern.',
@@ -302,6 +307,49 @@ describe('angular-eslint plugin adapter', () => {
     });
     expect(meta.fixable).toBe('code');
     expect(meta.hasSuggestions).toBe(true);
+  });
+
+  it('exposes the exact upstream prefer-signals contract and playground metadata', () => {
+    const { meta } = plugin.rules['prefer-signals'];
+    expect(meta.type).toBe('suggestion');
+    expect(meta.docs.description).toBe(
+      'Use readonly signals instead of `@Input()`, `@ViewChild()` and other legacy decorators',
+    );
+    expect(meta.schema).toEqual([
+      {
+        type: 'object',
+        properties: {
+          preferReadonlySignalProperties: { type: 'boolean', default: true },
+          preferInputSignals: { type: 'boolean', default: true },
+          preferQuerySignals: { type: 'boolean', default: true },
+          useTypeChecking: { type: 'boolean', default: false },
+          additionalSignalCreationFunctions: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+          },
+        },
+        additionalProperties: false,
+      },
+    ]);
+    expect(meta.messages).toEqual({
+      preferInputSignals:
+        'Use `InputSignal`s (e.g. via `input()`) for Component input properties rather than the legacy `@Input()` decorator',
+      preferQuerySignals:
+        'Use the `{{function}}` function instead of the `{{decorator}}` decorator',
+      preferReadonlySignalProperties:
+        'Properties declared using signals should be marked as `readonly` since they should not be reassigned',
+    });
+    expect(meta.fixable).toBe('code');
+    expect(meta.hasSuggestions).toBeUndefined();
+
+    const playgroundRule = playgroundCatalog.plugins
+      .find(({ plugin: pluginName }) => pluginName === '@angular-eslint')
+      .rules.find(({ name }) => name === 'prefer-signals');
+    expect(playgroundRule).toMatchObject({
+      description: meta.docs.description,
+      messages: meta.messages,
+    });
   });
 
   it('exposes the complete component inline declaration contract', () => {
@@ -995,6 +1043,135 @@ class Test {
         'Input bindings should not be aliased (https://angular.dev/guide/components/inputs#choosing-input-names)',
       ]);
       expect(payload.diagnostics.map(({ labels }) => labels[0].span.line)).toEqual([4, 5]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(preferSignalsFixture.valid)(
+    'accepts upstream prefer-signals valid case through createOnce: $name',
+    ({ code, options }) => {
+      expect(runRule('prefer-signals', code, options)).toEqual([]);
+    },
+  );
+
+  it.each(preferSignalsFixture.invalid)(
+    'matches upstream prefer-signals invalid diagnostic through createOnce: $name',
+    ({ code, errors, options }) => {
+      expect(runRule('prefer-signals', code, options)).toEqual(
+        errors.map((error) => ({
+          messageId: error.messageId,
+          data: error.data,
+          loc: {
+            start: {
+              line: error.line,
+              column: error.column - 1,
+            },
+            end: {
+              line: error.endLine,
+              column: error.endColumn - 1,
+            },
+          },
+        })),
+      );
+    },
+  );
+
+  it('forwards every prefer-signals option independently through createOnce', () => {
+    const code = `
+class Test {
+  @Input() custom = createCustomSignal();
+  @ViewChildren('item') items: QueryList<Item>;
+  typed = createTypedSignal();
+}
+declare function createTypedSignal(): Signal<boolean>;
+`;
+    expect(
+      runRule('prefer-signals', code, [
+        {
+          preferInputSignals: false,
+          preferQuerySignals: false,
+          additionalSignalCreationFunctions: ['createCustomSignal'],
+          useTypeChecking: true,
+        },
+      ]).map(({ messageId, loc }) => ({ messageId, line: loc.start.line })),
+    ).toEqual([
+      { messageId: 'preferReadonlySignalProperties', line: 3 },
+      { messageId: 'preferReadonlySignalProperties', line: 5 },
+    ]);
+  });
+
+  it('does not invent prefer-signals fixes outside the diagnostic ABI', () => {
+    const reports = runRule(
+      'prefer-signals',
+      `class Test { @Input() value = signal(1); @ViewChild('x') child: Widget; }`,
+    );
+    expect(reports).toHaveLength(3);
+    for (const report of reports) {
+      expect(report).not.toHaveProperty('fix');
+      expect(report).not.toHaveProperty('suggest');
+    }
+  });
+
+  it('honors prefer-signals options through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-prefer-signals-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.ts'),
+        'class Test {\n' +
+          '  custom = createCustomSignal();\n' +
+          '  typed = createTypedSignal();\n' +
+          '  @Input() legacy = 1;\n' +
+          '  @ViewChildren("item") items: QueryList<Item>;\n' +
+          '}\n' +
+          'declare function createTypedSignal(): Signal<boolean>;\n',
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: '@angular-eslint',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            '@angular-eslint/prefer-signals': [
+              'error',
+              {
+                preferInputSignals: false,
+                additionalSignalCreationFunctions: ['createCustomSignal'],
+                useTypeChecking: true,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(3);
+      expect(payload.diagnostics.map(({ code }) => code)).toEqual([
+        '@angular-eslint(prefer-signals)',
+        '@angular-eslint(prefer-signals)',
+        '@angular-eslint(prefer-signals)',
+      ]);
+      expect(payload.diagnostics.map(({ message }) => message)).toEqual([
+        'Properties declared using signals should be marked as `readonly` since they should not be reassigned',
+        'Properties declared using signals should be marked as `readonly` since they should not be reassigned',
+        'Use the `viewChildren` function instead of the `ViewChildren` decorator',
+      ]);
+      expect(payload.diagnostics.map(({ labels }) => labels[0].span.line)).toEqual([2, 3, 5]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "port:tests:astro": "node tools/tasks/sync-astro-tests.ts",
     "port:tests:angular:consistent-component-styles": "node tools/tasks/sync-angular-consistent-component-styles-tests.ts",
     "port:tests:angular:no-input-rename": "node tools/tasks/sync-angular-no-input-rename-tests.ts",
+    "port:tests:angular:prefer-signals": "node tools/tasks/sync-angular-prefer-signals-tests.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
     "port:tests:eslint-json": "node tools/tasks/sync-eslint-json-tests.ts",
     "port:tests:eslint-markdown": "node tools/tasks/sync-eslint-markdown-tests.ts",

--- a/playground/src/catalog.json
+++ b/playground/src/catalog.json
@@ -291,10 +291,12 @@
         },
         {
           "name": "prefer-signals",
-          "description": "enforce angular eslint prefer signals",
+          "description": "Use readonly signals instead of `@Input()`, `@ViewChild()` and other legacy decorators",
           "docsUrl": "https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-signals.md",
           "messages": {
-            "unexpected": "Unexpected Angular pattern."
+            "preferInputSignals": "Use `InputSignal`s (e.g. via `input()`) for Component input properties rather than the legacy `@Input()` decorator",
+            "preferQuerySignals": "Use the `{{function}}` function instead of the `{{decorator}}` decorator",
+            "preferReadonlySignalProperties": "Properties declared using signals should be marked as `readonly` since they should not be reassigned"
           }
         },
         {

--- a/status.json
+++ b/status.json
@@ -588,7 +588,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of @angular-eslint/eslint-plugin/prefer-signals; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Full Rust/Oxc AST port of the angular-eslint v22.1.0 prefer-signals contract, including five independent options, pinned authored-fixture replay, exact diagnostics, NAPI/API/plugin coverage, and real Oxlint jsPlugins integration."
       },
       {
         "name": "prefer-standalone",

--- a/tools/tasks/sync-angular-prefer-signals-tests.ts
+++ b/tools/tasks/sync-angular-prefer-signals-tests.ts
@@ -1,0 +1,204 @@
+// Snapshot every authored angular-eslint v22.1.0 prefer-signals RuleTester
+// case directly from the pinned upstream tag. The submodule itself remains at
+// the repository-pinned revision, so regenerating the fixture cannot alter the
+// workspace gitlink.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const UPSTREAM = resolve(ROOT, 'upstream/angular-eslint');
+const VERSION = '22.1.0';
+const SOURCE_TAG = `v${VERSION}`;
+const SOURCE_COMMIT = 'a666e1b45c9782d1ac2066fd55ec0127d0580950';
+const SOURCE_PATH = 'packages/eslint-plugin/tests/rules/prefer-signals/cases.ts';
+const OUTPUT_PATH = resolve(
+  ROOT,
+  `npm/angular-eslint/test/fixtures/prefer-signals-v${VERSION}.json`,
+);
+const HELPER_IMPORT =
+  "import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/test-utils';";
+
+type AuthoredError = {
+  data?: Record<string, string>;
+  messageId: string;
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+};
+
+type AuthoredCase = {
+  name?: string;
+  code: string;
+  options?: unknown[];
+};
+
+type AuthoredInvalidCase = AuthoredCase & {
+  errors: AuthoredError[];
+  output: null | string | string[];
+};
+
+const actualCommit = execFileSync('git', ['-C', UPSTREAM, 'rev-list', '-n', '1', SOURCE_TAG], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== SOURCE_COMMIT) {
+  throw new Error(
+    `Expected angular-eslint ${SOURCE_TAG} at ${SOURCE_COMMIT}, received ${actualCommit}.`,
+  );
+}
+
+const source = execFileSync('git', ['-C', UPSTREAM, 'show', `${SOURCE_TAG}:${SOURCE_PATH}`], {
+  encoding: 'utf8',
+});
+if (!source.includes(HELPER_IMPORT)) {
+  throw new Error('The upstream prefer-signals case harness changed shape.');
+}
+
+const executableSource = source.replace(HELPER_IMPORT, () => annotatedCaseHelper());
+const javascript = stripTypeScriptTypes(executableSource, { mode: 'strip' });
+const cases = (await import(
+  `data:text/javascript;base64,${Buffer.from(javascript).toString('base64')}`
+)) as {
+  valid: Array<AuthoredCase | string>;
+  invalid: AuthoredInvalidCase[];
+};
+
+const fixture = {
+  metadata: {
+    package: '@angular-eslint/eslint-plugin',
+    version: VERSION,
+    sourceCommit: SOURCE_COMMIT,
+    sourceTag: SOURCE_TAG,
+    sourcePath: SOURCE_PATH,
+    sourceSha256: createHash('sha256').update(source).digest('hex'),
+    capture: 'every authored valid and invalid semantic case exactly once',
+    counts: {
+      valid: cases.valid.length,
+      invalid: cases.invalid.length,
+      diagnostics: cases.invalid.reduce((count, testCase) => count + testCase.errors.length, 0),
+    },
+  },
+  valid: cases.valid.map((testCase, index) => normalizeValidCase(testCase, index)),
+  invalid: cases.invalid.map((testCase, index) => normalizeInvalidCase(testCase, index)),
+};
+
+mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+writeFileSync(OUTPUT_PATH, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', OUTPUT_PATH], { cwd: ROOT, stdio: 'ignore' });
+console.log(
+  `Captured ${fixture.metadata.counts.valid} valid and ${fixture.metadata.counts.invalid} invalid prefer-signals cases from ${SOURCE_TAG}.`,
+);
+
+function normalizeValidCase(testCase: AuthoredCase | string, index: number) {
+  if (typeof testCase === 'string') {
+    return { name: `valid-${index + 1}`, code: testCase, options: [] };
+  }
+  return {
+    name: testCase.name ?? `valid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+  };
+}
+
+function normalizeInvalidCase(testCase: AuthoredInvalidCase, index: number) {
+  return {
+    name: testCase.name ?? `invalid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+    errors: testCase.errors.map((error) => ({
+      messageId: error.messageId,
+      data: error.data ?? {},
+      line: error.line,
+      column: error.column,
+      endLine: error.endLine,
+      endColumn: error.endColumn,
+    })),
+    output: testCase.output,
+  };
+}
+
+function annotatedCaseHelper() {
+  return String.raw`
+function convertAnnotatedSourceToFailureCase(errorOptions) {
+  const messages =
+    'messageId' in errorOptions
+      ? [{ ...errorOptions, char: '~' }]
+      : errorOptions.messages;
+  let parsedSource = '';
+  const errors = messages.map(({ char, data, messageId, suggestions }) => {
+    const otherChars = messages
+      .map((message) => message.char)
+      .filter((candidate) => candidate !== char);
+    const parsed = parseInvalidSource(errorOptions.annotatedSource, char, otherChars);
+    parsedSource = parsed.source;
+    return {
+      data,
+      messageId,
+      line: parsed.start.line + 1,
+      column: parsed.start.character + 1,
+      endLine: parsed.end.line + 1,
+      endColumn: parsed.end.character + 1,
+      suggestions,
+    };
+  });
+  return {
+    name: errorOptions.description,
+    code: parsedSource,
+    options: errorOptions.options ?? [],
+    errors,
+    output: errorOptions.annotatedOutputs
+      ? errorOptions.annotatedOutputs.map((output) => parseInvalidSource(output).source)
+      : errorOptions.annotatedOutput
+        ? parseInvalidSource(errorOptions.annotatedOutput).source
+        : null,
+  };
+}
+
+function parseInvalidSource(source, specialChar = '~', otherChars = []) {
+  const ignored = new Set(otherChars);
+  let column = 0;
+  let line = 0;
+  let sourceLine = 0;
+  let annotationLine = false;
+  let start;
+  let end;
+  for (const character of source) {
+    if (character === '\n') {
+      if (annotationLine) annotationLine = false;
+      else sourceLine = line;
+      column = 0;
+      line += 1;
+      continue;
+    }
+    column += 1;
+    if (ignored.has(character)) annotationLine = true;
+    if (character !== specialChar) continue;
+    annotationLine = true;
+    start ??= { character: column - 1, line: sourceLine };
+    end = { character: column, line: sourceLine };
+  }
+  const ignoredPattern =
+    otherChars.length === 0
+      ? null
+      : new RegExp(
+          '[' +
+            otherChars
+              .map((value) => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'))
+              .join('') +
+            ']',
+          'g',
+        );
+  const withoutOtherAnnotations = ignoredPattern ? source.replace(ignoredPattern, ' ') : source;
+  return {
+    source: withoutOtherAnnotations.replaceAll(specialChar, ''),
+    start,
+    end,
+  };
+}
+`;
+}


### PR DESCRIPTION
## Summary
- port `@angular-eslint/prefer-signals` v22.1 to the native Oxc implementation
- support all five options, five known signal types, ten factories, `required`/`asReadonly`, `Input` and query decorators, and source-local `useTypeChecking` semantics
- preserve exact metadata, messages, schema, NAPI/API/plugin behavior, docs, status, playground catalog, and deterministic fixture synchronization

## Tests
- pin all 39 upstream valid cases and 26 invalid cases
- add focused regressions for every signal type/factory/decorator, partial and malformed options, member-expression edges, near misses, Unicode/UTF-16 locations, source ordering, parsing, and rule isolation
- full workspace: 16,694 JS tests plus all Rust/doc tests and full fmt/typecheck/lint/build/benchmark/security/license/status/publish-readiness gates
- latest-main rebase: 524 targeted JS tests and 56 Angular Rust tests

Refs #419

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->