### PR TITLE
feat(angular-eslint): port require-localize-metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,6 +1369,7 @@ dependencies = [
  "oxc_span",
  "oxlint-plugins-_carton",
  "regex",
+ "regress",
  "serde_json",
 ]
 

--- a/crates/angular_eslint/Cargo.toml
+++ b/crates/angular_eslint/Cargo.toml
@@ -17,6 +17,7 @@ oxc_parser.workspace = true
 oxc_span.workspace = true
 oxlint-plugins-carton.workspace = true
 regex.workspace = true
+regress.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/crates/angular_eslint/src/lib.rs
+++ b/crates/angular_eslint/src/lib.rs
@@ -6,6 +6,7 @@ mod inline_declarations;
 mod input_rename;
 mod prefer_signals;
 mod prefix;
+mod require_localize_metadata;
 mod scanner;
 mod selector;
 mod types;
@@ -14,7 +15,7 @@ mod types;
 mod tests;
 
 use oxc_allocator::Allocator;
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 use oxlint_plugins_carton::{CompactString, SmallVec};
 use serde_json::Value;
@@ -104,7 +105,14 @@ pub fn scan_angular_eslint_with_options(
     let source_type = SourceType::from_path(filename)
         .unwrap_or_else(|_| SourceType::tsx())
         .with_module(true);
-    let parser_return = Parser::new(&allocator, source_text, source_type).parse();
+    let parser_return = Parser::new(&allocator, source_text, source_type)
+        .with_options(ParseOptions {
+            // angular-eslint's RuleTester parser accepts authored top-level
+            // return-statement cases, so preserve that parse contract.
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        })
+        .parse();
     if !parser_return.errors.is_empty() {
         return SmallVec::new();
     }

--- a/crates/angular_eslint/src/require_localize_metadata.rs
+++ b/crates/angular_eslint/src/require_localize_metadata.rs
@@ -1,0 +1,506 @@
+use oxc_ast::ast::{Expression, TaggedTemplateExpression};
+use oxc_span::Span;
+use oxlint_plugins_carton::{CompactString, SmallVec};
+use regress::Regex;
+use serde_json::Value;
+
+use crate::scanner::Scanner;
+use crate::types::{Diagnostic, DiagnosticDatum};
+
+const REQUIRE_LOCALIZE_METADATA: &str = "require-localize-metadata";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CustomIdRequirement<'a> {
+    Disabled,
+    Present,
+    Pattern(&'a str),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RequireLocalizeMetadataOptions<'a> {
+    require_description: bool,
+    require_meaning: bool,
+    require_custom_id: CustomIdRequirement<'a>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct LocalizeMetadata<'a> {
+    meaning: Option<&'a str>,
+    description: Option<&'a str>,
+    custom_id: Option<&'a str>,
+}
+
+impl Scanner<'_> {
+    pub(crate) fn check_require_localize_metadata(
+        &mut self,
+        tagged_template: &TaggedTemplateExpression<'_>,
+    ) {
+        if !self.options.is_enabled(REQUIRE_LOCALIZE_METADATA) {
+            return;
+        }
+        let options = configured_options(&self.options.options);
+        if !options.require_description
+            && !options.require_meaning
+            && options.require_custom_id == CustomIdRequirement::Disabled
+        {
+            return;
+        }
+        let Expression::Identifier(identifier) = tagged_template.tag.get_inner_expression() else {
+            return;
+        };
+        if identifier.name != "$localize" {
+            return;
+        }
+        let Some(template_element) = tagged_template.quasi.quasis.first() else {
+            return;
+        };
+        let report_span = Span::new(
+            template_element.span.start.saturating_sub(1),
+            template_element.span.end + if template_element.tail { 1 } else { 2 },
+        );
+        let metadata = parse_metadata(template_element.value.raw.as_str().trim());
+
+        if options.require_description
+            && metadata
+                .description
+                .is_none_or(|description| description.is_empty())
+        {
+            self.report_require_localize_metadata(
+                "requireLocalizeDescription",
+                SmallVec::new(),
+                report_span,
+            );
+        }
+        if options.require_meaning && metadata.meaning.is_none_or(|meaning| meaning.is_empty()) {
+            self.report_require_localize_metadata(
+                "requireLocalizeMeaning",
+                SmallVec::new(),
+                report_span,
+            );
+        }
+
+        let custom_id_matches = match options.require_custom_id {
+            CustomIdRequirement::Disabled => true,
+            CustomIdRequirement::Present => metadata.custom_id.is_some_and(|id| !id.is_empty()),
+            CustomIdRequirement::Pattern(pattern) => metadata
+                .custom_id
+                .filter(|id| !id.is_empty())
+                .is_some_and(|id| Regex::new(pattern).is_ok_and(|regex| regex.find(id).is_some())),
+        };
+        if !custom_id_matches {
+            let mut data = SmallVec::new();
+            let mut pattern_message = CompactString::new("");
+            if let CustomIdRequirement::Pattern(pattern) = options.require_custom_id {
+                pattern_message.push_str(" matching the pattern /");
+                pattern_message.push_str(pattern);
+                pattern_message.push_str("/ on '");
+                pattern_message.push_str(metadata.custom_id.unwrap_or("undefined"));
+                pattern_message.push('\'');
+            }
+            data.push(DiagnosticDatum {
+                key: CompactString::from("patternMessage"),
+                value: pattern_message,
+            });
+            self.report_require_localize_metadata("requireLocalizeCustomId", data, report_span);
+        }
+    }
+
+    fn report_require_localize_metadata(
+        &mut self,
+        message_id: &'static str,
+        data: SmallVec<[DiagnosticDatum; 2]>,
+        span: Span,
+    ) {
+        self.diagnostics.push(Diagnostic {
+            rule_name: REQUIRE_LOCALIZE_METADATA,
+            message_id,
+            data,
+            loc: self.line_index.loc_for_span(self.source_text, span),
+        });
+    }
+}
+
+fn configured_options(options: &Value) -> RequireLocalizeMetadataOptions<'_> {
+    let option = options.as_array().and_then(|options| options.first());
+    RequireLocalizeMetadataOptions {
+        require_description: option
+            .and_then(|option| option.get("requireDescription"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        require_meaning: option
+            .and_then(|option| option.get("requireMeaning"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        require_custom_id: option
+            .and_then(|option| option.get("requireCustomId"))
+            .map_or(CustomIdRequirement::Disabled, |requirement| {
+                if let Some(pattern) = requirement.as_str() {
+                    CustomIdRequirement::Pattern(pattern)
+                } else if requirement.as_bool() == Some(true) {
+                    CustomIdRequirement::Present
+                } else {
+                    CustomIdRequirement::Disabled
+                }
+            }),
+    }
+}
+
+fn parse_metadata(raw_text: &str) -> LocalizeMetadata<'_> {
+    if !raw_text.starts_with(':') {
+        return LocalizeMetadata::default();
+    }
+    let Some(end_of_block) = raw_text.rfind(':') else {
+        return LocalizeMetadata::default();
+    };
+    let text = if end_of_block < 1 {
+        ""
+    } else {
+        &raw_text[1..end_of_block]
+    };
+    let mut id_parts = text.split("@@");
+    let meaning_and_description = id_parts.next().unwrap_or_default();
+    let custom_id = id_parts.next();
+    let mut meaning_parts = meaning_and_description.split('|');
+    let first = meaning_parts.next().unwrap_or_default();
+    let second = meaning_parts.next();
+    let (meaning, description) = match second {
+        Some(description) => (
+            Some(first),
+            (!description.is_empty()).then_some(description),
+        ),
+        None => (None, (!first.is_empty()).then_some(first)),
+    };
+    LocalizeMetadata {
+        meaning,
+        description,
+        custom_id,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    reason = "Pinned upstream fixtures use serde_json values and Vec assertions to mirror the JavaScript ABI."
+)]
+mod tests {
+    use oxlint_plugins_carton::{CompactString, SmallVec};
+    use serde_json::{Value, json};
+
+    use super::{LocalizeMetadata, REQUIRE_LOCALIZE_METADATA, parse_metadata};
+    use crate::{Diagnostic, DiagnosticLoc, ScanOptions, scan_angular_eslint_with_options};
+
+    const UPSTREAM_FIXTURE: &str = include_str!(
+        "../../../npm/angular-eslint/test/fixtures/require-localize-metadata-v22.1.0.json"
+    );
+
+    fn scan(source: &str, options: Value) -> Vec<Diagnostic> {
+        scan_angular_eslint_with_options(
+            source,
+            "fixture.ts",
+            &ScanOptions {
+                rule_names: SmallVec::from_vec(vec![CompactString::from(
+                    REQUIRE_LOCALIZE_METADATA,
+                )]),
+                options,
+            },
+        )
+        .into_vec()
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_valid_case() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid require-localize fixture");
+        let valid = fixture["valid"]
+            .as_array()
+            .expect("fixture has valid cases");
+        assert_eq!(valid.len(), 13);
+        for test_case in valid {
+            let diagnostics = scan(
+                test_case["code"].as_str().expect("valid case has source"),
+                test_case["options"].clone(),
+            );
+            assert!(
+                diagnostics.is_empty(),
+                "{}: {diagnostics:#?}",
+                test_case["name"].as_str().expect("valid case has name"),
+            );
+        }
+    }
+
+    #[test]
+    fn replays_every_upstream_authored_invalid_location_message_and_data() {
+        let fixture: Value =
+            serde_json::from_str(UPSTREAM_FIXTURE).expect("valid require-localize fixture");
+        let invalid = fixture["invalid"]
+            .as_array()
+            .expect("fixture has invalid cases");
+        assert_eq!(invalid.len(), 15);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|case| case["errors"].as_array().expect("case errors").len())
+                .sum::<usize>(),
+            16,
+        );
+        for test_case in invalid {
+            let diagnostics = scan(
+                test_case["code"].as_str().expect("invalid case has source"),
+                test_case["options"].clone(),
+            );
+            let errors = test_case["errors"]
+                .as_array()
+                .expect("invalid case has errors");
+            assert_eq!(
+                diagnostics.len(),
+                errors.len(),
+                "{}: {diagnostics:#?}",
+                test_case["name"].as_str().expect("invalid case has name"),
+            );
+            for (diagnostic, error) in diagnostics.iter().zip(errors) {
+                assert_eq!(diagnostic.message_id, error["messageId"]);
+                assert_eq!(
+                    diagnostic.loc,
+                    DiagnosticLoc {
+                        start_line: error["line"].as_u64().expect("line") as u32,
+                        start_column: error["column"].as_u64().expect("column") as u32 - 1,
+                        end_line: error["endLine"].as_u64().expect("end line") as u32,
+                        end_column: error["endColumn"].as_u64().expect("end column") as u32 - 1,
+                    },
+                    "{}",
+                    test_case["name"].as_str().expect("invalid case has name"),
+                );
+                let actual_data = diagnostic
+                    .data
+                    .iter()
+                    .map(|datum| (datum.key.as_str(), datum.value.as_str()))
+                    .collect::<Vec<_>>();
+                let expected_data = error["data"]
+                    .as_object()
+                    .expect("error data is an object")
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.as_str().expect("string data")))
+                    .collect::<Vec<_>>();
+                assert_eq!(actual_data, expected_data);
+            }
+        }
+    }
+
+    #[test]
+    fn parses_upstream_metadata_delimiters_and_empty_fields_exactly() {
+        assert_eq!(parse_metadata("plain"), LocalizeMetadata::default());
+        assert_eq!(
+            parse_metadata(":description:message"),
+            LocalizeMetadata {
+                meaning: None,
+                description: Some("description"),
+                custom_id: None,
+            },
+        );
+        assert_eq!(
+            parse_metadata(":meaning|description@@id:message"),
+            LocalizeMetadata {
+                meaning: Some("meaning"),
+                description: Some("description"),
+                custom_id: Some("id"),
+            },
+        );
+        assert_eq!(
+            parse_metadata(":|description:message"),
+            LocalizeMetadata {
+                meaning: Some(""),
+                description: Some("description"),
+                custom_id: None,
+            },
+        );
+        assert_eq!(
+            parse_metadata(":@@id:message"),
+            LocalizeMetadata {
+                meaning: None,
+                description: None,
+                custom_id: Some("id"),
+            },
+        );
+        assert_eq!(
+            parse_metadata(":first|second|discarded@@id@@discarded:message"),
+            LocalizeMetadata {
+                meaning: Some("first"),
+                description: Some("second"),
+                custom_id: Some("id"),
+            },
+        );
+    }
+
+    #[test]
+    fn defaults_to_no_requirements_and_forwards_each_option_independently() {
+        let source = "$localize`Hello`;";
+        assert!(scan(source, json!([])).is_empty());
+        for (option, expected) in [
+            (
+                json!([{ "requireDescription": true }]),
+                "requireLocalizeDescription",
+            ),
+            (
+                json!([{ "requireMeaning": true }]),
+                "requireLocalizeMeaning",
+            ),
+            (
+                json!([{ "requireCustomId": true }]),
+                "requireLocalizeCustomId",
+            ),
+        ] {
+            let diagnostics = scan(source, option);
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].message_id, expected);
+        }
+    }
+
+    #[test]
+    fn reports_description_meaning_then_custom_id_in_upstream_order() {
+        let diagnostics = scan(
+            "$localize`Hello`;",
+            json!([{
+                "requireDescription": true,
+                "requireMeaning": true,
+                "requireCustomId": "^stable$"
+            }]),
+        );
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message_id)
+                .collect::<Vec<_>>(),
+            vec![
+                "requireLocalizeDescription",
+                "requireLocalizeMeaning",
+                "requireLocalizeCustomId",
+            ],
+        );
+        assert_eq!(
+            diagnostics[2].data[0].value,
+            " matching the pattern /^stable$/ on 'undefined'",
+        );
+    }
+
+    #[test]
+    fn checks_only_the_first_quasi_and_every_matching_tagged_template() {
+        let diagnostics = scan(
+            "$localize`:desc:${value}`;\n$localize`Hello`;\n$localize`:other:World`;",
+            json!([{ "requireDescription": true }]),
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].loc.start_line, 2);
+    }
+
+    #[test]
+    fn accepts_identifier_tags_after_upstream_parenthesis_normalization() {
+        let diagnostics = scan(
+            "i18n.$localize`Hello`;\nother`Hello`;\n($localize)`Hello`;\n$localize`Hello`;",
+            json!([{ "requireDescription": true }]),
+        );
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.loc.start_line)
+                .collect::<Vec<_>>(),
+            vec![3, 4],
+        );
+    }
+
+    #[test]
+    fn trims_the_first_raw_quasi_and_uses_the_last_metadata_colon() {
+        assert!(
+            scan(
+                "$localize`  :description:message  `;",
+                json!([{ "requireDescription": true }]),
+            )
+            .is_empty(),
+        );
+        assert!(
+            scan(
+                "$localize`:meaning|description:message:with:colons`;",
+                json!([{ "requireMeaning": true, "requireDescription": true }]),
+            )
+            .is_empty(),
+        );
+    }
+
+    #[test]
+    fn supports_pattern_matching_and_fails_closed_for_invalid_patterns() {
+        assert!(
+            scan(
+                "$localize`:@@some.custom.id:Hello`;",
+                json!([{ "requireCustomId": "^some.*id$" }]),
+            )
+            .is_empty(),
+        );
+        let mismatch = scan(
+            "$localize`:@@some.custom.id:Hello`;",
+            json!([{ "requireCustomId": "^wrong$" }]),
+        );
+        assert_eq!(mismatch.len(), 1);
+        assert_eq!(
+            mismatch[0].data[0].value,
+            " matching the pattern /^wrong$/ on 'some.custom.id'",
+        );
+        assert_eq!(
+            scan(
+                "$localize`:@@some.custom.id:Hello`;",
+                json!([{ "requireCustomId": "[" }]),
+            )
+            .len(),
+            1,
+        );
+        assert!(
+            scan(
+                "$localize`:@@samesame.id:Hello`;",
+                json!([{ "requireCustomId": "^(same)\\1\\.id$" }]),
+            )
+            .is_empty(),
+        );
+        assert!(
+            scan(
+                "$localize`:@@some.custom.id:Hello`;",
+                json!([{ "requireCustomId": "^(?=some)some.*id$" }]),
+            )
+            .is_empty(),
+        );
+    }
+
+    #[test]
+    fn preserves_utf16_columns_and_template_element_locations() {
+        let diagnostics = scan(
+            "const marker = '😀'; $localize`Hello ${name}`;",
+            json!([{ "requireMeaning": true }]),
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].loc,
+            DiagnosticLoc {
+                start_line: 1,
+                start_column: 30,
+                end_line: 1,
+                end_column: 39,
+            },
+        );
+    }
+
+    #[test]
+    fn ignores_strings_comments_and_malformed_typescript() {
+        let source = r#"
+const text = "$localize`Hello`";
+// $localize`Hello`;
+const tagged = $localize`:description:Hello`;
+"#;
+        assert!(scan(source, json!([{ "requireDescription": true }])).is_empty());
+        assert!(
+            scan(
+                "const tagged = $localize`unterminated",
+                json!([{ "requireDescription": true }]),
+            )
+            .is_empty(),
+        );
+    }
+}

--- a/crates/angular_eslint/src/scanner.rs
+++ b/crates/angular_eslint/src/scanner.rs
@@ -94,7 +94,6 @@ impl<'a> Scanner<'a> {
             "require-lifecycle-on-prototype",
             r#"ng(OnInit|OnDestroy|AfterViewInit|OnChanges)\s*=\s*\("#,
         );
-        self.check_regex("require-localize-metadata", r#"\$localize`"#);
         self.check_regex("runtime-localize", r#"\$localize\.locale\b"#);
         self.check_regex(
             "sort-keys-in-type-decorator",

--- a/crates/angular_eslint/src/selector.rs
+++ b/crates/angular_eslint/src/selector.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::{
     Class, Decorator, Expression, ObjectExpression, ObjectPropertyKind, PropertyDefinition,
-    PropertyKey,
+    PropertyKey, TaggedTemplateExpression,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
@@ -92,6 +92,11 @@ impl Visit<'_> for Scanner<'_> {
     fn visit_decorator(&mut self, decorator: &Decorator<'_>) {
         self.check_prefer_signals_decorator(decorator);
         walk::walk_decorator(self, decorator);
+    }
+
+    fn visit_tagged_template_expression(&mut self, tagged_template: &TaggedTemplateExpression<'_>) {
+        self.check_require_localize_metadata(tagged_template);
+        walk::walk_tagged_template_expression(self, tagged_template);
     }
 }
 

--- a/crates/angular_eslint/src/tests.rs
+++ b/crates/angular_eslint/src/tests.rs
@@ -65,7 +65,11 @@ fn scans_representative_rules() {
         .filter(|rule_name| {
             !matches!(
                 *rule_name,
-                "component-selector" | "directive-selector" | "no-input-prefix" | "pipe-prefix"
+                "component-selector"
+                    | "directive-selector"
+                    | "no-input-prefix"
+                    | "pipe-prefix"
+                    | "require-localize-metadata"
             )
         })
         .collect();

--- a/npm/angular-eslint/README.md
+++ b/npm/angular-eslint/README.md
@@ -32,6 +32,16 @@ all 39 authored valid and 26 authored invalid cases from tag `v22.1.0`
 (`a666e1b45c9782d1ac2066fd55ec0127d0580950`) with exact message IDs, data,
 and UTF-16 locations.
 
+`require-localize-metadata` is an Oxc AST port of the angular-eslint v22.1.0
+contract for bare `$localize` tagged templates. It preserves the independently
+optional description, meaning, and custom-ID requirements, including custom-ID
+ECMAScript patterns (including lookaround and backreferences), exact message
+data, report ordering, first-quasi metadata parsing, and ESTree TemplateElement
+locations. The checked-in deterministic fixture replays all 13 authored valid
+and 15 authored invalid cases (16 diagnostics) from tag `v22.1.0`
+(`a666e1b45c9782d1ac2066fd55ec0127d0580950`) with exact message IDs, data, and
+UTF-16 locations.
+
 The current native diagnostic ABI contains message data and locations, but not
 fix or suggestion edit payloads. The plugin therefore exposes upstream
 fixability and suggestion metadata where applicable, plus exact schemas and

--- a/npm/angular-eslint/api.d.ts
+++ b/npm/angular-eslint/api.d.ts
@@ -30,6 +30,14 @@ export type PreferSignalsOptions = [
   }?,
 ];
 
+export type RequireLocalizeMetadataOptions = [
+  {
+    readonly requireDescription?: boolean;
+    readonly requireMeaning?: boolean;
+    readonly requireCustomId?: boolean | string;
+  }?,
+];
+
 export function implementedAngularEslintRuleNames(): string[];
 export function scanAngularEslint(
   sourceText: string,

--- a/npm/angular-eslint/index.js
+++ b/npm/angular-eslint/index.js
@@ -19,6 +19,7 @@ const inlineDeclarationRuleName = 'component-max-inline-declarations';
 const consistentComponentStylesRuleName = 'consistent-component-styles';
 const inputRenameRuleName = 'no-input-rename';
 const preferSignalsRuleName = 'prefer-signals';
+const requireLocalizeMetadataRuleName = 'require-localize-metadata';
 const optionAwareRuleNames = new Set([
   ...selectorRuleNames,
   ...classSuffixRuleNames,
@@ -27,6 +28,7 @@ const optionAwareRuleNames = new Set([
   consistentComponentStylesRuleName,
   inputRenameRuleName,
   preferSignalsRuleName,
+  requireLocalizeMetadataRuleName,
 ]);
 
 const consistentComponentStylesSchema = [
@@ -183,6 +185,36 @@ const preferSignalsMessages = {
     'Properties declared using signals should be marked as `readonly` since they should not be reassigned',
 };
 
+const requireLocalizeMetadataSchema = [
+  {
+    type: 'object',
+    properties: {
+      requireDescription: {
+        type: 'boolean',
+        default: false,
+      },
+      requireMeaning: {
+        type: 'boolean',
+        default: false,
+      },
+      requireCustomId: {
+        oneOf: [{ type: 'boolean' }, { type: 'string' }],
+        default: false,
+      },
+    },
+    additionalProperties: false,
+  },
+];
+
+const requireLocalizeMetadataMessages = {
+  requireLocalizeDescription:
+    '$localize tagged messages should contain a description. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation',
+  requireLocalizeMeaning:
+    '$localize tagged messages should contain a meaning. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation',
+  requireLocalizeCustomId:
+    '$localize tagged messages should contain a custom id{{patternMessage}}. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation',
+};
+
 const selectorConfigSchema = {
   type: 'object',
   properties: {
@@ -299,6 +331,7 @@ function createAngularEslintRule(ruleName) {
   const isConsistentComponentStylesRule = ruleName === consistentComponentStylesRuleName;
   const isInputRenameRule = ruleName === inputRenameRuleName;
   const isPreferSignalsRule = ruleName === preferSignalsRuleName;
+  const isRequireLocalizeMetadataRule = ruleName === requireLocalizeMetadataRuleName;
   return {
     meta: {
       type: problemRules.has(ruleName) ? 'problem' : 'suggestion',
@@ -307,7 +340,9 @@ function createAngularEslintRule(ruleName) {
           ? 'Ensures consistent usage of `styles`/`styleUrls`/`styleUrl` within Component metadata'
           : isPreferSignalsRule
             ? 'Use readonly signals instead of `@Input()`, `@ViewChild()` and other legacy decorators'
-            : `enforce angular eslint ${ruleName.replaceAll('-', ' ')}`,
+            : isRequireLocalizeMetadataRule
+              ? 'Ensures that $localize tagged messages contain helpful metadata to aid with translations.'
+              : `enforce angular eslint ${ruleName.replaceAll('-', ' ')}`,
         category: 'Best Practices',
         recommended: false,
         url: `${DOCS_BASE}/${ruleName}.md`,
@@ -326,9 +361,11 @@ function createAngularEslintRule(ruleName) {
                   ? inputRenameMessages
                   : isPreferSignalsRule
                     ? preferSignalsMessages
-                    : {
-                        unexpected: 'Unexpected Angular pattern.',
-                      },
+                    : isRequireLocalizeMetadataRule
+                      ? requireLocalizeMetadataMessages
+                      : {
+                          unexpected: 'Unexpected Angular pattern.',
+                        },
       schema: isSelectorRule
         ? selectorSchema
         : isClassSuffixRule
@@ -343,7 +380,9 @@ function createAngularEslintRule(ruleName) {
                   ? inputRenameSchema
                   : isPreferSignalsRule
                     ? preferSignalsSchema
-                    : [],
+                    : isRequireLocalizeMetadataRule
+                      ? requireLocalizeMetadataSchema
+                      : [],
       ...(isConsistentComponentStylesRule ? { fixable: 'code' } : {}),
       ...(isInputRenameRule ? { fixable: 'code', hasSuggestions: true } : {}),
       ...(isPreferSignalsRule ? { fixable: 'code' } : {}),

--- a/npm/angular-eslint/test/api.test.mjs
+++ b/npm/angular-eslint/test/api.test.mjs
@@ -16,6 +16,12 @@ const noInputRenameFixture = JSON.parse(
 const preferSignalsFixture = JSON.parse(
   readFileSync(new URL('./fixtures/prefer-signals-v22.1.0.json', import.meta.url), 'utf8'),
 );
+const requireLocalizeMetadataFixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/require-localize-metadata-v22.1.0.json', import.meta.url),
+    'utf8',
+  ),
+);
 
 const expectedRuleNames = [
   'component-class-suffix',
@@ -123,6 +129,7 @@ describe('angular-eslint native API', () => {
               'directive-selector',
               'no-input-prefix',
               'pipe-prefix',
+              'require-localize-metadata',
             ].includes(ruleName),
         )
         .sort(),
@@ -835,6 +842,155 @@ declare function createTypedSignal(): Signal<boolean>;
       scanAngularEslint(`class Test { value = signal(`, 'fixture.ts', {
         ruleNames: ['prefer-signals'],
         options: [],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('require-localize-metadata native API', () => {
+  it('pins every authored angular-eslint v22.1.0 case deterministically', () => {
+    expect(requireLocalizeMetadataFixture.metadata).toEqual({
+      package: '@angular-eslint/eslint-plugin',
+      version: '22.1.0',
+      sourceCommit: 'a666e1b45c9782d1ac2066fd55ec0127d0580950',
+      sourceTag: 'v22.1.0',
+      sourcePath: 'packages/eslint-plugin/tests/rules/require-localize-metadata/cases.ts',
+      sourceSha256: '532a9e3c1d93294fd7245b183eab26098217f6971c3fa1fddb230dc5cc904faa',
+      capture: 'every authored valid and invalid semantic case exactly once',
+      counts: {
+        valid: 13,
+        invalid: 15,
+        diagnostics: 16,
+      },
+    });
+  });
+
+  it.each(requireLocalizeMetadataFixture.valid)(
+    'accepts upstream require-localize-metadata valid case: $name',
+    ({ code, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['require-localize-metadata'],
+          options,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it.each(requireLocalizeMetadataFixture.invalid)(
+    'matches upstream require-localize-metadata diagnostic: $name',
+    ({ code, errors, options }) => {
+      expect(
+        scanAngularEslint(code, 'fixture.ts', {
+          ruleNames: ['require-localize-metadata'],
+          options,
+        }),
+      ).toEqual(
+        errors.map((error) => ({
+          ruleName: 'require-localize-metadata',
+          messageId: error.messageId,
+          data: Object.entries(error.data).map(([key, value]) => ({ key, value })),
+          loc: {
+            startLine: error.line,
+            startColumn: error.column - 1,
+            endLine: error.endLine,
+            endColumn: error.endColumn - 1,
+          },
+        })),
+      );
+    },
+  );
+
+  it('keeps every requirement independently disabled by default', () => {
+    const source = '$localize`Hello`;';
+    expect(
+      scanAngularEslint(source, 'fixture.ts', {
+        ruleNames: ['require-localize-metadata'],
+        options: [],
+      }),
+    ).toEqual([]);
+    expect(
+      [{ requireDescription: true }, { requireMeaning: true }, { requireCustomId: true }].map(
+        (option) =>
+          scanAngularEslint(source, 'fixture.ts', {
+            ruleNames: ['require-localize-metadata'],
+            options: [option],
+          })[0].messageId,
+      ),
+    ).toEqual(['requireLocalizeDescription', 'requireLocalizeMeaning', 'requireLocalizeCustomId']);
+  });
+
+  it('preserves report order, pattern data, first-quasi parsing, and identifier tags', () => {
+    const source = [
+      '$localize`Hello`;',
+      '$localize`:meaning|description@@wrong:${value}`;',
+      'i18n.$localize`Hello`;',
+      '($localize)`:meaning|description@@stable:Hello`;',
+    ].join('\n');
+    const diagnostics = scanAngularEslint(source, 'fixture.ts', {
+      ruleNames: ['require-localize-metadata'],
+      options: [
+        {
+          requireDescription: true,
+          requireMeaning: true,
+          requireCustomId: '^stable$',
+        },
+      ],
+    });
+    expect(
+      diagnostics.map(({ messageId, data, loc }) => ({
+        messageId,
+        data,
+        line: loc.startLine,
+      })),
+    ).toEqual([
+      { messageId: 'requireLocalizeDescription', data: [], line: 1 },
+      { messageId: 'requireLocalizeMeaning', data: [], line: 1 },
+      {
+        messageId: 'requireLocalizeCustomId',
+        data: [
+          {
+            key: 'patternMessage',
+            value: " matching the pattern /^stable$/ on 'undefined'",
+          },
+        ],
+        line: 1,
+      },
+      {
+        messageId: 'requireLocalizeCustomId',
+        data: [
+          {
+            key: 'patternMessage',
+            value: " matching the pattern /^stable$/ on 'wrong'",
+          },
+        ],
+        line: 2,
+      },
+    ]);
+  });
+
+  it('preserves UTF-16 ESTree TemplateElement locations and fails closed on malformed syntax', () => {
+    const [diagnostic] = scanAngularEslint(
+      "const marker = '😀'; $localize`Hello ${name}`;",
+      'fixture.ts',
+      {
+        ruleNames: ['require-localize-metadata'],
+        options: [{ requireMeaning: true }],
+      },
+    );
+    expect(diagnostic).toMatchObject({
+      messageId: 'requireLocalizeMeaning',
+      loc: {
+        startLine: 1,
+        startColumn: 30,
+        endLine: 1,
+        endColumn: 39,
+      },
+    });
+    expect(
+      scanAngularEslint('const text = $localize`unterminated', 'fixture.ts', {
+        ruleNames: ['require-localize-metadata'],
+        options: [{ requireMeaning: true }],
       }),
     ).toEqual([]);
   });

--- a/npm/angular-eslint/test/fixtures/require-localize-metadata-v22.1.0.json
+++ b/npm/angular-eslint/test/fixtures/require-localize-metadata-v22.1.0.json
@@ -1,0 +1,440 @@
+{
+  "metadata": {
+    "package": "@angular-eslint/eslint-plugin",
+    "version": "22.1.0",
+    "sourceCommit": "a666e1b45c9782d1ac2066fd55ec0127d0580950",
+    "sourceTag": "v22.1.0",
+    "sourcePath": "packages/eslint-plugin/tests/rules/require-localize-metadata/cases.ts",
+    "sourceSha256": "532a9e3c1d93294fd7245b183eab26098217f6971c3fa1fddb230dc5cc904faa",
+    "capture": "every authored valid and invalid semantic case exactly once",
+    "counts": {
+      "valid": 13,
+      "invalid": 15,
+      "diagnostics": 16
+    }
+  },
+  "valid": [
+    {
+      "name": "valid-1",
+      "code": "const localizedText = $localize`Hello i18n!`;",
+      "options": []
+    },
+    {
+      "name": "valid-2",
+      "code": "const localizedText = $localize`:site header|:Hello i18n!`;",
+      "options": []
+    },
+    {
+      "name": "valid-3",
+      "code": "const localizedText = $localize`:@@custom_id:Hello i18n!`;",
+      "options": []
+    },
+    {
+      "name": "valid-4",
+      "code": "const localizedText = $localize`:site header|@@custom_id:Hello i18n!`;",
+      "options": []
+    },
+    {
+      "name": "valid-5",
+      "code": "\n      let localizedText = $localize`:An introduction header for this sample:Hello i18n!`;\n      localizedText = $localize`:An introduction header for this sample modified:Hello i18n modified!`;\n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ]
+    },
+    {
+      "name": "valid-6",
+      "code": "\n      const localizedTexts = {\n        helloI18n: $localize`:An introduction header for this sample:Hello i18n!`\n      };\n      localizedTexts.helloI18n = $localize`:An introduction header for this sample modified:Hello i18n modified!`;\n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ]
+    },
+    {
+      "name": "valid-7",
+      "code": "\n      return $localize`:An introduction header for this sample:Hello i18n!`;\n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ]
+    },
+    {
+      "name": "valid-8",
+      "code": "\n      someFunction($localize`:An introduction header for this sample:Hello i18n!`);\n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ]
+    },
+    {
+      "name": "valid-9",
+      "code": "const localizedText = `Hello i18n!`;",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ]
+    },
+    {
+      "name": "valid-10",
+      "code": "const localizedText = $localize`:site header|:Hello i18n!`;",
+      "options": [
+        {
+          "requireMeaning": true
+        }
+      ]
+    },
+    {
+      "name": "valid-11",
+      "code": "const localizedText = $localize`:site header|An introduction header for this sample:Hello i18n!`;",
+      "options": [
+        {
+          "requireDescription": true,
+          "requireMeaning": true
+        }
+      ]
+    },
+    {
+      "name": "valid-12",
+      "code": "const localizedText = $localize`:@@some.custom.id:Hello i18n!`;",
+      "options": [
+        {
+          "requireCustomId": true
+        }
+      ]
+    },
+    {
+      "name": "valid-13",
+      "code": "const localizedText = $localize`:@@some.custom.id:Hello i18n!`;",
+      "options": [
+        {
+          "requireCustomId": "^some.*id$"
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "name": "it should fail if no $localize description is provided when required for variable declarations",
+      "code": "\n      const localizedText = $localize`Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 51
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize description is provided when required for expressions statements",
+      "code": "\n      const localizedTexts = {\n        helloI18n: $localize`:An introduction header for this sample:Hello i18n!`\n      };\n      localizedTexts.helloI18n = $localize`Hello i18n!`;\n                                          \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 5,
+          "column": 43,
+          "endLine": 5,
+          "endColumn": 56
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize description is provided when required for return statements",
+      "code": "\n      return $localize`Hello i18n!`;\n                      \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 23,
+          "endLine": 2,
+          "endColumn": 36
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize description is provided when required for call expressions",
+      "code": "\n      someFunction($localize`Hello i18n!`);\n                            \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 29,
+          "endLine": 2,
+          "endColumn": 42
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize description is provided when required for variable declarations, despite a meaning being provided",
+      "code": "\n      const localizedText = $localize`:site header|:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 65
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize description is provided when required for variable declarations, despite a ID being provided",
+      "code": "\n      const localizedText = $localize`:@@custom_id:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 64
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize description is provided when required for variable declarations, despite a meaning and ID being provided",
+      "code": "\n      const localizedText = $localize`:site header|@@custom_id:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireDescription": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 76
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if no $localize meaning is provided",
+      "code": "\n      const localizedText = $localize`Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireMeaning": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeMeaning",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 51
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if no $localize meaning is provided despite a description being provided",
+      "code": "\n      const localizedText = $localize`:An introduction header for this sample:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireDescription": true,
+          "requireMeaning": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeMeaning",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 91
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if the $localize meaning is empty",
+      "code": "\n      const localizedText = $localize`:|An introduction header for this sample:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireMeaning": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeMeaning",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 92
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if no $localize metadata is provided",
+      "code": "\n      const localizedText = $localize`:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireDescription": true,
+          "requireMeaning": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeDescription",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 52
+        },
+        {
+          "messageId": "requireLocalizeMeaning",
+          "data": {},
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 52
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "should fail if the $localize metadata is not provided",
+      "code": "\n      const localizedText = $localize`Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireCustomId": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeCustomId",
+          "data": {
+            "patternMessage": ""
+          },
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 51
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if the $localize custom_id has wrong delimiter",
+      "code": "\n      const localizedText = $localize`:@some.custom.id:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireCustomId": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeCustomId",
+          "data": {
+            "patternMessage": ""
+          },
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 68
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if the $localize metadata doesn't contain custom_id",
+      "code": "\n      const localizedText = $localize`:meaning|description:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireCustomId": true
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeCustomId",
+          "data": {
+            "patternMessage": ""
+          },
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 72
+        }
+      ],
+      "output": null
+    },
+    {
+      "name": "it should fail if the $localize custom_id doesn't match the pattern",
+      "code": "\n      const localizedText = $localize`:@@some.custom.id:Hello i18n!`;\n                                     \n    ",
+      "options": [
+        {
+          "requireCustomId": "^some.wrong.pattern$"
+        }
+      ],
+      "errors": [
+        {
+          "messageId": "requireLocalizeCustomId",
+          "data": {
+            "patternMessage": " matching the pattern /^some.wrong.pattern$/ on 'some.custom.id'"
+          },
+          "line": 2,
+          "column": 38,
+          "endLine": 2,
+          "endColumn": 69
+        }
+      ],
+      "output": null
+    }
+  ]
+}

--- a/npm/angular-eslint/test/plugin.test.mjs
+++ b/npm/angular-eslint/test/plugin.test.mjs
@@ -22,6 +22,12 @@ const noInputRenameFixture = JSON.parse(
 const preferSignalsFixture = JSON.parse(
   readFileSync(new URL('./fixtures/prefer-signals-v22.1.0.json', import.meta.url), 'utf8'),
 );
+const requireLocalizeMetadataFixture = JSON.parse(
+  readFileSync(
+    new URL('./fixtures/require-localize-metadata-v22.1.0.json', import.meta.url),
+    'utf8',
+  ),
+);
 const playgroundCatalog = JSON.parse(
   readFileSync(resolve(workspaceRoot, 'playground/src/catalog.json'), 'utf8'),
 );
@@ -127,7 +133,6 @@ const invalidCases = [
   ['prefer-standalone', '@Component({ standalone: false }) class C {}\n'],
   ['relative-url-prefix', '@Component({ templateUrl: "cmp.html" }) class C {}\n'],
   ['require-lifecycle-on-prototype', 'class LifecycleField { ngOnInit = () => {}; }\n'],
-  ['require-localize-metadata', '$localize`Hello`;\n'],
   ['runtime-localize', '$localize.locale = "fr";\n'],
   [
     'sort-keys-in-type-decorator',
@@ -1220,6 +1225,179 @@ declare function createTypedSignal(): Signal<boolean>;
           message:
             'The selector should start with one of these prefixes: "app" or "lib" (https://angular.dev/style-guide#choosing-component-selectors)',
         },
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('require-localize-metadata plugin contract', () => {
+  it('exposes exact upstream metadata and matching playground catalog data', () => {
+    const { meta } = plugin.rules['require-localize-metadata'];
+    expect(meta.type).toBe('suggestion');
+    expect(meta.docs.description).toBe(
+      'Ensures that $localize tagged messages contain helpful metadata to aid with translations.',
+    );
+    expect(meta.schema).toEqual([
+      {
+        type: 'object',
+        properties: {
+          requireDescription: { type: 'boolean', default: false },
+          requireMeaning: { type: 'boolean', default: false },
+          requireCustomId: {
+            oneOf: [{ type: 'boolean' }, { type: 'string' }],
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ]);
+    expect(meta.messages).toEqual({
+      requireLocalizeDescription:
+        '$localize tagged messages should contain a description. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation',
+      requireLocalizeMeaning:
+        '$localize tagged messages should contain a meaning. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation',
+      requireLocalizeCustomId:
+        '$localize tagged messages should contain a custom id{{patternMessage}}. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation',
+    });
+    expect(meta.fixable).toBeUndefined();
+    expect(meta.hasSuggestions).toBeUndefined();
+
+    const playgroundRule = playgroundCatalog.plugins
+      .find(({ plugin: pluginName }) => pluginName === '@angular-eslint')
+      .rules.find(({ name }) => name === 'require-localize-metadata');
+    expect(playgroundRule).toMatchObject({
+      description: meta.docs.description,
+      messages: meta.messages,
+    });
+  });
+
+  it.each(requireLocalizeMetadataFixture.valid)(
+    'accepts upstream require-localize-metadata valid case through createOnce: $name',
+    ({ code, options }) => {
+      expect(runRule('require-localize-metadata', code, options)).toEqual([]);
+    },
+  );
+
+  it.each(requireLocalizeMetadataFixture.invalid)(
+    'matches upstream require-localize-metadata diagnostic through createOnce: $name',
+    ({ code, errors, options }) => {
+      expect(runRule('require-localize-metadata', code, options)).toEqual(
+        errors.map((error) => ({
+          messageId: error.messageId,
+          data: error.data,
+          loc: {
+            start: {
+              line: error.line,
+              column: error.column - 1,
+            },
+            end: {
+              line: error.endLine,
+              column: error.endColumn - 1,
+            },
+          },
+        })),
+      );
+    },
+  );
+
+  it('forwards defaults, independent options, exact order, data, and locations', () => {
+    expect(runRule('require-localize-metadata', '$localize`Hello`;')).toEqual([]);
+    const reports = runRule('require-localize-metadata', '$localize`Hello ${name}`;', [
+      {
+        requireDescription: true,
+        requireMeaning: true,
+        requireCustomId: '^stable$',
+      },
+    ]);
+    expect(reports).toEqual([
+      {
+        messageId: 'requireLocalizeDescription',
+        data: {},
+        loc: {
+          start: { line: 1, column: 9 },
+          end: { line: 1, column: 18 },
+        },
+      },
+      {
+        messageId: 'requireLocalizeMeaning',
+        data: {},
+        loc: {
+          start: { line: 1, column: 9 },
+          end: { line: 1, column: 18 },
+        },
+      },
+      {
+        messageId: 'requireLocalizeCustomId',
+        data: {
+          patternMessage: " matching the pattern /^stable$/ on 'undefined'",
+        },
+        loc: {
+          start: { line: 1, column: 9 },
+          end: { line: 1, column: 18 },
+        },
+      },
+    ]);
+    for (const report of reports) {
+      expect(report).not.toHaveProperty('fix');
+      expect(report).not.toHaveProperty('suggest');
+    }
+  });
+
+  it('honors all options through real oxlint jsPlugins', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-angular-require-localize-metadata-'));
+    try {
+      writeFileSync(
+        join(tempDir, 'fixture.ts'),
+        '$localize`Hello`;\n' + '$localize`:meaning|description@@wrong:World`;\n',
+      );
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: '@angular-eslint',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            '@angular-eslint/require-localize-metadata': [
+              'error',
+              {
+                requireDescription: true,
+                requireMeaning: true,
+                requireCustomId: '^stable$',
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(4);
+      expect(payload.diagnostics.map(({ code }) => code)).toEqual(
+        Array(4).fill('@angular-eslint(require-localize-metadata)'),
+      );
+      expect(payload.diagnostics.map(({ labels }) => labels[0].span.line)).toEqual([1, 1, 1, 2]);
+      expect(payload.diagnostics.map(({ message }) => message)).toEqual([
+        plugin.rules['require-localize-metadata'].meta.messages.requireLocalizeDescription,
+        plugin.rules['require-localize-metadata'].meta.messages.requireLocalizeMeaning,
+        '$localize tagged messages should contain a custom id matching the pattern /^stable$/ on ' +
+          "'undefined'. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation",
+        '$localize tagged messages should contain a custom id matching the pattern /^stable$/ on ' +
+          "'wrong'. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation",
       ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "port:tests:angular:consistent-component-styles": "node tools/tasks/sync-angular-consistent-component-styles-tests.ts",
     "port:tests:angular:no-input-rename": "node tools/tasks/sync-angular-no-input-rename-tests.ts",
     "port:tests:angular:prefer-signals": "node tools/tasks/sync-angular-prefer-signals-tests.ts",
+    "port:tests:angular:require-localize-metadata": "node tools/tasks/sync-angular-require-localize-metadata-tests.ts",
     "port:tests:eslint-comments": "node tools/tasks/sync-eslint-comments-tests.ts",
     "port:tests:eslint-json": "node tools/tasks/sync-eslint-json-tests.ts",
     "port:tests:eslint-markdown": "node tools/tasks/sync-eslint-markdown-tests.ts",

--- a/playground/src/catalog.json
+++ b/playground/src/catalog.json
@@ -325,10 +325,12 @@
         },
         {
           "name": "require-localize-metadata",
-          "description": "enforce angular eslint require localize metadata",
+          "description": "Ensures that $localize tagged messages contain helpful metadata to aid with translations.",
           "docsUrl": "https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/require-localize-metadata.md",
           "messages": {
-            "unexpected": "Unexpected Angular pattern."
+            "requireLocalizeDescription": "$localize tagged messages should contain a description. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation",
+            "requireLocalizeMeaning": "$localize tagged messages should contain a meaning. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation",
+            "requireLocalizeCustomId": "$localize tagged messages should contain a custom id{{patternMessage}}. See more at https://angular.dev/guide/i18n/prepare#i18n-metadata-for-translation"
           }
         },
         {

--- a/status.json
+++ b/status.json
@@ -652,7 +652,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of @angular-eslint/eslint-plugin/require-localize-metadata; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Full Rust/Oxc AST port of the angular-eslint v22.1.0 require-localize-metadata contract, including three independent options, custom-ID pattern data, pinned authored-fixture replay, exact ESTree TemplateElement diagnostics, NAPI/API/plugin coverage, and real Oxlint jsPlugins integration."
       },
       {
         "name": "runtime-localize",

--- a/tools/tasks/sync-angular-require-localize-metadata-tests.ts
+++ b/tools/tasks/sync-angular-require-localize-metadata-tests.ts
@@ -1,0 +1,203 @@
+// Snapshot every authored angular-eslint v22.1.0 require-localize-metadata
+// RuleTester case directly from the pinned upstream tag. The submodule remains
+// at the repository-pinned revision, so regeneration cannot alter the gitlink.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const UPSTREAM = resolve(ROOT, 'upstream/angular-eslint');
+const VERSION = '22.1.0';
+const SOURCE_TAG = `v${VERSION}`;
+const SOURCE_COMMIT = 'a666e1b45c9782d1ac2066fd55ec0127d0580950';
+const SOURCE_PATH = 'packages/eslint-plugin/tests/rules/require-localize-metadata/cases.ts';
+const OUTPUT_PATH = resolve(
+  ROOT,
+  `npm/angular-eslint/test/fixtures/require-localize-metadata-v${VERSION}.json`,
+);
+const HELPER_IMPORT =
+  "import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/test-utils';";
+
+type AuthoredError = {
+  data?: Record<string, string>;
+  messageId: string;
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+};
+
+type AuthoredCase = {
+  name?: string;
+  code: string;
+  options?: unknown[];
+};
+
+type AuthoredInvalidCase = AuthoredCase & {
+  errors: AuthoredError[];
+  output: null | string | string[];
+};
+
+const actualCommit = execFileSync('git', ['-C', UPSTREAM, 'rev-list', '-n', '1', SOURCE_TAG], {
+  encoding: 'utf8',
+}).trim();
+if (actualCommit !== SOURCE_COMMIT) {
+  throw new Error(
+    `Expected angular-eslint ${SOURCE_TAG} at ${SOURCE_COMMIT}, received ${actualCommit}.`,
+  );
+}
+
+const source = execFileSync('git', ['-C', UPSTREAM, 'show', `${SOURCE_TAG}:${SOURCE_PATH}`], {
+  encoding: 'utf8',
+});
+if (!source.includes(HELPER_IMPORT)) {
+  throw new Error('The upstream require-localize-metadata case harness changed shape.');
+}
+
+const executableSource = source.replace(HELPER_IMPORT, () => annotatedCaseHelper());
+const javascript = stripTypeScriptTypes(executableSource, { mode: 'strip' });
+const cases = (await import(
+  `data:text/javascript;base64,${Buffer.from(javascript).toString('base64')}`
+)) as {
+  valid: Array<AuthoredCase | string>;
+  invalid: AuthoredInvalidCase[];
+};
+
+const fixture = {
+  metadata: {
+    package: '@angular-eslint/eslint-plugin',
+    version: VERSION,
+    sourceCommit: SOURCE_COMMIT,
+    sourceTag: SOURCE_TAG,
+    sourcePath: SOURCE_PATH,
+    sourceSha256: createHash('sha256').update(source).digest('hex'),
+    capture: 'every authored valid and invalid semantic case exactly once',
+    counts: {
+      valid: cases.valid.length,
+      invalid: cases.invalid.length,
+      diagnostics: cases.invalid.reduce((count, testCase) => count + testCase.errors.length, 0),
+    },
+  },
+  valid: cases.valid.map((testCase, index) => normalizeValidCase(testCase, index)),
+  invalid: cases.invalid.map((testCase, index) => normalizeInvalidCase(testCase, index)),
+};
+
+mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+writeFileSync(OUTPUT_PATH, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', OUTPUT_PATH], { cwd: ROOT, stdio: 'ignore' });
+console.log(
+  `Captured ${fixture.metadata.counts.valid} valid and ${fixture.metadata.counts.invalid} invalid require-localize-metadata cases from ${SOURCE_TAG}.`,
+);
+
+function normalizeValidCase(testCase: AuthoredCase | string, index: number) {
+  if (typeof testCase === 'string') {
+    return { name: `valid-${index + 1}`, code: testCase, options: [] };
+  }
+  return {
+    name: testCase.name ?? `valid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+  };
+}
+
+function normalizeInvalidCase(testCase: AuthoredInvalidCase, index: number) {
+  return {
+    name: testCase.name ?? `invalid-${index + 1}`,
+    code: testCase.code,
+    options: testCase.options ?? [],
+    errors: testCase.errors.map((error) => ({
+      messageId: error.messageId,
+      data: error.data ?? {},
+      line: error.line,
+      column: error.column,
+      endLine: error.endLine,
+      endColumn: error.endColumn,
+    })),
+    output: testCase.output,
+  };
+}
+
+function annotatedCaseHelper() {
+  return String.raw`
+function convertAnnotatedSourceToFailureCase(errorOptions) {
+  const messages =
+    'messageId' in errorOptions
+      ? [{ ...errorOptions, char: '~' }]
+      : errorOptions.messages;
+  let parsedSource = '';
+  const errors = messages.map(({ char, data, messageId, suggestions }) => {
+    const otherChars = messages
+      .map((message) => message.char)
+      .filter((candidate) => candidate !== char);
+    const parsed = parseInvalidSource(errorOptions.annotatedSource, char, otherChars);
+    parsedSource = parsed.source;
+    return {
+      data,
+      messageId,
+      line: parsed.start.line + 1,
+      column: parsed.start.character + 1,
+      endLine: parsed.end.line + 1,
+      endColumn: parsed.end.character + 1,
+      suggestions,
+    };
+  });
+  return {
+    name: errorOptions.description,
+    code: parsedSource,
+    options: errorOptions.options ?? [],
+    errors,
+    output: errorOptions.annotatedOutputs
+      ? errorOptions.annotatedOutputs.map((output) => parseInvalidSource(output).source)
+      : errorOptions.annotatedOutput
+        ? parseInvalidSource(errorOptions.annotatedOutput).source
+        : null,
+  };
+}
+
+function parseInvalidSource(source, specialChar = '~', otherChars = []) {
+  const ignored = new Set(otherChars);
+  let column = 0;
+  let line = 0;
+  let sourceLine = 0;
+  let annotationLine = false;
+  let start;
+  let end;
+  for (const character of source) {
+    if (character === '\n') {
+      if (annotationLine) annotationLine = false;
+      else sourceLine = line;
+      column = 0;
+      line += 1;
+      continue;
+    }
+    column += 1;
+    if (ignored.has(character)) annotationLine = true;
+    if (character !== specialChar) continue;
+    annotationLine = true;
+    start ??= { character: column - 1, line: sourceLine };
+    end = { character: column, line: sourceLine };
+  }
+  const ignoredPattern =
+    otherChars.length === 0
+      ? null
+      : new RegExp(
+          '[' +
+            otherChars
+              .map((value) => value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'))
+              .join('') +
+            ']',
+          'g',
+        );
+  const withoutOtherAnnotations = ignoredPattern ? source.replace(ignoredPattern, ' ') : source;
+  return {
+    source: withoutOtherAnnotations.replaceAll(specialChar, ''),
+    start,
+    end,
+  };
+}
+`;
+}


### PR DESCRIPTION
## Summary
- port Angular ESLint v22.1.0 `require-localize-metadata` with Oxc AST traversal
- support the upstream description, meaning, custom ID, and pattern options with exact diagnostics
- add deterministic upstream fixtures plus Rust, NAPI, plugin, Playground, docs, and status coverage

## Testing
- `VITEST_MAX_WORKERS=1 pnpm verify` (16,756 passed, 1,159 skipped; all workspace gates passed)
- `VITEST_MAX_WORKERS=1 pnpm exec vitest run npm/angular-eslint/test/api.test.mjs npm/angular-eslint/test/plugin.test.mjs` (586 passed on latest main)
- `cargo test -p oxlint-plugins-angular-eslint` (67 passed on latest main)
- `cargo test -p oxlint-plugins-playground-wasm` (6 passed on latest main)
- `pnpm run status:check`
- `cargo fmt --check`
- `vp fmt --check`
- `git diff --check`

Part of #419.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->