### PR TITLE
feat(playwright): port prefer-lowercase-title options

### DIFF
--- a/crates/playground_wasm/src/plugins/playwright.rs
+++ b/crates/playground_wasm/src/plugins/playwright.rs
@@ -183,4 +183,33 @@ mod tests {
             (1, 6, 1, 10)
         );
     }
+
+    #[test]
+    fn preserves_prefer_lowercase_title_message_data_location_and_rule_selection() {
+        let filter = EnabledFilter::parse(r#"{"playwright":["prefer-lowercase-title"]}"#);
+        let mut diagnostics = Vec::new();
+        scan(
+            "test(\"Works!\", () => {});\n",
+            "fixture.spec.ts",
+            &filter,
+            &mut diagnostics,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "prefer-lowercase-title");
+        assert_eq!(diagnostics[0].message_id, "unexpectedLowercase");
+        assert_eq!(
+            diagnostics[0].data.get("method").map(String::as_str),
+            Some("test")
+        );
+        assert_eq!(
+            (
+                diagnostics[0].start_line,
+                diagnostics[0].start_column,
+                diagnostics[0].end_line,
+                diagnostics[0].end_column,
+            ),
+            (1, 5, 1, 13)
+        );
+    }
 }

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod expect_expect;
 mod patterns;
+mod prefer_lowercase_title;
 mod restricted;
 mod scanner;
 mod thresholds;
@@ -17,6 +18,7 @@ use oxlint_plugins_carton::SmallVec;
 
 use crate::expect_expect::scan_expect_expect;
 use crate::patterns::scan_pattern_rules;
+use crate::prefer_lowercase_title::scan_prefer_lowercase_title;
 use crate::restricted::scan_restricted_rules;
 use crate::scanner::Scanner;
 use crate::thresholds::scan_threshold_rules;
@@ -116,6 +118,13 @@ pub fn scan_playwright_with_options(
         diagnostics: SmallVec::new(),
     };
     scan_expect_expect(
+        &parser_return.program,
+        source_text,
+        &scanner.line_index,
+        options,
+        &mut scanner.diagnostics,
+    );
+    scan_prefer_lowercase_title(
         &parser_return.program,
         source_text,
         &scanner.line_index,

--- a/crates/playwright/src/prefer_lowercase_title.rs
+++ b/crates/playwright/src/prefer_lowercase_title.rs
@@ -1,0 +1,274 @@
+//! AST-backed port of Playwright's `prefer-lowercase-title` rule.
+
+use oxc_ast::ast::{
+    Argument, BindingPattern, CallExpression, Expression, ImportDeclaration,
+    ImportDeclarationSpecifier, MemberExpression, ModuleExportName, Program, VariableDeclarator,
+    match_member_expression,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::{
+    thresholds::{PlaywrightCall, classify_call},
+    types::{Diagnostic, DiagnosticData, DiagnosticFix, LineIndex, PlaywrightOptions},
+};
+
+const RULE_NAME: &str = "prefer-lowercase-title";
+const TEST_METHOD: &str = "test";
+const DESCRIBE_METHOD: &str = "test.describe";
+
+pub(crate) fn scan_prefer_lowercase_title<'ast>(
+    program: &Program<'ast>,
+    source_text: &str,
+    line_index: &LineIndex,
+    options: &PlaywrightOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 64]>,
+) {
+    let mut test_names = SmallVec::<[CompactString; 8]>::new();
+    test_names.push(CompactString::from("test"));
+    for alias in &options.test_aliases {
+        push_unique(&mut test_names, alias.as_str());
+    }
+
+    let mut extend_declarations = SmallVec::<[(CompactString, CompactString); 16]>::new();
+    NameCollector {
+        extend_declarations: &mut extend_declarations,
+        test_names: &mut test_names,
+    }
+    .visit_program(program);
+    resolve_extend_aliases(&mut test_names, &extend_declarations);
+
+    PreferLowercaseTitleVisitor {
+        describe_depth: 0,
+        diagnostics,
+        line_index,
+        options,
+        source_text,
+        test_names,
+    }
+    .visit_program(program);
+}
+
+struct NameCollector<'storage> {
+    extend_declarations: &'storage mut SmallVec<[(CompactString, CompactString); 16]>,
+    test_names: &'storage mut SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for NameCollector<'_> {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
+        let Some(specifiers) = &declaration.specifiers else {
+            return;
+        };
+        for specifier in specifiers {
+            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                continue;
+            };
+            if module_export_name(&specifier.imported) == Some("test") {
+                push_unique(self.test_names, specifier.local.name.as_str());
+            }
+        }
+    }
+
+    fn visit_variable_declarator(&mut self, declaration: &VariableDeclarator<'ast>) {
+        if let (BindingPattern::BindingIdentifier(identifier), Some(initializer)) =
+            (&declaration.id, &declaration.init)
+            && let Some(root) = test_extend_root(initializer)
+        {
+            self.extend_declarations.push((
+                CompactString::from(identifier.name.as_str()),
+                CompactString::from(root),
+            ));
+        }
+        walk::walk_variable_declarator(self, declaration);
+    }
+}
+
+struct PreferLowercaseTitleVisitor<'source, 'options, 'diagnostics> {
+    describe_depth: usize,
+    diagnostics: &'diagnostics mut SmallVec<[Diagnostic; 64]>,
+    line_index: &'source LineIndex,
+    options: &'options PlaywrightOptions,
+    source_text: &'source str,
+    test_names: SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for PreferLowercaseTitleVisitor<'_, '_, '_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        match classify_call(call, &self.test_names) {
+            Some(PlaywrightCall::Describe) => {
+                self.describe_depth += 1;
+                if !self.options.ignore_top_level_describe || self.describe_depth != 1 {
+                    self.check_title(call, DESCRIBE_METHOD);
+                }
+                walk::walk_call_expression(self, call);
+                self.describe_depth -= 1;
+            }
+            Some(PlaywrightCall::Test) => {
+                self.check_title(call, TEST_METHOD);
+                walk::walk_call_expression(self, call);
+            }
+            Some(PlaywrightCall::Hook) | None => walk::walk_call_expression(self, call),
+        }
+    }
+}
+
+impl PreferLowercaseTitleVisitor<'_, '_, '_> {
+    fn check_title(&mut self, call: &CallExpression<'_>, method: &'static str) {
+        if self
+            .options
+            .lowercase_title_ignored_methods
+            .iter()
+            .any(|ignored| ignored == method)
+        {
+            return;
+        }
+
+        let Some(title) = call.arguments.first().and_then(title_value) else {
+            return;
+        };
+        if title.description.is_empty()
+            || self
+                .options
+                .allowed_title_prefixes
+                .iter()
+                .any(|prefix| title.description.starts_with(prefix.as_str()))
+        {
+            return;
+        }
+
+        let Some(replacement) = lowercase_first_utf16_code_unit(title.description) else {
+            return;
+        };
+        self.diagnostics.push(Diagnostic {
+            rule_name: RULE_NAME,
+            message_id: "unexpectedLowercase",
+            data: DiagnosticData {
+                method: Some(CompactString::from(method)),
+                ..DiagnosticData::default()
+            },
+            loc: self.line_index.loc_for_span(self.source_text, title.span),
+            fix: Some(DiagnosticFix {
+                start: title.span.start + 1,
+                end: title.span.end.saturating_sub(1),
+                replacement,
+            }),
+        });
+    }
+}
+
+struct TitleValue<'ast> {
+    description: &'ast str,
+    span: Span,
+}
+
+fn title_value<'ast>(argument: &'ast Argument<'ast>) -> Option<TitleValue<'ast>> {
+    match argument {
+        Argument::StringLiteral(literal) => Some(TitleValue {
+            description: literal.value.as_str(),
+            span: literal.span,
+        }),
+        Argument::TemplateLiteral(template) if template.expressions.is_empty() => {
+            template.quasis.first().map(|quasi| TitleValue {
+                // Upstream `getStringValue` intentionally uses the raw template
+                // value, unlike decoded string literals.
+                description: quasi.value.raw.as_str(),
+                span: template.span,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn lowercase_first_utf16_code_unit(description: &str) -> Option<CompactString> {
+    let first = description.chars().next()?;
+
+    // JavaScript's `charAt(0)` returns one UTF-16 code unit. An astral scalar
+    // therefore becomes an unpaired high surrogate whose lowercase form is
+    // unchanged, even if the complete scalar has a Unicode case mapping.
+    if first.len_utf16() != 1 {
+        return None;
+    }
+
+    let lowercase = first.to_lowercase().collect::<CompactString>();
+    if lowercase.len() == first.len_utf8() && lowercase.starts_with(first) {
+        return None;
+    }
+
+    let mut replacement = lowercase;
+    replacement.push_str(&description[first.len_utf8()..]);
+    Some(replacement)
+}
+
+fn resolve_extend_aliases(
+    test_names: &mut SmallVec<[CompactString; 8]>,
+    declarations: &[(CompactString, CompactString)],
+) {
+    loop {
+        let mut changed = false;
+        for (name, root) in declarations {
+            if contains_name(test_names, root.as_str()) && !contains_name(test_names, name.as_str())
+            {
+                test_names.push(name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn test_extend_root<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return None;
+    };
+    let member = member_from_expression(&call.callee)?;
+    if member.static_property_name() != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn test_extend_root_from_call<'ast>(call: &'ast CallExpression<'ast>) -> Option<&'ast str> {
+    let member = member_from_expression(&call.callee)?;
+    if member.static_property_name() != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn member_from_expression<'ast>(
+    expression: &'ast Expression<'ast>,
+) -> Option<&'ast MemberExpression<'ast>> {
+    match expression.get_inner_expression() {
+        member @ match_member_expression!(Expression) => Some(member.to_member_expression()),
+        _ => None,
+    }
+}
+
+fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn contains_name(names: &[CompactString], value: &str) -> bool {
+    names.iter().any(|name| name == value)
+}
+
+fn push_unique(names: &mut SmallVec<[CompactString; 8]>, value: &str) {
+    if !contains_name(names, value) {
+        names.push(CompactString::from(value));
+    }
+}

--- a/crates/playwright/src/scanner.rs
+++ b/crates/playwright/src/scanner.rs
@@ -95,7 +95,6 @@ impl<'a> Scanner<'a> {
             "prefer-locator",
             r#"page\.(click|dblclick|fill|press|selectOption)\s*\("#,
         );
-        self.check_regex("prefer-lowercase-title", r#"test\s*\(\s*['"][A-Z]"#);
         self.check_regex(
             "prefer-native-locators",
             r#"page\.locator\s*\(\s*['"](?:text=|\[aria-label=|\[data-testid=)"#,

--- a/crates/playwright/src/tests.rs
+++ b/crates/playwright/src/tests.rs
@@ -725,6 +725,289 @@ fn expect_expect_uses_utf16_locations_and_malformed_sources_fail_closed() {
     );
 }
 
+#[test]
+fn prefer_lowercase_title_reports_exact_methods_locations_and_fixes() {
+    let source = concat!(
+        "test('Foo', () => {});\n",
+        "test.skip(`Bar baz`, () => {});\n",
+        "test[`describe`][\"only\"](\"Suite\", () => {});\n",
+        "describe('Group', () => {});\n",
+    );
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 4);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (
+                diagnostic.message_id,
+                diagnostic.data.method.as_deref(),
+                diagnostic.loc.start_line,
+                diagnostic.loc.start_column,
+                diagnostic.loc.end_column,
+            ))
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[
+            ("unexpectedLowercase", Some("test"), 1, 5, 10),
+            ("unexpectedLowercase", Some("test"), 2, 10, 19),
+            ("unexpectedLowercase", Some("test.describe"), 3, 25, 32),
+            ("unexpectedLowercase", Some("test.describe"), 4, 9, 16),
+        ]
+    );
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic
+                .fix
+                .as_ref()
+                .expect("uppercase titles are fixable")
+                .replacement
+                .as_str())
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &["foo", "bar baz", "suite", "group"]
+    );
+
+    let fixed = apply_diagnostic_fixes(source, &diagnostics);
+    assert_eq!(
+        fixed,
+        concat!(
+            "test('foo', () => {});\n",
+            "test.skip(`bar baz`, () => {});\n",
+            "test[`describe`][\"only\"](\"suite\", () => {});\n",
+            "describe('group', () => {});\n",
+        )
+    );
+}
+
+#[test]
+fn prefer_lowercase_title_honors_every_option_and_nested_describe_depth() {
+    let source = concat!(
+        "test.describe('Top', () => {\n",
+        "  test.describe('Nested', () => {\n",
+        "    test('Case', () => {});\n",
+        "  });\n",
+        "});\n",
+        "test.describe('Sibling', () => {});\n",
+        "test('GET /health', () => {});\n",
+        "test('POST /health', () => {});\n",
+    );
+    let options = PlaywrightOptions {
+        allowed_title_prefixes: [CompactString::from("GET")].into_iter().collect(),
+        ignore_top_level_describe: true,
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &options);
+
+    assert_eq!(diagnostics.len(), 3);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.data.method.as_deref(), diagnostic.loc.start_line))
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[
+            (Some("test.describe"), 2),
+            (Some("test"), 3),
+            (Some("test"), 8),
+        ]
+    );
+    assert_eq!(
+        diagnostics[2]
+            .fix
+            .as_ref()
+            .expect("POST title is fixable")
+            .replacement,
+        "pOST /health"
+    );
+
+    let ignore_tests = PlaywrightOptions {
+        lowercase_title_ignored_methods: [CompactString::from("test")].into_iter().collect(),
+        ..options.clone()
+    };
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &ignore_tests);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].data.method.as_deref(), Some("test.describe"));
+
+    let ignore_describes = PlaywrightOptions {
+        lowercase_title_ignored_methods: [CompactString::from("test.describe")]
+            .into_iter()
+            .collect(),
+        ..options
+    };
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &ignore_describes);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.loc.start_line)
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[3, 8]
+    );
+}
+
+#[test]
+fn prefer_lowercase_title_supports_global_import_and_transitive_extend_aliases() {
+    let source = concat!(
+        "import { test as scenario } from \"another-runner\";\n",
+        "const later = custom.extend({});\n",
+        "const custom = scenario.extend({}).extend({});\n",
+        "scenario('Imported', () => {});\n",
+        "custom.describe('Extended suite', () => {});\n",
+        "later.only('Forward alias', () => {});\n",
+        "it('Global alias', () => {});\n",
+    );
+    let options = PlaywrightOptions {
+        test_aliases: [CompactString::from("it")].into_iter().collect(),
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &options);
+
+    assert_eq!(diagnostics.len(), 4);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.data.method.as_deref(), diagnostic.loc.start_line))
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[
+            (Some("test"), 4),
+            (Some("test.describe"), 5),
+            (Some("test"), 6),
+            (Some("test"), 7),
+        ]
+    );
+    assert_eq!(
+        apply_diagnostic_fixes(source, &diagnostics),
+        source
+            .replace("'Imported'", "'imported'")
+            .replace("'Extended suite'", "'extended suite'")
+            .replace("'Forward alias'", "'forward alias'")
+            .replace("'Global alias'", "'global alias'")
+    );
+}
+
+#[test]
+fn prefer_lowercase_title_matches_static_string_and_template_semantics() {
+    let source = concat!(
+        "test(\"\\u0046oo\", () => {});\n",
+        "test(`\\u0046oo`, () => {});\n",
+        "test(`Dynamic ${name}`, () => {});\n",
+        "test(variable, () => {});\n",
+        "test(\"\", () => {});\n",
+        "test(\"<Component/>\", () => {});\n",
+        "test.describe.configure({ mode: \"parallel\" });\n",
+        "test.describe(\"No callback\");\n",
+    );
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+    assert_eq!(
+        diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("decoded string title is fixable")
+            .replacement,
+        "foo"
+    );
+    assert_eq!(
+        apply_diagnostic_fixes(source, &diagnostics),
+        source.replace("\"\\u0046oo\"", "\"foo\"")
+    );
+}
+
+#[test]
+fn prefer_lowercase_title_preserves_javascript_utf16_case_behavior() {
+    let source = concat!(
+        "const marker = \"🧪\"; test(\"İstanbul\", () => {});\n",
+        "test(\"𐐀eseret\", () => {});\n",
+        "test(\"Éclair\", () => {});\n",
+    );
+    let diagnostics = prefer_lowercase_title_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (
+                diagnostic.loc.start_line,
+                diagnostic.loc.start_column,
+                diagnostic.loc.end_column,
+            ))
+            .collect::<SmallVec<[_; 2]>>()
+            .as_slice(),
+        &[(1, 26, 36), (3, 5, 13)]
+    );
+    assert_eq!(
+        diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("BMP uppercase title is fixable")
+            .replacement,
+        "i\u{307}stanbul"
+    );
+    assert_eq!(
+        diagnostics[1]
+            .fix
+            .as_ref()
+            .expect("accented uppercase title is fixable")
+            .replacement,
+        "éclair"
+    );
+    assert_eq!(
+        apply_diagnostic_fixes(source, &diagnostics),
+        concat!(
+            "const marker = \"🧪\"; test(\"i\u{307}stanbul\", () => {});\n",
+            "test(\"𐐀eseret\", () => {});\n",
+            "test(\"éclair\", () => {});\n",
+        )
+    );
+}
+
+#[test]
+fn prefer_lowercase_title_is_inert_for_unrelated_calls_and_parse_errors() {
+    let source = concat!(
+        "random('Title', () => {});\n",
+        "foo.test('Title', () => {});\n",
+        "test.step('Title', () => {});\n",
+        "test('lowercase', () => {});\n",
+        "test('123 Number', () => {});\n",
+        "test('<Markup/>', () => {});\n",
+    );
+    assert!(prefer_lowercase_title_diagnostics(source, &PlaywrightOptions::default()).is_empty());
+    assert!(
+        prefer_lowercase_title_diagnostics("test(\"Broken", &PlaywrightOptions::default())
+            .is_empty()
+    );
+}
+
+fn prefer_lowercase_title_diagnostics(
+    source: &str,
+    options: &PlaywrightOptions,
+) -> SmallVec<[crate::Diagnostic; 8]> {
+    scan_playwright_with_options(source, "fixture.spec.ts", options)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.rule_name == "prefer-lowercase-title")
+        .collect()
+}
+
+fn apply_diagnostic_fixes(source: &str, diagnostics: &[crate::Diagnostic]) -> CompactString {
+    let mut fixed = CompactString::from(source);
+    for diagnostic in diagnostics.iter().rev() {
+        let fix = diagnostic
+            .fix
+            .as_ref()
+            .expect("prefer-lowercase-title diagnostics are fixable");
+        fixed.replace_range(
+            fix.start as usize..fix.end as usize,
+            fix.replacement.as_str(),
+        );
+    }
+    fixed
+}
+
 fn expect_expect_diagnostics(
     source: &str,
     options: &PlaywrightOptions,

--- a/crates/playwright/src/types.rs
+++ b/crates/playwright/src/types.rs
@@ -11,8 +11,11 @@ pub struct Restriction {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaywrightOptions {
+    pub allowed_title_prefixes: SmallVec<[CompactString; 4]>,
     pub assert_function_names: SmallVec<[CompactString; 4]>,
     pub assert_function_patterns: SmallVec<[CompactString; 4]>,
+    pub lowercase_title_ignored_methods: SmallVec<[CompactString; 4]>,
+    pub ignore_top_level_describe: bool,
     pub restricted_locators: SmallVec<[Restriction; 8]>,
     pub restricted_matchers: SmallVec<[Restriction; 8]>,
     pub restricted_roles: SmallVec<[Restriction; 8]>,
@@ -79,8 +82,11 @@ pub struct TagPattern {
 impl Default for PlaywrightOptions {
     fn default() -> Self {
         Self {
+            allowed_title_prefixes: SmallVec::new(),
             assert_function_names: SmallVec::new(),
             assert_function_patterns: SmallVec::new(),
+            lowercase_title_ignored_methods: SmallVec::new(),
+            ignore_top_level_describe: false,
             restricted_locators: SmallVec::new(),
             restricted_matchers: SmallVec::new(),
             restricted_roles: SmallVec::new(),
@@ -114,7 +120,9 @@ pub struct Diagnostic {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DiagnosticFix {
+    /// UTF-8 byte offset into the source text.
     pub start: u32,
+    /// UTF-8 byte offset into the source text.
     pub end: u32,
     pub replacement: CompactString,
 }

--- a/npm/playwright/README.md
+++ b/npm/playwright/README.md
@@ -29,6 +29,30 @@ Exact names match direct calls and terminal member identifiers such as
 syntax. Assertions inside nested callbacks and `test.step()` count toward their
 containing test, matching upstream ancestry behavior.
 
+## Lowercase title options
+
+`prefer-lowercase-title` implements the complete upstream v2.11.0 option and
+autofix contract:
+
+```json
+{
+  "rules": {
+    "playwright/prefer-lowercase-title": [
+      "error",
+      {
+        "allowedPrefixes": ["GET", "POST"],
+        "ignore": ["test.describe"],
+        "ignoreTopLevelDescribe": true
+      }
+    ]
+  }
+}
+```
+
+It checks static string and template titles for `test`, `test.describe`, global
+aliases, named import aliases, and `test.extend()` aliases. Fixes lowercase the
+first UTF-16 code unit with JavaScript-compatible behavior.
+
 ## Numeric threshold options
 
 The numeric threshold rules implement the complete upstream v2.10.4 option
@@ -96,8 +120,11 @@ The direct API accepts the same option values:
 const { scanPlaywright } = require('@oxlint-plugins/oxlint-plugin-playwright/api');
 
 scanPlaywright('page.getByTestId("submit")', 'fixture.spec.ts', {
+  allowedPrefixes: ['GET', 'POST'],
   assertFunctionNames: ['assertCustomCondition'],
   assertFunctionPatterns: ['^verify.*'],
+  ignore: ['test.describe'],
+  ignoreTopLevelDescribe: true,
   maxExpects: 5,
   maxNestedDescribe: 5,
   maxTopLevelDescribes: 2,

--- a/npm/playwright/api.d.ts
+++ b/npm/playwright/api.d.ts
@@ -28,7 +28,7 @@ export type PlaywrightDiagnostic = {
     start: number;
     end: number;
     replacement: string;
-  };
+  } | null;
 };
 
 export type PlaywrightRestrictedLocator =
@@ -46,8 +46,11 @@ export type PlaywrightRestrictedRole =
     };
 
 export type PlaywrightScanOptions = {
+  allowedPrefixes?: string[];
   assertFunctionNames?: string[];
   assertFunctionPatterns?: string[];
+  ignore?: Array<'test.describe' | 'test'>;
+  ignoreTopLevelDescribe?: boolean;
   noRestrictedLocators?: PlaywrightRestrictedLocator[];
   noRestrictedMatchers?: Record<string, string | null>;
   noRestrictedRoles?: PlaywrightRestrictedRole[];

--- a/npm/playwright/api.js
+++ b/npm/playwright/api.js
@@ -18,9 +18,12 @@ function scanPlaywright(sourceText, filename = 'file.spec.ts', options = {}) {
   }
 
   const diagnostics = native.scanPlaywright(sourceText, filename, {
+    allowedPrefixes: stringList(options.allowedPrefixes),
     assertFunctionNames: stringList(options.assertFunctionNames),
     assertFunctionPatterns: regexList(options.assertFunctionPatterns),
     expectAliases: stringList(options.expectAliases),
+    ignore: stringList(options.ignore),
+    ignoreTopLevelDescribe: options.ignoreTopLevelDescribe === true,
     testAliases: stringList(options.testAliases),
     maxExpects: integerOption(options.maxExpects, 'maxExpects', 1),
     maxNestedDescribe: integerOption(options.maxNestedDescribe, 'maxNestedDescribe', 0),
@@ -32,19 +35,7 @@ function scanPlaywright(sourceText, filename = 'file.spec.ts', options = {}) {
     validTestTags: validTestTagsOptions(options.validTestTags),
   });
   const byteToUtf16 = createByteToUtf16Mapper(sourceText);
-  return diagnostics.map((diagnostic) => {
-    if (!diagnostic.fix) {
-      return diagnostic;
-    }
-    return {
-      ...diagnostic,
-      fix: {
-        ...diagnostic.fix,
-        start: byteToUtf16(diagnostic.fix.start),
-        end: byteToUtf16(diagnostic.fix.end),
-      },
-    };
-  });
+  return diagnostics.map((diagnostic) => mapDiagnosticFix(diagnostic, byteToUtf16));
 }
 
 function validTitleOptions(value) {
@@ -197,6 +188,20 @@ function booleanOr(value, fallback) {
   return typeof value === 'boolean' ? value : fallback;
 }
 
+function mapDiagnosticFix(diagnostic, byteToUtf16) {
+  if (!diagnostic.fix) {
+    return diagnostic;
+  }
+  return {
+    ...diagnostic,
+    fix: {
+      start: byteToUtf16(diagnostic.fix.start),
+      end: byteToUtf16(diagnostic.fix.end),
+      replacement: diagnostic.fix.replacement,
+    },
+  };
+}
+
 function createByteToUtf16Mapper(sourceText) {
   const nonAsciiSpans = [];
   let byteOffset = 0;
@@ -204,7 +209,9 @@ function createByteToUtf16Mapper(sourceText) {
 
   while (utf16Offset < sourceText.length) {
     const codePoint = sourceText.codePointAt(utf16Offset);
-    if (codePoint === undefined) break;
+    if (codePoint === undefined) {
+      break;
+    }
     const utf16Length = codePoint > 0xffff ? 2 : 1;
     const byteLength = utf8ByteLength(codePoint);
     const byteEnd = byteOffset + byteLength;
@@ -224,25 +231,25 @@ function createByteToUtf16Mapper(sourceText) {
   if (nonAsciiSpans.length === 0) {
     return (offset) => clampOffset(offset, sourceText.length);
   }
+  const totalBytes = byteOffset;
   return (offset) => {
-    const clampedByteOffset = clampOffset(offset, byteOffset);
+    const clamped = clampOffset(offset, totalBytes);
     let low = 0;
     let high = nonAsciiSpans.length;
     while (low < high) {
       const mid = Math.floor((low + high) / 2);
-      if (nonAsciiSpans[mid].byteEnd <= clampedByteOffset) low = mid + 1;
-      else high = mid;
+      if (nonAsciiSpans[mid].byteEnd <= clamped) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
     }
-    const nextSpan = nonAsciiSpans[low];
-    if (
-      nextSpan &&
-      clampedByteOffset >= nextSpan.byteStart &&
-      clampedByteOffset < nextSpan.byteEnd
-    ) {
-      return nextSpan.utf16Start;
+    const next = nonAsciiSpans[low];
+    if (next && clamped >= next.byteStart && clamped < next.byteEnd) {
+      return next.utf16Start;
     }
     const delta = nonAsciiSpans[low - 1]?.deltaAfter ?? 0;
-    return clampOffset(clampedByteOffset - delta, sourceText.length);
+    return clampOffset(clamped - delta, sourceText.length);
   };
 }
 
@@ -253,9 +260,9 @@ function utf8ByteLength(codePoint) {
   return 4;
 }
 
-function clampOffset(offset, max) {
+function clampOffset(offset, maximum) {
   if (!Number.isFinite(offset) || offset <= 0) return 0;
-  if (offset >= max) return max;
+  if (offset >= maximum) return maximum;
   return Math.trunc(offset);
 }
 

--- a/npm/playwright/index.js
+++ b/npm/playwright/index.js
@@ -22,6 +22,7 @@ const thresholdRules = new Set([
   'max-nested-describe',
   'require-top-level-describe',
 ]);
+const optionAwareTitleRules = new Set(['prefer-lowercase-title']);
 
 const sharedGlobals = Object.freeze({
   expect: false,
@@ -141,6 +142,7 @@ function createLegacyRecommendedConfig() {
 function createPlaywrightRule(ruleName) {
   const specializedMeta =
     expectExpectRuleMeta(ruleName) ??
+    preferLowercaseTitleRuleMeta(ruleName) ??
     restrictedRuleMeta(ruleName) ??
     patternRuleMeta(ruleName) ??
     thresholdRuleMeta(ruleName);
@@ -198,7 +200,9 @@ function diagnosticsForRule(context, ruleName) {
         ? ruleScanOptions(context, ruleName)
         : thresholdRules.has(ruleName)
           ? thresholdScanOptions(context, ruleName)
-          : undefined;
+          : optionAwareTitleRules.has(ruleName)
+            ? preferLowercaseTitleScanOptions(context)
+            : undefined;
   return diagnosticsForContext(context, options).filter(
     (diagnostic) => diagnostic.ruleName === ruleName,
   );
@@ -272,6 +276,18 @@ function expectExpectScanOptions(context) {
     assertFunctionNames: configured.assertFunctionNames,
     assertFunctionPatterns: configured.assertFunctionPatterns,
     ...(Array.isArray(expectAliases) ? { expectAliases } : {}),
+    ...(Array.isArray(testAliases) ? { testAliases } : {}),
+  };
+}
+
+function preferLowercaseTitleScanOptions(context) {
+  const options = Array.isArray(context.options) ? context.options : [];
+  const configured = options[0] && typeof options[0] === 'object' ? options[0] : {};
+  const testAliases = context.settings?.playwright?.globalAliases?.test;
+  return {
+    allowedPrefixes: configured.allowedPrefixes,
+    ignore: configured.ignore,
+    ignoreTopLevelDescribe: configured.ignoreTopLevelDescribe,
     ...(Array.isArray(testAliases) ? { testAliases } : {}),
   };
 }
@@ -425,6 +441,43 @@ function expectExpectRuleMeta(ruleName) {
       },
     ],
     url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/expect-expect.md',
+  };
+}
+
+function preferLowercaseTitleRuleMeta(ruleName) {
+  if (ruleName !== 'prefer-lowercase-title') {
+    return null;
+  }
+  return {
+    description: 'Enforce lowercase test names',
+    messages: {
+      unexpectedLowercase: '`{{method}}`s should begin with lowercase',
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          allowedPrefixes: {
+            additionalItems: false,
+            items: { type: 'string' },
+            type: 'array',
+          },
+          ignore: {
+            additionalItems: false,
+            items: {
+              enum: ['test.describe', 'test'],
+            },
+            type: 'array',
+          },
+          ignoreTopLevelDescribe: {
+            default: false,
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/prefer-lowercase-title.md',
   };
 }
 

--- a/npm/playwright/src/lib.rs
+++ b/npm/playwright/src/lib.rs
@@ -27,8 +27,11 @@ mod napi_abi {
     #[napi(object)]
     #[derive(Clone, Debug, Default)]
     pub struct PlaywrightScanOptions {
+        pub allowed_prefixes: Option<Vec<String>>,
         pub assert_function_names: Option<Vec<String>>,
         pub assert_function_patterns: Option<Vec<String>>,
+        pub ignore: Option<Vec<String>>,
+        pub ignore_top_level_describe: Option<bool>,
         pub restricted_locators: Option<Vec<PlaywrightRestriction>>,
         pub restricted_matchers: Option<Vec<PlaywrightRestriction>>,
         pub restricted_roles: Option<Vec<PlaywrightRestriction>>,
@@ -146,8 +149,11 @@ mod napi_abi {
         let valid_title = compact_valid_title(options.valid_title);
         let valid_test_tags = compact_valid_test_tags(options.valid_test_tags);
         let core_options = core::PlaywrightOptions {
+            allowed_title_prefixes: compact_strings(options.allowed_prefixes),
             assert_function_names: compact_strings(options.assert_function_names),
             assert_function_patterns: compact_strings(options.assert_function_patterns),
+            lowercase_title_ignored_methods: compact_strings(options.ignore),
+            ignore_top_level_describe: options.ignore_top_level_describe.unwrap_or(false),
             restricted_locators: compact_restrictions(options.restricted_locators),
             restricted_matchers: compact_restrictions(options.restricted_matchers),
             restricted_roles: compact_restrictions(options.restricted_roles),

--- a/npm/playwright/test/fixtures/prefer-lowercase-title-v2.11.0.json
+++ b/npm/playwright/test/fixtures/prefer-lowercase-title-v2.11.0.json
@@ -1,0 +1,1106 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-playwright",
+    "version": "2.11.0",
+    "sourceCommit": "b6d3e5dac73c8aad4d5e62a933105579c319655f",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts",
+    "sourceFiles": [
+      "src/rules/prefer-lowercase-title.ts",
+      "src/rules/prefer-lowercase-title.test.ts",
+      "docs/rules/prefer-lowercase-title.md"
+    ],
+    "sourceHashes": {
+      "src/rules/prefer-lowercase-title.ts": "351bf97eb91d65da36f4e1bd079b399c786f621c06421d49f34c3c78b8246769",
+      "src/rules/prefer-lowercase-title.test.ts": "eae061c77c8c796bacb80e77e7add65344671e77bad521232516c9958fbde3a9",
+      "docs/rules/prefer-lowercase-title.md": "1fb0cf8238204964071adb4dbc5aa9be6200aafa3321e287573f99cf9b33738d"
+    },
+    "previousVersionAudit": {
+      "version": "2.10.4",
+      "sourceCommit": "894c0ec261763bb1e073b276c70bbf88b4ebad39",
+      "changedFiles": []
+    },
+    "inventory": {
+      "suites": 5,
+      "valid": 55,
+      "invalid": 27,
+      "diagnostics": 28,
+      "fixable": 27
+    }
+  },
+  "rule": "prefer-lowercase-title",
+  "suites": [
+    {
+      "name": "prefer-lowercase-title",
+      "valid": [
+        {
+          "code": "randomFunction()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "foo.bar()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test('foo Bar', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(`foo`, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(\"<Foo/>\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(\"123 foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(\"42\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(``, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(\"\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(42, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.fixme('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.skip('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.only('foo Bar', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test[\"fixme\"](\"foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test[\"skip\"](`foo`, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe()",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe('foo Bar', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe(`foo`, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test[\"describe\"](\"<Foo/>\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test[`describe`](\"123 foo\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe(\"42\", () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe(``)",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe(\"\")",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe(42)",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.skip('foo Bar', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.skip(`foo`, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.fixme('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.only('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.parallel.skip('foo Bar', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.parallel.skip(`foo`, () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.parallel.fixme('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.parallel.only('foo Bar Baz', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.serial.skip('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe[`serial`].fixme('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe['serial'].only('foo', () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom(\"foo\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test('Foo',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 5,
+                "endLine": 1,
+                "endColumn": 10
+              }
+            }
+          ],
+          "expectedOutput": "test('foo',  () => {})"
+        },
+        {
+          "code": "test(`Foo bar`,  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 5,
+                "endLine": 1,
+                "endColumn": 14
+              }
+            }
+          ],
+          "expectedOutput": "test(`foo bar`,  () => {})"
+        },
+        {
+          "code": "test.skip('Foo Bar',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 19
+              }
+            }
+          ],
+          "expectedOutput": "test.skip('foo Bar',  () => {})"
+        },
+        {
+          "code": "test.skip(`Foo`,  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 10,
+                "endLine": 1,
+                "endColumn": 15
+              }
+            }
+          ],
+          "expectedOutput": "test.skip(`foo`,  () => {})"
+        },
+        {
+          "code": "test['fixme']('Foo',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 14,
+                "endLine": 1,
+                "endColumn": 19
+              }
+            }
+          ],
+          "expectedOutput": "test['fixme']('foo',  () => {})"
+        },
+        {
+          "code": "test[`only`](`Foo`,  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 13,
+                "endLine": 1,
+                "endColumn": 18
+              }
+            }
+          ],
+          "expectedOutput": "test[`only`](`foo`,  () => {})"
+        },
+        {
+          "code": "test.describe('Foo bar',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 14,
+                "endLine": 1,
+                "endColumn": 23
+              }
+            }
+          ],
+          "expectedOutput": "test.describe('foo bar',  () => {})"
+        },
+        {
+          "code": "test[`describe`](`Foo Bar`,  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 17,
+                "endLine": 1,
+                "endColumn": 26
+              }
+            }
+          ],
+          "expectedOutput": "test[`describe`](`foo Bar`,  () => {})"
+        },
+        {
+          "code": "test.describe.skip('Foo',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 19,
+                "endLine": 1,
+                "endColumn": 24
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.skip('foo',  () => {})"
+        },
+        {
+          "code": "test.describe.fixme('Foo',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 20,
+                "endLine": 1,
+                "endColumn": 25
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.fixme('foo',  () => {})"
+        },
+        {
+          "code": "test[`describe`][\"only\"](\"Foo\",  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 25,
+                "endLine": 1,
+                "endColumn": 30
+              }
+            }
+          ],
+          "expectedOutput": "test[`describe`][\"only\"](\"foo\",  () => {})"
+        },
+        {
+          "code": "test.describe.parallel.skip('Foo',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 28,
+                "endLine": 1,
+                "endColumn": 33
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.parallel.skip('foo',  () => {})"
+        },
+        {
+          "code": "test.describe.parallel.fixme(`Foo`,  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 29,
+                "endLine": 1,
+                "endColumn": 34
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.parallel.fixme(`foo`,  () => {})"
+        },
+        {
+          "code": "test.describe.parallel.only(\"Foo\",  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 28,
+                "endLine": 1,
+                "endColumn": 33
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.parallel.only(\"foo\",  () => {})"
+        },
+        {
+          "code": "test.describe.serial.skip('Foo',  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 26,
+                "endLine": 1,
+                "endColumn": 31
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.serial.skip('foo',  () => {})"
+        },
+        {
+          "code": "test.describe.serial.fixme(`Foo`,  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 27,
+                "endLine": 1,
+                "endColumn": 32
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.serial.fixme(`foo`,  () => {})"
+        },
+        {
+          "code": "test.describe.serial.only(\"Foo\",  () => {})",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 26,
+                "endLine": 1,
+                "endColumn": 31
+              }
+            }
+          ],
+          "expectedOutput": "test.describe.serial.only(\"foo\",  () => {})"
+        },
+        {
+          "code": "it('Foo',  () => {})",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 3,
+                "endLine": 1,
+                "endColumn": 8
+              }
+            }
+          ],
+          "expectedOutput": "it('foo',  () => {})"
+        },
+        {
+          "code": "it.describe('Foo',  () => {})",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 12,
+                "endLine": 1,
+                "endColumn": 17
+              }
+            }
+          ],
+          "expectedOutput": "it.describe('foo',  () => {})"
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom('Foo',  () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 2,
+                "startColumn": 7,
+                "endLine": 2,
+                "endColumn": 12
+              }
+            }
+          ],
+          "expectedOutput": "const custom = test.extend({});\ncustom('foo',  () => {});"
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom.describe('Foo',  () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 2,
+                "startColumn": 16,
+                "endLine": 2,
+                "endColumn": 21
+              }
+            }
+          ],
+          "expectedOutput": "const custom = test.extend({});\ncustom.describe('foo',  () => {});"
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom('Foo',  () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 2,
+                "startColumn": 7,
+                "endLine": 2,
+                "endColumn": 12
+              }
+            }
+          ],
+          "expectedOutput": "import { test as custom } from '@playwright/test';\ncustom('foo',  () => {});"
+        }
+      ]
+    },
+    {
+      "name": "prefer-lowercase-title with ignore=test.describe",
+      "valid": [
+        {
+          "code": "test.describe('Foo', () => {})",
+          "options": [
+            {
+              "ignore": ["test.describe"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.parallel(`Foo`, () => {})",
+          "options": [
+            {
+              "ignore": ["test.describe"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe.skip(`Foo`, () => {})",
+          "options": [
+            {
+              "ignore": ["test.describe"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test('Foo', () => {})",
+          "options": [
+            {
+              "ignore": ["test.describe"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 5,
+                "endLine": 1,
+                "endColumn": 10
+              }
+            }
+          ],
+          "expectedOutput": "test('foo', () => {})"
+        }
+      ]
+    },
+    {
+      "name": "prefer-lowercase-title with ignore=test",
+      "valid": [
+        {
+          "code": "test('Foo', () => {})",
+          "options": [
+            {
+              "ignore": ["test"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(`Foo`, () => {})",
+          "options": [
+            {
+              "ignore": ["test"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.only(`Foo`, () => {})",
+          "options": [
+            {
+              "ignore": ["test"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test.describe('Foo', () => {})",
+          "options": [
+            {
+              "ignore": ["test"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 14,
+                "endLine": 1,
+                "endColumn": 19
+              }
+            }
+          ],
+          "expectedOutput": "test.describe('foo', () => {})"
+        }
+      ]
+    },
+    {
+      "name": "prefer-lowercase-title with allowedPrefixes",
+      "valid": [
+        {
+          "code": "test('GET /live', () => {})",
+          "options": [
+            {
+              "allowedPrefixes": ["GET"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(\"POST /live\", () => {})",
+          "options": [
+            {
+              "allowedPrefixes": ["GET", "POST"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(`PATCH /live`, () => {})",
+          "options": [
+            {
+              "allowedPrefixes": ["GET", "PATCH"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test(\"TODO: implement\", () => {})",
+          "options": [
+            {
+              "allowedPrefixes": ["TODO"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test(`POST /live`, () => {})",
+          "options": [
+            {
+              "allowedPrefixes": ["GET"]
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 5,
+                "endLine": 1,
+                "endColumn": 17
+              }
+            }
+          ],
+          "expectedOutput": "test(`pOST /live`, () => {})"
+        }
+      ]
+    },
+    {
+      "name": "prefer-lowercase-title with ignoreTopLevelDescribe",
+      "valid": [
+        {
+          "code": "test(\"already lower\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe(\"already lower\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "describe(\"MyClass\", () => {});",
+          "options": [
+            {
+              "ignoreTopLevelDescribe": true
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "test.describe('MyClass', () => {\n  test.describe('#myMethod', () => {\n    test('does things', () => {});\n  });\n});",
+          "options": [
+            {
+              "ignoreTopLevelDescribe": true
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "it(\"already lower\", () => {});",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "it.describe(\"already lower\", () => {});",
+          "options": [],
+          "settings": {
+            "playwright": {
+              "globalAliases": {
+                "test": ["it"]
+              }
+            }
+          },
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom(\"already lower\", () => {});",
+          "options": [
+            {
+              "ignoreTopLevelDescribe": true
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "const custom = test.extend({});\ncustom.describe(\"already lower\", () => {});",
+          "options": [
+            {
+              "ignoreTopLevelDescribe": true
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        },
+        {
+          "code": "import { test as custom } from '@playwright/test';\ncustom(\"already lower\", () => {});",
+          "options": [],
+          "settings": null,
+          "expectedDiagnostics": [],
+          "expectedOutput": null
+        }
+      ],
+      "invalid": [
+        {
+          "code": "test(\"Works!\", () => {});",
+          "options": [
+            {
+              "ignoreTopLevelDescribe": true
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 1,
+                "startColumn": 5,
+                "endLine": 1,
+                "endColumn": 13
+              }
+            }
+          ],
+          "expectedOutput": "test(\"works!\", () => {});"
+        },
+        {
+          "code": "test.describe('MyClass', () => {\n  test.describe('MyMethod', () => {\n    test('Does things', () => {});\n  });\n});",
+          "options": [
+            {
+              "ignoreTopLevelDescribe": true
+            }
+          ],
+          "settings": null,
+          "expectedDiagnostics": [
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test.describe"
+              },
+              "loc": {
+                "startLine": 2,
+                "startColumn": 16,
+                "endLine": 2,
+                "endColumn": 26
+              }
+            },
+            {
+              "messageId": "unexpectedLowercase",
+              "data": {
+                "method": "test"
+              },
+              "loc": {
+                "startLine": 3,
+                "startColumn": 9,
+                "endLine": 3,
+                "endColumn": 22
+              }
+            }
+          ],
+          "expectedOutput": "test.describe('MyClass', () => {\n  test.describe('myMethod', () => {\n    test('does things', () => {});\n  });\n});"
+        }
+      ]
+    }
+  ]
+}

--- a/npm/playwright/test/plugin.test.mjs
+++ b/npm/playwright/test/plugin.test.mjs
@@ -159,6 +159,9 @@ const expectedThresholdMessages = {
     'Maximum describe call depth exceeded ({{ depth }}). Maximum allowed is {{ max }}.',
   'require-top-level-describe': 'All test cases must be wrapped in a describe block.',
 };
+const expectedSpecializedMessages = {
+  'prefer-lowercase-title': '`{{method}}`s should begin with lowercase',
+};
 
 function runRule(ruleName, sourceText, options = [], filename = 'fixture.spec.ts') {
   const reports = [];
@@ -214,6 +217,7 @@ describe('playwright plugin adapter', () => {
     expect(plugin.rules[ruleName].meta.messages[reports[0].messageId]).toBe(
       expectedRestrictedMessages[ruleName] ??
         expectedThresholdMessages[ruleName] ??
+        expectedSpecializedMessages[ruleName] ??
         'Unexpected Playwright pattern.',
     );
   });

--- a/npm/playwright/test/prefer-lowercase-title-upstream.test.mjs
+++ b/npm/playwright/test/prefer-lowercase-title-upstream.test.mjs
@@ -1,0 +1,404 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanPlaywright } from '../api.js';
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+const fixture = JSON.parse(
+  readFileSync(join(packageRoot, 'test/fixtures/prefer-lowercase-title-v2.11.0.json'), 'utf8'),
+);
+const ruleName = 'prefer-lowercase-title';
+const rule = plugin.rules[ruleName];
+const validCases = fixture.suites.flatMap((suite) =>
+  suite.valid.map((testCase, index) => ({
+    ...testCase,
+    label: `${suite.name} valid ${index + 1}`,
+  })),
+);
+const invalidCases = fixture.suites.flatMap((suite) =>
+  suite.invalid.map((testCase, index) => ({
+    ...testCase,
+    label: `${suite.name} invalid ${index + 1}`,
+  })),
+);
+
+describe('playwright prefer-lowercase-title upstream v2.11.0 fixtures', () => {
+  it('pins exact upstream sources, previous-version drift, and authored inventory', () => {
+    expect(fixture.__generated).toEqual({
+      source: 'eslint-plugin-playwright',
+      version: '2.11.0',
+      sourceCommit: 'b6d3e5dac73c8aad4d5e62a933105579c319655f',
+      license: 'MIT',
+      tool: 'tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts',
+      sourceFiles: [
+        'src/rules/prefer-lowercase-title.ts',
+        'src/rules/prefer-lowercase-title.test.ts',
+        'docs/rules/prefer-lowercase-title.md',
+      ],
+      sourceHashes: {
+        'src/rules/prefer-lowercase-title.ts':
+          '351bf97eb91d65da36f4e1bd079b399c786f621c06421d49f34c3c78b8246769',
+        'src/rules/prefer-lowercase-title.test.ts':
+          'eae061c77c8c796bacb80e77e7add65344671e77bad521232516c9958fbde3a9',
+        'docs/rules/prefer-lowercase-title.md':
+          '1fb0cf8238204964071adb4dbc5aa9be6200aafa3321e287573f99cf9b33738d',
+      },
+      previousVersionAudit: {
+        version: '2.10.4',
+        sourceCommit: '894c0ec261763bb1e073b276c70bbf88b4ebad39',
+        changedFiles: [],
+      },
+      inventory: {
+        suites: 5,
+        valid: 55,
+        invalid: 27,
+        diagnostics: 28,
+        fixable: 27,
+      },
+    });
+    expect(validCases).toHaveLength(55);
+    expect(invalidCases).toHaveLength(27);
+  });
+
+  it.each(validCases)('$label is valid through native and plugin paths', (testCase) => {
+    expect(nativeDiagnostics(testCase)).toEqual([]);
+    expect(adapterReports(testCase)).toEqual([]);
+  });
+
+  it.each(invalidCases)('$label matches exact diagnostics and fixes', (testCase) => {
+    const diagnostics = nativeDiagnostics(testCase);
+    const reports = adapterReports(testCase);
+
+    expect(
+      diagnostics.map((diagnostic) => ({
+        messageId: diagnostic.messageId,
+        data: compactData(diagnostic.data),
+        loc: diagnostic.loc,
+      })),
+    ).toEqual(testCase.expectedDiagnostics);
+    expect(
+      reports.map((report) => ({
+        messageId: report.messageId,
+        data: compactData(report.data),
+        loc: {
+          startLine: report.loc.start.line,
+          startColumn: report.loc.start.column,
+          endLine: report.loc.end.line,
+          endColumn: report.loc.end.column,
+        },
+      })),
+    ).toEqual(testCase.expectedDiagnostics);
+
+    expect(diagnostics.every((diagnostic) => diagnostic.fix)).toBe(true);
+    expect(reports.every((report) => report.appliedFix)).toBe(true);
+    expect(applyNativeFixes(testCase.code, diagnostics)).toBe(testCase.expectedOutput);
+    expect(applyAdapterFixes(testCase.code, reports)).toBe(testCase.expectedOutput);
+    expect(
+      reports.map((report) =>
+        rule.meta.messages[report.messageId].replace('{{method}}', report.data.method),
+      ),
+    ).toEqual(
+      testCase.expectedDiagnostics.map(
+        (diagnostic) => `\`${diagnostic.data.method}\`s should begin with lowercase`,
+      ),
+    );
+  });
+
+  it('exposes the exact upstream metadata, schema, and autofix contract', () => {
+    expect(rule.meta).toMatchObject({
+      type: 'suggestion',
+      docs: {
+        description: 'Enforce lowercase test names',
+        recommended: false,
+        url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/prefer-lowercase-title.md',
+      },
+      fixable: 'code',
+      messages: {
+        unexpectedLowercase: '`{{method}}`s should begin with lowercase',
+      },
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            allowedPrefixes: {
+              additionalItems: false,
+              items: { type: 'string' },
+              type: 'array',
+            },
+            ignore: {
+              additionalItems: false,
+              items: { enum: ['test.describe', 'test'] },
+              type: 'array',
+            },
+            ignoreTopLevelDescribe: {
+              default: false,
+              type: 'boolean',
+            },
+          },
+          type: 'object',
+        },
+      ],
+    });
+    expect(rule.meta.hasSuggestions).toBeUndefined();
+  });
+
+  it('applies options together without leaking state across top-level siblings', () => {
+    const code = [
+      "test.describe('Top', () => {",
+      "  test.describe('Nested', () => { test('Case', () => {}); });",
+      '});',
+      "test.describe('Sibling', () => {});",
+      "test('GET /health', () => {});",
+      "test('POST /health', () => {});",
+    ].join('\n');
+    const testCase = {
+      code,
+      options: [
+        {
+          allowedPrefixes: ['GET'],
+          ignoreTopLevelDescribe: true,
+        },
+      ],
+      settings: null,
+    };
+    const diagnostics = nativeDiagnostics(testCase);
+
+    expect(diagnostics.map((diagnostic) => diagnostic.data.method)).toEqual([
+      'test.describe',
+      'test',
+      'test',
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.loc.startLine)).toEqual([2, 2, 6]);
+    expect(applyNativeFixes(code, diagnostics)).toContain("test.describe('nested'");
+    expect(applyNativeFixes(code, diagnostics)).toContain("test('case'");
+    expect(applyNativeFixes(code, diagnostics)).toContain("test('pOST /health'");
+    expect(applyNativeFixes(code, diagnostics)).toContain("test.describe('Top'");
+    expect(applyNativeFixes(code, diagnostics)).toContain("test.describe('Sibling'");
+  });
+
+  it('supports arbitrary import aliases, configured globals, and transitive extend aliases', () => {
+    const code = [
+      'import { test as scenario } from "another-runner";',
+      'const later = custom.extend({});',
+      'const custom = scenario.extend({}).extend({});',
+      "scenario('Imported', () => {});",
+      "custom.describe('Extended', () => {});",
+      "later.only('Forward', () => {});",
+      "it('Global', () => {});",
+    ].join('\n');
+    const testCase = {
+      code,
+      options: [],
+      settings: { playwright: { globalAliases: { test: ['it'] } } },
+    };
+    const diagnostics = nativeDiagnostics(testCase);
+
+    expect(diagnostics.map((diagnostic) => diagnostic.loc.startLine)).toEqual([4, 5, 6, 7]);
+    expect(diagnostics.map((diagnostic) => diagnostic.data.method)).toEqual([
+      'test',
+      'test.describe',
+      'test',
+      'test',
+    ]);
+    expect(adapterReports(testCase)).toHaveLength(4);
+  });
+
+  it('matches decoded strings, raw templates, dynamic titles, and JavaScript UTF-16 casing', () => {
+    const code = [
+      '"🧪"; test("\\u0046oo", () => {});',
+      'test(`\\u0046oo`, () => {});',
+      'test(`Dynamic ${name}`, () => {});',
+      'test("İstanbul", () => {});',
+      'test("𐐀eseret", () => {});',
+      'test("Éclair", () => {});',
+    ].join('\n');
+    const testCase = { code, options: [], settings: null };
+    const diagnostics = nativeDiagnostics(testCase);
+
+    expect(diagnostics.map((diagnostic) => diagnostic.loc.startLine)).toEqual([1, 4, 6]);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix.replacement)).toEqual([
+      'foo',
+      'i\u0307stanbul',
+      'éclair',
+    ]);
+    expect(diagnostics[0].fix.start).toBe(code.indexOf('"\\u0046oo"') + 1);
+    expect(diagnostics[1].fix.start).toBe(code.indexOf('İstanbul'));
+    expect(applyNativeFixes(code, diagnostics)).toBe(
+      code
+        .replace('"\\u0046oo"', '"foo"')
+        .replace('"İstanbul"', '"i\u0307stanbul"')
+        .replace('"Éclair"', '"éclair"'),
+    );
+  });
+
+  it('fails closed for malformed input and ignores non-test call shapes', () => {
+    expect(
+      nativeDiagnostics({
+        code: [
+          "random('Title', () => {});",
+          "foo.test('Title', () => {});",
+          "test.step('Title', () => {});",
+        ].join('\n'),
+        options: [],
+        settings: null,
+      }),
+    ).toEqual([]);
+    expect(
+      nativeDiagnostics({
+        code: 'test("Broken',
+        options: [],
+        settings: null,
+      }),
+    ).toEqual([]);
+  });
+
+  it('reports and fixes a TypeScript file through real Oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-playwright-lowercase-'));
+    try {
+      const source = [
+        'type Fixture = { title: string };',
+        'const fixture: Fixture = { title: "demo" };',
+        'test("Works with types", () => { void fixture; });',
+        '',
+      ].join('\n');
+      writeFileSync(join(tempDir, 'fixture.spec.ts'), source);
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [{ name: 'playwright', specifier: join(packageRoot, 'index.js') }],
+          rules: { 'playwright/prefer-lowercase-title': 'error' },
+        }),
+      );
+
+      const lint = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.spec.ts'],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      const payload = JSON.parse(lint.stdout);
+      expect(lint.status).toBe(1);
+      expect(lint.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(1);
+      expect(payload.diagnostics[0]).toMatchObject({
+        code: 'playwright(prefer-lowercase-title)',
+        message: '`test`s should begin with lowercase',
+      });
+
+      const fix = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', '--quiet', 'fixture.spec.ts'],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      expect(fix.status).toBe(0);
+      expect(fix.stderr).toBe('');
+      expect(readFileSync(join(tempDir, 'fixture.spec.ts'), 'utf8')).toBe(
+        source.replace('"Works with types"', '"works with types"'),
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function nativeDiagnostics(testCase) {
+  return scanPlaywright(testCase.code, 'fixture.spec.ts', scanOptions(testCase)).filter(
+    (diagnostic) => diagnostic.ruleName === ruleName,
+  );
+}
+
+function scanOptions(testCase) {
+  const configured = testCase.options?.[0] ?? {};
+  const testAliases = testCase.settings?.playwright?.globalAliases?.test;
+  return {
+    allowedPrefixes: configured.allowedPrefixes,
+    ignore: configured.ignore,
+    ignoreTopLevelDescribe: configured.ignoreTopLevelDescribe,
+    ...(Array.isArray(testAliases) ? { testAliases } : {}),
+  };
+}
+
+function adapterReports(testCase) {
+  const reports = [];
+  const sourceCode = {
+    text: testCase.code,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    filename: 'fixture.spec.ts',
+    options: testCase.options,
+    settings: testCase.settings,
+    sourceCode,
+    report(descriptor) {
+      reports.push({
+        ...descriptor,
+        appliedFix:
+          typeof descriptor.fix === 'function'
+            ? descriptor.fix({
+                replaceTextRange(range, replacementText) {
+                  return { range, replacementText };
+                },
+              })
+            : null,
+      });
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, testCase.code.length] });
+  return reports;
+}
+
+function compactData(data) {
+  return Object.fromEntries(
+    Object.entries(data).filter(
+      ([, value]) => value !== undefined && value !== null && value !== '',
+    ),
+  );
+}
+
+function applyNativeFixes(source, diagnostics) {
+  return applyFixes(
+    source,
+    diagnostics.map((diagnostic) => ({
+      range: [diagnostic.fix.start, diagnostic.fix.end],
+      replacementText: diagnostic.fix.replacement,
+    })),
+  );
+}
+
+function applyAdapterFixes(source, reports) {
+  return applyFixes(
+    source,
+    reports.map((report) => report.appliedFix),
+  );
+}
+
+function applyFixes(source, fixes) {
+  return [...fixes]
+    .sort((left, right) => right.range[0] - left.range[0])
+    .reduce(
+      (output, fix) =>
+        `${output.slice(0, fix.range[0])}${fix.replacementText}${output.slice(fix.range[1])}`,
+      source,
+    );
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((left, right) => left.localeCompare(right));
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+  return candidates[candidates.length - 1];
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "port:tests:perfectionist:sort-array-includes": "node tools/tasks/sync-perfectionist-sort-array-includes-options-tests.ts",
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:expect-expect": "node tools/tasks/sync-playwright-expect-expect-tests.ts",
+    "port:tests:playwright:prefer-lowercase-title": "node tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:playwright:patterns": "node tools/tasks/sync-playwright-pattern-tests.ts",
     "port:tests:playwright:thresholds": "node tools/tasks/sync-playwright-threshold-tests.ts",

--- a/status.json
+++ b/status.json
@@ -4867,7 +4867,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-playwright/prefer-lowercase-title; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Native Oxc AST port of eslint-plugin-playwright prefer-lowercase-title v2.11.0 with complete allowedPrefixes, ignore and ignoreTopLevelDescribe options, exact messages/data/UTF-16 title locations, JavaScript-compatible fixes, aliases, deterministic authored fixture replay, direct API/plugin/playground coverage, and real Oxlint lint/fix integration."
       },
       {
         "name": "prefer-native-locators",

--- a/tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts
+++ b/tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts
@@ -1,0 +1,224 @@
+// Captures every authored eslint-plugin-playwright v2.11.0 RuleTester case for
+// `prefer-lowercase-title` from the exact upstream commit.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type RawCase =
+  | string
+  | {
+      code: string;
+      errors?: RawError[];
+      options?: unknown[];
+      output?: string | null;
+      settings?: unknown;
+    };
+type RawError = {
+  column?: number;
+  data?: Record<string, unknown>;
+  endColumn?: number;
+  endLine?: number;
+  line?: number;
+  messageId?: string;
+};
+type CapturedSuite = {
+  invalid: RawCase[];
+  valid: RawCase[];
+};
+type NamedSuite = {
+  name: string;
+  suite: CapturedSuite;
+};
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    license: string;
+    submodule: string;
+  }>;
+};
+
+const ROOT = process.cwd();
+const VERSION = '2.11.0';
+const PINNED_COMMIT = 'b6d3e5dac73c8aad4d5e62a933105579c319655f';
+const PREVIOUS_VERSION = '2.10.4';
+const PREVIOUS_COMMIT = '894c0ec261763bb1e073b276c70bbf88b4ebad39';
+const RULE = 'prefer-lowercase-title';
+const SOURCE_FILES = [`src/rules/${RULE}.ts`, `src/rules/${RULE}.test.ts`, `docs/rules/${RULE}.md`];
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-playwright');
+if (!plugin) throw new Error('eslint-plugin-playwright is not registered');
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Run \`git submodule update --init ${plugin.submodule}\` first.`);
+}
+for (const commit of [PREVIOUS_COMMIT, PINNED_COMMIT]) {
+  execFileSync('git', ['-C', submodule, 'cat-file', '-e', `${commit}^{commit}`]);
+}
+
+const sourceHashes = Object.fromEntries(
+  SOURCE_FILES.map((sourceFile) => [
+    sourceFile,
+    createHash('sha256').update(upstreamSource(PINNED_COMMIT, sourceFile)).digest('hex'),
+  ]),
+);
+const changedFromPrevious = SOURCE_FILES.filter(
+  (sourceFile) =>
+    upstreamSource(PREVIOUS_COMMIT, sourceFile) !== upstreamSource(PINNED_COMMIT, sourceFile),
+);
+if (changedFromPrevious.length !== 0) {
+  throw new Error(
+    `${RULE} unexpectedly drifted from ${PREVIOUS_VERSION}: ${changedFromPrevious.join(', ')}`,
+  );
+}
+
+const captured = captureSuites(upstreamSource(PINNED_COMMIT, `src/rules/${RULE}.test.ts`));
+const suites = captured.map(({ name, suite }) => ({
+  name,
+  valid: suite.valid.map((testCase, index) =>
+    normalizeCase(testCase, false, `${name} valid ${index}`),
+  ),
+  invalid: suite.invalid.map((testCase, index) =>
+    normalizeCase(testCase, true, `${name} invalid ${index}`),
+  ),
+}));
+const inventory = {
+  suites: suites.length,
+  valid: suites.reduce((total, suite) => total + suite.valid.length, 0),
+  invalid: suites.reduce((total, suite) => total + suite.invalid.length, 0),
+  diagnostics: suites.reduce(
+    (total, suite) =>
+      total +
+      suite.invalid.reduce(
+        (suiteTotal, testCase) => suiteTotal + testCase.expectedDiagnostics.length,
+        0,
+      ),
+    0,
+  ),
+  fixable: suites.reduce(
+    (total, suite) =>
+      total + suite.invalid.filter((testCase) => testCase.expectedOutput !== null).length,
+    0,
+  ),
+};
+const fixture = {
+  __generated: {
+    source: 'eslint-plugin-playwright',
+    version: VERSION,
+    sourceCommit: PINNED_COMMIT,
+    license: plugin.license,
+    tool: 'tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts',
+    sourceFiles: SOURCE_FILES,
+    sourceHashes,
+    previousVersionAudit: {
+      version: PREVIOUS_VERSION,
+      sourceCommit: PREVIOUS_COMMIT,
+      changedFiles: changedFromPrevious,
+    },
+    inventory,
+  },
+  rule: RULE,
+  suites,
+};
+
+const outputDirectory = join(ROOT, 'npm', 'playwright', 'test', 'fixtures');
+mkdirSync(outputDirectory, { recursive: true });
+const outputPath = join(outputDirectory, `${RULE}-v${VERSION}.json`);
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { stdio: 'ignore' });
+console.log(
+  `Captured ${inventory.valid} valid, ${inventory.invalid} invalid, ` +
+    `${inventory.diagnostics} diagnostics, and ${inventory.fixable} fixed outputs ` +
+    `across ${inventory.suites} suites.`,
+);
+
+function captureSuites(source: string): NamedSuite[] {
+  const executable = source.replace(/^import .*$/gmu, '');
+  const captured: NamedSuite[] = [];
+  const sandbox = {
+    dedent,
+    rule: {},
+    runRuleTester(name: string, _capturedRuleModule: unknown, suite: CapturedSuite) {
+      if (!name.startsWith(RULE)) {
+        throw new Error(`Expected ${RULE}, captured ${name}.`);
+      }
+      captured.push({ name, suite });
+    },
+  };
+  runInNewContext(`"use strict";\n${executable}`, sandbox);
+  if (captured.length === 0) throw new Error(`Failed to capture ${RULE}.`);
+  return captured;
+}
+
+function normalizeCase(testCase: RawCase, invalid: boolean, label: string) {
+  const normalized = typeof testCase === 'string' ? { code: testCase } : testCase;
+  if (typeof normalized.code !== 'string') throw new Error(`${label} is missing source code.`);
+  const errors = invalid ? normalized.errors : [];
+  if (invalid && (!Array.isArray(errors) || errors.length === 0)) {
+    throw new Error(`${label} is missing expected errors.`);
+  }
+  return {
+    code: normalized.code,
+    options: normalized.options ?? [],
+    settings: normalized.settings ?? null,
+    expectedDiagnostics: (errors ?? []).map((error, index) =>
+      normalizeError(error, `${label} error ${index}`),
+    ),
+    expectedOutput: invalid && typeof normalized.output === 'string' ? normalized.output : null,
+  };
+}
+
+function normalizeError(error: RawError, label: string) {
+  if (
+    typeof error.messageId !== 'string' ||
+    typeof error.column !== 'number' ||
+    typeof error.endColumn !== 'number'
+  ) {
+    throw new Error(`${label} is missing its exact diagnostic contract.`);
+  }
+  const line = error.line ?? 1;
+  return {
+    messageId: error.messageId,
+    data: error.data ?? {},
+    loc: {
+      startLine: line,
+      startColumn: error.column - 1,
+      endLine: error.endLine ?? line,
+      endColumn: error.endColumn - 1,
+    },
+  };
+}
+
+function upstreamSource(commit: string, sourceFile: string): string {
+  return execFileSync('git', ['-C', submodule, 'show', `${commit}:${sourceFile}`], {
+    encoding: 'utf8',
+  });
+}
+
+function dedent(
+  strings: TemplateStringsArray | string,
+  ...values: Array<string | number | bigint | boolean | null | undefined>
+): string {
+  const value =
+    typeof strings === 'string'
+      ? strings
+      : strings.reduce(
+          (output, segment, index) => output + segment + String(values[index] ?? ''),
+          '',
+        );
+  const lines = value
+    .replace(/^\n/u, '')
+    .replace(/\n\s*$/u, '')
+    .split('\n');
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^\s*/u)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join('\n');
+}


### PR DESCRIPTION
## Summary
- port the complete eslint-plugin-playwright v2.11.0 `prefer-lowercase-title` behavior to the Oxc-backed scanner
- support imported/global/transitive aliases plus `allowedPrefixes`, `ignore`, and `ignoreTopLevelDescribe`
- add native, NAPI, plugin, Playground, generated upstream-fixture, UTF-16 location, and autofix coverage

## Testing
- `VITEST_MAX_WORKERS=1 pnpm verify` (agent source commit: 16,536 passed, 1,159 skipped)
- `VITEST_MAX_WORKERS=1 pnpm exec vitest run npm/playwright/test/prefer-lowercase-title-upstream.test.mjs npm/playwright/test/api.test.mjs npm/playwright/test/plugin.test.mjs` (153 passed on latest main)
- `cargo test -p oxlint-plugins-playwright` (27 passed on latest main)
- `cargo test -p oxlint-plugins-playground-wasm` (6 passed on latest main)
- `pnpm run status:check`
- `cargo fmt --check`
- `vp fmt --check`
- `git diff --check`

Part of #420.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->