### PR TITLE
feat(perfectionist): port sort-sets options

### DIFF
--- a/crates/perfectionist/src/lib.rs
+++ b/crates/perfectionist/src/lib.rs
@@ -5,6 +5,7 @@ mod scanner;
 mod sort_array_includes;
 mod sort_named_specifiers;
 mod sort_options;
+mod sort_sets;
 mod types;
 
 #[cfg(test)]
@@ -113,6 +114,12 @@ pub fn scan_perfectionist_rule(
         "sort-imports" => sort_named_specifiers::check_sort_imports(
             source_text,
             &parser_return.program.body,
+            &parser_return.program.comments,
+            options,
+        ),
+        "sort-sets" => sort_sets::check(
+            source_text,
+            &parser_return.program,
             &parser_return.program.comments,
             options,
         ),

--- a/crates/perfectionist/src/sort_array_includes.rs
+++ b/crates/perfectionist/src/sort_array_includes.rs
@@ -9,7 +9,7 @@
 
 use oxc_ast::{
     Comment,
-    ast::{Argument, ArrayExpressionElement, CallExpression, Expression, Program},
+    ast::{Argument, ArrayExpressionElement, CallExpression, Expression, NewExpression, Program},
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::{GetSpan, Span};
@@ -40,10 +40,30 @@ pub(crate) fn check<'ast>(
     comments: &[Comment],
     raw_options: &Value,
 ) -> SmallVec<[RuleDiagnostic; 8]> {
-    let mut visitor = ArrayIncludesVisitor {
+    check_with_target(
+        source_text,
+        program,
+        comments,
+        raw_options,
+        CONTRACT,
+        ArrayRuleTarget::Includes,
+    )
+}
+
+pub(crate) fn check_with_target<'ast>(
+    source_text: &'ast str,
+    program: &Program<'ast>,
+    comments: &[Comment],
+    raw_options: &Value,
+    contract: RuleContract,
+    target: ArrayRuleTarget,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    let mut visitor = ArrayRuleVisitor {
         source_text,
         comments,
         raw_options,
+        contract,
+        target,
         lines: LineIndex::new(source_text),
         diagnostics: SmallVec::new(),
     };
@@ -54,22 +74,39 @@ pub(crate) fn check<'ast>(
     visitor.diagnostics
 }
 
-struct ArrayIncludesVisitor<'source, 'options> {
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ArrayRuleTarget {
+    Includes,
+    Sets,
+}
+
+struct ArrayRuleVisitor<'source, 'options> {
     source_text: &'source str,
     comments: &'source [Comment],
     raw_options: &'options Value,
+    contract: RuleContract,
+    target: ArrayRuleTarget,
     lines: LineIndex,
     diagnostics: SmallVec<[RuleDiagnostic; 8]>,
 }
 
-impl<'ast> Visit<'ast> for ArrayIncludesVisitor<'ast, '_> {
+impl<'ast> Visit<'ast> for ArrayRuleVisitor<'ast, '_> {
     fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
-        self.check_call(call);
+        if self.target == ArrayRuleTarget::Includes {
+            self.check_call(call);
+        }
         walk::walk_call_expression(self, call);
+    }
+
+    fn visit_new_expression(&mut self, expression: &NewExpression<'ast>) {
+        if self.target == ArrayRuleTarget::Sets {
+            self.check_set(expression);
+        }
+        walk::walk_new_expression(self, expression);
     }
 }
 
-impl<'ast> ArrayIncludesVisitor<'ast, '_> {
+impl<'ast> ArrayRuleVisitor<'ast, '_> {
     fn check_call(&mut self, call: &CallExpression<'ast>) {
         let Expression::StaticMemberExpression(member) = call.callee.get_inner_expression() else {
             return;
@@ -108,6 +145,66 @@ impl<'ast> ArrayIncludesVisitor<'ast, '_> {
                     "NewExpression",
                     expression.span.end.saturating_sub(1),
                     expression
+                        .arguments
+                        .iter()
+                        .map(|argument| match argument {
+                            Argument::SpreadElement(spread) => ArrayItem::Barrier(spread.span),
+                            argument => argument
+                                .as_expression()
+                                .map_or(ArrayItem::Barrier(argument.span()), ArrayItem::Expression),
+                        })
+                        .collect(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn check_set(&mut self, expression: &NewExpression<'ast>) {
+        if !matches!(
+            expression.callee.get_inner_expression(),
+            Expression::Identifier(identifier) if identifier.name == "Set"
+        ) {
+            return;
+        }
+        let Some(argument) = expression
+            .arguments
+            .first()
+            .and_then(Argument::as_expression)
+        else {
+            return;
+        };
+
+        match argument.get_inner_expression() {
+            Expression::ArrayExpression(array) => self.check_array(
+                "ArrayExpression",
+                array.span.end.saturating_sub(1),
+                array
+                    .elements
+                    .iter()
+                    .map(|element| match element {
+                        ArrayExpressionElement::SpreadElement(spread) => {
+                            ArrayItem::Barrier(spread.span)
+                        }
+                        ArrayExpressionElement::Elision(elision) => {
+                            ArrayItem::Barrier(elision.span)
+                        }
+                        element => element
+                            .as_expression()
+                            .map_or(ArrayItem::Barrier(element.span()), ArrayItem::Expression),
+                    })
+                    .collect(),
+            ),
+            Expression::NewExpression(array)
+                if matches!(
+                    array.callee.get_inner_expression(),
+                    Expression::Identifier(identifier) if identifier.name == "Array"
+                ) =>
+            {
+                self.check_array(
+                    "NewExpression",
+                    array.span.end.saturating_sub(1),
+                    array
                         .arguments
                         .iter()
                         .map(|argument| match argument {
@@ -170,7 +267,7 @@ impl<'ast> ArrayIncludesVisitor<'ast, '_> {
             self.comments,
             options,
             &mut nodes,
-            CONTRACT,
+            self.contract,
             &self.lines,
             &mut self.diagnostics,
         );
@@ -199,7 +296,7 @@ impl<'ast> ArrayIncludesVisitor<'ast, '_> {
         let source = source_for_span(self.source_text, Span::new(source_start, source_end))?;
         let node_source = source_for_span(self.source_text, span)?;
         let name = expression_name(self.source_text, expression);
-        let group = compute_group(options, name.as_str(), &[], CONTRACT.selector);
+        let group = compute_group(options, name.as_str(), &[], self.contract.selector);
         let group_index = options.group_index(group.as_str());
         Some(SortableNode {
             span,
@@ -212,7 +309,12 @@ impl<'ast> ArrayIncludesVisitor<'ast, '_> {
             group,
             group_index,
             partition_id: 0,
-            is_disabled: is_rule_disabled(self.source_text, self.comments, span, CONTRACT.rule),
+            is_disabled: is_rule_disabled(
+                self.source_text,
+                self.comments,
+                span,
+                self.contract.rule,
+            ),
             is_ignored: false,
             preserve_order_in_group: false,
             is_type_import: false,

--- a/crates/perfectionist/src/sort_sets.rs
+++ b/crates/perfectionist/src/sort_sets.rs
@@ -1,0 +1,37 @@
+//! Oxc AST target matching for Perfectionist's `sort-sets` v5.10.0 contract.
+
+use oxc_ast::{Comment, ast::Program};
+use oxlint_plugins_carton::SmallVec;
+use serde_json::Value;
+
+use crate::{
+    sort_array_includes::{ArrayRuleTarget, check_with_target},
+    sort_named_specifiers::RuleContract,
+    types::RuleDiagnostic,
+};
+
+const CONTRACT: RuleContract = RuleContract {
+    rule: "sort-sets",
+    selector: "literal",
+    order_message_id: "unexpectedSetsOrder",
+    group_order_message_id: "unexpectedSetsGroupOrder",
+    extra_spacing_message_id: "extraSpacingBetweenSetsMembers",
+    missed_spacing_message_id: "missedSpacingBetweenSetsMembers",
+    missed_comment_above_message_id: None,
+};
+
+pub(crate) fn check<'ast>(
+    source_text: &'ast str,
+    program: &Program<'ast>,
+    comments: &[Comment],
+    raw_options: &Value,
+) -> SmallVec<[RuleDiagnostic; 8]> {
+    check_with_target(
+        source_text,
+        program,
+        comments,
+        raw_options,
+        CONTRACT,
+        ArrayRuleTarget::Sets,
+    )
+}

--- a/crates/perfectionist/src/tests.rs
+++ b/crates/perfectionist/src/tests.rs
@@ -86,6 +86,193 @@ fn configured_array_includes(
     scan_perfectionist_rule(source, "fixture.ts", "sort-array-includes", &options)
 }
 
+fn configured_sets(source: &str, options: serde_json::Value) -> SmallVec<[RuleDiagnostic; 8]> {
+    scan_perfectionist_rule(source, "fixture.ts", "sort-sets", &options)
+}
+
+#[test]
+fn sorts_sets_with_exact_data_and_fix() {
+    let diagnostics = configured_sets("new Set(['b', 'a'])", json!([]));
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "sort-sets");
+    assert_eq!(diagnostics[0].message_id, "unexpectedSetsOrder");
+    assert_eq!(diagnostics[0].data.left, "b");
+    assert_eq!(diagnostics[0].data.right, "a");
+    assert_eq!(diagnostics[0].fix.start, 9);
+    assert_eq!(diagnostics[0].fix.end, 17);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'b'");
+}
+
+#[test]
+fn sorts_only_supported_first_set_array_arguments() {
+    let diagnostics = configured_sets(
+        "new Set(new Array('bb', 'a'))",
+        json!([{ "type": "line-length", "order": "asc" }]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'bb'");
+
+    let generic = configured_sets("new Set<string>(['b', 'a'])", json!([]));
+    assert_eq!(generic.len(), 1);
+    assert_eq!(generic[0].fix.replacement, "'a', 'b'");
+
+    for source in [
+        "Set(['b', 'a'])",
+        "new Set()",
+        "new Set[0](['b', 'a'])",
+        "new NotASet(['b', 'a'])",
+        "new globalThis.Set(['b', 'a'])",
+        "new Set(new NotAnArray('b', 'a'))",
+        "new Set(value, ['b', 'a'])",
+        "new Set(value, new Array('b', 'a'))",
+        "['b', 'a']",
+        "new Array('b', 'a')",
+    ] {
+        assert!(configured_sets(source, json!([])).is_empty(), "{source}");
+    }
+}
+
+#[test]
+fn reports_multiple_sets_in_source_order() {
+    let diagnostics = configured_sets(
+        "new Set(['d', 'c']);\nnew Set(new Array('b', 'a'));",
+        json!([]),
+    );
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].data.left, "d");
+    assert_eq!(diagnostics[0].data.right, "c");
+    assert_eq!(diagnostics[1].data.left, "b");
+    assert_eq!(diagnostics[1].data.right, "a");
+    assert_eq!(diagnostics[0].loc.start_line, 1);
+    assert_eq!(diagnostics[1].loc.start_line, 2);
+}
+
+#[test]
+fn keeps_set_spreads_and_elisions_as_hard_boundaries() {
+    assert!(configured_sets("new Set(['a', 'b', ...spread, 'c', 'd'])", json!([])).is_empty());
+    assert!(configured_sets("new Set(['a', 'b',, 'c', 'd'])", json!([])).is_empty());
+
+    let diagnostics = configured_sets("new Set(['b', 'a', ...spread, 'd', 'c'])", json!([]));
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'b'");
+    assert_eq!(diagnostics[1].fix.replacement, "'c', 'd'");
+}
+
+#[test]
+fn applies_set_groups_spacing_and_comment_partitions() {
+    let grouped = configured_sets(
+        "new Set(['b',\n'a'])",
+        json!([{
+            "customGroups": [{ "groupName": "a", "elementNamePattern": "^a$" }],
+            "groups": ["a", "literal"],
+            "newlinesBetween": 1
+        }]),
+    );
+    assert_eq!(grouped.len(), 1);
+    assert_eq!(grouped[0].message_id, "unexpectedSetsGroupOrder");
+    assert_eq!(grouped[0].data.left_group.as_deref(), Some("literal"));
+    assert_eq!(grouped[0].data.right_group.as_deref(), Some("a"));
+
+    let spacing = configured_sets(
+        "new Set(['a',\n'b'])",
+        json!([{
+            "customGroups": [{ "groupName": "a", "elementNamePattern": "^a$" }],
+            "groups": ["a", "literal"],
+            "newlinesBetween": 1
+        }]),
+    );
+    assert_eq!(spacing.len(), 1);
+    assert_eq!(spacing[0].message_id, "missedSpacingBetweenSetsMembers");
+
+    assert!(
+        configured_sets(
+            "new Set(['b',\n// Part\n'a'])",
+            json!([{ "partitionByComment": "^Part" }])
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn selects_set_configuration_for_each_supported_ast_shape() {
+    let options = json!([
+        {
+            "type": "unsorted",
+            "useConfigurationIf": { "matchesAstSelector": "ArrayExpression" }
+        },
+        {
+            "type": "alphabetical",
+            "useConfigurationIf": { "matchesAstSelector": "NewExpression" }
+        }
+    ]);
+
+    assert!(configured_sets("new Set(['b', 'a'])", options.clone()).is_empty());
+    let diagnostics = configured_sets("new Set(new Array('b', 'a'))", options);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].fix.replacement, "'a', 'b'");
+}
+
+#[test]
+fn preserves_set_inline_comments_and_disable_directives() {
+    let diagnostics = configured_sets(
+        "new Set([\n  'b',\n  'a', // Comment after\n\n  'c'\n])",
+        json!([{
+            "customGroups": [{ "groupName": "bc", "elementNamePattern": "b|c" }],
+            "groups": ["literal", "bc"],
+            "newlinesBetween": 1,
+            "newlinesInside": 0
+        }]),
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].fix.replacement,
+        "'a', // Comment after\n  'b',"
+    );
+
+    let disabled = configured_sets(
+        "new Set([\n  'c',\n  'b',\n  // eslint-disable-next-line perfectionist/sort-sets\n  'a',\n])",
+        json!([]),
+    );
+    assert_eq!(disabled.len(), 1);
+    assert_eq!(disabled[0].fix.replacement, "'b',\n  'c'");
+}
+
+#[test]
+fn keeps_utf16_offsets_and_crlf_text_for_set_fixes() {
+    let source = "'😀';\r\nnew Set(['世界', 'api']);";
+    let diagnostics = configured_sets(
+        source,
+        json!([{
+            "customGroups": [{ "groupName": "api", "elementNamePattern": "^api$" }],
+            "groups": ["api", "unknown"],
+            "locales": "zh-CN"
+        }]),
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "unexpectedSetsGroupOrder");
+    assert_eq!(diagnostics[0].fix.start, 16);
+    assert_eq!(diagnostics[0].fix.end, 27);
+    assert_eq!(diagnostics[0].fix.replacement, "'api', '世界'");
+}
+
+#[test]
+fn set_rule_isolated_and_malformed_sources_fail_closed() {
+    assert!(
+        scan_perfectionist_rule(
+            "new Set(['b', 'a'])",
+            "fixture.ts",
+            "sort-array-includes",
+            &json!([])
+        )
+        .is_empty()
+    );
+    assert!(configured_sets("new Set(['b',", json!([])).is_empty());
+    assert!(configured_sets("new Set(['a', 'b'])", json!("bad")).is_empty());
+}
+
 #[test]
 fn sorts_array_includes_with_exact_data_and_fix() {
     let diagnostics = configured_array_includes("['b', 'a'].includes(value)", json!([]));

--- a/npm/perfectionist/README.md
+++ b/npm/perfectionist/README.md
@@ -21,3 +21,19 @@ spread boundaries, UTF-16 offsets, and CRLF text.
 
 React-specific behavior and JSX/TSX syntax are intentionally outside this
 rule's port.
+
+## `sort-sets`
+
+The rule implements the `eslint-plugin-perfectionist` v5.10.0 option contract
+for array literals and `new Array(...)` expressions used as the first argument
+of `new Set(...)`.
+
+It shares the complete comparator, grouping, custom-group, partition, newline,
+conditional-configuration, settings, diagnostic, and fixer engine with
+`sort-array-includes`. Set-specific AST matching ignores calls, non-`Set`
+constructors, non-array inputs, and arrays outside the first argument. Fixes
+preserve comments, sparse-array and spread boundaries, UTF-16 offsets, and
+CRLF text.
+
+React-specific behavior and JSX/TSX syntax are intentionally outside this
+rule's port.

--- a/npm/perfectionist/index.js
+++ b/npm/perfectionist/index.js
@@ -15,12 +15,14 @@ const PLUGIN_NAME = 'perfectionist';
 const DOCS_BASE = 'https://perfectionist.dev/rules';
 const diagnosticsCache = new WeakMap();
 const implementedRuleNames = Object.freeze(implementedPerfectionistRuleNames());
+const configuredArrayRuleNames = new Set(['sort-array-includes', 'sort-sets']);
 const configuredRuleNames = new Set([
   'sort-array-includes',
   'sort-exports',
   'sort-imports',
   'sort-named-exports',
   'sort-named-imports',
+  'sort-sets',
 ]);
 const recommendedRuleNames = Object.freeze(
   implementedRuleNames.filter((ruleName) => ruleName !== 'sort-arrays'),
@@ -87,7 +89,7 @@ function recommendedRules(options) {
 function createPerfectionistRule(ruleName) {
   return {
     meta: {
-      type: ruleName === 'sort-array-includes' ? 'suggestion' : 'layout',
+      type: configuredArrayRuleNames.has(ruleName) ? 'suggestion' : 'layout',
       docs: {
         description: `enforce sorted ${ruleName.replace(/^sort-/, '').replaceAll('-', ' ')}`,
         category: 'Stylistic Issues',
@@ -106,48 +108,59 @@ function createPerfectionistRule(ruleName) {
               missedSpacingBetweenArrayIncludesMembers:
                 'Missed spacing between "{{left}}" and "{{right}}".',
             }
-          : ruleName === 'sort-imports'
+          : ruleName === 'sort-sets'
             ? {
-                unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                unexpectedImportsGroupOrder:
+                unexpectedSetsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                unexpectedSetsGroupOrder:
                   'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                unexpectedImportsDependencyOrder:
-                  'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-                extraSpacingBetweenImports: 'Extra spacing between "{{left}}" and "{{right}}".',
-                missedSpacingBetweenImports: 'Missed spacing between "{{left}}" and "{{right}}".',
-                missedCommentAboveImport:
-                  'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
+                extraSpacingBetweenSetsMembers: 'Extra spacing between "{{left}}" and "{{right}}".',
+                missedSpacingBetweenSetsMembers:
+                  'Missed spacing between "{{left}}" and "{{right}}".',
               }
-            : ruleName === 'sort-named-imports'
+            : ruleName === 'sort-imports'
               ? {
-                  unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                  unexpectedNamedImportsGroupOrder:
+                  unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                  unexpectedImportsGroupOrder:
                     'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                  extraSpacingBetweenNamedImports:
-                    'Extra spacing between "{{left}}" and "{{right}}".',
-                  missedSpacingBetweenNamedImports:
-                    'Missed spacing between "{{left}}" and "{{right}}".',
+                  unexpectedImportsDependencyOrder:
+                    'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
+                  extraSpacingBetweenImports: 'Extra spacing between "{{left}}" and "{{right}}".',
+                  missedSpacingBetweenImports: 'Missed spacing between "{{left}}" and "{{right}}".',
+                  missedCommentAboveImport:
+                    'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
                 }
-              : ruleName === 'sort-named-exports'
+              : ruleName === 'sort-named-imports'
                 ? {
-                    unexpectedNamedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                    unexpectedNamedExportsGroupOrder:
+                    unexpectedNamedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                    unexpectedNamedImportsGroupOrder:
                       'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                    extraSpacingBetweenNamedExports:
+                    extraSpacingBetweenNamedImports:
                       'Extra spacing between "{{left}}" and "{{right}}".',
-                    missedSpacingBetweenNamedExports:
+                    missedSpacingBetweenNamedImports:
                       'Missed spacing between "{{left}}" and "{{right}}".',
                   }
-                : {
-                    unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
-                    unexpectedExportsGroupOrder:
-                      'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-                    extraSpacingBetweenExports: 'Extra spacing between "{{left}}" and "{{right}}".',
-                    missedSpacingBetweenExports:
-                      'Missed spacing between "{{left}}" and "{{right}}".',
-                    missedCommentAboveExport:
-                      'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
-                  }
+                : ruleName === 'sort-named-exports'
+                  ? {
+                      unexpectedNamedExportsOrder:
+                        'Expected "{{right}}" to come before "{{left}}".',
+                      unexpectedNamedExportsGroupOrder:
+                        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                      extraSpacingBetweenNamedExports:
+                        'Extra spacing between "{{left}}" and "{{right}}".',
+                      missedSpacingBetweenNamedExports:
+                        'Missed spacing between "{{left}}" and "{{right}}".',
+                    }
+                  : {
+                      unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+                      unexpectedExportsGroupOrder:
+                        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+                      extraSpacingBetweenExports:
+                        'Extra spacing between "{{left}}" and "{{right}}".',
+                      missedSpacingBetweenExports:
+                        'Missed spacing between "{{left}}" and "{{right}}".',
+                      missedCommentAboveExport:
+                        'Missed comment "{{missedCommentAbove}}" above "{{right}}".',
+                    }
         : {
             unexpected: 'Expected sorted order.',
           },
@@ -178,7 +191,7 @@ function configuredDiagnosticsForRule(context, ruleName) {
   const filename = typeof context.filename === 'string' ? context.filename : 'file.tsx';
   let options = Array.isArray(context.options) ? context.options : [];
   if (
-    ruleName === 'sort-array-includes' ||
+    configuredArrayRuleNames.has(ruleName) ||
     ruleName === 'sort-exports' ||
     ruleName === 'sort-imports'
   ) {
@@ -262,9 +275,9 @@ function schemaForRule(ruleName) {
   if (!configuredRuleNames.has(ruleName)) {
     return [];
   }
-  const sortsArrayIncludes = ruleName === 'sort-array-includes';
+  const sortsArrayRule = configuredArrayRuleNames.has(ruleName);
   const selector =
-    ruleName === 'sort-named-imports' ? 'import' : sortsArrayIncludes ? 'literal' : 'export';
+    ruleName === 'sort-named-imports' ? 'import' : sortsArrayRule ? 'literal' : 'export';
   const sortsExportDeclarations = ruleName === 'sort-exports';
   const sortsImportDeclarations = ruleName === 'sort-imports';
   const sortType = {
@@ -335,7 +348,7 @@ function schemaForRule(ruleName) {
   };
   const customMatch = {
     elementNamePattern: regex,
-    ...(sortsArrayIncludes
+    ...(sortsArrayRule
       ? {}
       : {
           modifiers: {
@@ -496,7 +509,7 @@ function schemaForRule(ruleName) {
       },
       alphabet: { type: 'string' },
       fallbackSort,
-      ...(!sortsArrayIncludes && !sortsExportDeclarations && !sortsImportDeclarations
+      ...(!sortsArrayRule && !sortsExportDeclarations && !sortsImportDeclarations
         ? { ignoreAlias: { type: 'boolean' } }
         : {}),
       groups,
@@ -532,14 +545,14 @@ function schemaForRule(ruleName) {
                   allNamesMatchPattern: regex,
                   matchesAstSelector: { type: 'string' },
                 },
-                ...(sortsArrayIncludes ? {} : { minProperties: 1 }),
+                ...(sortsArrayRule ? {} : { minProperties: 1 }),
                 additionalProperties: false,
               },
             }),
     },
     additionalProperties: false,
   };
-  return sortsArrayIncludes
+  return sortsArrayRule
     ? {
         items: optionSchema,
         uniqueItems: true,

--- a/npm/perfectionist/test/api.test.mjs
+++ b/npm/perfectionist/test/api.test.mjs
@@ -150,6 +150,39 @@ describe('perfectionist native API', () => {
     });
   });
 
+  it('returns exact Set groups, CRLF locations, and UTF-16 fixes', () => {
+    const source = `'😀';\r\nnew Set(['世界', 'api']);`;
+    const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-sets', [
+      {
+        customGroups: [{ groupName: 'api', elementNamePattern: '^api$' }],
+        groups: ['api', 'unknown'],
+        locales: 'zh-CN',
+      },
+    ]);
+
+    expect(diagnostic).toEqual({
+      ruleName: 'sort-sets',
+      messageId: 'unexpectedSetsGroupOrder',
+      data: {
+        left: '世界',
+        right: 'api',
+        leftGroup: 'unknown',
+        rightGroup: 'api',
+      },
+      loc: {
+        startLine: 2,
+        startColumn: 15,
+        endLine: 2,
+        endColumn: 20,
+      },
+      fix: {
+        start: 16,
+        end: 27,
+        replacement: `'api', '世界'`,
+      },
+    });
+  });
+
   it('returns exact named-export data and UTF-16 fix offsets', () => {
     const source = `'😀';\r\nexport { item2, item10 } from "pkg";\r\n`;
     const [diagnostic] = scanPerfectionistRule(source, 'fixture.ts', 'sort-named-exports', [

--- a/npm/perfectionist/test/fixtures/sort-sets-options-v5.10.0.json
+++ b/npm/perfectionist/test/fixtures/sort-sets-options-v5.10.0.json
@@ -1,0 +1,8473 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-perfectionist",
+    "version": "5.10.0",
+    "sourceCommit": "84aa039c46522f82a61ad43cf676afc92dd64704",
+    "sourceHashes": {
+      "rules/sort-sets.ts": "d069d550677d062a5c1d488a5a38e426bdf76ac681a3e2598e99d09016ad21fe",
+      "rules/sort-sets/types.ts": "927bfce114499a6e224415245e952a6eaa43c052dfd78b827bd7d8d085e7a098",
+      "rules/sort-arrays/types.ts": "9aa7faafdb1f2262aa32798623ebd6507b5a80f2ad6fa66446d66bb722bba582",
+      "rules/sort-arrays/sort-array.ts": "c65199dd2f5b56ae5302368f3e4fda46849f98641415bd77cf8d56a36ab0d60a",
+      "test/rules/sort-sets.test.ts": "44b4daf3d881e4a8ae80af1dc2d1ea92c405170c0cdda03c613577171b6215bd"
+    },
+    "license": "MIT",
+    "eslintVersion": "10.6.0",
+    "typescriptEslintParserVersion": "8.62.1",
+    "capturePolicy": "Every authored valid and invalid sort-sets case is captured; React-specific and JSX/TSX syntax is rejected. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.10.0 rule for exact diagnostics and fixes.",
+    "authoredCases": "upstream/eslint-plugin-perfectionist/test/rules/sort-sets.test.ts@v5.10.0",
+    "tool": "sync-perfectionist-sort-sets-options-tests.ts",
+    "inventory": {
+      "valid": 75,
+      "invalid": 138,
+      "diagnostics": 182,
+      "total": 213
+    }
+  },
+  "cases": [
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > oxlint > supports oxlint > valid",
+      "code": "new Set([\n  'a',\n  'b'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > oxlint > supports oxlint > invalid",
+      "code": "new Set([\n  'b',\n  'a'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b'\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores invalid set expressions",
+      "code": "new Set[0]([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores invalid set expressions",
+      "code": "new NotASet([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores invalid set expressions",
+      "code": "new Set()",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores invalid set expressions",
+      "code": "new Set(new NotAnArray(\n  b,\n  a,\n))",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores arrays that are not the first Set argument",
+      "code": "new Set(\n  foo,\n  [\n    b,\n    a,\n  ],\n)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores arrays that are not the first Set argument",
+      "code": "new Set(\n  foo,\n  new Array(\n    b,\n    a,\n  ),\n)",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > preserves set structure when fixing sort order",
+      "code": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > preserves set structure when fixing sort order",
+      "code": "new Set([\n  'a',\n  'c',\n  'b',\n  'd',\n  'e',\n  ...other,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [19, 29],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > does not sort spread elements",
+      "code": "new Set([\n  ...aaa,\n  ...ccc,\n  ...bbbb,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > treats spread elements as partition boundaries",
+      "code": "new Set([\n  'a',\n  'b',\n  ...spread1,\n  'd',\n  'e',\n  ...spread2,\n  'g',\n  'h',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > treats spread elements as partition boundaries",
+      "code": "new Set([\n  'b',\n  'a',\n  ...spread,\n  'c',\n  'd',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b',\n  ...spread,\n  'c',\n  'd',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > does not reorder spread operators to preserve Set iteration order",
+      "code": "const l = [1, 3]\nconst k = [2, 4]\nconst list = [...new Set([...l, ...k])]",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > handles sets with empty slots correctly",
+      "code": "new Set(['a', 'b', 'c',, 'd'])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > handles sets with empty slots correctly",
+      "code": "new Set(['b', 'a', 'c',, 'd'])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 15,
+            "endLine": 1,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [9, 17],
+            "text": "'a', 'b'"
+          }
+        }
+      ],
+      "output": "new Set(['a', 'b', 'c',, 'd'])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > sorts elements in Set with Array constructor",
+      "code": "new Set(new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n))",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > sorts elements in Set with Array constructor",
+      "code": "new Set(new Array(\n  'a',\n  'c',\n  'b',\n  'd',\n))",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [28, 38],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set(new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n))"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > sorts elements within newline-separated groups independently",
+      "code": "new Set([\n  'd',\n  'a',\n\n  'c',\n\n  'e',\n  'b',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"d\".",
+          "data": {
+            "right": "a",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 45],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"e\".",
+          "data": {
+            "right": "b",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 45],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > treats each newline-separated section as independent partition",
+      "code": "new Set([\n  'c',\n  'top2',\n\n  'a',\n  'top1',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "unknown"],
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 43],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 43],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top2',\n  'c',\n\n  'top1',\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > creates partitions based on matching comments",
+      "code": "new Set([\n  // Part: A\n  'cc',\n  'd',\n  // Not partition comment\n  'bbb',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  'gg',\n  // Not partition comment\n  'fff',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbb\" to come before \"d\".",
+          "data": {
+            "right": "bbb",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [25, 159],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"fff\" to come before \"gg\".",
+          "data": {
+            "right": "fff",
+            "left": "gg"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 3,
+            "endLine": 13,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [25, 159],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        }
+      ],
+      "output": "new Set([\n  // Part: A\n  // Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > treats every comment as partition boundary when set to true",
+      "code": "new Set([\n  // Comment\n  'bb',\n  // Other comment\n  'a',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > supports multiple partition comment patterns",
+      "code": "new Set([\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'c',\n  'bb',\n  /* Other */\n  'e',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [80, 91],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'bb',\n  'c',\n  /* Other */\n  'e',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > supports regex patterns for partition comments",
+      "code": "new Set([\n  'e',\n  'f',\n  // I am a partition comment because I don't have f o o\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > ignores line comments when block comments are specified",
+      "code": "new Set([\n  'b',\n  // Comment\n  'a'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 35],
+            "text": "// Comment\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  // Comment\n  'a',\n  'b'\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > uses block comments as partition boundaries",
+      "code": "new Set([\n  'b',\n  /* Comment */\n  'a'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > matches specific block comment patterns",
+      "code": "new Set([\n  'c',\n  /* b */\n  'b',\n  /* a */\n  'a'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > supports regex patterns for block comments",
+      "code": "new Set([\n  'b',\n  /* I am a partition comment because I don't have f o o */\n  'a'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores special characters at start when trimming",
+      "code": "new Set([\n  '$a',\n  'b',\n  '$c',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > ignores special characters completely when removing",
+      "code": "new Set([\n  'ab',\n  'a$c',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > sorts elements according to locale-specific rules",
+      "code": "new Set([\n  '你好',\n  '世界',\n  'a',\n  'A',\n  'b',\n  'B',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > sorts single-line sets correctly",
+      "code": "new Set([\n  b, a\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 16],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a, b\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > handles trailing commas in single-line sets",
+      "code": "new Set([\n  b, a,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 16],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a, b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > allows overriding options in groups",
+      "code": "new Set([\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "groups": [
+            {
+              "type": "alphabetical",
+              "newlinesInside": 1,
+              "group": "unknown",
+              "order": "desc"
+            }
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n\n  'a'"
+          }
+        },
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > enforces custom group ordering",
+      "code": "new Set([\n  'c',\n  'top1',\n  'a'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "literal"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"c\" (literal).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "literal"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 32],
+            "text": "'top1',\n  'a',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top1',\n  'a',\n  'c'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > applies custom groups based on element selectors",
+      "code": "new Set([\n  'b',\n  'top1',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "topElements"
+            }
+          ],
+          "groups": ["topElements", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (topElements) to come before \"b\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "topElements",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 25],
+            "text": "'top1',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top1',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > groups elements by name pattern - string pattern",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > groups elements by name pattern - array of patterns",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > groups elements by name pattern - case-insensitive regex",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > groups elements by name pattern - regex in array",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > overrides sort type and order for specific groups",
+      "code": "new Set([\n  'a',\n  'bb',\n  'ccc',\n  'dddd',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedLiteralsByLineLength",
+              "selector": "literal",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedLiteralsByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'dddd',\n  'ccc',\n  'bb',\n  'a',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > applies fallback sort when primary sort results in tie",
+      "code": "new Set([\n  'fooZar',\n  'fooBar',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 11
+          },
+          "fix": {
+            "range": [12, 32],
+            "text": "'fooBar',\n  'fooZar'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'fooBar',\n  'fooZar',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > preserves original order for unsorted groups",
+      "code": "new Set([\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'm',\n  'top3',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "unsortedTop",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedTop", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top3\" (unsortedTop) to come before \"m\" (unknown).",
+          "data": {
+            "right": "top3",
+            "rightGroup": "unsortedTop",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [52, 65],
+            "text": "'top3',\n  'm'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'top3',\n  'm',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > combines multiple selectors with anyOf",
+      "code": "new Set([\n  'a',\n  'bFoo',\n  'cFoo',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo"
+                },
+                {
+                  "elementNamePattern": "Foo"
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"bFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "bFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 35],
+            "text": "'bFoo',\n  'cFoo',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'bFoo',\n  'cFoo',\n  'a',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > supports negative regex patterns in custom groups",
+      "code": "new Set([\n  'iHaveFooInMyName',\n  'meTooIHaveFoo',\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - string pattern",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "foo"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - array of patterns",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": ["noMatch", "foo"]
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - case-insensitive regex",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "FOO",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - regex in array",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": [
+              "noMatch",
+              {
+                "pattern": "foo",
+                "flags": "i"
+              }
+            ]
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > skips config when selector does not match the sorted node type",
+      "code": "const array = new Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "VariableDeclarator"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [26, 32],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "const array = new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > applies config when selector matches the sorted node type",
+      "code": "Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > applies config when selector matches the sorted node type",
+      "code": "[\n  b,\n  a,\n].includes(value)",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > falls through to next matching config when not matching",
+      "code": "new Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ArrayExpression",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 18],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > falls through to next matching config when not matching",
+      "code": "new Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 18],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > falls through to next matching config when not matching",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression",
+            "allNamesMatchPattern": "^[ac]$"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[ab]$"
+          }
+        },
+        {
+          "type": "unsorted"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 18],
+            "text": "b,\n  a"
+          }
+        }
+      ],
+      "output": "new Set([\n  b,\n  a,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > applies first matching option when selectors overlap",
+      "code": "new Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > applies first matching option when selectors overlap",
+      "code": "new Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        },
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "* > ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 18],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > useConfigurationIf.matchesAstSelector > picks the first matching option when multiple options match",
+      "code": "new Set([\n  b,\n  a,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        },
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "useConfigurationIf": {
+            "matchesAstSelector": "ArrayExpression"
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [12, 18],
+            "text": "a,\n  b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines between and inside groups by default when \"newlinesBetween\" is 0",
+      "code": "new Set([\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n    'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n    'z'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n 'b',\n'y',\n    'z'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines inside groups when newlinesInside is 0",
+      "code": "new Set([\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [20, 38],
+            "text": "'b',\n'y',\n    'z'"
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"z\" and \"b\".",
+          "data": {
+            "left": "z",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [20, 38],
+            "text": "'b',\n'y',\n    'z'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n\n\n 'b',\n'y',\n    'z'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines between groups when newlinesBetween is 0",
+      "code": "new Set([\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n 'b',\n'y',\n\n    'z'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > applies inline newline settings between specific groups",
+      "code": "new Set([\n  'a',\n  'b',\n\n\n  'c',\n\n  'd',\n\n\n  'e'\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n\n  'b',\n\n  'c',\n  'd',\n\n\n  'e'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > enforces 2 newlines when global is 2 and group is 0",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > enforces 2 newlines when global is 2 and group is ignore",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > enforces 2 newlines when global is 0 and group is 2",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > enforces 2 newlines when global is ignore and group is 2",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines when 0 overrides global 1 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines when 0 overrides global 2 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines when 0 overrides global ignore between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > removes newlines when 0 overrides global 0 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > accepts any spacing when global is ignore and group is 0",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > accepts any spacing when global is ignore and group is 0",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > accepts any spacing when global is 0 and group is ignore",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > alphabetical > accepts any spacing when global is 0 and group is ignore",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > preserves inline comments when reordering elements",
+      "code": "new Set([\n  'b',\n  'a', // Comment after\n\n  'c'\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "b|c",
+              "groupName": "b|c"
+            }
+          ],
+          "groups": ["unknown", "b|c"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"a\" (unknown) to come before \"b\" (b|c).",
+          "data": {
+            "right": "a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "b|c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'a', // Comment after\n  'b',"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a', // Comment after\n\n  'b',\n  'c'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > alphabetical > preserves partition boundaries regardless of newlinesBetween 0",
+      "code": "new Set([\n  'a',\n\n  // Partition comment\n\n  'c',\n  'b',\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [44, 54],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n\n  // Partition comment\n\n  'b',\n  'c',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > preserves set structure when fixing sort order",
+      "code": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > preserves set structure when fixing sort order",
+      "code": "new Set([\n  'a',\n  'c',\n  'b',\n  'd',\n  'e',\n  ...other,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [19, 29],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n  'e',\n  ...other,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > does not sort spread elements",
+      "code": "new Set([\n  ...aaa,\n  ...ccc,\n  ...bbbb,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > treats spread elements as partition boundaries",
+      "code": "new Set([\n  'a',\n  'b',\n  ...spread1,\n  'd',\n  'e',\n  ...spread2,\n  'g',\n  'h',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > treats spread elements as partition boundaries",
+      "code": "new Set([\n  'b',\n  'a',\n  ...spread,\n  'c',\n  'd',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b',\n  ...spread,\n  'c',\n  'd',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > handles sets with empty slots correctly",
+      "code": "new Set(['a', 'b', 'c',, 'd'])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > handles sets with empty slots correctly",
+      "code": "new Set(['b', 'a', 'c',, 'd'])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 15,
+            "endLine": 1,
+            "endColumn": 18
+          },
+          "fix": {
+            "range": [9, 17],
+            "text": "'a', 'b'"
+          }
+        }
+      ],
+      "output": "new Set(['a', 'b', 'c',, 'd'])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > sorts elements in Set with Array constructor",
+      "code": "new Set(new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n))",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > sorts elements in Set with Array constructor",
+      "code": "new Set(new Array(\n  'a',\n  'c',\n  'b',\n  'd',\n))",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [28, 38],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set(new Array(\n  'a',\n  'b',\n  'c',\n  'd',\n))"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > sorts elements within newline-separated groups independently",
+      "code": "new Set([\n  'd',\n  'a',\n\n  'c',\n\n  'e',\n  'b',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"d\".",
+          "data": {
+            "right": "a",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 45],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"e\".",
+          "data": {
+            "right": "b",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 45],
+            "text": "'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'd',\n\n  'c',\n\n  'b',\n  'e',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > treats each newline-separated section as independent partition",
+      "code": "new Set([\n  'c',\n  'top2',\n\n  'a',\n  'top1',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "unknown"],
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 43],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 43],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top2',\n  'c',\n\n  'top1',\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > creates partitions based on matching comments",
+      "code": "new Set([\n  // Part: A\n  'cc',\n  'd',\n  // Not partition comment\n  'bbb',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  'gg',\n  // Not partition comment\n  'fff',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbb\" to come before \"d\".",
+          "data": {
+            "right": "bbb",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [25, 159],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"fff\" to come before \"gg\".",
+          "data": {
+            "right": "fff",
+            "left": "gg"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 3,
+            "endLine": 13,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [25, 159],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        }
+      ],
+      "output": "new Set([\n  // Part: A\n  // Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > treats every comment as partition boundary when set to true",
+      "code": "new Set([\n  // Comment\n  'bb',\n  // Other comment\n  'a',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > supports multiple partition comment patterns",
+      "code": "new Set([\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'c',\n  'bb',\n  /* Other */\n  'e',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [80, 91],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'bb',\n  'c',\n  /* Other */\n  'e',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > supports regex patterns for partition comments",
+      "code": "new Set([\n  'e',\n  'f',\n  // I am a partition comment because I don't have f o o\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > ignores line comments when block comments are specified",
+      "code": "new Set([\n  'b',\n  // Comment\n  'a'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 35],
+            "text": "// Comment\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  // Comment\n  'a',\n  'b'\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > uses block comments as partition boundaries",
+      "code": "new Set([\n  'b',\n  /* Comment */\n  'a'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > matches specific block comment patterns",
+      "code": "new Set([\n  'c',\n  /* b */\n  'b',\n  /* a */\n  'a'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > supports regex patterns for block comments",
+      "code": "new Set([\n  'b',\n  /* I am a partition comment because I don't have f o o */\n  'a'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > ignores special characters at start when trimming",
+      "code": "new Set([\n  '$a',\n  'b',\n  '$c',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > ignores special characters completely when removing",
+      "code": "new Set([\n  'ab',\n  'a$c',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > sorts elements according to locale-specific rules",
+      "code": "new Set([\n  '你好',\n  '世界',\n  'a',\n  'A',\n  'b',\n  'B',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > sorts single-line sets correctly",
+      "code": "new Set([\n  b, a\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 16],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a, b\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > handles trailing commas in single-line sets",
+      "code": "new Set([\n  b, a,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 16],
+            "text": "a, b"
+          }
+        }
+      ],
+      "output": "new Set([\n  a, b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > enforces custom group ordering",
+      "code": "new Set([\n  'c',\n  'top1',\n  'a'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "literal"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"c\" (literal).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "literal"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 32],
+            "text": "'top1',\n  'a',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top1',\n  'a',\n  'c'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > applies custom groups based on element selectors",
+      "code": "new Set([\n  'b',\n  'top1',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "topElements"
+            }
+          ],
+          "groups": ["topElements", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (topElements) to come before \"b\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "topElements",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 25],
+            "text": "'top1',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top1',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > groups elements by name pattern - string pattern",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > groups elements by name pattern - array of patterns",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > groups elements by name pattern - case-insensitive regex",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > groups elements by name pattern - regex in array",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > overrides sort type and order for specific groups",
+      "code": "new Set([\n  'a',\n  'bb',\n  'ccc',\n  'dddd',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedLiteralsByLineLength",
+              "selector": "literal",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedLiteralsByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'dddd',\n  'ccc',\n  'bb',\n  'a',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > applies fallback sort when primary sort results in tie",
+      "code": "new Set([\n  'fooZar',\n  'fooBar',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 11
+          },
+          "fix": {
+            "range": [12, 32],
+            "text": "'fooBar',\n  'fooZar'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'fooBar',\n  'fooZar',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > preserves original order for unsorted groups",
+      "code": "new Set([\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'm',\n  'top3',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "unsortedTop",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedTop", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top3\" (unsortedTop) to come before \"m\" (unknown).",
+          "data": {
+            "right": "top3",
+            "rightGroup": "unsortedTop",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [52, 65],
+            "text": "'top3',\n  'm'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'top3',\n  'm',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > combines multiple selectors with anyOf",
+      "code": "new Set([\n  'a',\n  'bFoo',\n  'cFoo',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo"
+                },
+                {
+                  "elementNamePattern": "Foo"
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"bFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "bFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 35],
+            "text": "'bFoo',\n  'cFoo',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'bFoo',\n  'cFoo',\n  'a',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > supports negative regex patterns in custom groups",
+      "code": "new Set([\n  'iHaveFooInMyName',\n  'meTooIHaveFoo',\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - string pattern",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "foo"
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - array of patterns",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": ["noMatch", "foo"]
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - case-insensitive regex",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "FOO",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - regex in array",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": [
+              "noMatch",
+              {
+                "pattern": "foo",
+                "flags": "i"
+              }
+            ]
+          }
+        },
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > removes newlines between groups when newlinesBetween is 0",
+      "code": "new Set([\n  'a',\n\n\n 'y',\n'z',\n\n    'b'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"y\".",
+          "data": {
+            "left": "a",
+            "right": "y"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 5
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"z\".",
+          "data": {
+            "right": "b",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [15, 38],
+            "text": ",\n 'b',\n'y',\n\n    'z'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n 'b',\n'y',\n\n    'z'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > applies inline newline settings between specific groups",
+      "code": "new Set([\n  'a',\n  'b',\n\n\n  'c',\n\n  'd',\n\n\n  'e'\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n\n  'b',\n\n  'c',\n  'd',\n\n\n  'e'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > enforces 2 newlines when global is 2 and group is 0",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > enforces 2 newlines when global is 2 and group is ignore",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > enforces 2 newlines when global is 0 and group is 2",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > enforces 2 newlines when global is ignore and group is 2",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > removes newlines when 0 overrides global 1 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > removes newlines when 0 overrides global 2 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > removes newlines when 0 overrides global ignore between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > removes newlines when 0 overrides global 0 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > accepts any spacing when global is ignore and group is 0",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > accepts any spacing when global is ignore and group is 0",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > accepts any spacing when global is 0 and group is ignore",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > natural > accepts any spacing when global is 0 and group is ignore",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > preserves inline comments when reordering elements",
+      "code": "new Set([\n  'b',\n  'a', // Comment after\n\n  'c'\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "b|c",
+              "groupName": "b|c"
+            }
+          ],
+          "groups": ["unknown", "b|c"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"a\" (unknown) to come before \"b\" (b|c).",
+          "data": {
+            "right": "a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "b|c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'a', // Comment after\n  'b',"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a', // Comment after\n\n  'b',\n  'c'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > natural > preserves partition boundaries regardless of newlinesBetween 0",
+      "code": "new Set([\n  'a',\n\n  // Partition comment\n\n  'c',\n  'b',\n])",
+      "options": [
+        {
+          "type": "natural",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [44, 54],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n\n  // Partition comment\n\n  'b',\n  'c',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > preserves set structure when fixing sort order",
+      "code": "new Set([\n  'aaaaa',\n  'bbbb',\n  'ccc',\n  'dd',\n  'e',\n  ...other,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > preserves set structure when fixing sort order",
+      "code": "new Set([\n  'aaaaa',\n  'ccc',\n  'bbbb',\n  'dd',\n  'e',\n  ...other,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbbb\" to come before \"ccc\".",
+          "data": {
+            "right": "bbbb",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [23, 38],
+            "text": "'bbbb',\n  'ccc'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aaaaa',\n  'bbbb',\n  'ccc',\n  'dd',\n  'e',\n  ...other,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > does not sort spread elements",
+      "code": "new Set([\n  ...aaa,\n  ...c,\n  ...bb,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > treats spread elements as partition boundaries",
+      "code": "new Set([\n  'aa',\n  'b',\n  ...spread1,\n  'dd',\n  'e',\n  ...spread2,\n  'gg',\n  'h',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > treats spread elements as partition boundaries",
+      "code": "new Set([\n  'b',\n  'aa',\n  ...spread,\n  'cc',\n  'd',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 23],
+            "text": "'aa',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aa',\n  'b',\n  ...spread,\n  'cc',\n  'd',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > handles sets with empty slots correctly",
+      "code": "new Set(['aaaa', 'bbb', 'cc',, 'd'])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > handles sets with empty slots correctly",
+      "code": "new Set(['bbb', 'aaaa', 'cc',, 'd'])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aaaa\" to come before \"bbb\".",
+          "data": {
+            "right": "aaaa",
+            "left": "bbb"
+          },
+          "loc": {
+            "startLine": 1,
+            "startColumn": 17,
+            "endLine": 1,
+            "endColumn": 23
+          },
+          "fix": {
+            "range": [9, 22],
+            "text": "'aaaa', 'bbb'"
+          }
+        }
+      ],
+      "output": "new Set(['aaaa', 'bbb', 'cc',, 'd'])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > sorts elements in Set with Array constructor",
+      "code": "new Set(new Array(\n  'aaaa',\n  'bbb',\n  'cc',\n  'd',\n))",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > sorts elements in Set with Array constructor",
+      "code": "new Set(new Array(\n  'aaaa',\n  'cc',\n  'bbb',\n  'd',\n))",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbb\" to come before \"cc\".",
+          "data": {
+            "right": "bbb",
+            "left": "cc"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [31, 44],
+            "text": "'bbb',\n  'cc'"
+          }
+        }
+      ],
+      "output": "new Set(new Array(\n  'aaaa',\n  'bbb',\n  'cc',\n  'd',\n))"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > sorts elements within newline-separated groups independently",
+      "code": "new Set([\n  'dd',\n  'aaaaa',\n\n  'ccc',\n\n  'e',\n  'bbbb',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aaaaa\" to come before \"dd\".",
+          "data": {
+            "right": "aaaaa",
+            "left": "dd"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [12, 55],
+            "text": "'aaaaa',\n  'dd',\n\n  'ccc',\n\n  'bbbb',\n  'e'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbbb\" to come before \"e\".",
+          "data": {
+            "right": "bbbb",
+            "left": "e"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 55],
+            "text": "'aaaaa',\n  'dd',\n\n  'ccc',\n\n  'bbbb',\n  'e'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aaaaa',\n  'dd',\n\n  'ccc',\n\n  'bbbb',\n  'e',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > treats each newline-separated section as independent partition",
+      "code": "new Set([\n  'c',\n  'top2',\n\n  'a',\n  'top1',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "unknown"],
+          "partitionByNewLine": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top2\" (top) to come before \"c\" (unknown).",
+          "data": {
+            "right": "top2",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 43],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"a\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 43],
+            "text": "'top2',\n  'c',\n\n  'top1',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top2',\n  'c',\n\n  'top1',\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > creates partitions based on matching comments",
+      "code": "new Set([\n  // Part: A\n  'cc',\n  'd',\n  // Not partition comment\n  'bbb',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  'gg',\n  // Not partition comment\n  'fff',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": "^Part"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbb\" to come before \"d\".",
+          "data": {
+            "right": "bbb",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [25, 159],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"fff\" to come before \"gg\".",
+          "data": {
+            "right": "fff",
+            "left": "gg"
+          },
+          "loc": {
+            "startLine": 13,
+            "startColumn": 3,
+            "endLine": 13,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [25, 159],
+            "text": "// Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg'"
+          }
+        }
+      ],
+      "output": "new Set([\n  // Part: A\n  // Not partition comment\n  'bbb',\n  'cc',\n  'd',\n  // Part: B\n  'aaaa',\n  'e',\n  // Part: C\n  // Not partition comment\n  'fff',\n  'gg',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > treats every comment as partition boundary when set to true",
+      "code": "new Set([\n  // Comment\n  'bb',\n  // Other comment\n  'a',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > supports multiple partition comment patterns",
+      "code": "new Set([\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'c',\n  'bb',\n  /* Other */\n  'e',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["Partition Comment", "Part:", "Other"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [80, 91],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  /* Partition Comment */\n  // Part: A\n  'd',\n  // Part: B\n  'aaa',\n  'bb',\n  'c',\n  /* Other */\n  'e',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > supports regex patterns for partition comments",
+      "code": "new Set([\n  'e',\n  'f',\n  // I am a partition comment because I don't have f o o\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": ["^(?!.*foo).*$"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > ignores line comments when block comments are specified",
+      "code": "new Set([\n  'b',\n  // Comment\n  'aa'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 36],
+            "text": "// Comment\n  'aa',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  // Comment\n  'aa',\n  'b'\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > uses block comments as partition boundaries",
+      "code": "new Set([\n  'b',\n  /* Comment */\n  'a'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": true
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > matches specific block comment patterns",
+      "code": "new Set([\n  'c',\n  /* b */\n  'b',\n  /* a */\n  'a'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["a", "b"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > supports regex patterns for block comments",
+      "code": "new Set([\n  'b',\n  /* I am a partition comment because I don't have f o o */\n  'a'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "partitionByComment": {
+            "block": ["^(?!.*foo).*$"]
+          }
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > ignores special characters at start when trimming",
+      "code": "new Set([\n  '$a',\n  'bb',\n  '$c',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "trim"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > ignores special characters completely when removing",
+      "code": "new Set([\n  'abc',\n  'a$c',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "specialCharacters": "remove"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > sorts elements according to locale-specific rules",
+      "code": "new Set([\n  '你好',\n  '世界',\n  'a',\n  'A',\n  'b',\n  'B',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "locales": "zh-CN"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > sorts single-line sets correctly",
+      "code": "new Set([\n  b, aa\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 17],
+            "text": "aa, b"
+          }
+        }
+      ],
+      "output": "new Set([\n  aa, b\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > handles trailing commas in single-line sets",
+      "code": "new Set([\n  b, aa,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aa\" to come before \"b\".",
+          "data": {
+            "right": "aa",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 2,
+            "startColumn": 6,
+            "endLine": 2,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 17],
+            "text": "aa, b"
+          }
+        }
+      ],
+      "output": "new Set([\n  aa, b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > enforces custom group ordering",
+      "code": "new Set([\n  'c',\n  'top1',\n  'a'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "top"
+            }
+          ],
+          "groups": ["top", "literal"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (top) to come before \"c\" (literal).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "top",
+            "left": "c",
+            "leftGroup": "literal"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 25],
+            "text": "'top1',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top1',\n  'c',\n  'a'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > applies custom groups based on element selectors",
+      "code": "new Set([\n  'b',\n  'top1',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "topElements"
+            }
+          ],
+          "groups": ["topElements", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top1\" (topElements) to come before \"b\" (unknown).",
+          "data": {
+            "right": "top1",
+            "rightGroup": "topElements",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 25],
+            "text": "'top1',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top1',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > groups elements by name pattern - string pattern",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": "hello"
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > groups elements by name pattern - array of patterns",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": ["noMatch", "hello"]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > groups elements by name pattern - case-insensitive regex",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": {
+                "pattern": "HELLO",
+                "flags": "i"
+              }
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > groups elements by name pattern - regex in array",
+      "code": "new Set([\n  'a',\n  'b',\n  'helloLiteral',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "literalsStartingWithHello",
+              "selector": "literal",
+              "elementNamePattern": [
+                "noMatch",
+                {
+                  "pattern": "HELLO",
+                  "flags": "i"
+                }
+              ]
+            }
+          ],
+          "groups": ["literalsStartingWithHello", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"helloLiteral\" (literalsStartingWithHello) to come before \"b\" (unknown).",
+          "data": {
+            "right": "helloLiteral",
+            "rightGroup": "literalsStartingWithHello",
+            "left": "b",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 17
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'helloLiteral',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'helloLiteral',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > overrides sort type and order for specific groups",
+      "code": "new Set([\n  'a',\n  'bb',\n  'ccc',\n  'dddd',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "groupName": "reversedLiteralsByLineLength",
+              "selector": "literal",
+              "type": "line-length",
+              "order": "desc"
+            }
+          ],
+          "groups": ["reversedLiteralsByLineLength", "unknown"],
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"a\".",
+          "data": {
+            "right": "bb",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"ccc\" to come before \"bb\".",
+          "data": {
+            "right": "ccc",
+            "left": "bb"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 8
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"dddd\" to come before \"ccc\".",
+          "data": {
+            "right": "dddd",
+            "left": "ccc"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 42],
+            "text": "'dddd',\n  'ccc',\n  'bb',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'dddd',\n  'ccc',\n  'bb',\n  'a',\n  ...m,\n  'eee',\n  'ff',\n  'g',\n  ...o,\n  ...p,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > applies fallback sort when primary sort results in tie",
+      "code": "new Set([\n  'fooZar',\n  'fooBar',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "fallbackSort": {
+                "type": "alphabetical",
+                "order": "asc"
+              },
+              "elementNamePattern": "^foo",
+              "type": "line-length",
+              "groupName": "foo",
+              "order": "desc"
+            }
+          ],
+          "type": "alphabetical",
+          "groups": ["foo"],
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"fooBar\" to come before \"fooZar\".",
+          "data": {
+            "right": "fooBar",
+            "left": "fooZar"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 11
+          },
+          "fix": {
+            "range": [12, 32],
+            "text": "'fooBar',\n  'fooZar'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'fooBar',\n  'fooZar',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > preserves original order for unsorted groups",
+      "code": "new Set([\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'm',\n  'top3',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^top",
+              "groupName": "unsortedTop",
+              "type": "unsorted"
+            }
+          ],
+          "groups": ["unsortedTop", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"top3\" (unsortedTop) to come before \"m\" (unknown).",
+          "data": {
+            "right": "top3",
+            "rightGroup": "unsortedTop",
+            "left": "m",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [52, 65],
+            "text": "'top3',\n  'm'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'top2',\n  'top1',\n  'top4',\n  'top5',\n  'top3',\n  'm',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > combines multiple selectors with anyOf",
+      "code": "new Set([\n  'a',\n  'bFoo',\n  'cFoo',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "anyOf": [
+                {
+                  "elementNamePattern": "foo"
+                },
+                {
+                  "elementNamePattern": "Foo"
+                }
+              ],
+              "groupName": "elementsIncludingFoo"
+            }
+          ],
+          "groups": ["elementsIncludingFoo", "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"bFoo\" (elementsIncludingFoo) to come before \"a\" (unknown).",
+          "data": {
+            "right": "bFoo",
+            "rightGroup": "elementsIncludingFoo",
+            "left": "a",
+            "leftGroup": "unknown"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 9
+          },
+          "fix": {
+            "range": [12, 35],
+            "text": "'bFoo',\n  'cFoo',\n  'a'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'bFoo',\n  'cFoo',\n  'a',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > supports negative regex patterns in custom groups",
+      "code": "new Set([\n  'iHaveFooInMyName',\n  'meTooIHaveFoo',\n  'a',\n  'b',\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "^(?!.*Foo).*$",
+              "groupName": "elementsWithoutFoo"
+            }
+          ],
+          "groups": ["unknown", "elementsWithoutFoo"],
+          "type": "alphabetical"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - string pattern",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "foo"
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - array of patterns",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": ["noMatch", "foo"]
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - case-insensitive regex",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": {
+              "pattern": "FOO",
+              "flags": "i"
+            }
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > useConfigurationIf.allNamesMatchPattern > applies configuration when all names match pattern - regex in array",
+      "code": "new Set([\n  'b',\n  'g',\n  'r',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "useConfigurationIf": {
+            "allNamesMatchPattern": [
+              "noMatch",
+              {
+                "pattern": "foo",
+                "flags": "i"
+              }
+            ]
+          }
+        },
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^r$",
+              "groupName": "r"
+            },
+            {
+              "elementNamePattern": "^g$",
+              "groupName": "g"
+            },
+            {
+              "elementNamePattern": "^b$",
+              "groupName": "b"
+            }
+          ],
+          "useConfigurationIf": {
+            "allNamesMatchPattern": "^[rgb]$"
+          },
+          "groups": ["r", "g", "b"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"g\" (g) to come before \"b\" (b).",
+          "data": {
+            "right": "g",
+            "rightGroup": "g",
+            "left": "b",
+            "leftGroup": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"r\" (r) to come before \"g\" (g).",
+          "data": {
+            "right": "r",
+            "rightGroup": "r",
+            "left": "g",
+            "leftGroup": "g"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 29],
+            "text": "'r',\n  'g',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'r',\n  'g',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > removes newlines between groups when newlinesBetween is 0",
+      "code": "new Set([\n  'aaaa',\n\n\n 'yy',\n'z',\n\n    'bbb'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "aaaa",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "newlinesInside": "ignore",
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"aaaa\" and \"yy\".",
+          "data": {
+            "left": "aaaa",
+            "right": "yy"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 2,
+            "endLine": 5,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [18, 44],
+            "text": ",\n 'bbb',\n'yy',\n\n    'z'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bbb\" to come before \"z\".",
+          "data": {
+            "right": "bbb",
+            "left": "z"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 5,
+            "endLine": 8,
+            "endColumn": 10
+          },
+          "fix": {
+            "range": [18, 44],
+            "text": ",\n 'bbb',\n'yy',\n\n    'z'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aaaa',\n 'bbb',\n'yy',\n\n    'z'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > applies inline newline settings between specific groups",
+      "code": "new Set([\n  'a',\n  'b',\n\n\n  'c',\n\n  'd',\n\n\n  'e'\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "elementNamePattern": "d",
+              "groupName": "d"
+            },
+            {
+              "elementNamePattern": "e",
+              "groupName": "e"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 1
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c",
+            {
+              "newlinesBetween": 0
+            },
+            "d",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "e"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"b\" and \"c\".",
+          "data": {
+            "left": "b",
+            "right": "c"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        },
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"c\" and \"d\".",
+          "data": {
+            "left": "c",
+            "right": "d"
+          },
+          "loc": {
+            "startLine": 8,
+            "startColumn": 3,
+            "endLine": 8,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 36],
+            "text": ",\n\n  'b',\n\n  'c',\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n\n  'b',\n\n  'c',\n  'd',\n\n\n  'e'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > enforces 2 newlines when global is 2 and group is 0",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > enforces 2 newlines when global is 2 and group is ignore",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > enforces 2 newlines when global is 0 and group is 2",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > enforces 2 newlines when global is ignore and group is 2",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 2
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 17],
+            "text": ",\n\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n\n\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > removes newlines when 0 overrides global 1 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 1
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > removes newlines when 0 overrides global 2 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 2
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > removes newlines when 0 overrides global ignore between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > removes newlines when 0 overrides global 0 between specific groups",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "elementNamePattern": "c",
+              "groupName": "c"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            {
+              "newlinesBetween": 0
+            },
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b",
+            {
+              "newlinesBetween": 1
+            },
+            "c"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "extraSpacingBetweenSetsMembers",
+          "message": "Extra spacing between \"a\" and \"b\".",
+          "data": {
+            "left": "a",
+            "right": "b"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 4
+          },
+          "fix": {
+            "range": [13, 18],
+            "text": ",\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  a,\n  b,\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > accepts any spacing when global is ignore and group is 0",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > accepts any spacing when global is ignore and group is 0",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": 0
+            },
+            "b"
+          ],
+          "newlinesBetween": "ignore"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > accepts any spacing when global is 0 and group is ignore",
+      "code": "new Set([\n  a,\n\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > line-length > accepts any spacing when global is 0 and group is ignore",
+      "code": "new Set([\n  a,\n  b,\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            },
+            {
+              "groupName": "unusedGroup",
+              "elementNamePattern": "X"
+            }
+          ],
+          "groups": [
+            "a",
+            "unusedGroup",
+            {
+              "newlinesBetween": "ignore"
+            },
+            "b"
+          ],
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > preserves inline comments when reordering elements",
+      "code": "new Set([\n  'b',\n  'a', // Comment after\n\n  'c'\n])",
+      "options": [
+        {
+          "customGroups": [
+            {
+              "elementNamePattern": "b|c",
+              "groupName": "b|c"
+            }
+          ],
+          "groups": ["unknown", "b|c"],
+          "newlinesBetween": 1,
+          "newlinesInside": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"a\" (unknown) to come before \"b\" (b|c).",
+          "data": {
+            "right": "a",
+            "rightGroup": "unknown",
+            "left": "b",
+            "leftGroup": "b|c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'a', // Comment after\n  'b',"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a', // Comment after\n\n  'b',\n  'c'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > line-length > preserves partition boundaries regardless of newlinesBetween 0",
+      "code": "new Set([\n  'aaa',\n\n  // Partition comment\n\n  'c',\n  'bb',\n])",
+      "options": [
+        {
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "aaa",
+              "groupName": "a"
+            }
+          ],
+          "groups": ["a", "unknown"],
+          "partitionByComment": true,
+          "newlinesBetween": 0
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"c\".",
+          "data": {
+            "right": "bb",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 7,
+            "startColumn": 3,
+            "endLine": 7,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [46, 57],
+            "text": "'bb',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aaa',\n\n  // Partition comment\n\n  'bb',\n  'c',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > custom > sorts elements in sets",
+      "code": "new Set(\n  'a',\n  'b',\n  'c',\n  'd',\n)",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > custom > sorts elements in sets",
+      "code": "new Set([\n  'a',\n  'c',\n  'b',\n  'd',\n])",
+      "options": [
+        {
+          "type": "custom",
+          "order": "asc",
+          "alphabet": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [19, 29],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > subgroup-order > fallback sorts by subgroup order",
+      "code": "new Set([\n  'b',\n  'bb',\n  'a',\n  'aa',\n])",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order",
+            "order": "asc"
+          },
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [["a", "b"], "unknown"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"b\".",
+          "data": {
+            "right": "bb",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 38],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aa\" to come before \"a\".",
+          "data": {
+            "right": "aa",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 38],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aa',\n  'bb',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > subgroup-order > fallback sorts by subgroup order through overriding groups option",
+      "code": "new Set([\n  'b',\n  'bb',\n  'a',\n  'aa',\n])",
+      "options": [
+        {
+          "fallbackSort": {
+            "type": "subgroup-order",
+            "order": "asc"
+          },
+          "type": "line-length",
+          "order": "desc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "groups": [
+            {
+              "group": ["a", "b"],
+              "newlinesInside": 0
+            },
+            "unknown"
+          ]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"bb\" to come before \"b\".",
+          "data": {
+            "right": "bb",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 38],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"aa\" to come before \"a\".",
+          "data": {
+            "right": "aa",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 38],
+            "text": "'aa',\n  'bb',\n  'a',\n  'b'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'aa',\n  'bb',\n  'a',\n  'b',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > unsorted > accepts unsorted sets",
+      "code": "new Set([\n  'b',\n  'c',\n  'a'\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc"
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > unsorted > enforces custom group ordering",
+      "code": "new Set([\n  'ab',\n  'aa',\n  'ba',\n  'bb',\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "^a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "^b",
+              "groupName": "b"
+            }
+          ],
+          "groups": ["b", "a"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsGroupOrder",
+          "message": "Expected \"ba\" (b) to come before \"aa\" (a).",
+          "data": {
+            "right": "ba",
+            "rightGroup": "b",
+            "left": "aa",
+            "leftGroup": "a"
+          },
+          "loc": {
+            "startLine": 4,
+            "startColumn": 3,
+            "endLine": 4,
+            "endColumn": 7
+          },
+          "fix": {
+            "range": [12, 40],
+            "text": "'ba',\n  'bb',\n  'ab',\n  'aa'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'ba',\n  'bb',\n  'ab',\n  'aa',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > unsorted > adds required newlines between groups",
+      "code": "new Set([\n  'b',\n  'a',\n])",
+      "options": [
+        {
+          "type": "unsorted",
+          "order": "asc",
+          "customGroups": [
+            {
+              "elementNamePattern": "a",
+              "groupName": "a"
+            },
+            {
+              "elementNamePattern": "b",
+              "groupName": "b"
+            }
+          ],
+          "newlinesBetween": 1,
+          "groups": ["b", "a"]
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "missedSpacingBetweenSetsMembers",
+          "message": "Missed spacing between \"b\" and \"a\".",
+          "data": {
+            "left": "b",
+            "right": "a"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [15, 19],
+            "text": ",\n\n  "
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n\n  'a',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > uses alphabetical ascending order by default",
+      "code": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n])",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > uses alphabetical ascending order by default",
+      "code": "new Set([\n  'v1.png',\n  'v10.png',\n  'v12.png',\n  'v2.png',\n])",
+      "options": [
+        {
+          "ignoreCase": false
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > uses alphabetical ascending order by default",
+      "code": "new Set([\n  'b',\n  'a',\n  'd',\n  'c',\n])",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 36],
+            "text": "'a',\n  'b',\n  'c',\n  'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 5,
+            "startColumn": 3,
+            "endLine": 5,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 36],
+            "text": "'a',\n  'b',\n  'c',\n  'd'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'b',\n  'c',\n  'd',\n])"
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > handles empty and single-element sets",
+      "code": "new Set([])",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > handles empty and single-element sets",
+      "code": "new Set(['a'])",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > treats different quote styles as equivalent",
+      "code": "new Set(['a', \"b\", 'c'])",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > respects the global settings configuration",
+      "code": "new Set([\n  ccc,\n  bb,\n  a,\n])",
+      "options": [{}],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > respects the global settings configuration",
+      "code": "new Set([\n  a,\n  bb,\n  ccc,\n])",
+      "options": [
+        {
+          "type": "alphabetical",
+          "order": "asc"
+        }
+      ],
+      "settings": {
+        "perfectionist": {
+          "type": "line-length",
+          "order": "desc"
+        }
+      },
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "valid",
+      "name": "sort-sets > misc > respects eslint-disable-next-line comments",
+      "code": "new Set([\n  'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n])",
+      "options": [],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [],
+      "output": null
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > respects eslint-disable-next-line comments",
+      "code": "new Set([\n  'c',\n  'b',\n  // eslint-disable-next-line\n  'a',\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles eslint-disable with partition comments",
+      "code": "new Set([\n  'd',\n  'c',\n  // eslint-disable-next-line\n  'a',\n  'b'\n])",
+      "options": [
+        {
+          "partitionByComment": true
+        }
+      ],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"c\" to come before \"d\".",
+          "data": {
+            "right": "c",
+            "left": "d"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 66],
+            "text": "'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n  'd'"
+          }
+        },
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"a\".",
+          "data": {
+            "right": "b",
+            "left": "a"
+          },
+          "loc": {
+            "startLine": 6,
+            "startColumn": 3,
+            "endLine": 6,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 66],
+            "text": "'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n  'd'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  // eslint-disable-next-line\n  'a',\n  'd'\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles inline eslint-disable-line comments",
+      "code": "new Set([\n  'c',\n  'b',\n  'a', // eslint-disable-line\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  'a', // eslint-disable-line\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles block-style eslint-disable comments",
+      "code": "new Set([\n  'c',\n  'b',\n  /* eslint-disable-next-line */\n  'a',\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  /* eslint-disable-next-line */\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles inline block-style eslint-disable comments",
+      "code": "new Set([\n  'c',\n  'b',\n  'a', /* eslint-disable-line */\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  'a', /* eslint-disable-line */\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > respects eslint-disable/enable block regions",
+      "code": "new Set([\n  'd',\n  'e',\n  /* eslint-disable */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'a',\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 3,
+            "endLine": 9,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 108],
+            "text": "'a',\n  'd',\n  /* eslint-disable */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'e'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'd',\n  /* eslint-disable */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'e',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles rule-specific eslint-disable comments",
+      "code": "new Set([\n  'c',\n  'b',\n  // eslint-disable-next-line rule-to-test/sort-sets\n  'a',\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  // eslint-disable-next-line rule-to-test/sort-sets\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles inline rule-specific eslint-disable comments",
+      "code": "new Set([\n  'c',\n  'b',\n  'a', // eslint-disable-line rule-to-test/sort-sets\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  'a', // eslint-disable-line rule-to-test/sort-sets\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles block-style rule-specific eslint-disable comments",
+      "code": "new Set([\n  'c',\n  'b',\n  /* eslint-disable-next-line rule-to-test/sort-sets */\n  'a',\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  /* eslint-disable-next-line rule-to-test/sort-sets */\n  'a',\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > handles inline block-style rule-specific eslint-disable comments",
+      "code": "new Set([\n  'c',\n  'b',\n  'a', /* eslint-disable-line rule-to-test/sort-sets */\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"b\" to come before \"c\".",
+          "data": {
+            "right": "b",
+            "left": "c"
+          },
+          "loc": {
+            "startLine": 3,
+            "startColumn": 3,
+            "endLine": 3,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 22],
+            "text": "'b',\n  'c'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'b',\n  'c',\n  'a', /* eslint-disable-line rule-to-test/sort-sets */\n])"
+    },
+    {
+      "kind": "invalid",
+      "name": "sort-sets > misc > respects rule-specific eslint-disable/enable regions",
+      "code": "new Set([\n  'd',\n  'e',\n  /* eslint-disable rule-to-test/sort-sets */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'a',\n])",
+      "options": [{}],
+      "filename": "fixture.ts",
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedSetsOrder",
+          "message": "Expected \"a\" to come before \"b\".",
+          "data": {
+            "right": "a",
+            "left": "b"
+          },
+          "loc": {
+            "startLine": 9,
+            "startColumn": 3,
+            "endLine": 9,
+            "endColumn": 6
+          },
+          "fix": {
+            "range": [12, 131],
+            "text": "'a',\n  'd',\n  /* eslint-disable rule-to-test/sort-sets */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'e'"
+          }
+        }
+      ],
+      "output": "new Set([\n  'a',\n  'd',\n  /* eslint-disable rule-to-test/sort-sets */\n  'c',\n  'b',\n  // Shouldn't move\n  /* eslint-enable */\n  'e',\n])"
+    }
+  ]
+}

--- a/npm/perfectionist/test/plugin.test.mjs
+++ b/npm/perfectionist/test/plugin.test.mjs
@@ -131,6 +131,7 @@ describe('perfectionist plugin adapter', () => {
         'sort-imports',
         'sort-named-exports',
         'sort-named-imports',
+        'sort-sets',
       ].includes(ruleName)
         ? 'Expected "{{right}}" to come before "{{left}}".'
         : 'Expected sorted order.',
@@ -184,6 +185,29 @@ describe('perfectionist plugin adapter', () => {
       'modifiers',
     );
     expect(schema.properties.useConfigurationIf.properties).toHaveProperty('matchesAstSelector');
+    expect(schema.properties.useConfigurationIf).not.toHaveProperty('minProperties');
+  });
+
+  it('reuses the complete v5.10.0 array schema with Set-specific messages', () => {
+    const arrayRule = plugin.rules['sort-array-includes'];
+    const setRule = plugin.rules['sort-sets'];
+    const schema = setRule.meta.schema.items;
+
+    expect(setRule.meta.type).toBe('suggestion');
+    expect(setRule.meta.schema).toEqual(arrayRule.meta.schema);
+    expect(Object.keys(setRule.meta.messages).sort()).toEqual([
+      'extraSpacingBetweenSetsMembers',
+      'missedSpacingBetweenSetsMembers',
+      'unexpectedSetsGroupOrder',
+      'unexpectedSetsOrder',
+    ]);
+    expect(schema.properties.customGroups.items.oneOf[0].properties.selector.enum).toEqual([
+      'literal',
+    ]);
+    expect(schema.properties.customGroups.items.oneOf[0].properties).not.toHaveProperty(
+      'modifiers',
+    );
+    expect(schema.properties).not.toHaveProperty('ignoreAlias');
     expect(schema.properties.useConfigurationIf).not.toHaveProperty('minProperties');
   });
 
@@ -360,6 +384,7 @@ describe('perfectionist plugin adapter', () => {
       'error',
       { type: 'natural', order: 'asc' },
     ]);
+    expect(rules['perfectionist/sort-sets']).toEqual(['error', { type: 'natural', order: 'asc' }]);
   });
 
   it('merges settings and isolates sort-array-includes options and cache entries', () => {
@@ -398,6 +423,35 @@ describe('perfectionist plugin adapter', () => {
         { perfectionist: { type: 'natural', order: 'asc' } },
       ),
     ).toHaveLength(1);
+  });
+
+  it('merges settings across conditional Set options and isolates cache entries', () => {
+    const source = `new Set(['item2', 'item10'])`;
+    const conditionalOptions = [
+      {
+        type: 'unsorted',
+        useConfigurationIf: { allNamesMatchPattern: '^does-not-match$' },
+      },
+      { useConfigurationIf: { matchesAstSelector: 'ArrayExpression' } },
+    ];
+    const settings = { perfectionist: { type: 'natural', order: 'asc' } };
+
+    expect(runRule('sort-sets', source, 'fixture.ts', conditionalOptions, settings)).toEqual([]);
+    expect(
+      runRule(
+        'sort-sets',
+        `new Set(['item10', 'item2'])`,
+        'fixture.ts',
+        conditionalOptions,
+        settings,
+      ),
+    ).toHaveLength(1);
+    expect(
+      runRule('sort-sets', source, 'fixture.ts', [{ type: 'natural', order: 'desc' }]),
+    ).toHaveLength(1);
+    expect(runRule('sort-sets', source, 'fixture.ts', [{ type: 'natural', order: 'asc' }])).toEqual(
+      [],
+    );
   });
 
   it('merges global perfectionist settings with explicit sort-imports options', () => {
@@ -528,6 +582,66 @@ describe('perfectionist plugin adapter', () => {
       expect(fixed.status).toBe(0);
       expect(fixed.stderr).toBe('');
       expect(readFileSync(fixturePath, 'utf8')).toBe(`['a', 'b'].includes(value);\n`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads Set groups and fixes through real oxlint without JSX/TSX parsing', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-perfectionist-sets-'));
+    try {
+      const fixturePath = join(tempDir, 'fixture.ts');
+      writeFileSync(fixturePath, `new Set(['b', 'a']);\n`);
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [
+            {
+              name: 'perfectionist',
+              specifier: join(packageRoot, 'index.js'),
+            },
+          ],
+          rules: {
+            'perfectionist/sort-sets': [
+              'error',
+              {
+                customGroups: [{ groupName: 'a', elementNamePattern: '^a$' }],
+                groups: ['a', 'literal'],
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(1);
+      expect(payload.diagnostics[0]).toMatchObject({
+        code: 'perfectionist(sort-sets)',
+        message: 'Expected "a" (a) to come before "b" (literal).',
+      });
+
+      const fixed = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', 'fixture.ts'],
+        {
+          cwd: tempDir,
+          encoding: 'utf8',
+        },
+      );
+      expect(fixed.status).toBe(0);
+      expect(fixed.stderr).toBe('');
+      expect(readFileSync(fixturePath, 'utf8')).toBe(`new Set(['a', 'b']);\n`);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/npm/perfectionist/test/sort-sets-options-upstream.test.mjs
+++ b/npm/perfectionist/test/sort-sets-options-upstream.test.mjs
@@ -1,0 +1,176 @@
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../index.js';
+
+const fixture = JSON.parse(
+  readFileSync(new URL('./fixtures/sort-sets-options-v5.10.0.json', import.meta.url), 'utf8'),
+);
+const fixtureSource = readFileSync(
+  new URL('./fixtures/sort-sets-options-v5.10.0.json', import.meta.url),
+);
+const rule = plugin.rules['sort-sets'];
+
+describe('perfectionist/sort-sets v5.10.0 option parity', () => {
+  it('pins every non-React authored upstream case and its exact fixture inventory', () => {
+    expect(fixture.__generated).toMatchObject({
+      source: 'eslint-plugin-perfectionist',
+      version: '5.10.0',
+      sourceCommit: '84aa039c46522f82a61ad43cf676afc92dd64704',
+      sourceHashes: {
+        'rules/sort-sets.ts': 'd069d550677d062a5c1d488a5a38e426bdf76ac681a3e2598e99d09016ad21fe',
+        'rules/sort-sets/types.ts':
+          '927bfce114499a6e224415245e952a6eaa43c052dfd78b827bd7d8d085e7a098',
+        'rules/sort-arrays/types.ts':
+          '9aa7faafdb1f2262aa32798623ebd6507b5a80f2ad6fa66446d66bb722bba582',
+        'rules/sort-arrays/sort-array.ts':
+          'c65199dd2f5b56ae5302368f3e4fda46849f98641415bd77cf8d56a36ab0d60a',
+        'test/rules/sort-sets.test.ts':
+          '44b4daf3d881e4a8ae80af1dc2d1ea92c405170c0cdda03c613577171b6215bd',
+      },
+      inventory: {
+        valid: 75,
+        invalid: 138,
+        diagnostics: 182,
+        total: 213,
+      },
+    });
+    expect(fixture.cases).toHaveLength(fixture.__generated.inventory.total);
+    expect(
+      fixture.cases.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+    ).toBe(fixture.__generated.inventory.diagnostics);
+    expect(
+      fixture.cases.some(
+        (testCase) =>
+          /\.(?:jsx|tsx)$/u.test(testCase.filename) ||
+          /<[A-Z][A-Za-z]*(?:\s|\/?>)/u.test(testCase.code),
+      ),
+    ).toBe(false);
+    expect(createHash('sha256').update(fixtureSource).digest('hex')).toBe(
+      '7e541bfeda9369ef6d3a30681a079b84769447d43c51a4691be0742440c0d0d7',
+    );
+  });
+
+  for (const [index, testCase] of fixture.cases.entries()) {
+    it(`replays case ${index + 1}/${fixture.cases.length}: ${testCase.name}`, () => {
+      const reports = runRule(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(
+        reports.map((report) => exactDiagnostic(report)),
+        testCase.name,
+      ).toEqual(testCase.expectedDiagnostics);
+
+      if (testCase.output === null) {
+        expect(reports, testCase.name).toEqual([]);
+        return;
+      }
+
+      const convergence = applyIteratively(
+        testCase.code,
+        testCase.options,
+        testCase.filename,
+        testCase.settings,
+      );
+      expect(convergence.output, testCase.name).toBe(testCase.output);
+      expect(convergence.remainingReports, testCase.name).toEqual([]);
+      expect(convergence.passes, testCase.name).toBeGreaterThanOrEqual(1);
+      expect(convergence.passes, testCase.name).toBeLessThanOrEqual(16);
+    });
+  }
+});
+
+function runRule(sourceText, options, filename, settings) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = rule.createOnce({
+    options,
+    settings,
+    sourceCode,
+    filename,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function exactDiagnostic(report) {
+  const replacement = report.fix?.({
+    replaceTextRange(range, text) {
+      return { range, text };
+    },
+  });
+  return {
+    messageId: report.messageId,
+    message: Object.entries(report.data).reduce(
+      (message, [key, value]) => message.replace(`{{${key}}}`, value),
+      rule.meta.messages[report.messageId],
+    ),
+    data: report.data,
+    loc: {
+      startLine: report.loc.start.line,
+      startColumn: report.loc.start.column + 1,
+      endLine: report.loc.end.line,
+      endColumn: report.loc.end.column + 1,
+    },
+    fix: replacement ?? null,
+  };
+}
+
+function applyIteratively(sourceText, options, filename, settings) {
+  let output = sourceText;
+  let passes = 0;
+  for (; passes < 16; passes += 1) {
+    const reports = runRule(output, options, filename, settings);
+    const next = applyFixPass(output, reports);
+    if (next === null) {
+      return { output, passes, remainingReports: reports };
+    }
+    output = next;
+  }
+  throw new Error(`Fixes did not converge for ${JSON.stringify(sourceText)}`);
+}
+
+function applyFixPass(sourceText, reports) {
+  const fixes = reports
+    .flatMap((report) => {
+      const fix = report.fix?.({
+        replaceTextRange(range, text) {
+          return { range, text };
+        },
+      });
+      return fix ? [fix] : [];
+    })
+    .sort((left, right) => left.range[0] - right.range[0] || left.range[1] - right.range[1]);
+  if (fixes.length === 0) {
+    return null;
+  }
+
+  const accepted = [];
+  let lastEnd = -1;
+  for (const fix of fixes) {
+    if (fix.range[0] < lastEnd) {
+      continue;
+    }
+    accepted.push(fix);
+    lastEnd = fix.range[1];
+  }
+
+  let output = sourceText;
+  for (const fix of accepted.toReversed()) {
+    output = output.slice(0, fix.range[0]) + fix.text + output.slice(fix.range[1]);
+  }
+  return output;
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "port:tests:perfectionist:sort-named-exports": "node tools/tasks/sync-perfectionist-sort-named-exports-options-tests.ts",
     "port:tests:perfectionist:sort-imports": "node tools/tasks/sync-perfectionist-sort-imports-options-tests.ts",
     "port:tests:perfectionist:sort-array-includes": "node tools/tasks/sync-perfectionist-sort-array-includes-options-tests.ts",
+    "port:tests:perfectionist:sort-sets": "node tools/tasks/sync-perfectionist-sort-sets-options-tests.ts",
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:expect-expect": "node tools/tasks/sync-playwright-expect-expect-tests.ts",
     "port:tests:playwright:prefer-lowercase-title": "node tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts",

--- a/playground/src/catalog.json
+++ b/playground/src/catalog.json
@@ -1652,7 +1652,10 @@
           "description": "enforce sorted sets",
           "docsUrl": "https://perfectionist.dev/rules/sort-sets",
           "messages": {
-            "unexpected": "Expected sorted order."
+            "unexpectedSetsOrder": "Expected \"{{right}}\" to come before \"{{left}}\".",
+            "unexpectedSetsGroupOrder": "Expected \"{{right}}\" ({{rightGroup}}) to come before \"{{left}}\" ({{leftGroup}}).",
+            "extraSpacingBetweenSetsMembers": "Extra spacing between \"{{left}}\" and \"{{right}}\".",
+            "missedSpacingBetweenSetsMembers": "Missed spacing between \"{{left}}\" and \"{{right}}\"."
           }
         },
         {

--- a/status.json
+++ b/status.json
@@ -4160,9 +4160,9 @@
           "insta": false,
           "vitest": true,
           "lsp": false,
-          "oxlintIntegration": false
+          "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-perfectionist/sort-sets with focused Set entry ordering coverage."
+        "notes": "Full Rust/Oxc AST port of eslint-plugin-perfectionist/sort-sets v5.10.0 options, diagnostics, fixes, comments, partitions, conditional configuration, settings, and UTF-16 locations. Pinned 213-case authored fixture plus Rust, NAPI, plugin, and real Oxlint regression coverage; React/JSX/TSX is intentionally excluded."
       },
       {
         "name": "sort-switch-case",

--- a/tools/tasks/sync-perfectionist-sort-imports-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-imports-options-tests.ts
@@ -39,14 +39,23 @@ type CapturedCase = {
 
 const ROOT = process.cwd();
 const capturesArrayIncludes = process.argv.includes('--sort-array-includes');
-const RULE = capturesArrayIncludes ? 'sort-array-includes' : 'sort-imports';
-const PINNED_COMMIT = capturesArrayIncludes
+const capturesSets = process.argv.includes('--sort-sets');
+if (capturesArrayIncludes && capturesSets) {
+  throw new Error('Choose only one Perfectionist array rule to capture.');
+}
+const capturesV510ArrayRule = capturesArrayIncludes || capturesSets;
+const RULE = capturesArrayIncludes
+  ? 'sort-array-includes'
+  : capturesSets
+    ? 'sort-sets'
+    : 'sort-imports';
+const PINNED_COMMIT = capturesV510ArrayRule
   ? '84aa039c46522f82a61ad43cf676afc92dd64704'
   : 'b35e8e4caf0c8d350cf386e504241f21827dd60b';
-const PINNED_REF = capturesArrayIncludes ? 'v5.10.0' : 'v5.9.1';
-const TARGET_VERSION = capturesArrayIncludes ? '5.10.0' : '5.9.1';
-const ESLINT_VERSION = capturesArrayIncludes ? '10.6.0' : '9.39.2';
-const TYPESCRIPT_ESLINT_VERSION = capturesArrayIncludes ? '8.62.1' : '8.60.0';
+const PINNED_REF = capturesV510ArrayRule ? 'v5.10.0' : 'v5.9.1';
+const TARGET_VERSION = capturesV510ArrayRule ? '5.10.0' : '5.9.1';
+const ESLINT_VERSION = capturesV510ArrayRule ? '10.6.0' : '9.39.2';
+const TYPESCRIPT_ESLINT_VERSION = capturesV510ArrayRule ? '8.62.1' : '8.60.0';
 const SOURCE_HASHES: Readonly<Record<string, string>> = capturesArrayIncludes
   ? {
       'rules/sort-array-includes.ts':
@@ -60,13 +69,25 @@ const SOURCE_HASHES: Readonly<Record<string, string>> = capturesArrayIncludes
       'test/rules/sort-array-includes.test.ts':
         'c6f8a4dea072ce3d1fc2af72430e7247551bd81870077bde12d5ad7bbb67e534',
     }
-  : {
-      'rules/sort-imports.ts': 'c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05',
-      'rules/sort-imports/types.ts':
-        '81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe',
-      'test/rules/sort-imports.test.ts':
-        '8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab',
-    };
+  : capturesSets
+    ? {
+        'rules/sort-sets.ts': 'd069d550677d062a5c1d488a5a38e426bdf76ac681a3e2598e99d09016ad21fe',
+        'rules/sort-sets/types.ts':
+          '927bfce114499a6e224415245e952a6eaa43c052dfd78b827bd7d8d085e7a098',
+        'rules/sort-arrays/types.ts':
+          '9aa7faafdb1f2262aa32798623ebd6507b5a80f2ad6fa66446d66bb722bba582',
+        'rules/sort-arrays/sort-array.ts':
+          'c65199dd2f5b56ae5302368f3e4fda46849f98641415bd77cf8d56a36ab0d60a',
+        'test/rules/sort-sets.test.ts':
+          '44b4daf3d881e4a8ae80af1dc2d1ea92c405170c0cdda03c613577171b6215bd',
+      }
+    : {
+        'rules/sort-imports.ts': 'c5102c424e0364b0e9ce7681b41d9d3543d3a76b9227b3fea70371a4e83efa05',
+        'rules/sort-imports/types.ts':
+          '81aa65e9d8f085fa7e8479ea9a5e98c1c2e180450632e484494a1d64395ebffe',
+        'test/rules/sort-imports.test.ts':
+          '8065552b1ccf4d8110524ee48cdc5ee4ab701302d5316a0e2eef9c55ada249ab',
+      };
 
 const manifest = JSON.parse(
   readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
@@ -88,7 +109,7 @@ if (!existsSync(join(submodule, '.git'))) {
 const actualCommit = execFileSync('git', ['-C', submodule, 'rev-parse', 'HEAD'], {
   encoding: 'utf8',
 }).trim();
-const sourceCommit = capturesArrayIncludes
+const sourceCommit = capturesV510ArrayRule
   ? execFileSync('git', ['-C', submodule, 'rev-parse', PINNED_REF], {
       encoding: 'utf8',
     }).trim()
@@ -99,7 +120,7 @@ if (sourceCommit !== PINNED_COMMIT) {
 for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
   const actualHash = createHash('sha256')
     .update(
-      capturesArrayIncludes
+      capturesV510ArrayRule
         ? execFileSync('git', ['-C', submodule, 'show', `${PINNED_REF}:${sourceFile}`])
         : readFileSync(join(submodule, sourceFile)),
     )
@@ -112,7 +133,7 @@ for (const [sourceFile, expectedHash] of Object.entries(SOURCE_HASHES)) {
 const runnerDirectory = mkdtempSync(join(tmpdir(), 'perfectionist-sort-imports-'));
 try {
   const authoredTestPath = `test/rules/${RULE}.test.ts`;
-  const completeAuthoredSource = capturesArrayIncludes
+  const completeAuthoredSource = capturesV510ArrayRule
     ? execFileSync('git', ['-C', submodule, 'show', `${PINNED_REF}:${authoredTestPath}`], {
         encoding: 'utf8',
       })
@@ -153,7 +174,7 @@ try {
   const authoredCases = JSON.parse(
     readFileSync(join(runnerDirectory, 'authored-cases.json'), 'utf8'),
   ) as CapturedCase[];
-  if (capturesArrayIncludes) {
+  if (capturesV510ArrayRule) {
     const forbiddenCases = authoredCases.filter(
       (testCase) =>
         /\.(?:jsx|tsx)$/u.test(testCase.filename) ||
@@ -213,15 +234,17 @@ try {
       license: plugin.license,
       eslintVersion: ESLINT_VERSION,
       typescriptEslintParserVersion: TYPESCRIPT_ESLINT_VERSION,
-      capturePolicy: capturesArrayIncludes
+      capturePolicy: capturesV510ArrayRule
         ? `Every authored valid and invalid ${RULE} case is captured; React-specific and JSX/TSX syntax is rejected. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v${TARGET_VERSION} rule for exact diagnostics and fixes.`
         : 'Every authored valid and invalid sort-imports case is captured; none exercises React-specific or JSX/TSX syntax. Authored valid cases remain diagnostic-free; invalid cases are replayed against the published v5.9.1 rule for exact diagnostics and fixes.',
-      authoredCases: capturesArrayIncludes
+      authoredCases: capturesV510ArrayRule
         ? `upstream/eslint-plugin-perfectionist/${authoredTestPath}@${PINNED_REF}`
         : `upstream/eslint-plugin-perfectionist/${authoredTestPath}`,
       tool: capturesArrayIncludes
         ? 'sync-perfectionist-sort-array-includes-options-tests.ts'
-        : basename(import.meta.filename),
+        : capturesSets
+          ? 'sync-perfectionist-sort-sets-options-tests.ts'
+          : basename(import.meta.filename),
       inventory: {
         valid,
         invalid,

--- a/tools/tasks/sync-perfectionist-sort-sets-options-tests.ts
+++ b/tools/tasks/sync-perfectionist-sort-sets-options-tests.ts
@@ -1,0 +1,7 @@
+// Captures the v5.10.0 sort-sets authored suite through the shared
+// Perfectionist fixture synchronizer without moving the repository-wide v5.9.1
+// submodule pin.
+
+process.argv.push('--sort-sets');
+const synchronizer = new URL('./sync-perfectionist-sort-imports-options-tests.ts', import.meta.url);
+await import(synchronizer.href);


### PR DESCRIPTION
## Summary
- port eslint-plugin-perfectionist v5.10.0 `sort-sets` to the Oxc-backed scanner
- support conditional configuration, groups, partitions, comments, disabled ranges, Unicode locations, and autofix
- add deterministic upstream fixtures plus Rust, NAPI, plugin, Playground, docs, and status coverage

## Testing
- `VITEST_MAX_WORKERS=1 pnpm verify` (17,312 passed, 1,159 skipped; all workspace gates passed)
- `VITEST_MAX_WORKERS=1 pnpm exec vitest run npm/perfectionist/test/sort-sets-options-upstream.test.mjs npm/perfectionist/test/api.test.mjs npm/perfectionist/test/plugin.test.mjs` (275 passed on latest main)
- `cargo test -p oxlint-plugins-perfectionist` (66 passed on latest main)
- `cargo test -p oxlint-plugins-playground-wasm` (6 passed on latest main)
- `pnpm run status:check`
- `cargo fmt --check`
- `vp fmt --check`
- `git diff --check`

Part of #418.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->