### PR TITLE
feat(perfectionist): port sort-array-includes options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,7 @@ dependencies = [
  "icu_locale_core",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
  "oxlint-plugins-_carton",

--- a/crates/perfectionist/Cargo.toml
+++ b/crates/perfectionist/Cargo.toml
@@ -13,6 +13,7 @@ icu_collator.workspace = true
 icu_locale_core.workspace = true
 oxc_allocator.workspace = true
 oxc_ast.workspace = true
+oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true

--- a/crates/perfectionist/src/lib.rs
+++ b/crates/perfectionist/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod helpers;
 mod scanner;
+mod sort_array_includes;
 mod sort_named_specifiers;
 mod sort_options;
 mod types;
@@ -85,6 +86,12 @@ pub fn scan_perfectionist_rule(
         return SmallVec::new();
     }
     match rule_name {
+        "sort-array-includes" => sort_array_includes::check(
+            source_text,
+            &parser_return.program,
+            &parser_return.program.comments,
+            options,
+        ),
         "sort-named-imports" => sort_named_specifiers::check(
             source_text,
             &parser_return.program.body,

--- a/crates/perfectionist/src/sort_array_includes.rs
+++ b/crates/perfectionist/src/sort_array_includes.rs
@@ -1,0 +1,322 @@
+//! Oxc AST port of Perfectionist's `sort-array-includes` v5.10.0 contract.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types,
+    reason = "serde_json option maps require String keys, AST element inventories are user-sized, and numeric literal names must match JavaScript String(value) semantics."
+)]
+
+use oxc_ast::{
+    Comment,
+    ast::{Argument, ArrayExpressionElement, CallExpression, Expression, Program},
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::{GetSpan, Span};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use serde_json::{Map, Value};
+
+use crate::{
+    sort_named_specifiers::{
+        RuleContract, RuleOptions, SortableNode, check_specifiers, compute_group, is_rule_disabled,
+        is_same_line, matches_regex, movable_leading_comment_start,
+    },
+    types::{LineIndex, RuleDiagnostic},
+};
+
+const CONTRACT: RuleContract = RuleContract {
+    rule: "sort-array-includes",
+    selector: "literal",
+    order_message_id: "unexpectedArrayIncludesOrder",
+    group_order_message_id: "unexpectedArrayIncludesGroupOrder",
+    extra_spacing_message_id: "extraSpacingBetweenArrayIncludesMembers",
+    missed_spacing_message_id: "missedSpacingBetweenArrayIncludesMembers",
+    missed_comment_above_message_id: None,
+};
+
+pub(crate) fn check<'ast>(
+    source_text: &'ast str,
+    program: &Program<'ast>,
+    comments: &[Comment],
+    raw_options: &Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    let mut visitor = ArrayIncludesVisitor {
+        source_text,
+        comments,
+        raw_options,
+        lines: LineIndex::new(source_text),
+        diagnostics: SmallVec::new(),
+    };
+    visitor.visit_program(program);
+    visitor
+        .diagnostics
+        .sort_by_key(|diagnostic| (diagnostic.loc.start_line, diagnostic.loc.start_column));
+    visitor.diagnostics
+}
+
+struct ArrayIncludesVisitor<'source, 'options> {
+    source_text: &'source str,
+    comments: &'source [Comment],
+    raw_options: &'options Value,
+    lines: LineIndex,
+    diagnostics: SmallVec<[RuleDiagnostic; 8]>,
+}
+
+impl<'ast> Visit<'ast> for ArrayIncludesVisitor<'ast, '_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        self.check_call(call);
+        walk::walk_call_expression(self, call);
+    }
+}
+
+impl<'ast> ArrayIncludesVisitor<'ast, '_> {
+    fn check_call(&mut self, call: &CallExpression<'ast>) {
+        let Expression::StaticMemberExpression(member) = call.callee.get_inner_expression() else {
+            return;
+        };
+        if member.property.name != "includes" {
+            return;
+        }
+
+        match member.object.get_inner_expression() {
+            Expression::ArrayExpression(array) => self.check_array(
+                "ArrayExpression",
+                array.span.end.saturating_sub(1),
+                array
+                    .elements
+                    .iter()
+                    .map(|element| match element {
+                        ArrayExpressionElement::SpreadElement(spread) => {
+                            ArrayItem::Barrier(spread.span)
+                        }
+                        ArrayExpressionElement::Elision(elision) => {
+                            ArrayItem::Barrier(elision.span)
+                        }
+                        element => element
+                            .as_expression()
+                            .map_or(ArrayItem::Barrier(element.span()), ArrayItem::Expression),
+                    })
+                    .collect(),
+            ),
+            Expression::NewExpression(expression)
+                if matches!(
+                    expression.callee.get_inner_expression(),
+                    Expression::Identifier(identifier) if identifier.name == "Array"
+                ) =>
+            {
+                self.check_array(
+                    "NewExpression",
+                    expression.span.end.saturating_sub(1),
+                    expression
+                        .arguments
+                        .iter()
+                        .map(|argument| match argument {
+                            Argument::SpreadElement(spread) => ArrayItem::Barrier(spread.span),
+                            argument => argument
+                                .as_expression()
+                                .map_or(ArrayItem::Barrier(argument.span()), ArrayItem::Expression),
+                        })
+                        .collect(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn check_array(&mut self, ast_type: &str, container_end: u32, items: Vec<ArrayItem<'_, 'ast>>) {
+        let names: SmallVec<[CompactString; 16]> = items
+            .iter()
+            .filter_map(|item| match item {
+                ArrayItem::Expression(expression) => {
+                    Some(expression_name(self.source_text, expression))
+                }
+                ArrayItem::Barrier(_) => None,
+            })
+            .collect();
+        let selected = select_options(self.raw_options, ast_type, &names);
+        let options = RuleOptions::from_object(with_defaults(selected));
+        let mut segment: SmallVec<[(&Expression<'ast>, u32); 16]> = SmallVec::new();
+
+        for (index, item) in items.iter().enumerate() {
+            match item {
+                ArrayItem::Expression(expression) => {
+                    let boundary = items
+                        .get(index + 1)
+                        .map_or(container_end, |next| next.span().start);
+                    segment.push((expression, boundary));
+                }
+                ArrayItem::Barrier(_) => {
+                    self.check_segment(&options, &segment);
+                    segment.clear();
+                }
+            }
+        }
+        self.check_segment(&options, &segment);
+    }
+
+    fn check_segment(&mut self, options: &RuleOptions, segment: &[(&Expression<'ast>, u32)]) {
+        if segment.len() < 2 {
+            return;
+        }
+        let mut nodes: SmallVec<[SortableNode<'ast>; 16]> = segment
+            .iter()
+            .filter_map(|(expression, boundary)| self.sortable_node(options, expression, *boundary))
+            .collect();
+        if nodes.len() < 2 {
+            return;
+        }
+        check_specifiers(
+            self.source_text,
+            self.comments,
+            options,
+            &mut nodes,
+            CONTRACT,
+            &self.lines,
+            &mut self.diagnostics,
+        );
+    }
+
+    fn sortable_node(
+        &self,
+        options: &RuleOptions,
+        expression: &Expression<'ast>,
+        boundary: u32,
+    ) -> Option<SortableNode<'ast>> {
+        let span = expression.span();
+        let source_start =
+            movable_leading_comment_start(self.source_text, self.comments, span, options);
+        let source_end = self
+            .comments
+            .iter()
+            .filter(|comment| {
+                comment.span.start >= span.end
+                    && comment.span.end <= boundary
+                    && is_same_line(self.source_text, span.end, comment.span.start)
+            })
+            .map(|comment| comment.span.end)
+            .max()
+            .unwrap_or(span.end);
+        let source = source_for_span(self.source_text, Span::new(source_start, source_end))?;
+        let node_source = source_for_span(self.source_text, span)?;
+        let name = expression_name(self.source_text, expression);
+        let group = compute_group(options, name.as_str(), &[], CONTRACT.selector);
+        let group_index = options.group_index(group.as_str());
+        Some(SortableNode {
+            span,
+            compare_name: name.clone(),
+            name,
+            source,
+            source_start,
+            source_end,
+            size: node_source.encode_utf16().count(),
+            group,
+            group_index,
+            partition_id: 0,
+            is_disabled: is_rule_disabled(self.source_text, self.comments, span, CONTRACT.rule),
+            is_ignored: false,
+            preserve_order_in_group: false,
+            is_type_import: false,
+            dependencies: SmallVec::new(),
+            dependency_names: SmallVec::new(),
+            add_safety_semicolon_when_inline: false,
+            use_original_groups_for_spacing: false,
+            requires_comma_separator: true,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ArrayItem<'node, 'ast> {
+    Expression(&'node Expression<'ast>),
+    Barrier(Span),
+}
+
+impl ArrayItem<'_, '_> {
+    fn span(self) -> Span {
+        match self {
+            Self::Expression(expression) => expression.span(),
+            Self::Barrier(span) => span,
+        }
+    }
+}
+
+fn expression_name(source_text: &str, expression: &Expression<'_>) -> CompactString {
+    match expression.get_inner_expression() {
+        Expression::StringLiteral(literal) => CompactString::from(literal.value.as_str()),
+        Expression::NumericLiteral(literal) => CompactString::from(literal.value.to_string()),
+        Expression::BooleanLiteral(literal) => {
+            CompactString::from(if literal.value { "true" } else { "false" })
+        }
+        Expression::NullLiteral(_) => CompactString::from("null"),
+        expression => source_for_span(source_text, expression.span())
+            .map_or_else(|| CompactString::new(""), CompactString::from),
+    }
+}
+
+fn select_options(
+    raw_options: &Value,
+    ast_type: &str,
+    names: &[CompactString],
+) -> Map<String, Value> {
+    let candidates: SmallVec<[&Map<String, Value>; 8]> = match raw_options {
+        Value::Array(values) => values.iter().filter_map(Value::as_object).collect(),
+        Value::Object(object) => SmallVec::from_vec(vec![object]),
+        _ => SmallVec::new(),
+    };
+    for candidate in candidates {
+        let Some(condition) = candidate
+            .get("useConfigurationIf")
+            .and_then(Value::as_object)
+        else {
+            return candidate.clone();
+        };
+        if let Some(pattern) = condition.get("allNamesMatchPattern")
+            && !names
+                .iter()
+                .all(|name| matches_regex(name.as_str(), pattern))
+        {
+            continue;
+        }
+        if let Some(selector) = condition.get("matchesAstSelector").and_then(Value::as_str)
+            && !matches_ast_selector(selector, ast_type)
+        {
+            continue;
+        }
+        return candidate.clone();
+    }
+    Map::new()
+}
+
+fn matches_ast_selector(selector: &str, ast_type: &str) -> bool {
+    let selector = selector.trim();
+    selector == ast_type || selector == format!("* > {ast_type}")
+}
+
+fn with_defaults(mut selected: Map<String, Value>) -> Map<String, Value> {
+    let defaults = serde_json::json!({
+        "fallbackSort": { "type": "unsorted" },
+        "newlinesInside": "newlinesBetween",
+        "specialCharacters": "keep",
+        "partitionByComment": false,
+        "partitionByNewLine": false,
+        "newlinesBetween": "ignore",
+        "useConfigurationIf": {},
+        "type": "alphabetical",
+        "groups": ["literal"],
+        "ignoreCase": true,
+        "locales": "en-US",
+        "customGroups": [],
+        "alphabet": "",
+        "order": "asc"
+    });
+    if let Some(defaults) = defaults.as_object() {
+        for (key, value) in defaults {
+            selected.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
+    selected
+}
+
+fn source_for_span(source_text: &str, span: Span) -> Option<&str> {
+    source_text.get(usize::try_from(span.start).ok()?..usize::try_from(span.end).ok()?)
+}

--- a/crates/perfectionist/src/sort_named_specifiers.rs
+++ b/crates/perfectionist/src/sort_named_specifiers.rs
@@ -30,14 +30,14 @@ use crate::types::{LineIndex, RuleDiagnostic, RuleDiagnosticData, RuleDiagnostic
 type RegexCache = RwLock<FastHashMap<(CompactString, CompactString), Option<Regex>>>;
 
 #[derive(Clone, Copy)]
-struct RuleContract {
-    rule: &'static str,
-    selector: &'static str,
-    order_message_id: &'static str,
-    group_order_message_id: &'static str,
-    extra_spacing_message_id: &'static str,
-    missed_spacing_message_id: &'static str,
-    missed_comment_above_message_id: Option<&'static str>,
+pub(crate) struct RuleContract {
+    pub(crate) rule: &'static str,
+    pub(crate) selector: &'static str,
+    pub(crate) order_message_id: &'static str,
+    pub(crate) group_order_message_id: &'static str,
+    pub(crate) extra_spacing_message_id: &'static str,
+    pub(crate) missed_spacing_message_id: &'static str,
+    pub(crate) missed_comment_above_message_id: Option<&'static str>,
 }
 
 const IMPORT_CONTRACT: RuleContract = RuleContract {
@@ -114,7 +114,7 @@ struct CustomGroup {
 }
 
 #[derive(Debug)]
-struct RuleOptions {
+pub(crate) struct RuleOptions {
     raw: Map<String, Value>,
     sort: SortOptions,
     groups: Vec<GroupEntry>,
@@ -126,24 +126,25 @@ struct RuleOptions {
 }
 
 pub(crate) struct SortableNode<'a> {
-    span: Span,
-    name: CompactString,
-    compare_name: CompactString,
-    source: &'a str,
-    source_start: u32,
-    source_end: u32,
-    size: usize,
-    group: CompactString,
-    group_index: usize,
-    partition_id: usize,
-    is_disabled: bool,
-    is_ignored: bool,
-    preserve_order_in_group: bool,
-    is_type_import: bool,
-    dependencies: SmallVec<[CompactString; 2]>,
-    dependency_names: SmallVec<[CompactString; 4]>,
-    add_safety_semicolon_when_inline: bool,
-    use_original_groups_for_spacing: bool,
+    pub(crate) span: Span,
+    pub(crate) name: CompactString,
+    pub(crate) compare_name: CompactString,
+    pub(crate) source: &'a str,
+    pub(crate) source_start: u32,
+    pub(crate) source_end: u32,
+    pub(crate) size: usize,
+    pub(crate) group: CompactString,
+    pub(crate) group_index: usize,
+    pub(crate) partition_id: usize,
+    pub(crate) is_disabled: bool,
+    pub(crate) is_ignored: bool,
+    pub(crate) preserve_order_in_group: bool,
+    pub(crate) is_type_import: bool,
+    pub(crate) dependencies: SmallVec<[CompactString; 2]>,
+    pub(crate) dependency_names: SmallVec<[CompactString; 4]>,
+    pub(crate) add_safety_semicolon_when_inline: bool,
+    pub(crate) use_original_groups_for_spacing: bool,
+    pub(crate) requires_comma_separator: bool,
 }
 
 struct PendingDiagnostic {
@@ -473,6 +474,7 @@ fn check_import_block<'a>(
                 dependency_names: import_dependency_names(source_text, declaration),
                 add_safety_semicolon_when_inline: true,
                 use_original_groups_for_spacing: false,
+                requires_comma_separator: false,
             })
         })
         .collect();
@@ -595,6 +597,7 @@ pub(crate) fn check_sort_exports(
                 dependency_names: SmallVec::new(),
                 add_safety_semicolon_when_inline: true,
                 use_original_groups_for_spacing: true,
+                requires_comma_separator: false,
             })
         })
         .collect();
@@ -1053,7 +1056,7 @@ fn source_for_span(source_text: &str, span: Span) -> Option<&str> {
     source_text.get(usize::try_from(span.start).ok()?..usize::try_from(span.end).ok()?)
 }
 
-fn check_specifiers(
+pub(crate) fn check_specifiers(
     source_text: &str,
     comments: &[Comment],
     options: &RuleOptions,
@@ -1202,7 +1205,7 @@ fn check_specifiers(
 }
 
 impl RuleOptions {
-    fn from_object(raw: Map<String, Value>) -> Self {
+    pub(crate) fn from_object(raw: Map<String, Value>) -> Self {
         let value = Value::Object(raw.clone());
         let groups = raw
             .get("groups")
@@ -1245,7 +1248,7 @@ impl RuleOptions {
         })
     }
 
-    fn group_index(&self, group_name: &str) -> usize {
+    pub(crate) fn group_index(&self, group_name: &str) -> usize {
         self.groups
             .iter()
             .position(|group| match group {
@@ -1559,6 +1562,7 @@ fn named_import<'a>(
         dependency_names: SmallVec::new(),
         add_safety_semicolon_when_inline: false,
         use_original_groups_for_spacing: false,
+        requires_comma_separator: false,
     })
 }
 
@@ -1617,10 +1621,11 @@ fn named_export<'a>(
         dependency_names: SmallVec::new(),
         add_safety_semicolon_when_inline: false,
         use_original_groups_for_spacing: false,
+        requires_comma_separator: false,
     })
 }
 
-fn movable_leading_comment_start(
+pub(crate) fn movable_leading_comment_start(
     source_text: &str,
     comments: &[Comment],
     specifier_span: Span,
@@ -1646,7 +1651,12 @@ fn movable_leading_comment_start(
     start
 }
 
-fn is_rule_disabled(source_text: &str, comments: &[Comment], span: Span, rule_name: &str) -> bool {
+pub(crate) fn is_rule_disabled(
+    source_text: &str,
+    comments: &[Comment],
+    span: Span,
+    rule_name: &str,
+) -> bool {
     let node_line = line_number_at(source_text, span.start);
     let mut block_disabled = false;
     let mut ordered_comments: SmallVec<[&Comment; 16]> = comments.iter().collect();
@@ -1729,7 +1739,7 @@ fn line_number_at(source_text: &str, offset: u32) -> u32 {
         + 1
 }
 
-fn compute_group(
+pub(crate) fn compute_group(
     options: &RuleOptions,
     name: &str,
     modifiers: &[&str],
@@ -2097,7 +2107,7 @@ fn compare_in_group(
             .and_then(|value| value.get("type"))
             .and_then(Value::as_str)
         {
-            Some("subgroup-order") => subgroup_compare(options, left, right, object),
+            Some("subgroup-order") => subgroup_compare(options, left, right, fallback),
             Some("type-import-first") => compare_type_imports(
                 left,
                 right,
@@ -2142,7 +2152,7 @@ fn fallback_compare(
         return Ordering::Equal;
     };
     if fallback.get("type").and_then(Value::as_str) == Some("subgroup-order") {
-        return subgroup_compare(options, left, right, raw);
+        return subgroup_compare(options, left, right, Some(fallback));
     }
     let mut value = raw.cloned().unwrap_or_default();
     for (key, item) in fallback {
@@ -2513,6 +2523,11 @@ fn build_fix(
         let separator = source_text.get(separator_start..separator_end)?;
         let sorted_left = &specifiers[*sorted_indices.get(position)?];
         let sorted_right = &specifiers[*sorted_indices.get(position + 1)?];
+        let separator = if sorted_left.requires_comma_separator {
+            array_separator(sorted_left, separator)
+        } else {
+            CompactString::from(separator)
+        };
         let checks_original_groups = specifiers
             .iter()
             .any(|specifier| specifier.use_original_groups_for_spacing);
@@ -2534,7 +2549,7 @@ fn build_fix(
             && let Newlines::Count(expected) = newlines_between(options, sorted_left, sorted_right)
         {
             normalize_separator(
-                separator,
+                separator.as_str(),
                 expected,
                 is_same_line(
                     source_text,
@@ -2543,9 +2558,9 @@ fn build_fix(
                 ),
             )
         } else {
-            CompactString::from(separator)
+            separator.clone()
         };
-        if desired_separator.as_str() != separator {
+        if desired_separator.as_str() != separator.as_str() {
             changed_start = Some(
                 changed_start.map_or(specifiers[position].span.end, |start| {
                     start.min(specifiers[position].span.end)
@@ -2567,12 +2582,20 @@ fn build_fix(
         &desired_source_starts,
         &desired_source_ends,
     )?;
-    let replacement_end = desired_offset_for_boundary(
+    let mut replacement_end = desired_offset_for_boundary(
         changed_end,
         specifiers,
         &desired_source_starts,
         &desired_source_ends,
     )?;
+    if specifiers.iter().any(|specifier| {
+        specifier.requires_comma_separator
+            && specifier.source_end == changed_end
+            && specifier.source_end > specifier.span.end
+    }) && replacement.as_bytes().get(replacement_end) == Some(&b',')
+    {
+        replacement_end += 1;
+    }
     Some(RuleDiagnosticFix {
         start: LineIndex::utf16_offset(source_text, changed_start),
         end: LineIndex::utf16_offset(source_text, changed_end),
@@ -2582,6 +2605,27 @@ fn build_fix(
                 .get(replacement_start..replacement_end)?,
         ),
     })
+}
+
+fn array_separator(node: &SortableNode<'_>, separator: &str) -> CompactString {
+    let embedded_comma = node
+        .source
+        .get(usize::try_from(node.span.end - node.source_start).unwrap_or(0)..)
+        .is_some_and(|trailing| trailing.contains(','));
+    let comma = separator.find(',');
+    match (embedded_comma, comma) {
+        (true, Some(index)) => {
+            let mut normalized = CompactString::from(separator);
+            normalized.remove(index);
+            normalized
+        }
+        (false, None) => {
+            let mut normalized = CompactString::new(",");
+            normalized.push_str(separator);
+            normalized
+        }
+        _ => CompactString::from(separator),
+    }
 }
 
 fn node_ends_with_safe_character(source_text: &str, node: &SortableNode<'_>) -> bool {
@@ -2698,7 +2742,7 @@ fn export_name(specifier: &ExportSpecifier<'_>, ignore_alias: bool) -> CompactSt
     }
 }
 
-fn matches_regex(value: &str, option: &Value) -> bool {
+pub(crate) fn matches_regex(value: &str, option: &Value) -> bool {
     match option {
         Value::Array(options) => options.iter().any(|option| matches_regex(value, option)),
         Value::String(pattern) => matches_single_regex(value, pattern, ""),
@@ -2811,7 +2855,7 @@ fn empty_lines_between(source_text: &str, left: u32, right: u32) -> usize {
         .map_or(0, |between| between.matches('\n').count().saturating_sub(1))
 }
 
-fn is_same_line(source_text: &str, left: u32, right: u32) -> bool {
+pub(crate) fn is_same_line(source_text: &str, left: u32, right: u32) -> bool {
     let Ok(left) = usize::try_from(left) else {
         return false;
     };

--- a/crates/perfectionist/src/tests.rs
+++ b/crates/perfectionist/src/tests.rs
@@ -79,6 +79,210 @@ fn configured_import_declarations(
     scan_perfectionist_rule(source, "fixture.ts", "sort-imports", &options)
 }
 
+fn configured_array_includes(
+    source: &str,
+    options: serde_json::Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    scan_perfectionist_rule(source, "fixture.ts", "sort-array-includes", &options)
+}
+
+#[test]
+fn sorts_array_includes_with_exact_data_and_fix() {
+    let diagnostics = configured_array_includes("['b', 'a'].includes(value)", json!([]));
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedArrayIncludesOrder");
+    assert_eq!(diagnostics[0].data.left, "b");
+    assert_eq!(diagnostics[0].data.right, "a");
+    assert_eq!(diagnostics[0].fix.start, 1);
+    assert_eq!(diagnostics[0].fix.end, 9);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'b'");
+}
+
+#[test]
+fn sorts_array_constructor_arguments_only_for_includes_calls() {
+    let diagnostics = configured_array_includes(
+        "new Array('bb', 'a').includes(value)",
+        json!([{ "type": "line-length", "order": "asc" }]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'bb'");
+
+    for source in [
+        "new NotAnArray('b', 'a').includes(value)",
+        "new Array[0]('b', 'a').includes(value)",
+        "['b', 'a'].includes",
+        "someFunction(['b', 'a'].includes)",
+        "['b', 'a']['includes'](value)",
+        "['b', 'a'].map(value)",
+    ] {
+        assert!(
+            configured_array_includes(source, json!([])).is_empty(),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn treats_spreads_and_elisions_as_array_partition_boundaries() {
+    assert!(
+        configured_array_includes("['a', 'b', ...spread, 'c', 'd'].includes(value)", json!([]))
+            .is_empty()
+    );
+    assert!(
+        configured_array_includes("['a', 'b',, 'c', 'd'].includes(value)", json!([])).is_empty()
+    );
+
+    let diagnostics =
+        configured_array_includes("['b', 'a', ...spread, 'd', 'c'].includes(value)", json!([]));
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'b'");
+    assert_eq!(diagnostics[1].fix.replacement, "'c', 'd'");
+}
+
+#[test]
+fn applies_array_custom_groups_and_newline_policies() {
+    let diagnostics = configured_array_includes(
+        "['b',\n'a'].includes(value)",
+        json!([{
+            "customGroups": [{ "groupName": "a", "elementNamePattern": "^a$" }],
+            "groups": ["a", "literal"],
+            "newlinesBetween": 1
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].message_id,
+        "unexpectedArrayIncludesGroupOrder"
+    );
+    assert_eq!(diagnostics[0].data.left_group.as_deref(), Some("literal"));
+    assert_eq!(diagnostics[0].data.right_group.as_deref(), Some("a"));
+
+    let spacing = configured_array_includes(
+        "['a',\n'b'].includes(value)",
+        json!([{
+            "customGroups": [{ "groupName": "a", "elementNamePattern": "^a$" }],
+            "groups": ["a", "literal"],
+            "newlinesBetween": 1
+        }]),
+    );
+    assert_eq!(spacing.len(), 1);
+    assert_eq!(
+        spacing[0].message_id,
+        "missedSpacingBetweenArrayIncludesMembers"
+    );
+}
+
+#[test]
+fn selects_first_matching_array_conditional_configuration() {
+    let diagnostics = configured_array_includes(
+        "[b, a].includes(value)",
+        json!([
+            {
+                "type": "unsorted",
+                "useConfigurationIf": {
+                    "matchesAstSelector": "ArrayExpression",
+                    "allNamesMatchPattern": "^[bc]$"
+                }
+            },
+            {
+                "type": "alphabetical",
+                "useConfigurationIf": { "matchesAstSelector": "* > ArrayExpression" }
+            },
+            { "type": "unsorted" }
+        ]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].fix.replacement, "a, b");
+
+    assert!(
+        configured_array_includes(
+            "[b, a].includes(value)",
+            json!([{
+                "type": "unsorted",
+                "useConfigurationIf": { "matchesAstSelector": "ArrayExpression" }
+            }])
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn preserves_array_comments_and_partition_directives() {
+    let diagnostics = configured_array_includes(
+        "[\n  'b',\n  'a', // Comment after\n\n  'c'\n].includes(value)",
+        json!([{
+            "customGroups": [{ "groupName": "bc", "elementNamePattern": "b|c" }],
+            "groups": ["literal", "bc"],
+            "newlinesBetween": 1,
+            "newlinesInside": 0
+        }]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "'a', // Comment after\n  'b',"
+    );
+
+    assert!(
+        configured_array_includes(
+            "['b',\n// Part\n'a'].includes(value)",
+            json!([{ "partitionByComment": "^Part" }])
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn keeps_disabled_array_elements_fixed_in_place() {
+    let diagnostics = configured_array_includes(
+        "[\n  'c',\n  'b',\n  // eslint-disable-next-line perfectionist/sort-array-includes\n  'a',\n].includes(value)",
+        json!([]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].data.left, "c");
+    assert_eq!(diagnostics[0].data.right, "b");
+    assert_eq!(diagnostics[0].fix.replacement, "'b',\n  'c'");
+}
+
+#[test]
+fn keeps_utf16_offsets_for_unicode_array_fixes() {
+    let source = "'😀';\r\n['世界', 'api'].includes(value);";
+    let diagnostics = configured_array_includes(
+        source,
+        json!([{
+            "customGroups": [{ "groupName": "api", "elementNamePattern": "^api$" }],
+            "groups": ["api", "unknown"],
+            "locales": "zh-CN"
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].message_id,
+        "unexpectedArrayIncludesGroupOrder"
+    );
+    assert_eq!(diagnostics[0].fix.start, 8);
+    assert_eq!(diagnostics[0].fix.end, 19);
+    assert_eq!(diagnostics[0].fix.replacement, "'api', '世界'");
+}
+
+#[test]
+fn array_rule_isolated_and_malformed_sources_fail_closed() {
+    assert!(
+        scan_perfectionist_rule(
+            "['b', 'a'].includes(value)",
+            "fixture.ts",
+            "sort-named-imports",
+            &json!([])
+        )
+        .is_empty()
+    );
+    assert!(configured_array_includes("['b',", json!([])).is_empty());
+    assert!(configured_array_includes("['a', 'b'].includes(value)", json!("bad")).is_empty());
+}
+
 #[test]
 fn sorts_predefined_type_and_value_groups() {
     let diagnostics = configured(

--- a/npm/perfectionist/README.md
+++ b/npm/perfectionist/README.md
@@ -5,3 +5,19 @@ Rust-backed Oxlint plugin port of `eslint-plugin-perfectionist`.
 The JavaScript layer is an Oxlint/NAPI adapter. Representative sorting checks
 for imports, exports, object members, types, JSX props, collections, modules,
 and declarations run in Rust through Oxc.
+
+## `sort-array-includes`
+
+The rule implements the `eslint-plugin-perfectionist` v5.10.0 option contract
+for array literals and `new Array(...)` expressions immediately followed by a
+non-computed `.includes(...)` call.
+
+Supported options include alphabetical, natural, line-length, custom,
+subgroup, and unsorted ordering; fallback sorts; locale, case, special
+character, and custom alphabet handling; groups and custom groups; comment and
+newline partitions; spacing policies; conditional configuration; and shared
+`settings.perfectionist` defaults. Fixes preserve comments, sparse-array and
+spread boundaries, UTF-16 offsets, and CRLF text.
+
+React-specific behavior and JSX/TSX syntax are intentionally outside this
+rule's port.

--- a/npm/perfectionist/api.d.ts
+++ b/npm/perfectionist/api.d.ts
@@ -10,10 +10,12 @@ export type PerfectionistDiagnostic = {
   messageId: string;
   loc: PerfectionistDiagnosticLoc;
   data?: {
-    left: string;
+    left?: string;
     right: string;
     leftGroup?: string;
     rightGroup?: string;
+    missedCommentAbove?: string;
+    nodeDependentOnRight?: string;
   };
   fix?: {
     start: number;

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -16,6 +16,7 @@ const DOCS_BASE = 'https://perfectionist.dev/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedPerfectionistRuleNames());
 const configuredRuleNames = new Set([
+  'sort-array-includes',
   'sort-exports',
   'sort-imports',
   'sort-named-exports',
@@ -86,7 +87,7 @@ function recommendedRules(options) {
 function createPerfectionistRule(ruleName) {
   return {
     meta: {
-      type: 'layout',
+      type: ruleName === 'sort-array-includes' ? 'suggestion' : 'layout',
       docs: {
         description: `enforce sorted ${ruleName.replace(/^sort-/, '').replaceAll('-', ' ')}`,
         category: 'Stylistic Issues',
@@ -95,47 +96,58 @@ function createPerfectionistRule(ruleName) {
       },
       fixable: 'code',
       messages: configuredRuleNames.has(ruleName)
-        ? ruleName === 'sort-imports'
+        ? ruleName === 'sort-array-includes'
           ? {
-              unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-              unexpectedImportsGroupOrder:
+              unexpectedArrayIncludesOrder: 'Expected "{{right}}" to come before "{{left}}".',
+              unexpectedArrayIncludesGroupOrder:
                 'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-              unexpectedImportsDependencyOrder:
-                'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-              extraSpacingBetweenImports: 'Extra spacing between "{{left}}" and "{{right}}".',
-              missedSpacingBetweenImports: 'Missed spacing between "{{left}}" and "{{right}}".',
-              missedCommentAboveImport:
-                'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
+              extraSpacingBetweenArrayIncludesMembers:
+                'Extra spacing between "{{left}}" and "{{right}}".',
+              missedSpacingBetweenArrayIncludesMembers:
+                'Missed spacing between "{{left}}" and "{{right}}".',
             }
-          : ruleName === 'sort-named-imports'
+          : ruleName === 'sort-imports'
             ? {
-                unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                unexpectedNamedImportsGroupOrder:
+                unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                unexpectedImportsGroupOrder:
                   'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                extraSpacingBetweenNamedImports:
-                  'Extra spacing between "{{left}}" and "{{right}}".',
-                missedSpacingBetweenNamedImports:
-                  'Missed spacing between "{{left}}" and "{{right}}".',
+                unexpectedImportsDependencyOrder:
+                  'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
+                extraSpacingBetweenImports: 'Extra spacing between "{{left}}" and "{{right}}".',
+                missedSpacingBetweenImports: 'Missed spacing between "{{left}}" and "{{right}}".',
+                missedCommentAboveImport:
+                  'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
               }
-            : ruleName === 'sort-named-exports'
+            : ruleName === 'sort-named-imports'
               ? {
-                  unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                  unexpectedNamedExportsGroupOrder:
+                  unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                  unexpectedNamedImportsGroupOrder:
                     'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                  extraSpacingBetweenNamedExports:
+                  extraSpacingBetweenNamedImports:
                     'Extra spacing between "{{left}}" and "{{right}}".',
-                  missedSpacingBetweenNamedExports:
+                  missedSpacingBetweenNamedImports:
                     'Missed spacing between "{{left}}" and "{{right}}".',
                 }
-              : {
-                  unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                  unexpectedExportsGroupOrder:
-                    'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                  extraSpacingBetweenExports: 'Extra spacing between "{{left}}" and "{{right}}".',
-                  missedSpacingBetweenExports: 'Missed spacing between "{{left}}" and "{{right}}".',
-                  missedCommentAboveExport:
-                    'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
-                }
+              : ruleName === 'sort-named-exports'
+                ? {
+                    unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                    unexpectedNamedExportsGroupOrder:
+                      'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                    extraSpacingBetweenNamedExports:
+                      'Extra spacing between "{{left}}" and "{{right}}".',
+                    missedSpacingBetweenNamedExports:
+                      'Missed spacing between "{{left}}" and "{{right}}".',
+                  }
+                : {
+                    unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                    unexpectedExportsGroupOrder:
+                      'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                    extraSpacingBetweenExports: 'Extra spacing between "{{left}}" and "{{right}}".',
+                    missedSpacingBetweenExports:
+                      'Missed spacing between "{{left}}" and "{{right}}".',
+                    missedCommentAboveExport:
+                      'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
+                  }
         : {
             unexpected: 'Expected sorted order.',
           },
@@ -165,14 +177,22 @@ function configuredDiagnosticsForRule(context, ruleName) {
   const sourceText = sourceTextForContext(context);
   const filename = typeof context.filename === 'string' ? context.filename : 'file.tsx';
   let options = Array.isArray(context.options) ? context.options : [];
-  if (ruleName === 'sort-exports' || ruleName === 'sort-imports') {
+  if (
+    ruleName === 'sort-array-includes' ||
+    ruleName === 'sort-exports' ||
+    ruleName === 'sort-imports'
+  ) {
     const settings = context.settings?.perfectionist;
     if (settings && typeof settings === 'object' && !Array.isArray(settings)) {
-      const configured =
-        options[0] && typeof options[0] === 'object' && !Array.isArray(options[0])
-          ? options[0]
-          : {};
-      options = [{ ...settings, ...configured }];
+      options =
+        options.length === 0
+          ? [{ ...settings }]
+          : options.map((configured) => ({
+              ...settings,
+              ...(configured && typeof configured === 'object' && !Array.isArray(configured)
+                ? configured
+                : {}),
+            }));
     }
   }
   const key = JSON.stringify({ filename, options, ruleName, sourceText });
@@ -242,7 +262,9 @@ function schemaForRule(ruleName) {
   if (!configuredRuleNames.has(ruleName)) {
     return [];
   }
-  const selector = ruleName === 'sort-named-imports' ? 'import' : 'export';
+  const sortsArrayIncludes = ruleName === 'sort-array-includes';
+  const selector =
+    ruleName === 'sort-named-imports' ? 'import' : sortsArrayIncludes ? 'literal' : 'export';
   const sortsExportDeclarations = ruleName === 'sort-exports';
   const sortsImportDeclarations = ruleName === 'sort-imports';
   const sortType = {
@@ -313,28 +335,32 @@ function schemaForRule(ruleName) {
   };
   const customMatch = {
     elementNamePattern: regex,
-    modifiers: {
-      type: 'array',
-      items: {
-        type: 'string',
-        enum: sortsImportDeclarations
-          ? [
-              'default',
-              'multiline',
-              'named',
-              'require',
-              'side-effect',
-              'singleline',
-              'ts-equals',
-              'type',
-              'value',
-              'wildcard',
-            ]
-          : sortsExportDeclarations
-            ? ['value', 'type', 'named', 'wildcard', 'singleline', 'multiline']
-            : ['value', 'type'],
-      },
-    },
+    ...(sortsArrayIncludes
+      ? {}
+      : {
+          modifiers: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: sortsImportDeclarations
+                ? [
+                    'default',
+                    'multiline',
+                    'named',
+                    'require',
+                    'side-effect',
+                    'singleline',
+                    'ts-equals',
+                    'type',
+                    'value',
+                    'wildcard',
+                  ]
+                : sortsExportDeclarations
+                  ? ['value', 'type', 'named', 'wildcard', 'singleline', 'multiline']
+                  : ['value', 'type'],
+            },
+          },
+        }),
     selector: {
       type: 'string',
       enum: sortsImportDeclarations
@@ -449,72 +475,77 @@ function schemaForRule(ruleName) {
       },
     ],
   };
-  return [
-    {
-      type: 'object',
-      properties: {
-        type: sortType,
-        order,
-        ignoreCase: { type: 'boolean' },
-        specialCharacters: {
-          type: 'string',
-          enum: ['keep', 'trim', 'remove'],
-        },
-        locales: {
-          oneOf: [
-            { type: 'string' },
-            {
-              type: 'array',
-              items: { type: 'string' },
+  const optionSchema = {
+    type: 'object',
+    properties: {
+      type: sortType,
+      order,
+      ignoreCase: { type: 'boolean' },
+      specialCharacters: {
+        type: 'string',
+        enum: ['keep', 'trim', 'remove'],
+      },
+      locales: {
+        oneOf: [
+          { type: 'string' },
+          {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        ],
+      },
+      alphabet: { type: 'string' },
+      fallbackSort,
+      ...(!sortsArrayIncludes && !sortsExportDeclarations && !sortsImportDeclarations
+        ? { ignoreAlias: { type: 'boolean' } }
+        : {}),
+      groups,
+      customGroups,
+      partitionByComment,
+      partitionByNewLine: { type: 'boolean' },
+      newlinesBetween: newlines,
+      newlinesInside,
+      ...(sortsImportDeclarations
+        ? {
+            sortBy: { type: 'string', enum: ['specifier', 'path'] },
+            internalPattern: regex,
+            environment: { type: 'string', enum: ['node', 'bun'] },
+            sortSideEffects: { type: 'boolean' },
+            maxLineLength: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+            useExperimentalDependencyDetection: { type: 'boolean' },
+            tsconfig: {
+              type: 'object',
+              properties: {
+                rootDir: { type: 'string' },
+                filename: { type: 'string' },
+              },
+              required: ['rootDir'],
+              additionalProperties: false,
             },
-          ],
-        },
-        alphabet: { type: 'string' },
-        fallbackSort,
-        ...(!sortsExportDeclarations && !sortsImportDeclarations
-          ? { ignoreAlias: { type: 'boolean' } }
-          : {}),
-        groups,
-        customGroups,
-        partitionByComment,
-        partitionByNewLine: { type: 'boolean' },
-        newlinesBetween: newlines,
-        newlinesInside,
-        ...(sortsImportDeclarations
-          ? {
-              sortBy: { type: 'string', enum: ['specifier', 'path'] },
-              internalPattern: regex,
-              environment: { type: 'string', enum: ['node', 'bun'] },
-              sortSideEffects: { type: 'boolean' },
-              maxLineLength: { type: 'integer', minimum: 0, exclusiveMinimum: true },
-              useExperimentalDependencyDetection: { type: 'boolean' },
-              tsconfig: {
+          }
+        : sortsExportDeclarations
+          ? {}
+          : {
+              useConfigurationIf: {
                 type: 'object',
                 properties: {
-                  rootDir: { type: 'string' },
-                  filename: { type: 'string' },
+                  allNamesMatchPattern: regex,
+                  matchesAstSelector: { type: 'string' },
                 },
-                required: ['rootDir'],
+                ...(sortsArrayIncludes ? {} : { minProperties: 1 }),
                 additionalProperties: false,
               },
-            }
-          : sortsExportDeclarations
-            ? {}
-            : {
-                useConfigurationIf: {
-                  type: 'object',
-                  properties: {
-                    allNamesMatchPattern: regex,
-                    matchesAstSelector: { type: 'string' },
-                  },
-                  minProperties: 1,
-                  additionalProperties: false,
-                },
-              }),
-      },
-      additionalProperties: false,
+            }),
     },
-  ];
+    additionalProperties: false,
+  };
+  return sortsArrayIncludes
+    ? {
+        items: optionSchema,
+        uniqueItems: true,
+        type: 'array',
+      }
+    : [optionSchema];
 }
 
 function sourceTextForContext(context) {

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -117,6 +117,39 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact array-includes groups, CRLF locations, and UTF-16 fixes', () => {
+    const source = `'😀';\r\n['世界', 'api'].includes(value);`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-array-includes', [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        locales: 'zh-CN',
+      },
+    ]);
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-array-includes',
+      messageId: 'unexpectedArrayIncludesGroupOrder',
+      data: {
+        left: '世界',
+        right: 'api',
+        leftGroup: 'unknown',
+        rightGroup: 'api',
+      },
+      loc: {
+        startLine: 2,
+        startColumn: 7,
+        endLine: 2,
+        endColumn: 12,
+      },
+      fix: {
+        start: 8,
+        end: 19,
+        replacement: `'api', '世界'`,
+      },
+    });
+  });
+
   it('returns exact named-export data and UTF-16 fix offsets', () => {
     const source = `'😀';\r\nexport { item2, item10 } from "pkg";\r\n`;
     const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-named-exports', [

--- a/npm/perfectionist/test/fixtures/sort-array-includes-options-v5.10.0.json
+++ b/npm/perfectionist/test/fixtures/sort-array-includes-options-v5.10.0.json
@@ -1,0 +1,9095 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-perfectionist",
+    "version": "5.10.0",
+    "sourceCommit": "84aa039c46522f82a61ad43cf676afc92dd64704",
+    "sourceHashes": {
+      "rules/sort-array-includes.ts": "3f43cb92d44f5cd60de7ec9de9b4b72be936d3f1bf410d21e325bf18400788b9",
+      "rules/sort-array-includes/types.ts": "927bfce114499a6e224415245e952a6eaa43c052dfd78b827bd7d8d085e7a098",
+      "rules/sort-arrays/types.ts": "9aa7faafdb1f2262aa32798623ebd6507b5a80f2ad6fa66446d66bb722bba582",
+      "rules/sort-arrays/sort-array.ts": "c65199dd2f5b56ae5302368f3e4fda46849f98641415bd77cf8d56a36ab0d60a",
+      "test/rules/sort-array-includes.test.ts": "c6f8a4dea072ce3d1fc2af72430e7247551bd81870077bde12d5ad7bbb67e534"
+    },
+    "license": "MIT",
+    "eslintVersion": "10.6.0",
+    "typescriptEslintParserVersion": "8.62.1",
+    "capturePolicy": "Every authored valid and invalid sort-array-includes case is captured; React-specific and JSX/TSX syntax is rejected. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.10.0 rule for exact diagnostics and fixes.",
+    "authoredCases": "upstream/eslint-plugin-perfectionist/test/rules/sort-array-includes.test.ts@v5.10.0",
+    "tool": "sync-perfectionist-sort-array-includes-options-tests.ts",
+    "inventory": {
+      "valid": 91,
+      "invalid": 142,
+      "diagnostics": 194,
+      "total": 233
+    }
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > oxlint > supports oxlint > valid",
+      "code": "[\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > misc > oxlint > supports oxlint > invalid",
+      "code": "[\n  'b',\n  'a',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > ignores invalid array includes expressions",
+      "code": "new Array[0]([\n  b,\n  a,\n]).includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > ignores invalid array includes expressions",
+      "code": "new NotAnArray(\n  b,\n  a,\n).includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > ignores invalid array includes expressions",
+      "code": "[\n  b,\n  a,\n].includes",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > ignores invalid array includes expressions",
+      "code": "someFunction([\n  b,\n  a,\n].includes)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > accepts sorted arrays in includes() calls",
+      "code": "['aaa', 'bb', 'c'].includes('aaa')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > reports error when array in includes() is not sorted",
+      "code": "['bb', 'c', 'aaa'].includes('aaa')",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aaa\" to come before \"c\".",
+          "data": {
+            "right": "aaa",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [1, 17],
+            "text": "'aaa', 'bb', 'c'"
+          }
+        }
+      ],
+      "output": "['aaa', 'bb', 'c'].includes('aaa')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > preserves array structure when fixing sort order",
+      "code": "[\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > preserves array structure when fixing sort order",
+      "code": "[\n  'a',\n  'c',\n  'b',\n  'd',\n  'e',\n  ...other,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [11, 21],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > does not sort spread elements",
+      "code": "[\n  ...aaa,\n  ...ccc,\n  ...bbbb,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > treats spread elements as partition boundaries",
+      "code": "[\n  'a',\n  'b',\n  ...spread1,\n  'd',\n  'e',\n  ...spread2,\n  'g',\n  'h',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > treats spread elements as partition boundaries",
+      "code": "[\n  'b',\n  'a',\n  ...spread,\n  'c',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n  ...spread,\n  'c',\n  'd',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > handles arrays with empty slots correctly",
+      "code": "['a', 'b', 'c',, 'd'].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > handles arrays with empty slots correctly",
+      "code": "['b', 'a', 'c',, 'd'].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 7,
+            "endLine": 1,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [1, 9],
+            "text": "'a', 'b'"
+          }
+        }
+      ],
+      "output": "['a', 'b', 'c',, 'd'].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > sorts elements in Array constructor calls",
+      "code": "new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n).includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > sorts elements in Array constructor calls",
+      "code": "new Array(\n  'a',\n  'c',\n  'b',\n  'd',\n).includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [20, 30],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n).includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > sorts elements within newline-separated groups independently",
+      "code": "[\n  'd',\n  'a',\n\n  'c',\n\n  'e',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"d\".",
+          "data": {
+            "right": "a",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 37],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"e\".",
+          "data": {
+            "right": "b",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 37],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > treats each newline-separated section as independent partition",
+      "code": "[\n  'c',\n  'top2',\n\n  'a',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "unknown"],
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 35],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 35],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'c',\n\n  'top1',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > applies grouping rules within each partition separately",
+      "code": "[\n  'a',\n  'b',\n\n  'c',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > creates partitions based on matching comments",
+      "code": "[\n  // Part: A\n  'cc',\n  'd',\n  // Not partition comment\n  'bbb',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  'gg',\n  // Not partition comment\n  'fff',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbb\" to come before \"d\".",
+          "data": {
+            "right": "bbb",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [17, 151],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"fff\" to come before \"gg\".",
+          "data": {
+            "right": "fff",
+            "left": "gg"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 3,
+            "endLine": 13,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [17, 151],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        }
+      ],
+      "output": "[\n  // Part: A\n  // Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > treats every comment as partition boundary when set to true",
+      "code": "[\n  // Comment\n  'bb',\n  // Other comment\n  'a',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > supports multiple partition comment patterns",
+      "code": "[\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'c',\n  'bb',\n  /* Other */\n  'e',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [72, 83],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'bb',\n  'c',\n  /* Other */\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > applies grouping within comment-defined partitions",
+      "code": "[\n  'c',\n  'top2',\n  // Part: 1\n  'a',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "partitionByComment": "^Part:",
+          "groups": ["top", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > ignores block comments when line comments are specified",
+      "code": "[\n  'b',\n  /* Comment */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 30],
+            "text": "/* Comment */\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  /* Comment */\n  'a',\n  'b'\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > uses line comments as partition boundaries",
+      "code": "[\n  'b',\n  // Comment\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > matches specific line comment patterns",
+      "code": "[\n  'c',\n  // b\n  'b',\n  // a\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > supports regex patterns for line comments",
+      "code": "[\n  'b',\n  // I am a partition comment because I don't have f o o\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > ignores line comments when block comments are specified",
+      "code": "[\n  'b',\n  // Comment\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 27],
+            "text": "// Comment\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  // Comment\n  'a',\n  'b'\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > uses block comments as partition boundaries",
+      "code": "[\n  'b',\n  /* Comment */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > matches specific block comment patterns",
+      "code": "[\n  'c',\n  /* b */\n  'b',\n  /* a */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > supports regex patterns for block comments",
+      "code": "[\n  'b',\n  /* I am a partition comment because I don't have f o o */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > supports regex patterns for partition comments",
+      "code": "[\n  'e',\n  'f',\n  // I am a partition comment because I don't have f o o\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > ignores special characters at start when trimming",
+      "code": "[\n  '$a',\n  'b',\n  '$c',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > ignores special characters completely when removing",
+      "code": "[\n  'ab',\n  'a$c',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > sorts elements according to locale-specific rules",
+      "code": "[\n  '你好',\n  '世界',\n  'a',\n  'A',\n  'b',\n  'B'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > sorts single-line arrays correctly",
+      "code": "[\n  b, a\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 8],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "[\n  a, b\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > handles trailing commas in single-line arrays",
+      "code": "[\n  b, a,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 8],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "[\n  a, b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > allows overriding options in groups",
+      "code": "[\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "groups": [
+            {
+              "type": "alphabetical",
+              "newlinesInside": 1,
+              "group": "unknown",
+              "order": "desc"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'b',\n\n  'a'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'b',\n\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'b',\n\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > enforces custom group ordering",
+      "code": "[\n  'c',\n  'top1',\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "literal"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"c\" (literal).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "literal"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 24],
+            "text": "'top1',\n  'a',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'top1',\n  'a',\n  'c'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > applies custom groups based on element selectors",
+      "code": "[\n  'b',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "topElements"
+            }
+          ],
+          "groups": ["topElements", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (topElements) to come before \"b\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "topElements",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 17],
+            "text": "'top1',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'top1',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > groups elements by name pattern - string pattern",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > groups elements by name pattern - array of patterns",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > groups elements by name pattern - case-insensitive regex",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > groups elements by name pattern - regex in array",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > overrides sort type and order for specific groups",
+      "code": "[\n  'a',\n  'bb',\n  'ccc',\n  'dddd',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedLiteralsByLineLength",
+              "selector": "literal",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedLiteralsByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'dddd',\n  'ccc',\n  'bb',\n  'a',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > applies fallback sort when primary sort results in tie",
+      "code": "[\n  'fooZar',\n  'fooBar',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 11
+          },
+          "fix": {
+            "range": [4, 24],
+            "text": "'fooBar',\n  'fooZar'"
+          }
+        }
+      ],
+      "output": "[\n  'fooBar',\n  'fooZar',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > preserves original order for unsorted groups",
+      "code": "[\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'm',\n  'top3',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "unsortedTop",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedTop", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top3\" (unsortedTop) to come before \"m\" (unknown).",
+          "data": {
+            "right": "top3",
+            "rightGroup": "unsortedTop",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [44, 57],
+            "text": "'top3',\n  'm'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'top3',\n  'm',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > combines multiple selectors with anyOf",
+      "code": "[\n  'a',\n  'bFoo',\n  'cFoo',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo"
+                },
+                {
+                  "elementNamePattern": "Foo"
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"bFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "bFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 27],
+            "text": "'bFoo',\n  'cFoo',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'bFoo',\n  'cFoo',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > supports negative regex patterns in custom groups",
+      "code": "[\n  'iHaveFooInMyName',\n  'meTooIHaveFoo',\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - string pattern",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "foo"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - array of patterns",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": ["noMatch", "foo"]
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - case-insensitive regex",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "FOO",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - regex in array",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": [
+              "noMatch",
+              {
+                "pattern": "foo",
+                "flags": "i"
+              }
+            ]
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > skips config when selector does not match the sorted node type",
+      "code": "const array = [\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "VariableDeclarator"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [18, 24],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "const array = [\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > applies config when selector matches the sorted node type",
+      "code": "[\n  b,\n  a,\n]",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > applies config when selector matches the sorted node type",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > falls through to next matching config when not matching",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ArrayExpression",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [4, 10],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > falls through to next matching config when not matching",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [4, 10],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > falls through to next matching config when not matching",
+      "code": "const a = [\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[ab]$"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [14, 20],
+            "text": "b,\n  a"
+          }
+        }
+      ],
+      "output": "const a = [\n  b,\n  a,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > applies first matching option when selectors overlap",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > applies first matching option when selectors overlap",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [4, 10],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > useConfigurationIf.matchesAstSelector > picks the first matching option when multiple options match",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        },
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [4, 10],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines between and inside groups by default when \"newlinesBetween\" is 0",
+      "code": "[\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n    'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n    'z'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n 'b',\n'y',\n    'z'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines inside groups when newlinesInside is 0",
+      "code": "[\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 30],
+            "text": "'b',\n'y',\n    'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 30],
+            "text": "'b',\n'y',\n    'z'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n\n 'b',\n'y',\n    'z'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines between groups when newlinesBetween is 0",
+      "code": "[\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n 'b',\n'y',\n\n    'z'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > adds newlines between multiple groups",
+      "code": "[\n  'a',\n\n\n 'z',\n'y',\n    'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": ["a", "unknown", "b"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"z\".",
+          "data": {
+            "left": "a",
+            "right": "z"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [7, 26],
+            "text": ",\n\n 'y',\n'z',\n\n    "
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"y\" to come before \"z\".",
+          "data": {
+            "right": "y",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [7, 26],
+            "text": ",\n\n 'y',\n'z',\n\n    "
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"y\" and \"b\".",
+          "data": {
+            "left": "y",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [7, 26],
+            "text": ",\n\n 'y',\n'z',\n\n    "
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n 'y',\n'z',\n\n    'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > applies inline newline settings between specific groups",
+      "code": "[\n  'a',\n  'b',\n\n\n  'c',\n\n  'd',\n\n\n  'e'\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n  'b',\n\n  'c',\n  'd',\n\n\n  'e'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > enforces 2 newlines when global is 2 and group is 0",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > enforces 2 newlines when global is 2 and group is ignore",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > enforces 2 newlines when global is 0 and group is 2",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > enforces 2 newlines when global is ignore and group is 2",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines when 0 overrides global 1 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines when 0 overrides global 2 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines when 0 overrides global ignore between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > removes newlines when 0 overrides global 0 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > accepts any spacing when global is ignore and group is 0",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > accepts any spacing when global is ignore and group is 0",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > accepts any spacing when global is 0 and group is ignore",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > alphabetical > accepts any spacing when global is 0 and group is ignore",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > preserves inline comments when reordering elements",
+      "code": "[\n  'b',\n  'a', // Comment after\n\n  'c'\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "b|c",
+              "groupName": "b|c"
+            }
+          ],
+          "groups": ["unknown", "b|c"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"a\" (unknown) to come before \"b\" (b|c).",
+          "data": {
+            "right": "a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "b|c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'a', // Comment after\n  'b',"
+          }
+        }
+      ],
+      "output": "[\n  'a', // Comment after\n\n  'b',\n  'c'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > alphabetical > preserves partition boundaries regardless of newlinesBetween 0",
+      "code": "[\n  'a',\n\n  // Partition comment\n\n  'c',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [36, 46],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n  // Partition comment\n\n  'b',\n  'c',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > accepts sorted arrays in includes() calls",
+      "code": "['aaa', 'bb', 'c'].includes('aaa')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > reports error when array in includes() is not sorted",
+      "code": "['bb', 'c', 'aaa'].includes('aaa')",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aaa\" to come before \"c\".",
+          "data": {
+            "right": "aaa",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [1, 17],
+            "text": "'aaa', 'bb', 'c'"
+          }
+        }
+      ],
+      "output": "['aaa', 'bb', 'c'].includes('aaa')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > preserves array structure when fixing sort order",
+      "code": "[\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > preserves array structure when fixing sort order",
+      "code": "[\n  'a',\n  'c',\n  'b',\n  'd',\n  'e',\n  ...other,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [11, 21],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > does not sort spread elements",
+      "code": "[\n  ...aaa,\n  ...ccc,\n  ...bbbb,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > treats spread elements as partition boundaries",
+      "code": "[\n  'a',\n  'b',\n  ...spread1,\n  'd',\n  'e',\n  ...spread2,\n  'g',\n  'h',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > treats spread elements as partition boundaries",
+      "code": "[\n  'b',\n  'a',\n  ...spread,\n  'c',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n  ...spread,\n  'c',\n  'd',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > handles arrays with empty slots correctly",
+      "code": "['a', 'b', 'c',, 'd'].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > handles arrays with empty slots correctly",
+      "code": "['b', 'a', 'c',, 'd'].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 7,
+            "endLine": 1,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [1, 9],
+            "text": "'a', 'b'"
+          }
+        }
+      ],
+      "output": "['a', 'b', 'c',, 'd'].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > sorts elements in Array constructor calls",
+      "code": "new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n).includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > sorts elements in Array constructor calls",
+      "code": "new Array(\n  'a',\n  'c',\n  'b',\n  'd',\n).includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [20, 30],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n).includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > sorts elements within newline-separated groups independently",
+      "code": "[\n  'd',\n  'a',\n\n  'c',\n\n  'e',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"d\".",
+          "data": {
+            "right": "a",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 37],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"e\".",
+          "data": {
+            "right": "b",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 37],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > treats each newline-separated section as independent partition",
+      "code": "[\n  'c',\n  'top2',\n\n  'a',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "unknown"],
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 35],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 35],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'c',\n\n  'top1',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > applies grouping rules within each partition separately",
+      "code": "[\n  'a',\n  'b',\n\n  'c',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > creates partitions based on matching comments",
+      "code": "[\n  // Part: A\n  'cc',\n  'd',\n  // Not partition comment\n  'bbb',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  'gg',\n  // Not partition comment\n  'fff',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbb\" to come before \"d\".",
+          "data": {
+            "right": "bbb",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [17, 151],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"fff\" to come before \"gg\".",
+          "data": {
+            "right": "fff",
+            "left": "gg"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 3,
+            "endLine": 13,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [17, 151],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        }
+      ],
+      "output": "[\n  // Part: A\n  // Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > treats every comment as partition boundary when set to true",
+      "code": "[\n  // Comment\n  'bb',\n  // Other comment\n  'a',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > supports multiple partition comment patterns",
+      "code": "[\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'c',\n  'bb',\n  /* Other */\n  'e',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [72, 83],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'bb',\n  'c',\n  /* Other */\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > applies grouping within comment-defined partitions",
+      "code": "[\n  'c',\n  'top2',\n  // Part: 1\n  'a',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "partitionByComment": "^Part:",
+          "groups": ["top", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > ignores block comments when line comments are specified",
+      "code": "[\n  'b',\n  /* Comment */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 30],
+            "text": "/* Comment */\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  /* Comment */\n  'a',\n  'b'\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > uses line comments as partition boundaries",
+      "code": "[\n  'b',\n  // Comment\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > matches specific line comment patterns",
+      "code": "[\n  'c',\n  // b\n  'b',\n  // a\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > supports regex patterns for line comments",
+      "code": "[\n  'b',\n  // I am a partition comment because I don't have f o o\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "line": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > ignores line comments when block comments are specified",
+      "code": "[\n  'b',\n  // Comment\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 27],
+            "text": "// Comment\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  // Comment\n  'a',\n  'b'\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > uses block comments as partition boundaries",
+      "code": "[\n  'b',\n  /* Comment */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > matches specific block comment patterns",
+      "code": "[\n  'c',\n  /* b */\n  'b',\n  /* a */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > supports regex patterns for block comments",
+      "code": "[\n  'b',\n  /* I am a partition comment because I don't have f o o */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > supports regex patterns for partition comments",
+      "code": "[\n  'e',\n  'f',\n  // I am a partition comment because I don't have f o o\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > ignores special characters at start when trimming",
+      "code": "[\n  '$a',\n  'b',\n  '$c',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > ignores special characters completely when removing",
+      "code": "[\n  'ab',\n  'a$c',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > sorts elements according to locale-specific rules",
+      "code": "[\n  '你好',\n  '世界',\n  'a',\n  'A',\n  'b',\n  'B'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > sorts single-line arrays correctly",
+      "code": "[\n  b, a\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 8],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "[\n  a, b\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > handles trailing commas in single-line arrays",
+      "code": "[\n  b, a,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 8],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "[\n  a, b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > enforces custom group ordering",
+      "code": "[\n  'c',\n  'top1',\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "literal"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"c\" (literal).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "literal"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 24],
+            "text": "'top1',\n  'a',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'top1',\n  'a',\n  'c'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > applies custom groups based on element selectors",
+      "code": "[\n  'b',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "topElements"
+            }
+          ],
+          "groups": ["topElements", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (topElements) to come before \"b\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "topElements",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 17],
+            "text": "'top1',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'top1',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > groups elements by name pattern - string pattern",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > groups elements by name pattern - array of patterns",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > groups elements by name pattern - case-insensitive regex",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > groups elements by name pattern - regex in array",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > overrides sort type and order for specific groups",
+      "code": "[\n  'a',\n  'bb',\n  'ccc',\n  'dddd',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedLiteralsByLineLength",
+              "selector": "literal",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedLiteralsByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'dddd',\n  'ccc',\n  'bb',\n  'a',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > applies fallback sort when primary sort results in tie",
+      "code": "[\n  'fooZar',\n  'fooBar',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 11
+          },
+          "fix": {
+            "range": [4, 24],
+            "text": "'fooBar',\n  'fooZar'"
+          }
+        }
+      ],
+      "output": "[\n  'fooBar',\n  'fooZar',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > preserves original order for unsorted groups",
+      "code": "[\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'm',\n  'top3',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "unsortedTop",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedTop", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top3\" (unsortedTop) to come before \"m\" (unknown).",
+          "data": {
+            "right": "top3",
+            "rightGroup": "unsortedTop",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [44, 57],
+            "text": "'top3',\n  'm'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'top3',\n  'm',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > combines multiple selectors with anyOf",
+      "code": "[\n  'a',\n  'bFoo',\n  'cFoo',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo"
+                },
+                {
+                  "elementNamePattern": "Foo"
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"bFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "bFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 27],
+            "text": "'bFoo',\n  'cFoo',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'bFoo',\n  'cFoo',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > supports negative regex patterns in custom groups",
+      "code": "[\n  'iHaveFooInMyName',\n  'meTooIHaveFoo',\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - string pattern",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "foo"
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - array of patterns",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": ["noMatch", "foo"]
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - case-insensitive regex",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "FOO",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - regex in array",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": [
+              "noMatch",
+              {
+                "pattern": "foo",
+                "flags": "i"
+              }
+            ]
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > removes newlines between groups when newlinesBetween is 0",
+      "code": "[\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [7, 30],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n 'b',\n'y',\n\n    'z'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > adds newlines between multiple groups",
+      "code": "[\n  'a',\n\n\n 'z',\n'y',\n    'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": ["a", "unknown", "b"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"z\".",
+          "data": {
+            "left": "a",
+            "right": "z"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [7, 26],
+            "text": ",\n\n 'y',\n'z',\n\n    "
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"y\" to come before \"z\".",
+          "data": {
+            "right": "y",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [7, 26],
+            "text": ",\n\n 'y',\n'z',\n\n    "
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"y\" and \"b\".",
+          "data": {
+            "left": "y",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [7, 26],
+            "text": ",\n\n 'y',\n'z',\n\n    "
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n 'y',\n'z',\n\n    'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > applies inline newline settings between specific groups",
+      "code": "[\n  'a',\n  'b',\n\n\n  'c',\n\n  'd',\n\n\n  'e'\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n  'b',\n\n  'c',\n  'd',\n\n\n  'e'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > enforces 2 newlines when global is 2 and group is 0",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > enforces 2 newlines when global is 2 and group is ignore",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > enforces 2 newlines when global is 0 and group is 2",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > enforces 2 newlines when global is ignore and group is 2",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > removes newlines when 0 overrides global 1 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > removes newlines when 0 overrides global 2 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > removes newlines when 0 overrides global ignore between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > removes newlines when 0 overrides global 0 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > accepts any spacing when global is ignore and group is 0",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > accepts any spacing when global is ignore and group is 0",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > accepts any spacing when global is 0 and group is ignore",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > natural > accepts any spacing when global is 0 and group is ignore",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > preserves inline comments when reordering elements",
+      "code": "[\n  'b',\n  'a', // Comment after\n\n  'c'\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "b|c",
+              "groupName": "b|c"
+            }
+          ],
+          "groups": ["unknown", "b|c"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"a\" (unknown) to come before \"b\" (b|c).",
+          "data": {
+            "right": "a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "b|c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'a', // Comment after\n  'b',"
+          }
+        }
+      ],
+      "output": "[\n  'a', // Comment after\n\n  'b',\n  'c'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > natural > preserves partition boundaries regardless of newlinesBetween 0",
+      "code": "[\n  'a',\n\n  // Partition comment\n\n  'c',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [36, 46],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n  // Partition comment\n\n  'b',\n  'c',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > accepts sorted arrays in includes() calls",
+      "code": "['aaa', 'bb', 'c'].includes('aaa')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > reports error when array in includes() is not sorted",
+      "code": "['bb', 'c', 'aaa'].includes('aaa')",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aaa\" to come before \"c\".",
+          "data": {
+            "right": "aaa",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 13,
+            "endLine": 1,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [1, 17],
+            "text": "'aaa', 'bb', 'c'"
+          }
+        }
+      ],
+      "output": "['aaa', 'bb', 'c'].includes('aaa')"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > preserves array structure when fixing sort order",
+      "code": "[\n  'aaaaa',\n  'bbbb',\n  'ccc',\n  'dd',\n  'e',\n  ...other,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > preserves array structure when fixing sort order",
+      "code": "[\n  'aaaaa',\n  'ccc',\n  'bbbb',\n  'dd',\n  'e',\n  ...other,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbbb\" to come before \"ccc\".",
+          "data": {
+            "right": "bbbb",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [15, 30],
+            "text": "'bbbb',\n  'ccc'"
+          }
+        }
+      ],
+      "output": "[\n  'aaaaa',\n  'bbbb',\n  'ccc',\n  'dd',\n  'e',\n  ...other,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > does not sort spread elements",
+      "code": "[\n  ...aaa,\n  ...bbbb,\n  ...ccc,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > treats spread elements as partition boundaries",
+      "code": "[\n  'aa',\n  'b',\n  ...spread1,\n  'dd',\n  'e',\n  ...spread2,\n  'gg',\n  'h',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > treats spread elements as partition boundaries",
+      "code": "[\n  'b',\n  'aa',\n  ...spread,\n  'cc',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 15],
+            "text": "'aa',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'aa',\n  'b',\n  ...spread,\n  'cc',\n  'd',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > handles arrays with empty slots correctly",
+      "code": "['a', 'b', 'c',, 'd'].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > sorts elements in Array constructor calls",
+      "code": "new Array(\n  'aaaa',\n  'bbb',\n  'cc',\n  'd',\n).includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > sorts elements in Array constructor calls",
+      "code": "new Array(\n  'aaaa',\n  'cc',\n  'bbb',\n  'd',\n).includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbb\" to come before \"cc\".",
+          "data": {
+            "right": "bbb",
+            "left": "cc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [23, 36],
+            "text": "'bbb',\n  'cc'"
+          }
+        }
+      ],
+      "output": "new Array(\n  'aaaa',\n  'bbb',\n  'cc',\n  'd',\n).includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > sorts elements within newline-separated groups independently",
+      "code": "[\n  'dd',\n  'aaaaa',\n\n  'ccc',\n\n  'e',\n  'bbbb',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aaaaa\" to come before \"dd\".",
+          "data": {
+            "right": "aaaaa",
+            "left": "dd"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'aaaaa',\n  'dd',\n\n  'ccc',\n\n  'bbbb',\n  'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbbb\" to come before \"e\".",
+          "data": {
+            "right": "bbbb",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'aaaaa',\n  'dd',\n\n  'ccc',\n\n  'bbbb',\n  'e'"
+          }
+        }
+      ],
+      "output": "[\n  'aaaaa',\n  'dd',\n\n  'ccc',\n\n  'bbbb',\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > treats each newline-separated section as independent partition",
+      "code": "[\n  'c',\n  'top2',\n\n  'a',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "unknown"],
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 35],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 35],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'c',\n\n  'top1',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > applies grouping rules within each partition separately",
+      "code": "[\n  'a',\n  'b',\n\n  'c',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > creates partitions based on matching comments",
+      "code": "[\n  // Part: A\n  'cc',\n  'd',\n  // Not partition comment\n  'bbb',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  'gg',\n  // Not partition comment\n  'fff',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbb\" to come before \"d\".",
+          "data": {
+            "right": "bbb",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [17, 151],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"fff\" to come before \"gg\".",
+          "data": {
+            "right": "fff",
+            "left": "gg"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 3,
+            "endLine": 13,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [17, 151],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        }
+      ],
+      "output": "[\n  // Part: A\n  // Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > treats every comment as partition boundary when set to true",
+      "code": "[\n  // Comment\n  'bb',\n  // Other comment\n  'a',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > supports multiple partition comment patterns",
+      "code": "[\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'c',\n  'bb',\n  /* Other */\n  'e',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [72, 83],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'bb',\n  'c',\n  /* Other */\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > applies grouping within comment-defined partitions",
+      "code": "[\n  'c',\n  'top2',\n  // Part: 1\n  'a',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "partitionByComment": "^Part:",
+          "groups": ["top", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 47],
+            "text": "'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'c',\n  // Part: 1\n  'top1',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > ignores block comments when line comments are specified",
+      "code": "[\n  'b',\n  /* Comment */\n  'aa'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 31],
+            "text": "/* Comment */\n  'aa',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  /* Comment */\n  'aa',\n  'b'\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > uses line comments as partition boundaries",
+      "code": "[\n  'b',\n  // Comment\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > matches specific line comment patterns",
+      "code": "[\n  'c',\n  // b\n  'b',\n  // a\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > supports regex patterns for line comments",
+      "code": "[\n  'b',\n  // I am a partition comment because I don't have f o o\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "line": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > ignores line comments when block comments are specified",
+      "code": "[\n  'b',\n  // Comment\n  'aa'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 28],
+            "text": "// Comment\n  'aa',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  // Comment\n  'aa',\n  'b'\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > uses block comments as partition boundaries",
+      "code": "[\n  'b',\n  /* Comment */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > matches specific block comment patterns",
+      "code": "[\n  'c',\n  /* b */\n  'b',\n  /* a */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > supports regex patterns for block comments",
+      "code": "[\n  'b',\n  /* I am a partition comment because I don't have f o o */\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > supports regex patterns for partition comments",
+      "code": "[\n  'e',\n  'f',\n  // I am a partition comment because I don't have f o o\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > ignores special characters at start when trimming",
+      "code": "[\n  '$aa',\n  'bb',\n  '$c',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > ignores special characters completely when removing",
+      "code": "[\n  'abc',\n  'a$c',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > sorts elements according to locale-specific rules",
+      "code": "[\n  '你好',\n  '世界',\n  'a',\n  'A',\n  'b',\n  'B'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > sorts single-line arrays correctly",
+      "code": "[\n  b, aa\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [4, 9],
+            "text": "aa, b"
+          }
+        }
+      ],
+      "output": "[\n  aa, b\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > handles trailing commas in single-line arrays",
+      "code": "[\n  b, aa,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [4, 9],
+            "text": "aa, b"
+          }
+        }
+      ],
+      "output": "[\n  aa, b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > enforces custom group ordering",
+      "code": "[\n  'c',\n  'top1',\n  'aa'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "literal"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"c\" (literal).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "literal"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 25],
+            "text": "'top1',\n  'aa',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'top1',\n  'aa',\n  'c'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > applies custom groups based on element selectors",
+      "code": "[\n  'b',\n  'top1',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "topElements"
+            }
+          ],
+          "groups": ["topElements", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top1\" (topElements) to come before \"b\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "topElements",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 17],
+            "text": "'top1',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'top1',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > groups elements by name pattern - string pattern",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > groups elements by name pattern - array of patterns",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > groups elements by name pattern - case-insensitive regex",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > groups elements by name pattern - regex in array",
+      "code": "[\n  'a',\n  'b',\n  'helloLiteral',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'helloLiteral',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > overrides sort type and order for specific groups",
+      "code": "[\n  'a',\n  'bb',\n  'ccc',\n  'dddd',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedLiteralsByLineLength",
+              "selector": "literal",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedLiteralsByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 34],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'dddd',\n  'ccc',\n  'bb',\n  'a',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > applies fallback sort when primary sort results in tie",
+      "code": "[\n  'fooZar',\n  'fooBar',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 11
+          },
+          "fix": {
+            "range": [4, 24],
+            "text": "'fooBar',\n  'fooZar'"
+          }
+        }
+      ],
+      "output": "[\n  'fooBar',\n  'fooZar',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > preserves original order for unsorted groups",
+      "code": "[\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'm',\n  'top3',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "unsortedTop",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedTop", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"top3\" (unsortedTop) to come before \"m\" (unknown).",
+          "data": {
+            "right": "top3",
+            "rightGroup": "unsortedTop",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [44, 57],
+            "text": "'top3',\n  'm'"
+          }
+        }
+      ],
+      "output": "[\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'top3',\n  'm',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > combines multiple selectors with anyOf",
+      "code": "[\n  'a',\n  'bFoo',\n  'cFoo',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo"
+                },
+                {
+                  "elementNamePattern": "Foo"
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"bFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "bFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [4, 27],
+            "text": "'bFoo',\n  'cFoo',\n  'a'"
+          }
+        }
+      ],
+      "output": "[\n  'bFoo',\n  'cFoo',\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > supports negative regex patterns in custom groups",
+      "code": "[\n  'iHaveFooInMyName',\n  'meTooIHaveFoo',\n  'a',\n  'b',\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - string pattern",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "foo"
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - array of patterns",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": ["noMatch", "foo"]
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - case-insensitive regex",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "FOO",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - regex in array",
+      "code": "[\n  'b',\n  'g',\n  'r',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": [
+              "noMatch",
+              {
+                "pattern": "foo",
+                "flags": "i"
+              }
+            ]
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 21],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'r',\n  'g',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > removes newlines between groups when newlinesBetween is 0",
+      "code": "[\n  'aaaa',\n\n\n 'yy',\n'z',\n\n    'bbb'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "aa",
+              "groupName": "aa"
+            }
+          ],
+          "groups": ["aa", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"aaaa\" and \"yy\".",
+          "data": {
+            "left": "aaaa",
+            "right": "yy"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [10, 36],
+            "text": ",\n 'bbb',\n'yy',\n\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bbb\" to come before \"z\".",
+          "data": {
+            "right": "bbb",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [10, 36],
+            "text": ",\n 'bbb',\n'yy',\n\n    'z'"
+          }
+        }
+      ],
+      "output": "[\n  'aaaa',\n 'bbb',\n'yy',\n\n    'z'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > adds newlines between multiple groups",
+      "code": "[\n  'aaaa',\n\n\n 'z',\n'yy',\n    'bbb',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "aa",
+              "groupName": "aa"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": ["aa", "unknown", "b"],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"aaaa\" and \"z\".",
+          "data": {
+            "left": "aaaa",
+            "right": "z"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [10, 30],
+            "text": ",\n\n 'yy',\n'z',\n\n    "
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"yy\" to come before \"z\".",
+          "data": {
+            "right": "yy",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [10, 30],
+            "text": ",\n\n 'yy',\n'z',\n\n    "
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"yy\" and \"bbb\".",
+          "data": {
+            "left": "yy",
+            "right": "bbb"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 5,
+            "endLine": 7,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [10, 30],
+            "text": ",\n\n 'yy',\n'z',\n\n    "
+          }
+        }
+      ],
+      "output": "[\n  'aaaa',\n\n 'yy',\n'z',\n\n    'bbb',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > applies inline newline settings between specific groups",
+      "code": "[\n  'a',\n  'b',\n\n\n  'c',\n\n  'd',\n\n\n  'e'\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 28],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        }
+      ],
+      "output": "[\n  'a',\n\n  'b',\n\n  'c',\n  'd',\n\n\n  'e'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > enforces 2 newlines when global is 2 and group is 0",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > enforces 2 newlines when global is 2 and group is ignore",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > enforces 2 newlines when global is 0 and group is 2",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > enforces 2 newlines when global is ignore and group is 2",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 9],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n\n\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > removes newlines when 0 overrides global 1 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > removes newlines when 0 overrides global 2 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > removes newlines when 0 overrides global ignore between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > removes newlines when 0 overrides global 0 between specific groups",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenArrayIncludesMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [5, 10],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "[\n  a,\n  b,\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > accepts any spacing when global is ignore and group is 0",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > accepts any spacing when global is ignore and group is 0",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > accepts any spacing when global is 0 and group is ignore",
+      "code": "[\n  a,\n\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > line-length > accepts any spacing when global is 0 and group is ignore",
+      "code": "[\n  a,\n  b,\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > preserves inline comments when reordering elements",
+      "code": "[\n  'b',\n  'a', // Comment after\n\n  'c'\n].includes(value)",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "b|c",
+              "groupName": "b|c"
+            }
+          ],
+          "groups": ["unknown", "b|c"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"a\" (unknown) to come before \"b\" (b|c).",
+          "data": {
+            "right": "a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "b|c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'a', // Comment after\n  'b',"
+          }
+        }
+      ],
+      "output": "[\n  'a', // Comment after\n\n  'b',\n  'c'\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > line-length > preserves partition boundaries regardless of newlinesBetween 0",
+      "code": "[\n  'aaa',\n\n  // Partition comment\n\n  'c',\n  'bb',\n].includes(value)",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [38, 49],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'aaa',\n\n  // Partition comment\n\n  'bb',\n  'c',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > custom > sorts elements according to custom alphabet order",
+      "code": "[\n  'a',\n  'b',\n  'c',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > custom > sorts elements according to custom alphabet order",
+      "code": "[\n  'a',\n  'c',\n  'b',\n  'd',\n].includes(value)",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [11, 21],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n  'c',\n  'd',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > subgroup-order > fallback sorts by subgroup order",
+      "code": "[\n  'b',\n  'bb',\n  'a',\n  'aa',\n].includes(value)",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order",
+            "order": "asc"
+          },
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [["a", "b"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"b\".",
+          "data": {
+            "right": "bb",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 30],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"a\".",
+          "data": {
+            "right": "aa",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 30],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'aa',\n  'bb',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > subgroup-order > fallback sorts by subgroup order through overriding groups option",
+      "code": "[\n  'b',\n  'bb',\n  'a',\n  'aa',\n].includes(value)",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order",
+            "order": "asc"
+          },
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            {
+              "group": ["a", "b"],
+              "newlinesInside": 0
+            },
+            "unknown"
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"bb\" to come before \"b\".",
+          "data": {
+            "right": "bb",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 30],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"aa\" to come before \"a\".",
+          "data": {
+            "right": "aa",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 30],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "[\n  'aa',\n  'bb',\n  'a',\n  'b',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > unsorted > allows any order when type is unsorted",
+      "code": "[\n  'b',\n  'c',\n  'a'\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > unsorted > enforces grouping even with unsorted type",
+      "code": "[\n  'ab',\n  'aa',\n  'ba',\n  'bb',\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "^b",
+              "groupName": "b"
+            }
+          ],
+          "groups": ["b", "a"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesGroupOrder",
+          "message": "Expected \"ba\" (b) to come before \"aa\" (a).",
+          "data": {
+            "right": "ba",
+            "rightGroup": "b",
+            "left": "aa",
+            "leftGroup": "a"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [4, 32],
+            "text": "'ba',\n  'bb',\n  'ab',\n  'aa'"
+          }
+        }
+      ],
+      "output": "[\n  'ba',\n  'bb',\n  'ab',\n  'aa',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > unsorted > enforces newlines between groups with unsorted type",
+      "code": "[\n  'b',\n  'a',\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "newlinesBetween": 1,
+          "groups": ["b", "a"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenArrayIncludesMembers",
+          "message": "Missed spacing between \"b\" and \"a\".",
+          "data": {
+            "left": "b",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [7, 11],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "[\n  'b',\n\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > uses alphabetical ascending order by default",
+      "code": "[\n  'a',\n  'b',\n  'c',\n  'd',\n].includes(value)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > misc > uses alphabetical ascending order by default",
+      "code": "[\n  'b',\n  'a',\n  'd',\n  'c',\n].includes(value)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 28],
+            "text": "'a',\n  'b',\n  'c',\n  'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 28],
+            "text": "'a',\n  'b',\n  'c',\n  'd'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'b',\n  'c',\n  'd',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > respects natural sorting with numbers",
+      "code": "[\n  'v1.png',\n  'v10.png',\n  'v12.png',\n  'v2.png',\n].includes(value)",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > handles empty arrays and single-element arrays",
+      "code": "[].includes(value)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > handles empty arrays and single-element arrays",
+      "code": "['a'].includes(value)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > treats different quote styles as equivalent",
+      "code": "['a', \"b\", 'c'].includes(value)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > respects the global settings configuration",
+      "code": "[\n  ccc,\n  bb,\n  a,\n].includes(value)",
+      "options": [{}],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > respects the global settings configuration",
+      "code": "[\n  a,\n  bb,\n  ccc,\n].includes(value)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > excludes disabled elements from sorting",
+      "code": "[\n  'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n].includes(value)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > excludes disabled elements from sorting",
+      "code": "[\n  'c',\n  'b',\n  // eslint-disable-next-line\n  'a',\n].includes(value)",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > handles inline eslint-disable comments",
+      "code": "[\n  'c',\n  'b',\n  'a', // eslint-disable-line\n].includes(value)",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'b',\n  'c',\n  'a', // eslint-disable-line\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > respects eslint-disable blocks",
+      "code": "[\n  'd',\n  'e',\n  /* eslint-disable */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'a',\n].includes(value)",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 3,
+            "endLine": 9,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 100],
+            "text": "'a',\n  'd',\n  /* eslint-disable */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'e'"
+          }
+        }
+      ],
+      "output": "[\n  'a',\n  'd',\n  /* eslint-disable */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'e',\n].includes(value)"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > handles rule-specific eslint-disable comments",
+      "code": "[\n  'c',\n  'b',\n  // eslint-disable-next-line rule-to-test/sort-array-includes\n  'a',\n].includes(value)",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedArrayIncludesOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [4, 14],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "[\n  'b',\n  'c',\n  // eslint-disable-next-line rule-to-test/sort-array-includes\n  'a',\n].includes(value)"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > ignores arrays with other methods",
+      "code": "['c', 'b', 'a'].map(x => x)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > ignores arrays with other methods",
+      "code": "['c', 'b', 'a'].filter(x => x)",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > ignores arrays with other methods",
+      "code": "['c', 'b', 'a'].forEach(x => console.log(x))",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-array-includes > misc > with eslint-disable comments > ignores computed property access",
+      "code": "['c', 'b', 'a']['includes']('a')",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    }
+  ]
+}

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -117,16 +117,74 @@ describe('perfectionist plugin adapter', () => {
   });
 
   it.each(invalidCases)('reports %s through direct createOnce', (ruleName, code) => {
-    const reports = runRule(ruleName, code);
+    const reports = runRule(
+      ruleName,
+      code,
+      ruleName === 'sort-jsx-props' ? 'fixture.tsx' : 'fixture.ts',
+    );
 
     expect(reports).toHaveLength(1);
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
-      ['sort-exports', 'sort-imports', 'sort-named-exports', 'sort-named-imports'].includes(
-        ruleName,
-      )
+      [
+        'sort-array-includes',
+        'sort-exports',
+        'sort-imports',
+        'sort-named-exports',
+        'sort-named-imports',
+      ].includes(ruleName)
         ? 'Expected "{{right}}" to come before "{{left}}".'
         : 'Expected sorted order.',
     );
+  });
+
+  it('declares the complete v5.10.0 sort-array-includes schema and messages', () => {
+    const rule = plugin.rules['sort-array-includes'];
+    const schema = rule.meta.schema.items;
+
+    expect(rule.meta.type).toBe('suggestion');
+    expect(rule.meta.schema).toMatchObject({
+      type: 'array',
+      uniqueItems: true,
+    });
+    expect(Object.keys(rule.meta.messages).sort()).toEqual([
+      'extraSpacingBetweenArrayIncludesMembers',
+      'missedSpacingBetweenArrayIncludesMembers',
+      'unexpectedArrayIncludesGroupOrder',
+      'unexpectedArrayIncludesOrder',
+    ]);
+    expect(Object.keys(schema.properties).sort()).toEqual([
+      'alphabet',
+      'customGroups',
+      'fallbackSort',
+      'groups',
+      'ignoreCase',
+      'locales',
+      'newlinesBetween',
+      'newlinesInside',
+      'order',
+      'partitionByComment',
+      'partitionByNewLine',
+      'specialCharacters',
+      'type',
+      'useConfigurationIf',
+    ]);
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties.type.enum).toEqual([
+      'subgroup-order',
+      'alphabetical',
+      'natural',
+      'line-length',
+      'custom',
+      'unsorted',
+    ]);
+    expect(schema.properties.customGroups.items.oneOf[0].properties.selector.enum).toEqual([
+      'literal',
+    ]);
+    expect(schema.properties.customGroups.items.oneOf[0].properties).not.toHaveProperty(
+      'modifiers',
+    );
+    expect(schema.properties.useConfigurationIf.properties).toHaveProperty('matchesAstSelector');
+    expect(schema.properties.useConfigurationIf).not.toHaveProperty('minProperties');
   });
 
   it('declares the complete sort-exports schema without named-specifier-only options', () => {
@@ -298,6 +356,48 @@ describe('perfectionist plugin adapter', () => {
       'error',
       { type: 'natural', order: 'asc' },
     ]);
+    expect(rules['perfectionist/sort-array-includes']).toEqual([
+      'error',
+      { type: 'natural', order: 'asc' },
+    ]);
+  });
+
+  it('merges settings and isolates sort-array-includes options and cache entries', () => {
+    const source = `['item2', 'item10'].includes(value)`;
+    const settings = { perfectionist: { type: 'natural', order: 'desc' } };
+
+    expect(runRule('sort-array-includes', source, 'fixture.ts', [], settings)).toHaveLength(1);
+    expect(
+      runRule('sort-array-includes', source, 'fixture.ts', [{ order: 'asc' }], settings),
+    ).toEqual([]);
+    expect(
+      runRule('sort-array-includes', source, 'fixture.ts', [{ type: 'natural', order: 'desc' }]),
+    ).toHaveLength(1);
+    expect(
+      runRule('sort-array-includes', source, 'fixture.ts', [{ type: 'natural', order: 'asc' }]),
+    ).toEqual([]);
+
+    const conditionalOptions = [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { allNamesMatchPattern: '^does-not-match$' },
+      },
+      { useConfigurationIf: { matchesAstSelector: 'ArrayExpression' } },
+    ];
+    expect(
+      runRule('sort-array-includes', source, 'fixture.ts', conditionalOptions, {
+        perfectionist: { type: 'natural', order: 'asc' },
+      }),
+    ).toEqual([]);
+    expect(
+      runRule(
+        'sort-array-includes',
+        `['item10', 'item2'].includes(value)`,
+        'fixture.ts',
+        conditionalOptions,
+        { perfectionist: { type: 'natural', order: 'asc' } },
+      ),
+    ).toHaveLength(1);
   });
 
   it('merges global perfectionist settings with explicit sort-imports options', () => {
@@ -368,6 +468,66 @@ describe('perfectionist plugin adapter', () => {
       expect(fixed.status).toBe(0);
       expect(fixed.stderr).toBe('');
       expect(readFileSync(fixturePath, 'utf8')).toBe('import { item10, item2 } from "pkg";\n');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads array groups and fixes through real oxlint without JSX/TSX parsing', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-array-includes-'));
+    try {
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(fixturePath, `['b', 'a'].includes(value);\n`);
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'perfectionist',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'perfectionist/sort-array-includes': [
+              'error',
+              {
+                customGroups: [{ groupName: 'a', elementNamePattern: '^a$' }],
+                groups: ['a', 'literal'],
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(1);
+      expect(payload.diagnostics[0]).toMatchObject({
+        code: 'perfectionist(sort-array-includes)',
+        message: 'Expected "a" (a) to come before "b" (literal).',
+      });
+
+      const fixed = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe(`['a', 'b'].includes(value);\n`);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/npm/perfectionist/test/sort-array-includes-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-array-includes-options-upstream.test.mjs
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/sort-array-includes-options-v5.10.0.json', import.meta.url),
+    'utf8',
+  ),
+);
+const fixtureSource = readFileSync(
+  new URL('./fixtures/sort-array-includes-options-v5.10.0.json', import.meta.url),
+);
+const rule = plugin.rules['sort-array-includes'];
+
+describe('perfectionist/sort-array-includes v5.10.0 option parity', () => {
+  it('pins every non-React authored upstream case and its exact fixture inventory', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-perfectionist',
+      version: '5.10.0',
+      sourceCommit: '84aa039c46522f82a61ad43cf676afc92dd64704',
+      sourceHashes: {
+        'rules/sort-array-includes.ts':
+          '3f43cb92d44f5cd60de7ec9de9b4b72be936d3f1bf410d21e325bf18400788b9',
+        'rules/sort-array-includes/types.ts':
+          '927bfce114499a6e224415245e952a6eaa43c052dfd78b827bd7d8d085e7a098',
+        'rules/sort-arrays/types.ts':
+          '9aa7faafdb1f2262aa32798623ebd6507b5a80f2ad6fa66446d66bb722bba582',
+        'rules/sort-arrays/sort-array.ts':
+          'c65199dd2f5b56ae5302368f3e4fda46849f98641415bd77cf8d56a36ab0d60a',
+        'test/rules/sort-array-includes.test.ts':
+          'c6f8a4dea072ce3d1fc2af72430e7247551bd81870077bde12d5ad7bbb67e534',
+      },
+      inventory: {
+        valid: 91,
+        invalid: 142,
+        diagnostics: 194,
+        total: 233,
+      },
+    });
+    expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
+    expect(
+      fixture.cases.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+    ).toBe(fixture.__generated.inventory.diagnostics);
+    expect(
+      fixture.cases.some(
+        (testCase) =>
+          /\.(?:jsx|tsx)$/u.test(testCase.filename) ||
+          /<[A-Z][A-Za-z]*(?:\s|\/?>)/u.test(testCase.code),
+      ),
+    ).toBe(false);
+    expect(createHash('sha256').update(fixtureSource).digest('hex')).toBe(
+      'c1636bbba04e6a1e6635b5e2367128aec694b28d904535a91765ef7e9b2ff04b',
+    );
+  });
+
+  for (const [index, testCase] of fixture.cases.entries()) {
+    it(`replays case ${index + 1}/${fixture.cases.length}: ${testCase.name}`, () => {
+      const reports = runRule(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(
+        reports.map((report) => exactDiagnostic(report)),
+        testCase.name,
+      ).toEqual(testCase.expectedDiagnostics);
+
+      if (testCase.output === null) {
+        expect(reports, testCase.name).toEqual([]);
+        return;
+      }
+
+      const convergence = applyIteratively(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(convergence.output, testCase.name).toBe(testCase.output);
+      expect(convergence.remainingReports, testCase.name).toEqual([]);
+      expect(convergence.passes, testCase.name).toBeGreaterThanOrEqual(1);
+      expect(convergence.passes, testCase.name).toBeLessThanOrEqual(16);
+    });
+  }
+});
+
+function runRule(sourceText, options, filename, settings) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    options,
+    settings,
+    sourceCode,
+    filename,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function exactDiagnostic(report) {
+  const replacement = report.fix?.({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return {
+    messageId: report.messageId,
+    message: Object.entries(report.data).reduce(
+      (message, [key, value]) => message.replace(`{{${key}}}`, value),
+      rule.meta.messages[report.messageId],
+    ),
+    data: report.data,
+    loc: {
+      startLine: report.loc.start.line,
+      startColumn: report.loc.start.column + 1,
+      endLine: report.loc.end.line,
+      endColumn: report.loc.end.column + 1,
+    },
+    fix: replacement ?? null,
+  };
+}
+
+function applyIteratively(sourceText, options, filename, settings) {
+  let output = sourceText;
+  let passes = 0;
+  for (; passes < 16; passes += 1) {
+    const reports = runRule(output, options, filename, settings);
+    const next = applyFixPass(output, reports);
+    if (next === null) {
+      return { output, passes, remainingReports: reports };
+    }
+    output = next;
+  }
+  throw new Error(`Fixes did not converge for ${JSON.stringify(sourceText)}`);
+}
+
+function applyFixPass(sourceText, reports) {
+  const fixes = reports
+    .flatMap((report) => {
+      const fix = report.fix?.({
+        replaceTextRange(range, text) {
+          return { range, text };
+        },
+      });
+      return fix ? [fix] : [];
+    })
+    .sort((left, right) => left.range[0] - right.range[0] || left.range[1] - right.range[1]);
+  if (fixes.length === 0) {
+    return null;
+  }
+
+  const accepted = [];
+  let lastEnd = -1;
+  for (const fix of fixes) {
+    if (fix.range[0] < lastEnd) {
+      continue;
+    }
+    accepted.push(fix);
+    lastEnd = fix.range[1];
+  }
+
+  let output = sourceText;
+  for (const fix of accepted.toReversed()) {
+    output = output.slice(0, fix.range[0]) + fix.text + output.slice(fix.range[1]);
+  }
+  return output;
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "port:tests:perfectionist:sort-named-imports": "node tools/tasks/sync-perfectionist-sort-named-imports-options-tests.ts",
     "port:tests:perfectionist:sort-named-exports": "node tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
     "port:tests:perfectionist:sort-imports": "node tools/tasks/sync-perfectionist-sort-imports-options-tests.ts",
+    "port:tests:perfectionist:sort-array-includes": "node tools/tasks/sync-perfectionist-sort-array-includes-options-tests.ts",
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:expect-expect": "node tools/tasks/sync-playwright-expect-expect-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",

--- a/playground/src/catalog.json
+++ b/playground/src/catalog.json
@@ -1497,7 +1497,10 @@
           "description": "enforce sorted array includes",
           "docsUrl": "https://perfectionist.dev/rules/sort-array-includes",
           "messages": {
-            "unexpected": "Expected sorted order."
+            "unexpectedArrayIncludesOrder": "Expected \"{{right}}\" to come before \"{{left}}\".",
+            "unexpectedArrayIncludesGroupOrder": "Expected \"{{right}}\" ({{rightGroup}}) to come before \"{{left}}\" ({{leftGroup}}).",
+            "extraSpacingBetweenArrayIncludesMembers": "Extra spacing between \"{{left}}\" and \"{{right}}\".",
+            "missedSpacingBetweenArrayIncludesMembers": "Missed spacing between \"{{left}}\" and \"{{right}}\"."
           }
         },
         {

--- a/status.json
+++ b/status.json
@@ -3856,9 +3856,9 @@
           "insta": false,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-perfectionist/sort-array-includes with focused unsorted array includes coverage."
+        "notes": "Full Rust/Oxc AST port of eslint-plugin-perfectionist/sort-array-includes v5.10.0 options, diagnostics, fixes, comments, partitions, conditional configuration, settings, and UTF-16 locations. Pinned 233-case authored fixture plus Rust, NAPI, plugin, and real Oxlint regression coverage; React/JSX/TSX is intentionally excluded."
       },
       {
         "name": "sort-arrays",

--- a/tools/tasks/sync-perfectionist-sort-array-includes-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-array-includes-options-tests.ts
@@ -1,0 +1,7 @@
+// Captures the v5.10.0 sort-array-includes authored suite through the shared
+// Perfectionist fixture synchronizer without moving the repository-wide v5.9.1
+// submodule pin.
+
+process.argv.push('--sort-array-includes');
+const synchronizer = new URL('./sync-perfectionist-sort-imports-options-tests.ts', import.meta.url);
+await import(synchronizer.href);

--- a/tools/tasks/sync-perfectionist-sort-imports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-imports-options-tests.ts
@@ -38,16 +38,35 @@ type CapturedCase = {
 };
 
 const ROOT = process.cwd();
-const RULE = 'sort-imports';
-const PINNED_COMMIT = 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
-const ESLINT_VERSION = '9.39.2';
-const TYPESCRIPT_ESLINT_VERSION = '8.60.0';
-const SOURCE_HASHES = {
-  'rules/sort-imports.ts': 'c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05',
-  'rules/sort-imports/types.ts': '81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe',
-  'test/rules/sort-imports.test.ts':
-    '8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab',
-} as const;
+const capturesArrayIncludes = process.argv.includes('--sort-array-includes');
+const RULE = capturesArrayIncludes ? 'sort-array-includes' : 'sort-imports';
+const PINNED_COMMIT = capturesArrayIncludes
+  ? '84aa039c46522f82a61ad43cf676afc92dd64704'
+  : 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
+const PINNED_REF = capturesArrayIncludes ? 'v5.10.0' : 'v5.9.1';
+const TARGET_VERSION = capturesArrayIncludes ? '5.10.0' : '5.9.1';
+const ESLINT_VERSION = capturesArrayIncludes ? '10.6.0' : '9.39.2';
+const TYPESCRIPT_ESLINT_VERSION = capturesArrayIncludes ? '8.62.1' : '8.60.0';
+const SOURCE_HASHES: Readonly<Record<string, string>> = capturesArrayIncludes
+  ? {
+      'rules/sort-array-includes.ts':
+        '3f43cb92d44f5cd60de7ec9de9b4b72be936d3f1bf410d21e325bf18400788b9',
+      'rules/sort-array-includes/types.ts':
+        '927bfce114499a6e224415245e952a6eaa43c052dfd78b827bd7d8d085e7a098',
+      'rules/sort-arrays/types.ts':
+        '9aa7faafdb1f2262aa32798623ebd6507b5a80f2ad6fa66446d66bb722bba582',
+      'rules/sort-arrays/sort-array.ts':
+        'c65199dd2f5b56ae5302368f3e4fda46849f98641415bd77cf8d56a36ab0d60a',
+      'test/rules/sort-array-includes.test.ts':
+        'c6f8a4dea072ce3d1fc2af72430e7247551bd81870077bde12d5ad7bbb67e534',
+    }
+  : {
+      'rules/sort-imports.ts': 'c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05',
+      'rules/sort-imports/types.ts':
+        '81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe',
+      'test/rules/sort-imports.test.ts':
+        '8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab',
+    };
 
 const manifest = JSON.parse(
   readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
@@ -69,12 +88,21 @@ if (!existsSync(join(submodule, '.git'))) {
 const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
   encoding: 'utf8',
 }).trim();
-if (actualCommit !== PINNED_COMMIT) {
-  throw new Error(`Expected ${PINNED_COMMIT}, received ${actualCommit}`);
+const sourceCommit = capturesArrayIncludes
+  ? execFileSync('git', ['-C', submodule, 'rev-parse', PINNED_REF], {
+      encoding: 'utf8',
+    }).trim()
+  : actualCommit;
+if (sourceCommit !== PINNED_COMMIT) {
+  throw new Error(`Expected ${PINNED_COMMIT}, received ${sourceCommit}`);
 }
 for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
   const actualHash = createHash('sha256')
-    .update(readFileSync(join(submodule, sourceFile)))
+    .update(
+      capturesArrayIncludes
+        ? execFileSync('git', ['-C', submodule, 'show', `${PINNED_REF}:${sourceFile}`])
+        : readFileSync(join(submodule, sourceFile)),
+    )
     .digest('hex');
   if (actualHash !== expectedHash) {
     throw new Error(`Expected ${sourceFile} hash ${expectedHash}, received ${actualHash}`);
@@ -83,13 +111,15 @@ for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
 
 const runnerDirectory = mkdtempSync(join(tmpdir(), 'perfectionist-sort-imports-'));
 try {
-  const completeAuthoredSource = readFileSync(
-    join(submodule, 'test', 'rules', 'sort-imports.test.ts'),
-    'utf8',
-  );
-  const suiteStart = completeAuthoredSource.indexOf("describe('sort-imports'");
+  const authoredTestPath = `test/rules/${RULE}.test.ts`;
+  const completeAuthoredSource = capturesArrayIncludes
+    ? execFileSync('git', ['-C', submodule, 'show', `${PINNED_REF}:${authoredTestPath}`], {
+        encoding: 'utf8',
+      })
+    : readFileSync(join(submodule, authoredTestPath), 'utf8');
+  const suiteStart = completeAuthoredSource.indexOf(`describe('${RULE}'`);
   if (suiteStart === -1) {
-    throw new Error('Unable to locate the authored sort-imports suite.');
+    throw new Error(`Unable to locate the authored ${RULE} suite.`);
   }
   const authoredSource = completeAuthoredSource.slice(suiteStart);
   const captureSourcePath = join(runnerDirectory, 'capture.ts');
@@ -123,6 +153,20 @@ try {
   const authoredCases = JSON.parse(
     readFileSync(join(runnerDirectory, 'authored-cases.json'), 'utf8'),
   ) as CapturedCase[];
+  if (capturesArrayIncludes) {
+    const forbiddenCases = authoredCases.filter(
+      (testCase) =>
+        /\.(?:jsx|tsx)$/u.test(testCase.filename) ||
+        /<[A-Z][A-Za-z]*(?:\s|\/?>)/u.test(testCase.code),
+    );
+    if (forbiddenCases.length > 0) {
+      throw new Error(
+        `React/JSX/TSX cases are outside this port: ${forbiddenCases
+          .map((testCase) => testCase.name)
+          .join(', ')}`,
+      );
+    }
+  }
 
   writeFileSync(
     join(runnerDirectory, 'package.json'),
@@ -133,7 +177,7 @@ try {
         dependencies: {
           '@typescript-eslint/parser': TYPESCRIPT_ESLINT_VERSION,
           eslint: ESLINT_VERSION,
-          'eslint-plugin-perfectionist': plugin.baselineVersion,
+          'eslint-plugin-perfectionist': TARGET_VERSION,
         },
       },
       null,
@@ -163,16 +207,21 @@ try {
   const fixture = {
     __generated: {
       source: plugin.npm,
-      version: plugin.baselineVersion,
+      version: TARGET_VERSION,
       sourceCommit: PINNED_COMMIT,
       sourceHashes: SOURCE_HASHES,
       license: plugin.license,
       eslintVersion: ESLINT_VERSION,
       typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
-      capturePolicy:
-        'Every authored valid and invalid sort-imports case is captured; none exercises React-specific or JSX/TSX syntax. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.9.1 rule for exact diagnostics and fixes.',
-      authoredCases: 'upstream/eslint-plugin-perfectionist/test/rules/sort-imports.test.ts',
-      tool: basename(import.meta.filename),
+      capturePolicy: capturesArrayIncludes
+        ? `Every authored valid and invalid ${RULE} case is captured; React-specific and JSX/TSX syntax is rejected. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v${TARGET_VERSION} rule for exact diagnostics and fixes.`
+        : 'Every authored valid and invalid sort-imports case is captured; none exercises React-specific or JSX/TSX syntax. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.9.1 rule for exact diagnostics and fixes.',
+      authoredCases: capturesArrayIncludes
+        ? `upstream/eslint-plugin-perfectionist/${authoredTestPath}@${PINNED_REF}`
+        : `upstream/eslint-plugin-perfectionist/${authoredTestPath}`,
+      tool: capturesArrayIncludes
+        ? 'sync-perfectionist-sort-array-includes-options-tests.ts'
+        : basename(import.meta.filename),
       inventory: {
         valid,
         invalid,
@@ -184,14 +233,14 @@ try {
   };
   const fixturesDirectory = join(ROOT, 'npm', 'perfectionist', 'test', 'fixtures');
   mkdirSync(fixturesDirectory, { recursive: true });
-  const fixturePath = join(fixturesDirectory, `${RULE}-options-v${plugin.baselineVersion}.json`);
+  const fixturePath = join(fixturesDirectory, `${RULE}-options-v${TARGET_VERSION}.json`);
   writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
   execFileSync('pnpm', ['exec', 'vp', 'fmt', fixturePath], {
     cwd: ROOT,
     stdio: 'inherit',
   });
   console.log(
-    `Captured ${RULE} v${plugin.baselineVersion}: ${valid} valid, ${invalid} invalid, ${diagnostics} diagnostics.`,
+    `Captured ${RULE} v${TARGET_VERSION}: ${valid} valid, ${invalid} invalid, ${diagnostics} diagnostics.`,
   );
 } finally {
   rmSync(runnerDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- port Perfectionist v5.10 `sort-array-includes` to the shared native sort engine
- support settings and conditional options, groups/custom groups, comments and partitions, newline policies, all comparators, disabled elements, spreads/elisions, and exact fixes
- expose Oxc AST, NAPI/API/plugin schema and metadata, docs, status, playground catalog, and deterministic upstream-fixture synchronization

## Tests
- pin all 233 upstream authored cases: 91 valid, 142 invalid, and 194 exact diagnostics
- add focused regressions for constructors/includes detection, options and conditionals, comments, partitions, newlines, groups, comparators, fixes, UTF-16, CRLF, malformed syntax, and rule isolation
- full workspace: 18,253 JS tests; all Rust/doc tests; clippy, fmt, typecheck, lint, build, benchmark, security, license, status, and publish-readiness gates
- latest-main rebase: 1,101 targeted JS tests and 57 Perfectionist Rust tests

Refs #418

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->