### PR TITLE
feat(playwright): port no-hooks options

### DIFF
--- a/crates/playground_wasm/src/plugins/playwright.rs
+++ b/crates/playground_wasm/src/plugins/playwright.rs
@@ -36,6 +36,7 @@ pub fn scan(
         push(&mut data, "amount", diagnostic.data.amount);
         push(&mut data, "count", diagnostic.data.count);
         push(&mut data, "depth", diagnostic.data.depth);
+        push(&mut data, "hookName", diagnostic.data.hook_name);
         push(&mut data, "max", diagnostic.data.max);
         push(&mut data, "method", diagnostic.data.method);
         push(&mut data, "restriction", diagnostic.data.restriction);
@@ -210,6 +211,35 @@ mod tests {
                 diagnostics[0].end_column,
             ),
             (1, 5, 1, 13)
+        );
+    }
+
+    #[test]
+    fn preserves_no_hooks_message_data_utf16_location_and_rule_selection() {
+        let filter = EnabledFilter::parse(r#"{"playwright":["no-hooks"]}"#);
+        let mut diagnostics = Vec::new();
+        scan(
+            "\"🧪\"; test.beforeEach(() => {});\n",
+            "fixture.spec.ts",
+            &filter,
+            &mut diagnostics,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "no-hooks");
+        assert_eq!(diagnostics[0].message_id, "unexpectedHook");
+        assert_eq!(
+            diagnostics[0].data.get("hookName").map(String::as_str),
+            Some("beforeEach")
+        );
+        assert_eq!(
+            (
+                diagnostics[0].start_line,
+                diagnostics[0].start_column,
+                diagnostics[0].end_line,
+                diagnostics[0].end_column,
+            ),
+            (1, 6, 1, 31)
         );
     }
 }

--- a/crates/playwright/src/lib.rs
+++ b/crates/playwright/src/lib.rs
@@ -1,10 +1,12 @@
 #![doc = "Rust implementation of eslint-plugin-playwright rule logic."]
 
 mod expect_expect;
+mod no_hooks;
 mod patterns;
 mod prefer_lowercase_title;
 mod restricted;
 mod scanner;
+mod test_names;
 mod thresholds;
 mod types;
 
@@ -17,6 +19,7 @@ use oxc_span::SourceType;
 use oxlint_plugins_carton::SmallVec;
 
 use crate::expect_expect::scan_expect_expect;
+use crate::no_hooks::scan_no_hooks;
 use crate::patterns::scan_pattern_rules;
 use crate::prefer_lowercase_title::scan_prefer_lowercase_title;
 use crate::restricted::scan_restricted_rules;
@@ -25,8 +28,9 @@ use crate::thresholds::scan_threshold_rules;
 use crate::types::LineIndex;
 
 pub use crate::types::{
-    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, PlaywrightOptions, Restriction,
-    TagPattern, TitlePattern, TitlePatternOptions, ValidTestTagsOptions, ValidTitleOptions,
+    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, HookAlias, PlaywrightOptions,
+    Restriction, TagPattern, TitlePattern, TitlePatternOptions, ValidTestTagsOptions,
+    ValidTitleOptions,
 };
 
 pub const RULE_NAMES: [&str; 58] = [
@@ -125,6 +129,13 @@ pub fn scan_playwright_with_options(
         &mut scanner.diagnostics,
     );
     scan_prefer_lowercase_title(
+        &parser_return.program,
+        source_text,
+        &scanner.line_index,
+        options,
+        &mut scanner.diagnostics,
+    );
+    scan_no_hooks(
         &parser_return.program,
         source_text,
         &scanner.line_index,

--- a/crates/playwright/src/no_hooks.rs
+++ b/crates/playwright/src/no_hooks.rs
@@ -1,0 +1,180 @@
+//! AST-backed port of Playwright's `no-hooks` rule.
+
+use oxc_ast::ast::{
+    CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier, MemberExpression,
+    ModuleExportName, Program, match_member_expression,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+use crate::{
+    test_names::collect_test_names,
+    types::{Diagnostic, DiagnosticData, HookAlias, LineIndex, PlaywrightOptions},
+};
+
+const RULE_NAME: &str = "no-hooks";
+const HOOK_NAMES: [&str; 4] = ["afterAll", "afterEach", "beforeAll", "beforeEach"];
+
+pub(crate) fn scan_no_hooks<'ast>(
+    program: &Program<'ast>,
+    source_text: &str,
+    line_index: &LineIndex,
+    options: &PlaywrightOptions,
+    diagnostics: &mut SmallVec<[Diagnostic; 64]>,
+) {
+    let test_names = collect_test_names(program, &options.test_aliases);
+    let mut hook_aliases = options.hook_aliases.clone();
+    HookImportCollector {
+        hook_aliases: &mut hook_aliases,
+    }
+    .visit_program(program);
+
+    NoHooksVisitor {
+        diagnostics,
+        hook_aliases,
+        line_index,
+        options,
+        source_text,
+        test_names,
+    }
+    .visit_program(program);
+}
+
+struct HookImportCollector<'storage> {
+    hook_aliases: &'storage mut SmallVec<[HookAlias; 8]>,
+}
+
+impl<'ast> Visit<'ast> for HookImportCollector<'_> {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
+        let Some(specifiers) = &declaration.specifiers else {
+            return;
+        };
+        for specifier in specifiers {
+            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                continue;
+            };
+            let Some(imported) = module_export_name(&specifier.imported) else {
+                continue;
+            };
+            if is_hook_name(imported) {
+                push_alias(self.hook_aliases, specifier.local.name.as_str(), imported);
+            }
+        }
+    }
+}
+
+struct NoHooksVisitor<'source, 'options, 'diagnostics> {
+    diagnostics: &'diagnostics mut SmallVec<[Diagnostic; 64]>,
+    hook_aliases: SmallVec<[HookAlias; 8]>,
+    line_index: &'source LineIndex,
+    options: &'options PlaywrightOptions,
+    source_text: &'source str,
+    test_names: SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for NoHooksVisitor<'_, '_, '_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        if let Some(hook_name) = hook_name(call, &self.test_names, &self.hook_aliases)
+            && !self.options.allowed_hooks.contains(&hook_name)
+        {
+            self.diagnostics.push(Diagnostic {
+                rule_name: RULE_NAME,
+                message_id: "unexpectedHook",
+                data: DiagnosticData {
+                    hook_name: Some(hook_name),
+                    ..DiagnosticData::default()
+                },
+                loc: self.line_index.loc_for_span(self.source_text, call.span),
+                fix: None,
+            });
+        }
+        walk::walk_call_expression(self, call);
+    }
+}
+
+fn hook_name(
+    call: &CallExpression<'_>,
+    test_names: &[CompactString],
+    hook_aliases: &[HookAlias],
+) -> Option<CompactString> {
+    let mut links = SmallVec::<[&str; 4]>::new();
+    let root = callee_chain(&call.callee, &mut links)?;
+
+    if test_names.iter().any(|name| name == root) {
+        return match links.as_slice() {
+            [name] if is_hook_name(name) => Some(CompactString::from(*name)),
+            _ => None,
+        };
+    }
+    if links.is_empty() {
+        if is_hook_name(root) {
+            return Some(CompactString::from(root));
+        }
+        return hook_aliases
+            .iter()
+            .find(|alias| alias.name == root)
+            .map(|alias| alias.hook_name.clone());
+    }
+    None
+}
+
+fn callee_chain<'ast>(
+    expression: &'ast Expression<'ast>,
+    links: &mut SmallVec<[&'ast str; 4]>,
+) -> Option<&'ast str> {
+    match expression.get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        member @ match_member_expression!(Expression) => {
+            let member = member.to_member_expression();
+            let root = callee_chain(member.object(), links)?;
+            links.push(member_name(member)?);
+            Some(root)
+        }
+        _ => None,
+    }
+}
+
+fn member_name<'ast>(member: &'ast MemberExpression<'ast>) -> Option<&'ast str> {
+    if let Some(name) = member.static_property_name() {
+        return Some(name);
+    }
+    match member {
+        MemberExpression::ComputedMemberExpression(member) => {
+            match member.expression.get_inner_expression() {
+                Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+                Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+                Expression::TemplateLiteral(template) if template.expressions.is_empty() => {
+                    template
+                        .quasis
+                        .first()
+                        .and_then(|quasi| quasi.value.cooked.as_ref())
+                        .map(|value| value.as_str())
+                }
+                _ => None,
+            }
+        }
+        MemberExpression::StaticMemberExpression(_)
+        | MemberExpression::PrivateFieldExpression(_) => None,
+    }
+}
+
+fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn is_hook_name(name: &str) -> bool {
+    HOOK_NAMES.contains(&name)
+}
+
+fn push_alias(aliases: &mut SmallVec<[HookAlias; 8]>, name: &str, hook_name: &str) {
+    if aliases.iter().all(|alias| alias.name != name) {
+        aliases.push(HookAlias {
+            name: CompactString::from(name),
+            hook_name: CompactString::from(hook_name),
+        });
+    }
+}

--- a/crates/playwright/src/prefer_lowercase_title.rs
+++ b/crates/playwright/src/prefer_lowercase_title.rs
@@ -1,15 +1,12 @@
 //! AST-backed port of Playwright's `prefer-lowercase-title` rule.
 
-use oxc_ast::ast::{
-    Argument, BindingPattern, CallExpression, Expression, ImportDeclaration,
-    ImportDeclarationSpecifier, MemberExpression, ModuleExportName, Program, VariableDeclarator,
-    match_member_expression,
-};
+use oxc_ast::ast::{Argument, CallExpression, Program};
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::Span;
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::{
+    test_names::collect_test_names,
     thresholds::{PlaywrightCall, classify_call},
     types::{Diagnostic, DiagnosticData, DiagnosticFix, LineIndex, PlaywrightOptions},
 };
@@ -25,19 +22,7 @@ pub(crate) fn scan_prefer_lowercase_title<'ast>(
     options: &PlaywrightOptions,
     diagnostics: &mut SmallVec<[Diagnostic; 64]>,
 ) {
-    let mut test_names = SmallVec::<[CompactString; 8]>::new();
-    test_names.push(CompactString::from("test"));
-    for alias in &options.test_aliases {
-        push_unique(&mut test_names, alias.as_str());
-    }
-
-    let mut extend_declarations = SmallVec::<[(CompactString, CompactString); 16]>::new();
-    NameCollector {
-        extend_declarations: &mut extend_declarations,
-        test_names: &mut test_names,
-    }
-    .visit_program(program);
-    resolve_extend_aliases(&mut test_names, &extend_declarations);
+    let test_names = collect_test_names(program, &options.test_aliases);
 
     PreferLowercaseTitleVisitor {
         describe_depth: 0,
@@ -48,40 +33,6 @@ pub(crate) fn scan_prefer_lowercase_title<'ast>(
         test_names,
     }
     .visit_program(program);
-}
-
-struct NameCollector<'storage> {
-    extend_declarations: &'storage mut SmallVec<[(CompactString, CompactString); 16]>,
-    test_names: &'storage mut SmallVec<[CompactString; 8]>,
-}
-
-impl<'ast> Visit<'ast> for NameCollector<'_> {
-    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
-        let Some(specifiers) = &declaration.specifiers else {
-            return;
-        };
-        for specifier in specifiers {
-            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
-                continue;
-            };
-            if module_export_name(&specifier.imported) == Some("test") {
-                push_unique(self.test_names, specifier.local.name.as_str());
-            }
-        }
-    }
-
-    fn visit_variable_declarator(&mut self, declaration: &VariableDeclarator<'ast>) {
-        if let (BindingPattern::BindingIdentifier(identifier), Some(initializer)) =
-            (&declaration.id, &declaration.init)
-            && let Some(root) = test_extend_root(initializer)
-        {
-            self.extend_declarations.push((
-                CompactString::from(identifier.name.as_str()),
-                CompactString::from(root),
-            ));
-        }
-        walk::walk_variable_declarator(self, declaration);
-    }
 }
 
 struct PreferLowercaseTitleVisitor<'source, 'options, 'diagnostics> {
@@ -198,77 +149,4 @@ fn lowercase_first_utf16_code_unit(description: &str) -> Option<CompactString> {
     let mut replacement = lowercase;
     replacement.push_str(&description[first.len_utf8()..]);
     Some(replacement)
-}
-
-fn resolve_extend_aliases(
-    test_names: &mut SmallVec<[CompactString; 8]>,
-    declarations: &[(CompactString, CompactString)],
-) {
-    loop {
-        let mut changed = false;
-        for (name, root) in declarations {
-            if contains_name(test_names, root.as_str()) && !contains_name(test_names, name.as_str())
-            {
-                test_names.push(name.clone());
-                changed = true;
-            }
-        }
-        if !changed {
-            break;
-        }
-    }
-}
-
-fn test_extend_root<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
-    let Expression::CallExpression(call) = expression.get_inner_expression() else {
-        return None;
-    };
-    let member = member_from_expression(&call.callee)?;
-    if member.static_property_name() != Some("extend") {
-        return None;
-    }
-    match member.object().get_inner_expression() {
-        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
-        Expression::CallExpression(call) => test_extend_root_from_call(call),
-        _ => None,
-    }
-}
-
-fn test_extend_root_from_call<'ast>(call: &'ast CallExpression<'ast>) -> Option<&'ast str> {
-    let member = member_from_expression(&call.callee)?;
-    if member.static_property_name() != Some("extend") {
-        return None;
-    }
-    match member.object().get_inner_expression() {
-        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
-        Expression::CallExpression(call) => test_extend_root_from_call(call),
-        _ => None,
-    }
-}
-
-fn member_from_expression<'ast>(
-    expression: &'ast Expression<'ast>,
-) -> Option<&'ast MemberExpression<'ast>> {
-    match expression.get_inner_expression() {
-        member @ match_member_expression!(Expression) => Some(member.to_member_expression()),
-        _ => None,
-    }
-}
-
-fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
-    match name {
-        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
-        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
-        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
-    }
-}
-
-fn contains_name(names: &[CompactString], value: &str) -> bool {
-    names.iter().any(|name| name == value)
-}
-
-fn push_unique(names: &mut SmallVec<[CompactString; 8]>, value: &str) {
-    if !contains_name(names, value) {
-        names.push(CompactString::from(value));
-    }
 }

--- a/crates/playwright/src/scanner.rs
+++ b/crates/playwright/src/scanner.rs
@@ -42,10 +42,6 @@ impl<'a> Scanner<'a> {
         self.check_regex("no-force-option", r#"\bforce\s*:\s*true\b"#);
         self.check_regex("no-get-by-title", r#"\.getByTitle\s*\("#);
         self.check_regex(
-            "no-hooks",
-            r#"\btest\.(beforeAll|beforeEach|afterAll|afterEach)\s*\("#,
-        );
-        self.check_regex(
             "no-nested-step",
             r#"(?s)test\.step\s*\(.*?\{.*test\.step\s*\("#,
         );

--- a/crates/playwright/src/test_names.rs
+++ b/crates/playwright/src/test_names.rs
@@ -1,0 +1,159 @@
+//! Shared discovery of Playwright `test` imports and `test.extend()` aliases.
+
+use oxc_ast::ast::{
+    BindingPattern, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
+    MemberExpression, ModuleExportName, Program, VariableDeclarator, match_member_expression,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxlint_plugins_carton::{CompactString, SmallVec};
+
+pub(crate) fn collect_test_names<'ast>(
+    program: &Program<'ast>,
+    configured_aliases: &[CompactString],
+) -> SmallVec<[CompactString; 8]> {
+    let mut test_names = SmallVec::<[CompactString; 8]>::new();
+    test_names.push(CompactString::from("test"));
+    for alias in configured_aliases {
+        push_unique(&mut test_names, alias.as_str());
+    }
+
+    let mut extend_declarations = SmallVec::<[(CompactString, CompactString); 16]>::new();
+    NameCollector {
+        extend_declarations: &mut extend_declarations,
+        test_names: &mut test_names,
+    }
+    .visit_program(program);
+    resolve_extend_aliases(&mut test_names, &extend_declarations);
+    test_names
+}
+
+struct NameCollector<'storage> {
+    extend_declarations: &'storage mut SmallVec<[(CompactString, CompactString); 16]>,
+    test_names: &'storage mut SmallVec<[CompactString; 8]>,
+}
+
+impl<'ast> Visit<'ast> for NameCollector<'_> {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'ast>) {
+        let Some(specifiers) = &declaration.specifiers else {
+            return;
+        };
+        for specifier in specifiers {
+            let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                continue;
+            };
+            if module_export_name(&specifier.imported) == Some("test") {
+                push_unique(self.test_names, specifier.local.name.as_str());
+            }
+        }
+    }
+
+    fn visit_variable_declarator(&mut self, declaration: &VariableDeclarator<'ast>) {
+        if let (BindingPattern::BindingIdentifier(identifier), Some(initializer)) =
+            (&declaration.id, &declaration.init)
+            && let Some(root) = test_extend_root(initializer)
+        {
+            self.extend_declarations.push((
+                CompactString::from(identifier.name.as_str()),
+                CompactString::from(root),
+            ));
+        }
+        walk::walk_variable_declarator(self, declaration);
+    }
+}
+
+fn resolve_extend_aliases(
+    test_names: &mut SmallVec<[CompactString; 8]>,
+    declarations: &[(CompactString, CompactString)],
+) {
+    loop {
+        let mut changed = false;
+        for (name, root) in declarations {
+            if contains_name(test_names, root.as_str()) && !contains_name(test_names, name.as_str())
+            {
+                test_names.push(name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn test_extend_root<'ast>(expression: &'ast Expression<'ast>) -> Option<&'ast str> {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return None;
+    };
+    let member = member_from_expression(&call.callee)?;
+    if member_name(member) != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn test_extend_root_from_call<'ast>(call: &'ast CallExpression<'ast>) -> Option<&'ast str> {
+    let member = member_from_expression(&call.callee)?;
+    if member_name(member) != Some("extend") {
+        return None;
+    }
+    match member.object().get_inner_expression() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => test_extend_root_from_call(call),
+        _ => None,
+    }
+}
+
+fn member_from_expression<'ast>(
+    expression: &'ast Expression<'ast>,
+) -> Option<&'ast MemberExpression<'ast>> {
+    match expression.get_inner_expression() {
+        member @ match_member_expression!(Expression) => Some(member.to_member_expression()),
+        _ => None,
+    }
+}
+
+fn member_name<'ast>(member: &'ast MemberExpression<'ast>) -> Option<&'ast str> {
+    if let Some(name) = member.static_property_name() {
+        return Some(name);
+    }
+    match member {
+        MemberExpression::ComputedMemberExpression(member) => {
+            match member.expression.get_inner_expression() {
+                Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+                Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+                Expression::TemplateLiteral(template) if template.expressions.is_empty() => {
+                    template
+                        .quasis
+                        .first()
+                        .and_then(|quasi| quasi.value.cooked.as_ref())
+                        .map(|value| value.as_str())
+                }
+                _ => None,
+            }
+        }
+        MemberExpression::StaticMemberExpression(_)
+        | MemberExpression::PrivateFieldExpression(_) => None,
+    }
+}
+
+fn module_export_name<'ast>(name: &'ast ModuleExportName<'ast>) -> Option<&'ast str> {
+    match name {
+        ModuleExportName::IdentifierName(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::IdentifierReference(identifier) => Some(identifier.name.as_str()),
+        ModuleExportName::StringLiteral(literal) => Some(literal.value.as_str()),
+    }
+}
+
+fn contains_name(names: &[CompactString], value: &str) -> bool {
+    names.iter().any(|name| name == value)
+}
+
+fn push_unique(names: &mut SmallVec<[CompactString; 8]>, value: &str) {
+    if !contains_name(names, value) {
+        names.push(CompactString::from(value));
+    }
+}

--- a/crates/playwright/src/tests.rs
+++ b/crates/playwright/src/tests.rs
@@ -1,9 +1,9 @@
 use oxlint_plugins_carton::{CompactString, SmallVec};
 
 use crate::{
-    PlaywrightOptions, RULE_NAMES, Restriction, TagPattern, TitlePattern, TitlePatternOptions,
-    ValidTestTagsOptions, ValidTitleOptions, implemented_playwright_rule_names, scan_playwright,
-    scan_playwright_with_options,
+    HookAlias, PlaywrightOptions, RULE_NAMES, Restriction, TagPattern, TitlePattern,
+    TitlePatternOptions, ValidTestTagsOptions, ValidTitleOptions,
+    implemented_playwright_rule_names, scan_playwright, scan_playwright_with_options,
 };
 
 const REPRESENTATIVE_SOURCE: &str = r#"
@@ -655,7 +655,7 @@ fn expect_expect_supports_global_import_and_chained_extend_aliases() {
     let source = concat!(
         "import { test as scenario, expect as assuming } from \"another-runner\";\n",
         "const later = custom.extend({});\n",
-        "const custom = scenario.extend({}).extend({});\n",
+        "const custom = scenario[\"extend\"]({})[`extend`]({});\n",
         "scenario(\"import\", () => assuming(true).toBeDefined());\n",
         "later(\"extended\", () => expect(true).toBeDefined());\n",
         "it(\"global\", () => verify(true).toBeDefined());\n",
@@ -981,6 +981,199 @@ fn prefer_lowercase_title_is_inert_for_unrelated_calls_and_parse_errors() {
         prefer_lowercase_title_diagnostics("test(\"Broken", &PlaywrightOptions::default())
             .is_empty()
     );
+}
+
+#[test]
+fn no_hooks_reports_every_hook_with_exact_data_locations_and_no_fix() {
+    let source = concat!(
+        "test.beforeAll(() => {});\n",
+        "test[\"beforeEach\"](() => {});\n",
+        "test[`afterAll`]();\n",
+        "afterEach(() => {});\n",
+    );
+    let diagnostics = no_hooks_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 4);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (
+                diagnostic.message_id,
+                diagnostic.data.hook_name.as_deref(),
+                diagnostic.loc.start_line,
+                diagnostic.loc.start_column,
+                diagnostic.loc.end_column,
+            ))
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[
+            ("unexpectedHook", Some("beforeAll"), 1, 0, 24),
+            ("unexpectedHook", Some("beforeEach"), 2, 0, 28),
+            ("unexpectedHook", Some("afterAll"), 3, 0, 18),
+            ("unexpectedHook", Some("afterEach"), 4, 0, 19),
+        ]
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.fix.is_none())
+    );
+}
+
+#[test]
+fn no_hooks_honors_allow_independently_for_member_and_bare_hooks() {
+    let source = concat!(
+        "test.beforeAll(() => {});\n",
+        "beforeEach(() => {});\n",
+        "test.afterAll(() => {});\n",
+        "afterEach(() => {});\n",
+    );
+    let options = PlaywrightOptions {
+        allowed_hooks: [
+            CompactString::from("beforeAll"),
+            CompactString::from("afterEach"),
+        ]
+        .into_iter()
+        .collect(),
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = no_hooks_diagnostics(source, &options);
+
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.data.hook_name.as_deref())
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[Some("beforeEach"), Some("afterAll")]
+    );
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.loc.start_line)
+            .collect::<SmallVec<[_; 4]>>()
+            .as_slice(),
+        &[2, 3]
+    );
+}
+
+#[test]
+fn no_hooks_supports_global_import_test_and_transitive_extend_aliases() {
+    let source = concat!(
+        "import { test as scenario, beforeAll as setupSuite } from \"another-runner\";\n",
+        "const later = custom.extend({});\n",
+        "const custom = scenario.extend({}).extend({});\n",
+        "setupEach(() => {});\n",
+        "setupSuite(() => {});\n",
+        "scenario.beforeEach(() => {});\n",
+        "custom.afterAll(() => {});\n",
+        "later[`afterEach`](() => {});\n",
+    );
+    let options = PlaywrightOptions {
+        hook_aliases: [HookAlias {
+            name: CompactString::from("setupEach"),
+            hook_name: CompactString::from("beforeEach"),
+        }]
+        .into_iter()
+        .collect(),
+        ..PlaywrightOptions::default()
+    };
+    let diagnostics = no_hooks_diagnostics(source, &options);
+
+    assert_eq!(diagnostics.len(), 5);
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (
+                diagnostic.data.hook_name.as_deref(),
+                diagnostic.loc.start_line
+            ))
+            .collect::<SmallVec<[_; 8]>>()
+            .as_slice(),
+        &[
+            (Some("beforeEach"), 4),
+            (Some("beforeAll"), 5),
+            (Some("beforeEach"), 6),
+            (Some("afterAll"), 7),
+            (Some("afterEach"), 8),
+        ]
+    );
+}
+
+#[test]
+fn no_hooks_reports_nested_hooks_in_source_order_and_utf16_call_ranges() {
+    let source = concat!(
+        "const marker = \"🧪\";\n",
+        "test.describe(\"outer\", () => {\n",
+        "  test.describe(\"inner\", () => {\n",
+        "    test.beforeEach(() => {});\n",
+        "    afterAll(() => {});\n",
+        "  });\n",
+        "});\n",
+    );
+    let diagnostics = no_hooks_diagnostics(source, &PlaywrightOptions::default());
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].data.hook_name.as_deref(), Some("beforeEach"));
+    assert_eq!(
+        diagnostics[0].loc,
+        crate::DiagnosticLoc {
+            start_line: 4,
+            start_column: 4,
+            end_line: 4,
+            end_column: 29,
+        }
+    );
+    assert_eq!(diagnostics[1].data.hook_name.as_deref(), Some("afterAll"));
+    assert_eq!(
+        diagnostics[1].loc,
+        crate::DiagnosticLoc {
+            start_line: 5,
+            start_column: 4,
+            end_line: 5,
+            end_column: 22,
+        }
+    );
+}
+
+#[test]
+fn no_hooks_ignores_non_playwright_members_and_invalid_chains() {
+    let source = concat!(
+        "subject.beforeEach();\n",
+        "runner.afterAll(() => {});\n",
+        "test.describe.beforeEach(() => {});\n",
+        "test.beforeEach.extra(() => {});\n",
+        "test.beforeEach;\n",
+        "test(\"case\", () => { expect(subject.beforeEach()).toBe(true); });\n",
+    );
+    assert!(no_hooks_diagnostics(source, &PlaywrightOptions::default()).is_empty());
+}
+
+#[test]
+fn no_hooks_fails_closed_on_malformed_input_and_keeps_rule_selection_isolated() {
+    assert!(no_hooks_diagnostics("test.beforeEach(", &PlaywrightOptions::default()).is_empty());
+    let diagnostics = scan_playwright_with_options(
+        "test.beforeEach(() => {});",
+        "fixture.spec.ts",
+        &PlaywrightOptions::default(),
+    );
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "no-hooks")
+            .count(),
+        1
+    );
+}
+
+fn no_hooks_diagnostics(
+    source: &str,
+    options: &PlaywrightOptions,
+) -> SmallVec<[crate::Diagnostic; 8]> {
+    scan_playwright_with_options(source, "fixture.spec.ts", options)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.rule_name == "no-hooks")
+        .collect()
 }
 
 fn prefer_lowercase_title_diagnostics(

--- a/crates/playwright/src/types.rs
+++ b/crates/playwright/src/types.rs
@@ -9,13 +9,21 @@ pub struct Restriction {
     pub message: Option<CompactString>,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct HookAlias {
+    pub name: CompactString,
+    pub hook_name: CompactString,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaywrightOptions {
+    pub allowed_hooks: SmallVec<[CompactString; 4]>,
     pub allowed_title_prefixes: SmallVec<[CompactString; 4]>,
     pub assert_function_names: SmallVec<[CompactString; 4]>,
     pub assert_function_patterns: SmallVec<[CompactString; 4]>,
     pub lowercase_title_ignored_methods: SmallVec<[CompactString; 4]>,
     pub ignore_top_level_describe: bool,
+    pub hook_aliases: SmallVec<[HookAlias; 8]>,
     pub restricted_locators: SmallVec<[Restriction; 8]>,
     pub restricted_matchers: SmallVec<[Restriction; 8]>,
     pub restricted_roles: SmallVec<[Restriction; 8]>,
@@ -82,11 +90,13 @@ pub struct TagPattern {
 impl Default for PlaywrightOptions {
     fn default() -> Self {
         Self {
+            allowed_hooks: SmallVec::new(),
             allowed_title_prefixes: SmallVec::new(),
             assert_function_names: SmallVec::new(),
             assert_function_patterns: SmallVec::new(),
             lowercase_title_ignored_methods: SmallVec::new(),
             ignore_top_level_describe: false,
+            hook_aliases: SmallVec::new(),
             restricted_locators: SmallVec::new(),
             restricted_matchers: SmallVec::new(),
             restricted_roles: SmallVec::new(),
@@ -133,6 +143,7 @@ pub struct DiagnosticData {
     pub amount: Option<CompactString>,
     pub count: Option<CompactString>,
     pub depth: Option<CompactString>,
+    pub hook_name: Option<CompactString>,
     pub max: Option<CompactString>,
     pub method: Option<CompactString>,
     pub restriction: Option<CompactString>,

--- a/npm/playwright/README.md
+++ b/npm/playwright/README.md
@@ -29,6 +29,28 @@ Exact names match direct calls and terminal member identifiers such as
 syntax. Assertions inside nested callbacks and `test.step()` count toward their
 containing test, matching upstream ancestry behavior.
 
+## Hook options
+
+`no-hooks` implements the complete upstream v2.11.0 `allow` option. It reports
+the full hook call and includes the canonical hook name in diagnostic data.
+
+```json
+{
+  "rules": {
+    "playwright/no-hooks": [
+      "error",
+      {
+        "allow": ["afterEach", "afterAll"]
+      }
+    ]
+  }
+}
+```
+
+The rule also recognizes bare hooks, computed properties, named import aliases,
+configured global aliases, and `test.extend()` aliases. Upstream does not define
+an autofix for this rule, so diagnostics intentionally have no fix.
+
 ## Lowercase title options
 
 `prefer-lowercase-title` implements the complete upstream v2.11.0 option and
@@ -120,11 +142,13 @@ The direct API accepts the same option values:
 const { scanPlaywright } = require('@oxlint-plugins/oxlint-plugin-playwright/api');
 
 scanPlaywright('page.getByTestId("submit")', 'fixture.spec.ts', {
+  allowedHooks: ['afterEach'],
   allowedPrefixes: ['GET', 'POST'],
   assertFunctionNames: ['assertCustomCondition'],
   assertFunctionPatterns: ['^verify.*'],
   ignore: ['test.describe'],
   ignoreTopLevelDescribe: true,
+  hookAliases: { beforeEach: ['setupEach'] },
   maxExpects: 5,
   maxNestedDescribe: 5,
   maxTopLevelDescribes: 2,

--- a/npm/playwright/api.d.ts
+++ b/npm/playwright/api.d.ts
@@ -13,6 +13,7 @@ export type PlaywrightDiagnostic = {
     amount?: string;
     count?: string;
     depth?: string;
+    hookName?: string;
     max?: string;
     method?: string;
     restriction?: string;
@@ -45,12 +46,16 @@ export type PlaywrightRestrictedRole =
       message?: string;
     };
 
+export type PlaywrightHookName = 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach';
+
 export type PlaywrightScanOptions = {
+  allowedHooks?: PlaywrightHookName[];
   allowedPrefixes?: string[];
   assertFunctionNames?: string[];
   assertFunctionPatterns?: string[];
   ignore?: Array<'test.describe' | 'test'>;
   ignoreTopLevelDescribe?: boolean;
+  hookAliases?: Partial<Record<PlaywrightHookName, string[]>>;
   noRestrictedLocators?: PlaywrightRestrictedLocator[];
   noRestrictedMatchers?: Record<string, string | null>;
   noRestrictedRoles?: PlaywrightRestrictedRole[];

--- a/npm/playwright/api.js
+++ b/npm/playwright/api.js
@@ -18,12 +18,14 @@ function scanPlaywright(sourceText, filename = 'file.spec.ts', options = {}) {
   }
 
   const diagnostics = native.scanPlaywright(sourceText, filename, {
+    allowedHooks: stringList(options.allowedHooks),
     allowedPrefixes: stringList(options.allowedPrefixes),
     assertFunctionNames: stringList(options.assertFunctionNames),
     assertFunctionPatterns: regexList(options.assertFunctionPatterns),
     expectAliases: stringList(options.expectAliases),
     ignore: stringList(options.ignore),
     ignoreTopLevelDescribe: options.ignoreTopLevelDescribe === true,
+    hookAliases: hookAliases(options.hookAliases),
     testAliases: stringList(options.testAliases),
     maxExpects: integerOption(options.maxExpects, 'maxExpects', 1),
     maxNestedDescribe: integerOption(options.maxNestedDescribe, 'maxNestedDescribe', 0),
@@ -120,6 +122,15 @@ function regexList(values) {
     new RegExp(value);
     return value;
   });
+}
+
+function hookAliases(aliases) {
+  if (!aliases || typeof aliases !== 'object' || Array.isArray(aliases)) {
+    return [];
+  }
+  return Object.entries(aliases).flatMap(([hookName, names]) =>
+    stringList(names).map((name) => ({ name, hookName })),
+  );
 }
 
 function integerOption(value, name, minimum) {

--- a/npm/playwright/index.js
+++ b/npm/playwright/index.js
@@ -22,6 +22,7 @@ const thresholdRules = new Set([
   'max-nested-describe',
   'require-top-level-describe',
 ]);
+const optionAwareHookRules = new Set(['no-hooks']);
 const optionAwareTitleRules = new Set(['prefer-lowercase-title']);
 
 const sharedGlobals = Object.freeze({
@@ -142,6 +143,7 @@ function createLegacyRecommendedConfig() {
 function createPlaywrightRule(ruleName) {
   const specializedMeta =
     expectExpectRuleMeta(ruleName) ??
+    noHooksRuleMeta(ruleName) ??
     preferLowercaseTitleRuleMeta(ruleName) ??
     restrictedRuleMeta(ruleName) ??
     patternRuleMeta(ruleName) ??
@@ -200,9 +202,11 @@ function diagnosticsForRule(context, ruleName) {
         ? ruleScanOptions(context, ruleName)
         : thresholdRules.has(ruleName)
           ? thresholdScanOptions(context, ruleName)
-          : optionAwareTitleRules.has(ruleName)
-            ? preferLowercaseTitleScanOptions(context)
-            : undefined;
+          : optionAwareHookRules.has(ruleName)
+            ? noHooksScanOptions(context)
+            : optionAwareTitleRules.has(ruleName)
+              ? preferLowercaseTitleScanOptions(context)
+              : undefined;
   return diagnosticsForContext(context, options).filter(
     (diagnostic) => diagnostic.ruleName === ruleName,
   );
@@ -288,6 +292,26 @@ function preferLowercaseTitleScanOptions(context) {
     allowedPrefixes: configured.allowedPrefixes,
     ignore: configured.ignore,
     ignoreTopLevelDescribe: configured.ignoreTopLevelDescribe,
+    ...(Array.isArray(testAliases) ? { testAliases } : {}),
+  };
+}
+
+function noHooksScanOptions(context) {
+  const options = Array.isArray(context.options) ? context.options : [];
+  const configured = options[0] && typeof options[0] === 'object' ? options[0] : {};
+  const globalAliases = context.settings?.playwright?.globalAliases;
+  const hookAliases =
+    globalAliases && typeof globalAliases === 'object'
+      ? Object.fromEntries(
+          Object.entries(globalAliases).filter(([name]) =>
+            ['afterAll', 'afterEach', 'beforeAll', 'beforeEach'].includes(name),
+          ),
+        )
+      : undefined;
+  const testAliases = globalAliases?.test;
+  return {
+    allowedHooks: configured.allow,
+    hookAliases,
     ...(Array.isArray(testAliases) ? { testAliases } : {}),
   };
 }
@@ -478,6 +502,31 @@ function preferLowercaseTitleRuleMeta(ruleName) {
       },
     ],
     url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/prefer-lowercase-title.md',
+  };
+}
+
+function noHooksRuleMeta(ruleName) {
+  if (ruleName !== 'no-hooks') {
+    return null;
+  }
+  return {
+    description: 'Disallow setup and teardown hooks',
+    messages: {
+      unexpectedHook: "Unexpected '{{ hookName }}' hook",
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          allow: {
+            contains: ['beforeAll', 'beforeEach', 'afterAll', 'afterEach'],
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/no-hooks.md',
   };
 }
 

--- a/npm/playwright/src/lib.rs
+++ b/npm/playwright/src/lib.rs
@@ -1,8 +1,8 @@
 //! NAPI boundary for the playwright oxlint plugin.
 
 pub use napi_abi::{
-    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, PlaywrightRestriction,
-    PlaywrightScanOptions, PlaywrightTagPattern, PlaywrightTitlePattern,
+    Diagnostic, DiagnosticData, DiagnosticFix, DiagnosticLoc, PlaywrightHookAlias,
+    PlaywrightRestriction, PlaywrightScanOptions, PlaywrightTagPattern, PlaywrightTitlePattern,
     PlaywrightTitlePatternOptions, PlaywrightValidTestTagsOptions, PlaywrightValidTitleOptions,
     implemented_playwright_rule_names, scan_playwright,
 };
@@ -25,13 +25,22 @@ mod napi_abi {
     }
 
     #[napi(object)]
+    #[derive(Clone, Debug)]
+    pub struct PlaywrightHookAlias {
+        pub name: String,
+        pub hook_name: String,
+    }
+
+    #[napi(object)]
     #[derive(Clone, Debug, Default)]
     pub struct PlaywrightScanOptions {
+        pub allowed_hooks: Option<Vec<String>>,
         pub allowed_prefixes: Option<Vec<String>>,
         pub assert_function_names: Option<Vec<String>>,
         pub assert_function_patterns: Option<Vec<String>>,
         pub ignore: Option<Vec<String>>,
         pub ignore_top_level_describe: Option<bool>,
+        pub hook_aliases: Option<Vec<PlaywrightHookAlias>>,
         pub restricted_locators: Option<Vec<PlaywrightRestriction>>,
         pub restricted_matchers: Option<Vec<PlaywrightRestriction>>,
         pub restricted_roles: Option<Vec<PlaywrightRestriction>>,
@@ -120,6 +129,7 @@ mod napi_abi {
         pub amount: Option<String>,
         pub count: Option<String>,
         pub depth: Option<String>,
+        pub hook_name: Option<String>,
         pub max: Option<String>,
         pub method: Option<String>,
         pub restriction: Option<String>,
@@ -149,11 +159,21 @@ mod napi_abi {
         let valid_title = compact_valid_title(options.valid_title);
         let valid_test_tags = compact_valid_test_tags(options.valid_test_tags);
         let core_options = core::PlaywrightOptions {
+            allowed_hooks: compact_strings(options.allowed_hooks),
             allowed_title_prefixes: compact_strings(options.allowed_prefixes),
             assert_function_names: compact_strings(options.assert_function_names),
             assert_function_patterns: compact_strings(options.assert_function_patterns),
             lowercase_title_ignored_methods: compact_strings(options.ignore),
             ignore_top_level_describe: options.ignore_top_level_describe.unwrap_or(false),
+            hook_aliases: options
+                .hook_aliases
+                .unwrap_or_default()
+                .into_iter()
+                .map(|alias| core::HookAlias {
+                    name: CompactString::from(alias.name),
+                    hook_name: CompactString::from(alias.hook_name),
+                })
+                .collect(),
             restricted_locators: compact_restrictions(options.restricted_locators),
             restricted_matchers: compact_restrictions(options.restricted_matchers),
             restricted_roles: compact_restrictions(options.restricted_roles),
@@ -187,6 +207,7 @@ mod napi_abi {
                     amount: diagnostic.data.amount.map(CompactString::into_string),
                     count: diagnostic.data.count.map(CompactString::into_string),
                     depth: diagnostic.data.depth.map(CompactString::into_string),
+                    hook_name: diagnostic.data.hook_name.map(CompactString::into_string),
                     max: diagnostic.data.max.map(CompactString::into_string),
                     method: diagnostic.data.method.map(CompactString::into_string),
                     restriction: diagnostic.data.restriction.map(CompactString::into_string),

--- a/npm/playwright/test/fixtures/no-hooks-v2.11.0.json
+++ b/npm/playwright/test/fixtures/no-hooks-v2.11.0.json
@@ -1,0 +1,163 @@
+{
+  "__generated": {
+    "source": "eslint-plugin-playwright",
+    "version": "2.11.0",
+    "sourceCommit": "b6d3e5dac73c8aad4d5e62a933105579c319655f",
+    "license": "MIT",
+    "tool": "tools/tasks/sync-playwright-no-hooks-tests.ts",
+    "sourceFiles": [
+      "src/rules/no-hooks.ts",
+      "src/rules/no-hooks.test.ts",
+      "docs/rules/no-hooks.md"
+    ],
+    "sourceHashes": {
+      "src/rules/no-hooks.ts": "bfa7ad98ee3e395919654904c5eaf1dc64c0dfb24ebd07321d9247a9d7a98c57",
+      "src/rules/no-hooks.test.ts": "94d9bc99d3db616b81d8dff8355bf2bb23a4a69262b3a2806819e744868b9a07",
+      "docs/rules/no-hooks.md": "aef2a1119c63d0469fd99b98882b2953ee450a8c63c6de5b99ca0bfeb01d3e7e"
+    },
+    "previousVersionAudit": {
+      "version": "2.10.4",
+      "sourceCommit": "894c0ec261763bb1e073b276c70bbf88b4ebad39",
+      "changedFiles": []
+    },
+    "inventory": {
+      "suites": 1,
+      "valid": 5,
+      "invalid": 6,
+      "diagnostics": 6,
+      "fixable": 0
+    }
+  },
+  "rule": "no-hooks",
+  "valid": [
+    {
+      "code": "test(\"foo\")",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.describe(\"foo\", () => { test(\"bar\") })",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [],
+      "expectedOutput": null
+    },
+    {
+      "code": "test(\"foo\", () => { expect(subject.beforeEach()).toBe(true) })",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.afterEach(() => {}); afterAll(() => {});",
+      "options": [
+        {
+          "allow": ["afterEach", "afterAll"]
+        }
+      ],
+      "settings": null,
+      "expectedDiagnostics": [],
+      "expectedOutput": null
+    },
+    {
+      "code": "test(\"foo\")",
+      "options": [{}],
+      "settings": null,
+      "expectedDiagnostics": [],
+      "expectedOutput": null
+    }
+  ],
+  "invalid": [
+    {
+      "code": "test.beforeAll(() => {})",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedHook",
+          "data": {
+            "hookName": "beforeAll"
+          }
+        }
+      ],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.beforeEach(() => {})",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedHook",
+          "data": {
+            "hookName": "beforeEach"
+          }
+        }
+      ],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.afterAll(() => {})",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedHook",
+          "data": {
+            "hookName": "afterAll"
+          }
+        }
+      ],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.afterEach(() => {})",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedHook",
+          "data": {
+            "hookName": "afterEach"
+          }
+        }
+      ],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.beforeEach(() => {}); afterEach(() => { doStuff() });",
+      "options": [
+        {
+          "allow": ["afterEach"]
+        }
+      ],
+      "settings": null,
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedHook",
+          "data": {
+            "hookName": "beforeEach"
+          }
+        }
+      ],
+      "expectedOutput": null
+    },
+    {
+      "code": "test.describe(\"outer\", () => {\n  test.describe(\"inner\", () => {\n    test.beforeEach(() => {})\n  })\n})",
+      "options": [],
+      "settings": null,
+      "expectedDiagnostics": [
+        {
+          "messageId": "unexpectedHook",
+          "data": {
+            "hookName": "beforeEach"
+          }
+        }
+      ],
+      "expectedOutput": null
+    }
+  ]
+}

--- a/npm/playwright/test/no-hooks-upstream.test.mjs
+++ b/npm/playwright/test/no-hooks-upstream.test.mjs
@@ -1,0 +1,334 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { scanPlaywright } from '../api.js';
+import plugin from '../index.js';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = resolve(packageRoot, '../..');
+const fixture = JSON.parse(
+  readFileSync(join(packageRoot, 'test/fixtures/no-hooks-v2.11.0.json'), 'utf8'),
+);
+const ruleName = 'no-hooks';
+const rule = plugin.rules[ruleName];
+
+describe('playwright no-hooks upstream v2.11.0 fixtures', () => {
+  it('pins exact upstream sources, previous-version drift, and authored inventory', () => {
+    expect(fixture.__generated).toEqual({
+      source: 'eslint-plugin-playwright',
+      version: '2.11.0',
+      sourceCommit: 'b6d3e5dac73c8aad4d5e62a933105579c319655f',
+      license: 'MIT',
+      tool: 'tools/tasks/sync-playwright-no-hooks-tests.ts',
+      sourceFiles: [
+        'src/rules/no-hooks.ts',
+        'src/rules/no-hooks.test.ts',
+        'docs/rules/no-hooks.md',
+      ],
+      sourceHashes: {
+        'src/rules/no-hooks.ts': 'bfa7ad98ee3e395919654904c5eaf1dc64c0dfb24ebd07321d9247a9d7a98c57',
+        'src/rules/no-hooks.test.ts':
+          '94d9bc99d3db616b81d8dff8355bf2bb23a4a69262b3a2806819e744868b9a07',
+        'docs/rules/no-hooks.md':
+          'aef2a1119c63d0469fd99b98882b2953ee450a8c63c6de5b99ca0bfeb01d3e7e',
+      },
+      previousVersionAudit: {
+        version: '2.10.4',
+        sourceCommit: '894c0ec261763bb1e073b276c70bbf88b4ebad39',
+        changedFiles: [],
+      },
+      inventory: {
+        suites: 1,
+        valid: 5,
+        invalid: 6,
+        diagnostics: 6,
+        fixable: 0,
+      },
+    });
+  });
+
+  it.each(
+    fixture.valid.map((testCase, index) => ({
+      ...testCase,
+      label: `valid ${index + 1}`,
+    })),
+  )('$label is valid through native and plugin paths', (testCase) => {
+    expect(nativeDiagnostics(testCase)).toEqual([]);
+    expect(adapterReports(testCase)).toEqual([]);
+  });
+
+  it.each(
+    fixture.invalid.map((testCase, index) => ({
+      ...testCase,
+      label: `invalid ${index + 1}`,
+    })),
+  )('$label matches exact authored messages, data, and no-fix contract', (testCase) => {
+    const diagnostics = nativeDiagnostics(testCase);
+    const reports = adapterReports(testCase);
+
+    expect(
+      diagnostics.map(({ messageId, data }) => ({
+        messageId,
+        data: compactData(data),
+      })),
+    ).toEqual(testCase.expectedDiagnostics);
+    expect(
+      reports.map(({ messageId, data }) => ({
+        messageId,
+        data: compactData(data),
+      })),
+    ).toEqual(testCase.expectedDiagnostics);
+    expect(reports.map(({ loc }) => loc)).toEqual(
+      diagnostics.map(({ loc }) => ({
+        start: { line: loc.startLine, column: loc.startColumn },
+        end: { line: loc.endLine, column: loc.endColumn },
+      })),
+    );
+    expect(diagnostics.every((diagnostic) => diagnostic.fix == null)).toBe(true);
+    expect(reports.every((report) => report.fix === undefined)).toBe(true);
+    expect(
+      reports.map((report) =>
+        rule.meta.messages[report.messageId].replace('{{ hookName }}', report.data.hookName),
+      ),
+    ).toEqual(
+      testCase.expectedDiagnostics.map(
+        (diagnostic) => `Unexpected '${diagnostic.data.hookName}' hook`,
+      ),
+    );
+  });
+
+  it('exposes exact upstream metadata, schema, and non-fixable contract', () => {
+    expect(rule.meta).toMatchObject({
+      type: 'suggestion',
+      docs: {
+        description: 'Disallow setup and teardown hooks',
+        recommended: false,
+        url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/no-hooks.md',
+      },
+      messages: {
+        unexpectedHook: "Unexpected '{{ hookName }}' hook",
+      },
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            allow: {
+              contains: ['beforeAll', 'beforeEach', 'afterAll', 'afterEach'],
+              type: 'array',
+            },
+          },
+          type: 'object',
+        },
+      ],
+    });
+    expect(rule.meta.fixable).toBeUndefined();
+    expect(rule.meta.hasSuggestions).toBeUndefined();
+  });
+
+  it('reports complete call ranges and canonical data for every member and bare hook', () => {
+    const code = [
+      '"🧪"; test.beforeAll(() => {});',
+      'test["beforeEach"](() => {});',
+      'test[`afterAll`]();',
+      'afterEach(() => {});',
+    ].join('\n');
+    const diagnostics = nativeDiagnostics({ code, options: [], settings: null });
+
+    expect(diagnostics.map(({ data, loc }) => [data.hookName, loc])).toEqual([
+      ['beforeAll', { startLine: 1, startColumn: 6, endLine: 1, endColumn: 30 }],
+      ['beforeEach', { startLine: 2, startColumn: 0, endLine: 2, endColumn: 28 }],
+      ['afterAll', { startLine: 3, startColumn: 0, endLine: 3, endColumn: 18 }],
+      ['afterEach', { startLine: 4, startColumn: 0, endLine: 4, endColumn: 19 }],
+    ]);
+  });
+
+  it('supports configured globals, import aliases, test imports, and transitive extend aliases', () => {
+    const code = [
+      'import { test as scenario, beforeAll as setupSuite } from "another-runner";',
+      'const later = custom.extend({});',
+      'const custom = scenario["extend"]({})[`extend`]({});',
+      'setupEach(() => {});',
+      'setupSuite(() => {});',
+      'scenario.beforeEach(() => {});',
+      'custom.afterAll(() => {});',
+      'later[`afterEach`](() => {});',
+    ].join('\n');
+    const testCase = {
+      code,
+      options: [],
+      settings: {
+        playwright: {
+          globalAliases: {
+            beforeEach: ['setupEach'],
+          },
+        },
+      },
+    };
+    const diagnostics = nativeDiagnostics(testCase);
+
+    expect(diagnostics.map(({ data }) => data.hookName)).toEqual([
+      'beforeEach',
+      'beforeAll',
+      'beforeEach',
+      'afterAll',
+      'afterEach',
+    ]);
+    expect(diagnostics.map(({ loc }) => loc.startLine)).toEqual([4, 5, 6, 7, 8]);
+    expect(adapterReports(testCase)).toHaveLength(5);
+  });
+
+  it('honors allow after alias resolution without suppressing other hooks', () => {
+    const testCase = {
+      code: [
+        'setupEach(() => {});',
+        'test.beforeEach(() => {});',
+        'test.afterEach(() => {});',
+        'afterAll(() => {});',
+      ].join('\n'),
+      options: [{ allow: ['beforeEach', 'afterAll'] }],
+      settings: {
+        playwright: {
+          globalAliases: {
+            beforeEach: ['setupEach'],
+          },
+        },
+      },
+    };
+    expect(nativeDiagnostics(testCase).map(({ data }) => data.hookName)).toEqual(['afterEach']);
+    expect(adapterReports(testCase)).toHaveLength(1);
+  });
+
+  it('ignores unrelated members, invalid chains, references, and dynamic properties', () => {
+    const code = [
+      'subject.beforeEach();',
+      'runner.afterAll(() => {});',
+      'test.describe.beforeEach(() => {});',
+      'test.beforeEach.extra(() => {});',
+      'test.beforeEach;',
+      'test[hookName](() => {});',
+    ].join('\n');
+    expect(nativeDiagnostics({ code, options: [], settings: null })).toEqual([]);
+  });
+
+  it('fails closed for malformed input and isolates rule selection', () => {
+    expect(
+      nativeDiagnostics({
+        code: 'test.beforeEach(',
+        options: [],
+        settings: null,
+      }),
+    ).toEqual([]);
+    expect(runRule('prefer-lowercase-title', 'test.beforeEach(() => {});', [], null)).toEqual([]);
+  });
+
+  it('reports TypeScript through real Oxlint and stays unchanged under --fix', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'oxlint-playwright-no-hooks-'));
+    try {
+      const source = [
+        'type Setup = () => void;',
+        'const setup: Setup = () => {};',
+        'test.beforeEach(() => setup());',
+        '',
+      ].join('\n');
+      writeFileSync(join(tempDir, 'fixture.spec.ts'), source);
+      writeFileSync(
+        join(tempDir, 'oxlint.config.jsonc'),
+        JSON.stringify({
+          jsPlugins: [{ name: 'playwright', specifier: join(packageRoot, 'index.js') }],
+          rules: { 'playwright/no-hooks': 'error' },
+        }),
+      );
+
+      const lint = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--quiet', '--format', 'json', 'fixture.spec.ts'],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      const payload = JSON.parse(lint.stdout);
+      expect(lint.status).toBe(1);
+      expect(lint.stderr).toBe('');
+      expect(payload.diagnostics).toHaveLength(1);
+      expect(payload.diagnostics[0]).toMatchObject({
+        code: 'playwright(no-hooks)',
+        message: "Unexpected 'beforeEach' hook",
+      });
+
+      const fix = spawnSync(
+        findOxlintCli(),
+        ['--config', 'oxlint.config.jsonc', '--fix', '--quiet', 'fixture.spec.ts'],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      expect(fix.status).toBe(1);
+      expect(readFileSync(join(tempDir, 'fixture.spec.ts'), 'utf8')).toBe(source);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function nativeDiagnostics(testCase) {
+  return scanPlaywright(testCase.code, 'fixture.spec.ts', scanOptions(testCase)).filter(
+    ({ ruleName: diagnosticRule }) => diagnosticRule === ruleName,
+  );
+}
+
+function scanOptions(testCase) {
+  const configured = testCase.options?.[0] ?? {};
+  const globalAliases = testCase.settings?.playwright?.globalAliases;
+  return {
+    allowedHooks: configured.allow,
+    hookAliases: globalAliases,
+    ...(Array.isArray(globalAliases?.test) ? { testAliases: globalAliases.test } : {}),
+  };
+}
+
+function adapterReports(testCase) {
+  return runRule(ruleName, testCase.code, testCase.options, testCase.settings);
+}
+
+function runRule(selectedRule, sourceText, options = [], settings = null) {
+  const reports = [];
+  const sourceCode = {
+    text: sourceText,
+    getText() {
+      return this.text;
+    },
+  };
+  const visitor = plugin.rules[selectedRule].createOnce({
+    filename: 'fixture.spec.ts',
+    options,
+    settings,
+    sourceCode,
+    report(descriptor) {
+      reports.push(descriptor);
+    },
+  });
+  visitor.Program({ type: 'Program', range: [0, sourceText.length] });
+  return reports;
+}
+
+function compactData(data) {
+  return Object.fromEntries(
+    Object.entries(data).filter(
+      ([, value]) => value !== undefined && value !== null && value !== '',
+    ),
+  );
+}
+
+function findOxlintCli() {
+  const store = join(workspaceRoot, 'node_modules/.pnpm');
+  const candidates = readdirSync(store)
+    .filter((entry) => entry.startsWith('oxlint@'))
+    .map((entry) => join(store, entry, 'node_modules/oxlint/bin/oxlint'))
+    .filter((candidate) => existsSync(candidate))
+    .sort((left, right) => left.localeCompare(right));
+  if (candidates.length === 0) {
+    throw new Error('Could not find oxlint CLI in node_modules/.pnpm.');
+  }
+  return candidates[candidates.length - 1];
+}

--- a/npm/playwright/test/plugin.test.mjs
+++ b/npm/playwright/test/plugin.test.mjs
@@ -160,6 +160,7 @@ const expectedThresholdMessages = {
   'require-top-level-describe': 'All test cases must be wrapped in a describe block.',
 };
 const expectedSpecializedMessages = {
+  'no-hooks': "Unexpected '{{ hookName }}' hook",
   'prefer-lowercase-title': '`{{method}}`s should begin with lowercase',
 };
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "port:tests:perfectionist:sort-sets": "node tools/tasks/sync-perfectionist-sort-sets-options-tests.ts",
     "port:tests:perfectionist:sort-exports": "node tools/tasks/sync-perfectionist-sort-exports-options-tests.ts",
     "port:tests:playwright:expect-expect": "node tools/tasks/sync-playwright-expect-expect-tests.ts",
+    "port:tests:playwright:no-hooks": "node tools/tasks/sync-playwright-no-hooks-tests.ts",
     "port:tests:playwright:prefer-lowercase-title": "node tools/tasks/sync-playwright-prefer-lowercase-title-tests.ts",
     "port:tests:playwright:restricted": "node tools/tasks/sync-playwright-restricted-tests.ts",
     "port:tests:playwright:patterns": "node tools/tasks/sync-playwright-pattern-tests.ts",

--- a/status.json
+++ b/status.json
@@ -4483,7 +4483,7 @@
           "lsp": false,
           "oxlintIntegration": true
         },
-        "notes": "Rust/Oxc syntax-pattern port of eslint-plugin-playwright/no-hooks; focused invalid coverage is included in Vitest, with plugin loading covered through Oxlint jsPlugins."
+        "notes": "Native Oxc AST port of eslint-plugin-playwright no-hooks v2.11.0 with the complete allow option, exact messages/data/UTF-16 call locations, bare/member/computed hooks, global/import/test.extend aliases, deterministic authored fixture replay, direct API/plugin/playground coverage, and real Oxlint TypeScript integration; upstream defines no autofix."
       },
       {
         "name": "no-nested-step",

--- a/tools/tasks/sync-playwright-no-hooks-tests.ts
+++ b/tools/tasks/sync-playwright-no-hooks-tests.ts
@@ -1,0 +1,215 @@
+// Captures every authored eslint-plugin-playwright v2.11.0 RuleTester case for
+// `no-hooks` from the exact upstream commit.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type RawCase =
+  | string
+  | {
+      code: string;
+      errors?: RawError[];
+      options?: unknown[];
+      output?: string | null;
+      settings?: unknown;
+    };
+type RawError = {
+  column?: number;
+  data?: Record<string, unknown>;
+  endColumn?: number;
+  endLine?: number;
+  line?: number;
+  messageId?: string;
+};
+type CapturedSuite = {
+  invalid: RawCase[];
+  valid: RawCase[];
+};
+type Manifest = {
+  plugins: Array<{
+    id: string;
+    license: string;
+    submodule: string;
+  }>;
+};
+
+const ROOT = process.cwd();
+const VERSION = '2.11.0';
+const PINNED_COMMIT = 'b6d3e5dac73c8aad4d5e62a933105579c319655f';
+const PREVIOUS_VERSION = '2.10.4';
+const PREVIOUS_COMMIT = '894c0ec261763bb1e073b276c70bbf88b4ebad39';
+const RULE = 'no-hooks';
+const SOURCE_FILES = [`src/rules/${RULE}.ts`, `src/rules/${RULE}.test.ts`, `docs/rules/${RULE}.md`];
+
+const manifest = JSON.parse(
+  readFileSync(join(ROOT, 'tools', 'port-targets.json'), 'utf8'),
+) as Manifest;
+const plugin = manifest.plugins.find((entry) => entry.id === 'eslint-plugin-playwright');
+if (!plugin) throw new Error('eslint-plugin-playwright is not registered');
+
+const submodule = join(ROOT, plugin.submodule);
+if (!existsSync(join(submodule, '.git'))) {
+  throw new Error(`Run \`git submodule update --init ${plugin.submodule}\` first.`);
+}
+for (const commit of [PREVIOUS_COMMIT, PINNED_COMMIT]) {
+  execFileSync('git', ['-C', submodule, 'cat-file', '-e', `${commit}^{commit}`]);
+}
+
+const sourceHashes = Object.fromEntries(
+  SOURCE_FILES.map((sourceFile) => [
+    sourceFile,
+    createHash('sha256').update(upstreamSource(PINNED_COMMIT, sourceFile)).digest('hex'),
+  ]),
+);
+const changedFromPrevious = SOURCE_FILES.filter(
+  (sourceFile) =>
+    upstreamSource(PREVIOUS_COMMIT, sourceFile) !== upstreamSource(PINNED_COMMIT, sourceFile),
+);
+if (changedFromPrevious.length !== 0) {
+  throw new Error(
+    `${RULE} unexpectedly drifted from ${PREVIOUS_VERSION}: ${changedFromPrevious.join(', ')}`,
+  );
+}
+
+const suite = captureSuite(upstreamSource(PINNED_COMMIT, `src/rules/${RULE}.test.ts`));
+const valid = suite.valid.map((testCase, index) =>
+  normalizeCase(testCase, false, `valid ${index}`),
+);
+const invalid = suite.invalid.map((testCase, index) =>
+  normalizeCase(testCase, true, `invalid ${index}`),
+);
+const inventory = {
+  suites: 1,
+  valid: valid.length,
+  invalid: invalid.length,
+  diagnostics: invalid.reduce((total, testCase) => total + testCase.expectedDiagnostics.length, 0),
+  fixable: invalid.filter((testCase) => testCase.expectedOutput !== null).length,
+};
+const fixture = {
+  __generated: {
+    source: 'eslint-plugin-playwright',
+    version: VERSION,
+    sourceCommit: PINNED_COMMIT,
+    license: plugin.license,
+    tool: 'tools/tasks/sync-playwright-no-hooks-tests.ts',
+    sourceFiles: SOURCE_FILES,
+    sourceHashes,
+    previousVersionAudit: {
+      version: PREVIOUS_VERSION,
+      sourceCommit: PREVIOUS_COMMIT,
+      changedFiles: changedFromPrevious,
+    },
+    inventory,
+  },
+  rule: RULE,
+  valid,
+  invalid,
+};
+
+const outputDirectory = join(ROOT, 'npm', 'playwright', 'test', 'fixtures');
+mkdirSync(outputDirectory, { recursive: true });
+const outputPath = join(outputDirectory, `${RULE}-v${VERSION}.json`);
+writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+execFileSync('vp', ['fmt', outputPath], { stdio: 'ignore' });
+console.log(
+  `Captured ${inventory.valid} valid, ${inventory.invalid} invalid, ` +
+    `${inventory.diagnostics} diagnostics, and ${inventory.fixable} fixed outputs.`,
+);
+
+function captureSuite(source: string): CapturedSuite {
+  const executable = source.replace(/^import .*$/gmu, '');
+  const sandbox: {
+    captured?: CapturedSuite;
+    dedent: typeof dedent;
+    rule: object;
+    runRuleTester: (
+      capturedRule: string,
+      capturedRuleModule: unknown,
+      suite: CapturedSuite,
+    ) => void;
+  } = {
+    dedent,
+    rule: {},
+    runRuleTester(capturedRule, _capturedRuleModule, suite) {
+      if (capturedRule !== RULE) {
+        throw new Error(`Expected ${RULE}, captured ${capturedRule}.`);
+      }
+      sandbox.captured = suite;
+    },
+  };
+  runInNewContext(`"use strict";\n${executable}`, sandbox);
+  if (!sandbox.captured) throw new Error(`Failed to capture ${RULE}.`);
+  return sandbox.captured;
+}
+
+function normalizeCase(testCase: RawCase, invalid: boolean, label: string) {
+  const normalized = typeof testCase === 'string' ? { code: testCase } : testCase;
+  if (typeof normalized.code !== 'string') throw new Error(`${label} is missing source code.`);
+  const errors = invalid ? normalized.errors : [];
+  if (invalid && (!Array.isArray(errors) || errors.length === 0)) {
+    throw new Error(`${label} is missing expected errors.`);
+  }
+  return {
+    code: normalized.code,
+    options: normalized.options ?? [],
+    settings: normalized.settings ?? null,
+    expectedDiagnostics: (errors ?? []).map((error, index) =>
+      normalizeError(error, `${label} error ${index}`),
+    ),
+    expectedOutput: invalid && typeof normalized.output === 'string' ? normalized.output : null,
+  };
+}
+
+function normalizeError(error: RawError, label: string) {
+  if (typeof error.messageId !== 'string') throw new Error(`${label} is missing messageId.`);
+  const line = error.line ?? 1;
+  return {
+    messageId: error.messageId,
+    data: error.data ?? {},
+    ...(typeof error.column === 'number'
+      ? {
+          loc: {
+            startLine: line,
+            startColumn: error.column - 1,
+            ...(typeof error.endColumn === 'number'
+              ? {
+                  endLine: error.endLine ?? line,
+                  endColumn: error.endColumn - 1,
+                }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function upstreamSource(commit: string, sourceFile: string): string {
+  return execFileSync('git', ['-C', submodule, 'show', `${commit}:${sourceFile}`], {
+    encoding: 'utf8',
+  });
+}
+
+function dedent(
+  strings: TemplateStringsArray | string,
+  ...values: Array<string | number | bigint | boolean | null | undefined>
+): string {
+  const value =
+    typeof strings === 'string'
+      ? strings
+      : strings.reduce(
+          (output, segment, index) => output + segment + String(values[index] ?? ''),
+          '',
+        );
+  const lines = value
+    .replace(/^\n/u, '')
+    .replace(/\n\s*$/u, '')
+    .split('\n');
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^\s*/u)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join('\n');
+}


### PR DESCRIPTION
## Summary

- port eslint-plugin-playwright `no-hooks` behavior and its `allow` / `aliases` options
- share Playwright test-name resolution with `prefer-lowercase-title`
- expose the rule through the native package, JavaScript API, README, status, and playground adapter
- add a pinned upstream fixture plus focused Rust, JavaScript, and playground regressions

## Testing

- `VITEST_MAX_WORKERS=1 pnpm verify` (112 files; 17,714 JS tests; all Rust, bench, audit, license, status, and publish-readiness gates)
- `VITEST_MAX_WORKERS=1 pnpm exec vitest run npm/playwright/test/no-hooks-upstream.test.mjs npm/playwright/test/api.test.mjs npm/playwright/test/plugin.test.mjs` (83 tests)
- `cargo test -p oxlint-plugins-playwright` (33 tests)
- `cargo test -p oxlint-plugins-playground-wasm` (7 tests)
- `pnpm run status:check`
- `cargo fmt --check`
- `vp fmt --check`
- `git diff --check`

Part of #420.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/oxlint-plugins/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Playwright `no-hooks` rule to detect disallowed `beforeAll`, `beforeEach`, `afterAll`, and `afterEach` hooks.
  * Added support for allowed hooks and custom hook aliases, including imported and extended test aliases.
  * Diagnostics now include the detected hook name and precise source locations.

* **Documentation**
  * Documented hook options, aliases, supported forms, and the rule’s no-autofix behavior.

* **Tests**
  * Added comprehensive coverage for aliases, nested hooks, options, malformed input, API parity, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->